### PR TITLE
Import org.gnome.Photos from gnome-apps-nightly:stable

### DIFF
--- a/exiv2-no-builddir.patch
+++ b/exiv2-no-builddir.patch
@@ -1,0 +1,25 @@
+From ba7a8cfe30342592e277ad41837f0eb5c6e88648 Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Wed, 20 Jan 2016 17:00:19 +0000
+Subject: [PATCH] Disable builddir for exiv2
+
+It's not supported.
+---
+ configure | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/configure b/configure
+index 4cd76eb..7848532 100755
+--- a/configure
++++ b/configure
+@@ -19914,6 +19914,8 @@ fi
+ # Configuration summary.
+ # ---------------------------------------------------------------------------
+ 
++echo \#buildapi-variable-no-builddir >/dev/null
++
+ echo ""
+ echo "------------------------------------------------------------------"
+ echo "-- Exiv2 $VERSION feature configuration summary"
+-- 
+2.5.0

--- a/libraw-CVE-2017-13735-radc_divbyzero.patch
+++ b/libraw-CVE-2017-13735-radc_divbyzero.patch
@@ -1,0 +1,26 @@
+--- a/internal/dcraw_common.cpp~	2017-03-04 12:35:59.000000000 -0600
++++ b/internal/dcraw_common.cpp	2017-09-06 10:47:04.613293577 -0500
+@@ -2716,6 +2716,10 @@
+     checkCancel();
+ #endif
+     FORC3 mul[c] = getbits(6);
++#ifdef LIBRAW_LIBRARY_BUILD
++    if(!mul[0] || !mul[1] || !mul[2])
++      throw LIBRAW_EXCEPTION_IO_CORRUPT;
++#endif
+     FORC3 {
+       val = ((0x1000000/last[c] + 0x7ff) >> 12) * mul[c];
+       s = val > 65564 ? 10:12;
+--- a/dcraw/dcraw.c~	2017-09-06 10:48:15.000000000 -0500
++++ b/dcraw/dcraw.c	2017-09-06 10:49:23.103787467 -0500
+@@ -2228,6 +2228,10 @@
+     ((short *)buf)[i] = 2048;
+   for (row=0; row < height; row+=4) {
+     FORC3 mul[c] = getbits(6);
++#ifdef LIBRAW_LIBRARY_BUILD
++    if(!mul[0] || !mul[1] || !mul[2])
++      throw LIBRAW_EXCEPTION_IO_CORRUPT;
++#endif
+     FORC3 {
+       val = ((0x1000000/last[c] + 0x7ff) >> 12) * mul[c];
+       s = val > 65564 ? 10:12;

--- a/libraw-pkgconfig.patch
+++ b/libraw-pkgconfig.patch
@@ -1,0 +1,44 @@
+From bf4b0b6a3ec1579916475295ac42a5f98559a04b Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Fri, 12 Feb 2016 18:29:35 +0000
+Subject: [PATCH] Add pkg-config file to LibRaw
+
+Taken from the Fedora package.
+---
+ libraw.pc.in   | 5 +++--
+ libraw_r.pc.in | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/libraw.pc.in b/libraw.pc.in
+index 0e530b2..0c635f0 100644
+--- a/libraw.pc.in
++++ b/libraw.pc.in
+@@ -5,7 +5,8 @@ includedir=@includedir@
+ 
+ Name: libraw
+ Description: Raw image decoder library (non-thread-safe)
+-Requires: @PACKAGE_REQUIRES@
++Requires.private: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw@PC_OPENMP@
++Libs.private: -lstdc++
+ Cflags: -I${includedir}/libraw
+diff --git a/libraw_r.pc.in b/libraw_r.pc.in
+index a7f4535..c4e6028 100644
+--- a/libraw_r.pc.in
++++ b/libraw_r.pc.in
+@@ -5,7 +5,8 @@ includedir=@includedir@
+ 
+ Name: libraw
+ Description: Raw image decoder library (thread-safe)
+-Requires: @PACKAGE_REQUIRES@
++Requires.private: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw_r@PC_OPENMP@
++Libs.private: -lstdc++
+ Cflags: -I${includedir}/libraw
+-- 
+2.5.0
+

--- a/org.gnome.Photos.json
+++ b/org.gnome.Photos.json
@@ -62,16 +62,18 @@
         },
         {
             "name": "geocode-glib",
+            "config-opts": [ "--disable-introspection" ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/geocode-glib/3.20/geocode-glib-3.20.1.tar.xz",
-                    "sha256": "669fc832cabf8cc2f0fc4194a8fa464cdb9c03ebf9aca5353d7cf935ba8637a2"
+                    "url": "https://download.gnome.org/sources/geocode-glib/3.24/geocode-glib-3.24.0.tar.xz",
+                    "sha256": "19c1fef4fd89eb4bfe6decca45ac45a2eca9bb7933be560ce6c172194840c35e"
                 }
             ]
         },
         {
             "name": "librest",
+            "config-opts": [ "--disable-introspection" ],
             "sources": [
                 {
                     "type": "archive",
@@ -82,18 +84,22 @@
         },
         {
             "name": "gnome-online-accounts",
-            "config-opts": [ "--disable-telepathy", "--disable-documentation", "--disable-backend" ],
+            "config-opts": [ "--disable-introspection",
+                             "--disable-telepathy",
+                             "--disable-documentation",
+                             "--disable-backend" ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.24/gnome-online-accounts-3.24.2.tar.xz",
-                    "sha256": "b70ad52d1541e1e5192dd060bb11552a3af5007ab477aa81d265d1cd1cf7afba"
+                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.24/gnome-online-accounts-3.24.3.tar.xz",
+                    "sha256": "252e58eb953032f84731724ff2e8c8afb403ca803bd35382eabcfeee9c703854"
                 }
             ]
         },
         {
             "name": "libgfbgraph",
             "cleanup": [ "/doc" ],
+            "config-opts": [ "--disable-introspection" ],
             "sources": [
                 {
                     "type": "archive",
@@ -114,7 +120,7 @@
         },
         {
             "name": "libgdata",
-            "config-opts": [ "--disable-always-build-tests", "--disable-static" ],
+            "config-opts": [ "--disable-always-build-tests", "--disable-introspection", "--disable-static" ],
             "sources": [
                 {
                     "type": "archive",
@@ -132,6 +138,14 @@
                     "type": "archive",
                     "url": "http://www.libraw.org/data/LibRaw-0.18.2.tar.gz",
                     "sha256": "ce366bb38c1144130737eb16e919038937b4dc1ab165179a225d5e847af2abc6"
+                },
+                {
+                    "type": "patch",
+                    "path": "libraw-pkgconfig.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "libraw-CVE-2017-13735-radc_divbyzero.patch"
                 }
             ]
         },
@@ -142,8 +156,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://ftp.acc.umu.se/pub/gimp/gegl/0.3/gegl-0.3.14.tar.bz2",
-                    "sha256": "09f5e2e6899697641d4660e3e274aed696f5bacc96ba389ac77674ee1156590a"
+                    "url": "http://ftp.acc.umu.se/pub/gimp/gegl/0.3/gegl-0.3.16.tar.bz2",
+                    "sha256": "11174f20d01f25d4b5425ff77457ee00fbde7bc26ea4b1ff0765fc1ba6028006"
                 }
             ]
         },
@@ -181,19 +195,9 @@
             ]
         },
         {
-            "name": "gnome-desktop",
-            "config-opts": [ "--disable-debug-tools", "--disable-udev" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-desktop/3.24/gnome-desktop-3.24.2.tar.xz",
-                    "sha256": "8fa1de66a6a75963bffc79b01a60434c71237d44c51beca09c0f714a032d785e"
-                }
-            ]
-        },
-        {
             "name": "grilo",
             "cleanup": [ "/bin" ],
+            "config-opts": [ "--disable-introspection" ],
             "sources": [
                 {
                     "type": "archive",
@@ -239,11 +243,15 @@
         },
         {
             "name": "tracker",
-            "cleanup": [ "/bin", "/etc", "/libexec" ],
-            "config-opts": [ "--disable-miner-apps",
+            "cleanup": [ "/bin",
+                         "/etc",
+                         "/lib/systemd",
+                         "/libexec",
+                         "/share/dbus-1/services/org.freedesktop.Tracker1.service" ],
+            "config-opts": [ "--disable-introspection",
+                             "--disable-miner-apps",
                              "--disable-miner-evolution",
                              "--disable-miner-firefox",
-                             "--disable-miner-fs",
                              "--disable-miner-rss",
                              "--disable-miner-thunderbird",
                              "--disable-miner-user-guides",
@@ -253,13 +261,13 @@
                              "--disable-tracker-needle",
                              "--disable-tracker-preferences",
                              "--disable-tracker-writeback",
-                             "--enable-minimal",
+                             "--enable-miner-fs",
                              "--with-bash-completion-dir=no" ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/tracker/1.12/tracker-1.12.1.tar.xz",
-                    "sha256": "b912cb06944abc676b4644219db777896455fb33aa5589f0b46e417bc9b82a4b"
+                    "url": "https://download.gnome.org/sources/tracker/1.12/tracker-1.12.3.tar.xz",
+                    "sha256": "23ce943878c1165c3f52fe97150c71708ebfbb5da3020e9a7247ad4f5120f8d6"
                 }
             ]
         },
@@ -269,8 +277,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-photos/3.24/gnome-photos-3.24.2.tar.xz",
-                    "sha256": "31ddc078ad2f6bc4bbfa2f71eb23377782750b9cb2ad2b0e6ff2a1971548cdf9"
+                    "url": "https://download.gnome.org/sources/gnome-photos/3.24/gnome-photos-3.24.3.tar.xz",
+                    "sha256": "cd365629ce584d223c023676a88b6194012bbc561c4a4b1c8eca462425e76288"
                 }
             ]
         }

--- a/org.gnome.Photos.json
+++ b/org.gnome.Photos.json
@@ -1,0 +1,280 @@
+{
+    "app-id": "org.gnome.Photos",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "branch": "stable",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-photos",
+    "tags": [],
+    "finish-args": [
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--filesystem=xdg-download",
+        "--filesystem=xdg-pictures",
+        "--filesystem=xdg-run/dconf",
+        "--share=ipc",
+        "--share=network",
+        "--socket=wayland",
+        "--socket=x11",
+        "--talk-name=ca.desrt.dconf",
+        "--talk-name=org.freedesktop.Tracker1",
+        "--talk-name=org.freedesktop.Tracker1.Miner.Extract",
+        "--talk-name=com.intel.dleyna-renderer",
+        "--talk-name=org.gnome.SettingsDaemon"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": [ "/include", "/lib/pkgconfig",
+                 "/share/pkgconfig", "/share/aclocal",
+                 "/man", "/share/man", "/share/gtk-doc",
+                 "/share/vala",
+                 "*.la", "*.a"
+               ],
+    "modules": [
+           {
+            "name": "babl",
+            "build-options" : {
+                "arch" : {
+                    "i386" : {
+                        "config-opts" : [
+                            "--build=i586-unknown-linux-gnu"
+                        ]
+                    },
+		    "arm" : {
+                        "config-opts" : [
+                            "--build=arm-unknown-linux-gnueabi"
+			]
+		    }
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/gimp/babl/0.1/babl-0.1.26.tar.bz2",
+                    "sha256": "fd80e165f1534c64457a8cce7a8aa90559ab28ecd32beb9e3948c5b8cd373d34"
+                }
+            ]
+        },
+        {
+            "name": "geocode-glib",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/geocode-glib/3.20/geocode-glib-3.20.1.tar.xz",
+                    "sha256": "669fc832cabf8cc2f0fc4194a8fa464cdb9c03ebf9aca5353d7cf935ba8637a2"
+                }
+            ]
+        },
+        {
+            "name": "librest",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/rest/0.8/rest-0.8.0.tar.xz",
+                    "sha256": "e7b89b200c1417073aef739e8a27ff2ab578056c27796ec74f5886a5e0dff647"
+                }
+            ]
+        },
+        {
+            "name": "gnome-online-accounts",
+            "config-opts": [ "--disable-telepathy", "--disable-documentation", "--disable-backend" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-online-accounts/3.24/gnome-online-accounts-3.24.2.tar.xz",
+                    "sha256": "b70ad52d1541e1e5192dd060bb11552a3af5007ab477aa81d265d1cd1cf7afba"
+                }
+            ]
+        },
+        {
+            "name": "libgfbgraph",
+            "cleanup": [ "/doc" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gfbgraph/0.2/gfbgraph-0.2.3.tar.xz",
+                    "sha256": "da1179083cde2b649d7491c745250a00d292e390fd620b7dd2dd95a122dae0b6"
+                }
+            ]
+        },
+        {
+            "name": "liboauth",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://netix.dl.sourceforge.net/project/liboauth/liboauth-1.0.3.tar.gz",
+                    "sha256": "0df60157b052f0e774ade8a8bac59d6e8d4b464058cc55f9208d72e41156811f"
+                }
+            ]
+        },
+        {
+            "name": "libgdata",
+            "config-opts": [ "--disable-always-build-tests", "--disable-static" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgdata/0.17/libgdata-0.17.8.tar.xz",
+                    "sha256": "e5e735bfac219c6cbe4a14df481cb3cb4b1c4b8b5e70f9a105a884035bc3a161"
+                }
+            ]
+        },
+        {
+            "name": "libraw",
+            "config-opts": [ "--disable-examples", "--disable-static" ],
+            "cleanup": [ "/share/doc" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.libraw.org/data/LibRaw-0.18.2.tar.gz",
+                    "sha256": "ce366bb38c1144130737eb16e919038937b4dc1ab165179a225d5e847af2abc6"
+                }
+            ]
+        },
+        {
+            "name": "gegl",
+            "cleanup": [ "/bin" ],
+            "config-opts": [ "--disable-docs", "--disable-introspection" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.acc.umu.se/pub/gimp/gegl/0.3/gegl-0.3.14.tar.bz2",
+                    "sha256": "09f5e2e6899697641d4660e3e274aed696f5bacc96ba389ac77674ee1156590a"
+                }
+            ]
+        },
+        {
+            "name": "exiv2",
+            "cleanup": [ "/bin" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://exiv2.org/builds/exiv2-0.26-trunk.tar.gz",
+                    "sha256": "c75e3c4a0811bf700d92c82319373b7a825a2331c12b8b37d41eb58e4f18eafb"
+                },
+                {
+                    "type": "patch",
+                    "path": "exiv2-no-builddir.patch"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cp -f /usr/share/gnu-config/config.sub ./config/",
+                        "cp -f /usr/share/gnu-config/config.guess ./config/"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "gexiv2",
+            "config-opts": [ "--disable-introspection" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gexiv2/0.10/gexiv2-0.10.6.tar.xz",
+                    "sha256": "132788919667254b42c026ab39ab3c3a5be59be8575c05fa4b371ca8aed55825"
+                }
+            ]
+        },
+        {
+            "name": "gnome-desktop",
+            "config-opts": [ "--disable-debug-tools", "--disable-udev" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-desktop/3.24/gnome-desktop-3.24.2.tar.xz",
+                    "sha256": "8fa1de66a6a75963bffc79b01a60434c71237d44c51beca09c0f714a032d785e"
+                }
+            ]
+        },
+        {
+            "name": "grilo",
+            "cleanup": [ "/bin" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/grilo/0.3/grilo-0.3.3.tar.xz",
+                    "sha256": "5c874222c7bdf42490cd56765a593c41407247706bb1f24a1bd5d007aa38a0e3"
+                }
+            ]
+        },
+        {
+            "name": "grilo-plugins",
+            "cleanup": [ "/include" ],
+            "config-opts": [ "--disable-bookmarks",
+                             "--disable-chromaprint",
+                             "--disable-dleyna",
+                             "--disable-dmap",
+                             "--disable-filesystem",
+                             "--disable-freebox",
+                             "--disable-gravatar",
+                             "--disable-jamendo",
+                             "--disable-local-metadata",
+                             "--disable-lua-factory",
+                             "--disable-magnatune",
+                             "--disable-metadata-store",
+                             "--disable-opensubtitles",
+                             "--disable-optical-media",
+                             "--disable-podcasts",
+                             "--disable-raitv",
+                             "--disable-shoutcast",
+                             "--disable-tmdb",
+                             "--disable-thetvdb",
+                             "--disable-tracker",
+                             "--disable-vimeo",
+                             "--disable-youtube",
+                             "--enable-flickr",
+                             "--enable-goa" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/grilo-plugins/0.3/grilo-plugins-0.3.4.tar.xz",
+                    "sha256": "990282a518968c52f6a67b96c6b708e236a59da1c7c920ed45e6316ab49ddeb5"
+                }
+            ]
+        },
+        {
+            "name": "tracker",
+            "cleanup": [ "/bin", "/etc", "/libexec" ],
+            "config-opts": [ "--disable-miner-apps",
+                             "--disable-miner-evolution",
+                             "--disable-miner-firefox",
+                             "--disable-miner-fs",
+                             "--disable-miner-rss",
+                             "--disable-miner-thunderbird",
+                             "--disable-miner-user-guides",
+                             "--disable-nautilus-extension",
+                             "--disable-static",
+                             "--disable-tracker-extract",
+                             "--disable-tracker-needle",
+                             "--disable-tracker-preferences",
+                             "--disable-tracker-writeback",
+                             "--enable-minimal",
+                             "--with-bash-completion-dir=no" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/tracker/1.12/tracker-1.12.1.tar.xz",
+                    "sha256": "b912cb06944abc676b4644219db777896455fb33aa5589f0b46e417bc9b82a4b"
+                }
+            ]
+        },
+        {
+            "name": "gnome-photos",
+            "config-opts": [ "--disable-documentation" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-photos/3.24/gnome-photos-3.24.2.tar.xz",
+                    "sha256": "31ddc078ad2f6bc4bbfa2f71eb23377782750b9cb2ad2b0e6ff2a1971548cdf9"
+                }
+            ]
+        }
+    ]
+}
+
+


### PR DESCRIPTION
I'd like to move the stable org.gnome.Photos Flatpak to Flathub. This is the same manifest that existed under git://git.gnome.org/gnome-photos/flatpak/ and was being built via gnome-apps-nightly:stable.