### PR TITLE
Add Digital: A Love Story

### DIFF
--- a/Digital-launcher.sh
+++ b/Digital-launcher.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec "/app/lib/python" "-OO" "/app/Digital.py" "$@"

--- a/com.scoutshonour.Digital.appdata.xml
+++ b/com.scoutshonour.Digital.appdata.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">com.scoutshonour.Digital.desktop</id>
+  <name>Digital: A Love Story</name>
+  <developer_name>Christine Love</developer_name>
+  <summary>A computer mistery/romance set five minutes into the future of 1988</summary>
+  <categories>
+    <category>Game</category>
+    <category>AdventureGame</category>
+  </categories>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>CC-BY-NC-SA-3.0</project_license>
+  <url type="homepage">http://scoutshonour.com/digital/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">http://scoutshonour.com/digital/full.png</image>
+    </screenshot>
+  </screenshots>
+</application>

--- a/com.scoutshonour.Digital.desktop
+++ b/com.scoutshonour.Digital.desktop
@@ -2,4 +2,6 @@
 Type=Application
 Version=1.1
 Name=Digital: A Love Story
+Exec=Digital.sh
+Icon=com.scoutshonour.Digital
 Categories=Game;AdventureGame

--- a/com.scoutshonour.Digital.desktop
+++ b/com.scoutshonour.Digital.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Type=Application
+Version=1.1
+Name=Digital: A Love Story
+Categories=Game;AdventureGame

--- a/com.scoutshonour.Digital.json
+++ b/com.scoutshonour.Digital.json
@@ -1,0 +1,53 @@
+{
+  "app-id": "com.scoutshonour.Digital",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "1.6",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "Digital.sh",
+  "finish-args": [
+    "--socket=x11",
+    "--socket=pulseaudio",
+    "--filesystem=~/.renpy:create"
+  ],
+  "build-options": {
+    "env": {
+      "PREFIX": "/app"
+    }
+  },
+  "modules": [
+    {
+      "name": "digital",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cp -R common /app/common",
+        "cp -R game /app/game",
+        "cp -R lib /app/lib",
+        "cp -R renpy /app/renpy",
+        "install Digital.py /app/Digital.py",
+        "install -D Digital-launcher.sh /app/bin/Digital.sh",
+        "install -D README.html /app/README.html",
+        "install -Dm644 com.scoutshonour.Digital.appdata.xml /app/share/appdata/com.scoutshonour.Digital.appdata.xml",
+        "install -Dm644 com.scoutshonour.Digital.desktop /app/templates/com.scoutshonour.Digital.desktop"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://www.scoutshonour.com/lilyofthevalley/digital-1.1.tar.bz2",
+          "sha256": "e84f5245ca5b348fad3a25b272d55b839a6348501d3e876290c23f8ad4ff0201"
+        },
+        {
+          "type": "file",
+          "path": "Digital-launcher.sh"
+        },
+        {
+          "type": "file",
+          "path": "com.scoutshonour.Digital.appdata.xml"
+        },
+        {
+          "type": "file",
+          "path": "com.scoutshonour.Digital.desktop"
+        }
+      ]
+    }
+  ]
+}

--- a/com.scoutshonour.Digital.json
+++ b/com.scoutshonour.Digital.json
@@ -23,11 +23,12 @@
         "cp -R game /app/game",
         "cp -R lib /app/lib",
         "cp -R renpy /app/renpy",
-        "install Digital.py /app/Digital.py",
-        "install -D Digital-launcher.sh /app/bin/Digital.sh",
-        "install -D README.html /app/README.html",
+        "install -Dm755 Digital.py /app/Digital.py",
+        "install -Dm755 Digital-launcher.sh /app/bin/Digital.sh",
+        "install -Dm644 README.html /app/README.html",
         "install -Dm644 com.scoutshonour.Digital.appdata.xml /app/share/appdata/com.scoutshonour.Digital.appdata.xml",
-        "install -Dm644 com.scoutshonour.Digital.desktop /app/templates/com.scoutshonour.Digital.desktop"
+        "install -Dm644 com.scoutshonour.Digital.desktop /app/share/applications/com.scoutshonour.Digital.desktop",
+        "install -Dm644 game/icon.png /app/share/icons/hicolor/128x128/apps/com.scoutshonour.Digital.png"
       ],
       "sources": [
         {

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-arches": ["aarch64", "arm", "x86_64"]
+}


### PR DESCRIPTION
The game is only distributed as 32-bits, so running it on the 64-bits runtime fails due to not finding python.
On the 32-bits runtime it seems to work pretty well. It currently only runs from the command line though.

I'm allowing the game access to ~/.renpy so the user can know where their saves is, and also because of the Ren'py's Multi-Game Persistance feature (which the direct sequel uses for a minor plot point tying it to this game).

I didn't manage to export the desktop file and would like some help with it.
I didn't include an icon currently, but there is already one of 128x128 dimensions in the "game" folder which could be used.