### PR TITLE
Build manifest for org.mypaint.MyPaint

### DIFF
--- a/org.mypaint.MyPaint.json
+++ b/org.mypaint.MyPaint.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.mypaint.MyPaint",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.22",
+    "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
     "command": "mypaint",
     "rename-desktop-file": "mypaint.desktop",
@@ -11,7 +11,7 @@
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
-        "--filesystem=host"
+        "--filesystem=home"
     ],
     "modules": [
         {

--- a/org.mypaint.MyPaint.json
+++ b/org.mypaint.MyPaint.json
@@ -1,0 +1,106 @@
+{
+    "app-id": "org.mypaint.MyPaint",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.22",
+    "sdk": "org.gnome.Sdk",
+    "command": "mypaint",
+    "rename-desktop-file": "mypaint.desktop",
+    "rename-appdata-file": "mypaint.appdata.xml",
+    "rename-icon": "mypaint",
+    "copy-icon": true,
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--filesystem=host"
+    ],
+    "modules": [
+        {
+            "name": "scons",
+            "cleanup": [ "*" ],
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/scons/scons/2.5.1/scons-2.5.1.tar.gz",
+                    "sha256": "0b25218ae7b46a967db42f2a53721645b3d42874a65f9552ad16ce26d30f51f2"
+                }
+            ],
+            "build-commands": [
+                "python setup.py install --prefix=/app"
+            ]
+        },
+        {
+            "name": "swig",
+            "config-opts": ["--without-boost", "--without-pcre"],
+            "cleanup": [ "*" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz",
+                    "sha256": "7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d"
+                }
+            ]
+        },
+        {
+            "name": "numpy",
+            "buildsystem": "simple",
+            "sources": [
+                    {
+                        "type": "archive",
+                        "url": "https://downloads.sourceforge.net/project/numpy/NumPy/1.11.2/numpy-1.11.2.tar.gz",
+                        "sha256": "04db2fbd64e2e7c68e740b14402b25af51418fc43a59d9e54172b38b906b0f69"
+                    }
+            ],
+            "build-commands": [
+                "python2 setup.py build -j 4",
+                "python2 setup.py install --prefix /app"
+            ]
+        },
+        {
+            "name": "pycairo",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/pygobject/pycairo/releases/download/v1.13.1/pycairo-1.13.1.tar.gz",
+                    "sha256": "d8f58de67ddd01eda9e5112de57599b7d0154d71c9474821e98866c228794641"
+                }
+            ],
+            "build-commands": [
+                "python2 setup.py build",
+                "python2 setup.py install --prefix /app"
+            ]
+        },
+        {
+            "name": "pygobject",
+            "build-options" : {
+                "env": {
+                    "PYTHON": "python2"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pygobject/3.25/pygobject-3.25.1.tar.xz",
+                    "sha256": "8728bb27078f7ee45c431ccbc237a58fb6d6eb1b7a0668bbe29eb107267bd736"
+                }
+            ]
+        },
+        {
+            "name": "mypaint",
+            "buildsystem": "simple",
+            "sources": [
+                    {
+                        "type": "git",
+                        "url": "https://github.com/mypaint/mypaint.git",
+                        "branch": "v1.2.1",
+                        "commit": "bcf5a28d38bbd586cc9d4cee223f849fa303864f"
+                    }
+            ],
+            "build-commands": [
+                "scons",
+                "scons prefix=/app install"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This will build current stable MyPaint v1.2.1 .

MyPaint still needs to be ported to use the File Chooser portal, so I'm
opening access to the host files until that's fixed.

Wacom tablets won't work under Wayland.  This is fixed in MyPaint
master, so I'll be watching for next stable release to update the
manifest.  By the way, under Wayland the application starts fine, but if
you want to use a wacom you better switch to X11.  For the momment I'll
be providing a (Nightly) Mypaint outside Flathub.