### PR TITLE
Update urls in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ Flathub
 -------
 
 Flathub is the central place for building and hosting Flatpak builds.
-Go to http://flathub.org/builds/ to see Flathub in action.
+Go to https://flathub.org/builds/ to see Flathub in action.
 
 Building applications
 ---------------------
 
-Application manifests should go in their own repository in the [Flathub](http://github.com/flathub) organization,
+Application manifests should go in their own repository in the [Flathub](https://github.com/flathub) organization,
 named after the application ID.
 
 For example, for gnome-recipes, there is a repository named org.gnome.Recipes which has the org.gnome.Recipes.json


### PR DESCRIPTION
Changed protocol from http to https on flathub url because on http flathub reports errors. 