### PR TITLE
Add a manifest for Dungeon Crawl Stone Soup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.develz.Crawl.appdata.xml
+++ b/org.develz.Crawl.appdata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.develz.Crawl.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <name>crawl</name>
+  <summary>Dungeon Crawl Stone Soup</summary>
+  <description>
+    <p>
+      A roguelike adventure through dungeons filled with dangerous monsters in
+      a quest to find the mystifyingly fabulous Orb of Zot.
+    </p>
+  </description>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <url type="homepage">http://crawl.develz.org/</url>
+  <launchable type="desktop-id">crawl.desktop</launchable>
+  <screenshots>
+    <screenshot>
+      <caption>The Dungeon</caption>
+      <image type="source">http://crawl.develz.org/wordpress/wp-content/uploads/2014/05/musu.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Sigmund</caption>
+      <image type="source">http://crawl.develz.org/wordpress/wp-content/uploads/2014/05/meph.png</image>
+    </screenshot>
+  </screenshots>
+  <update_contact>guillaumepoiriermorency@gmail.com</update_contact>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">mild</content_attribute>
+    <content_attribute id="violence-bloodshed">mild</content_attribute>
+  </content_rating>
+</component>

--- a/org.develz.Crawl.json
+++ b/org.develz.Crawl.json
@@ -1,0 +1,44 @@
+{
+    "app-id": "org.develz.Crawl",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "crawl",
+    "finish-args": [
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--socket=wayland",
+        "--share=ipc",
+        "--device=dri",
+        "--filesystem=~/.crawl:create"
+    ],
+    "modules": [
+        "shared-modules/glu/glu-9.0.0.json",
+        {
+            "name": "crawl",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://crawl.develz.org/release/0.20/stone_soup-0.20.1.tar.xz",
+                    "sha256": "77d238bd859166e09bbf56127997f810d1c9794e1cf4a0d1edc0687b6f194dee"
+                },
+                {
+                    "type": "file",
+                    "path": "org.develz.Crawl.appdata.xml",
+                    "dest-filename": "source/org.develz.Crawl.appdata.xml"
+                }
+            ],
+            "subdir": "source",
+            "no-autogen": true,
+            "make-args": ["prefix=/app", "SAVEDIR=~/.crawl", "EXTERNAL_LDFLAGS=-L/app/lib", "TILES=y"],
+            "make-install-args": ["prefix=/app", "SAVEDIR=~/.crawl", "EXTERNAL_LDFLAGS=-L/app/lib", "TILES=y"],
+            "post-install": [
+                "install -D org.develz.Crawl.appdata.xml /app/share/appdata/org.develz.Crawl.appdata.xml",
+                "desktop-file-edit --set-key Exec --set-value /app/bin/crawl --set-key Icon --set-value org.develz.Crawl debian/crawl-tiles.desktop",
+                "install -D debian/crawl-tiles.desktop /app/share/applications/org.develz.Crawl.desktop",
+                "install -D debian/crawl.png /app/share/icons/hicolor/48x48/apps/org.develz.Crawl.png"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I'm still having the following issue at link time and it would be nice if any of you could investigate the build.

```
/usr/lib/gcc/x86_64-unknown-linux/6.2.0/../../../../x86_64-unknown-linux/bin/ld.gold: error: cannot find -lGLU
glwrapper-ogl.o:glwrapper-ogl.cc:function OGLStateManager::load_texture(unsigned char*, unsigned int, unsigned int, MipMapOptions, int, int): error: undefined reference to 'gluBuild2DMipmaps'
collect2: error: ld returned 1 exit status
make: *** [Makefile:1473: crawl] Error 1
Error: module crawl: Le processus fils s'est terminé avec le code 2
make: *** [Makefile:2: repo] Error 1
```