### PR TITLE
Add org.libretro.RetroArch

### DIFF
--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -9,6 +9,6 @@
     </p>
   </description>
   <url type="homepage">http://retroarch.com</url>
-  <metadata_license>GPL-3.0</metadata_license>
-  <project_license>CC0-1.0</project_license>
+  <project_license>GPL-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
 </application>

--- a/org.libretro.RetroArch.appdata.xml
+++ b/org.libretro.RetroArch.appdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">org.libretro.RetroArch.desktop</id>
+  <name>RetroArch</name>
+  <summary>Frontend for emulators, game engines and media players.</summary>
+  <description>
+    <p>
+      RetroArch enables you to run classic games on a wide range of computers and consoles through its slick graphical interface. Settings are also unified so configuration is done once and for all.
+    </p>
+  </description>
+  <url type="homepage">http://retroarch.com</url>
+  <metadata_license>GPL-3.0</metadata_license>
+  <project_license>CC0-1.0</project_license>
+</application>

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -56,7 +56,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/libretro/retroarch-assets.git"
+          "url": "https://github.com/libretro/retroarch-assets.git",
+          "commit": "3dc9395b362f5316918b2fb95f4642a2940147b8"
         }
       ]
     },
@@ -68,7 +69,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/libretro/libretro-database.git"
+          "url": "https://github.com/libretro/libretro-database.git",
+          "commit": "4b3aa272d50ea123f58cbff899b0825cb32c6c51"
         }
       ]
     },
@@ -80,7 +82,8 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://github.com/libretro/libretro-core-info.git"
+          "url": "https://github.com/libretro/libretro-core-info.git",
+          "commit": "92b0077e641503f29609d60eda1a961fe256a2e6"
         }
       ]
     }

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -85,6 +85,19 @@
           "commit": "92b0077e641503f29609d60eda1a961fe256a2e6"
         }
       ]
+    },
+    {
+      "name": "retroarch-joypad-autoconfig",
+      "make-install-args": [
+        "DESTDIR=/app/share/libretro/autoconfig"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/libretro/retroarch-joypad-autoconfig.git",
+          "commit": "3dfe09433dffe7a1a6fbc30b65f41c87cb098f2f"
+        }
+      ]
     }
   ]
 }

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -10,16 +10,10 @@
     "--socket=x11",
     "--socket=wayland",
     "--socket=pulseaudio",
-    "--socket=system-bus",
     "--share=ipc",
     "--share=network",
     "--device=dri",
-    "--filesystem=home",
-    "--filesystem=xdg-videos",
-    "--filesystem=xdg-music",
-    "--filesystem=xdg-pictures",
-    "--talk-name=org.gtk.vfs",
-    "--talk-name=org.gtk.vfs.*"
+    "--filesystem=home"
   ],
   "modules": [
     {

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -1,8 +1,8 @@
 {
   "app-id": "org.libretro.RetroArch",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "3.24",
-  "sdk": "org.gnome.Sdk",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "1.6",
+  "sdk": "org.freedesktop.Sdk",
   "command": "retroarch",
   "rename-desktop-file": "retroarch.desktop",
   "rename-icon": "retroarch",
@@ -19,8 +19,7 @@
     "--filesystem=xdg-music",
     "--filesystem=xdg-pictures",
     "--talk-name=org.gtk.vfs",
-    "--talk-name=org.gtk.vfs.*",
-    "--talk-name=org.gnome.ScreenSaver"
+    "--talk-name=org.gtk.vfs.*"
   ],
   "modules": [
     {

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -12,8 +12,9 @@
     "--socket=pulseaudio",
     "--share=ipc",
     "--share=network",
-    "--device=dri",
-    "--filesystem=home"
+    "--device=all",
+    "--filesystem=home",
+    "--allow=multiarch"
   ],
   "modules": [
     {

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -31,6 +31,10 @@
         {
             "type": "file",
             "path": "org.libretro.RetroArch.appdata.xml"
+        },
+        {
+            "type": "file",
+            "path": "retroarch.cfg"
         }
       ],
       "post-install": [
@@ -38,12 +42,7 @@
         "mv /app/share/pixmaps/retroarch.svg /app/share/icons/hicolor/scalable/apps/",
         "rmdir /app/share/pixmaps/",
         "mkdir -p /app/etc",
-        "echo 'assets_directory = \"/app/share/libretro/assets/\"' >> /app/etc/retroarch.cfg",
-        "echo 'suspend_screensaver_enable  = false' >> /app/etc/retroarch.cfg",
-        "echo 'content_database_path = \"/app/share/libretro/database/rdb\"' >> /app/etc/retroarch.cfg",
-        "echo 'cheat_database_directory = \"/app/share/libretro/database/cht\"' >> /app/etc/retroarch.cfg",
-        "echo 'cursor_directory = \"/app/share/libretro/database/cursors\"' >> /app/etc/retroarch.cfg",
-        "echo 'libretro_info_path = \"/app/share/libretro/info\"' >> /app/etc/retroarch.cfg",
+        "cp retroarch.cfg /app/etc",
         "mkdir -p /app/share/appdata",
         "cp org.libretro.RetroArch.appdata.xml /app/share/appdata"
       ]

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -1,0 +1,89 @@
+{
+  "app-id": "org.libretro.RetroArch",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.24",
+  "sdk": "org.gnome.Sdk",
+  "command": "retroarch",
+  "rename-desktop-file": "retroarch.desktop",
+  "rename-icon": "retroarch",
+  "finish-args": [
+    "--socket=x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--socket=system-bus",
+    "--share=ipc",
+    "--share=network",
+    "--device=dri",
+    "--filesystem=home",
+    "--filesystem=xdg-videos",
+    "--filesystem=xdg-music",
+    "--filesystem=xdg-pictures",
+    "--talk-name=org.gtk.vfs",
+    "--talk-name=org.gtk.vfs.*",
+    "--talk-name=org.gnome.ScreenSaver"
+  ],
+  "modules": [
+    {
+      "name": "retroarch",
+      "make-args": [
+        "GLOBAL_CONFIG_DIR=/app/etc"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/libretro/RetroArch.git",
+          "branch": "v1.6.1",
+          "commit": "681351c5810c8dd86fed10c9993453c10bd3cd57"
+        }
+      ],
+      "post-install": [
+        "mkdir -p /app/share/icons/hicolor/scalable/apps/",
+        "mv /app/share/pixmaps/retroarch.svg /app/share/icons/hicolor/scalable/apps/",
+        "rmdir /app/share/pixmaps/",
+        "mkdir -p /app/etc",
+        "echo 'assets_directory = \"/app/share/libretro/assets/\"' >> /app/etc/retroarch.cfg",
+        "echo 'suspend_screensaver_enable  = false' >> /app/etc/retroarch.cfg",
+        "echo 'content_database_path = \"/app/share/libretro/database/rdb\"' >> /app/etc/retroarch.cfg",
+        "echo 'cheat_database_directory = \"/app/share/libretro/database/cht\"' >> /app/etc/retroarch.cfg",
+        "echo 'cursor_directory = \"/app/share/libretro/database/cursors\"' >> /app/etc/retroarch.cfg",
+        "echo 'libretro_info_path = \"/app/share/libretro/info\"' >> /app/etc/retroarch.cfg"
+      ]
+    },
+    {
+      "name": "retroarch-assets",
+      "make-install-args": [
+        "DESTDIR=/app/share/libretro/assets"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/libretro/retroarch-assets.git"
+        }
+      ]
+    },
+    {
+      "name": "libretro-database",
+      "make-install-args": [
+        "DESTDIR=/app/share/libretro/database"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/libretro/libretro-database.git"
+        }
+      ]
+    },
+    {
+      "name": "libretro-core-info",
+      "make-install-args": [
+        "DESTDIR=/app/share/libretro/info"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/libretro/libretro-core-info.git"
+        }
+      ]
+    }
+  ]
+}

--- a/org.libretro.RetroArch.json
+++ b/org.libretro.RetroArch.json
@@ -27,6 +27,10 @@
           "url": "https://github.com/libretro/RetroArch.git",
           "branch": "v1.6.1",
           "commit": "681351c5810c8dd86fed10c9993453c10bd3cd57"
+        },
+        {
+            "type": "file",
+            "path": "org.libretro.RetroArch.appdata.xml"
         }
       ],
       "post-install": [
@@ -39,7 +43,9 @@
         "echo 'content_database_path = \"/app/share/libretro/database/rdb\"' >> /app/etc/retroarch.cfg",
         "echo 'cheat_database_directory = \"/app/share/libretro/database/cht\"' >> /app/etc/retroarch.cfg",
         "echo 'cursor_directory = \"/app/share/libretro/database/cursors\"' >> /app/etc/retroarch.cfg",
-        "echo 'libretro_info_path = \"/app/share/libretro/info\"' >> /app/etc/retroarch.cfg"
+        "echo 'libretro_info_path = \"/app/share/libretro/info\"' >> /app/etc/retroarch.cfg",
+        "mkdir -p /app/share/appdata",
+        "cp org.libretro.RetroArch.appdata.xml /app/share/appdata"
       ]
     },
     {

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -3,4 +3,5 @@ content_database_path = "/app/share/libretro/database/rdb"
 cheat_database_directory = "/app/share/libretro/database/cht"
 cursor_directory = "/app/share/libretro/database/cursors"
 libretro_info_path = "/app/share/libretro/info"
+joypad_autoconfig_dir = "/app/share/libretro/autoconfig"
 suspend_screensaver_enable  = false

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -1,0 +1,6 @@
+assets_directory = "/app/share/libretro/assets/"
+content_database_path = "/app/share/libretro/database/rdb"
+cheat_database_directory = "/app/share/libretro/database/cht"
+cursor_directory = "/app/share/libretro/database/cursors"
+libretro_info_path = "/app/share/libretro/info"
+suspend_screensaver_enable  = false

--- a/retroarch.cfg
+++ b/retroarch.cfg
@@ -4,4 +4,6 @@ cheat_database_directory = "/app/share/libretro/database/cht"
 cursor_directory = "/app/share/libretro/database/cursors"
 libretro_info_path = "/app/share/libretro/info"
 joypad_autoconfig_dir = "/app/share/libretro/autoconfig"
+input_driver = "sdl2"
+input_joypad_driver = "sdl2"
 suspend_screensaver_enable  = false


### PR DESCRIPTION
Add support for [RetroArch](http://retroarch.com/), a frontend for emulators, game engines and media players. This is based off of FreeDesktop, but also works with Gnome.

## TODO
- [x] [retroarch-joypad-autoconf](https://github.com/libretro/retroarch-joypad-autoconfig) to fix the controllers
- [x] Move the retroarch.cfg additions to their own file