### PR TITLE
Add 4 Adapta-gtk-theme variants to flathub

### DIFF
--- a/org.gtk.Gtk3theme.Adapta-Eta.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Eta.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta-Eta</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta-Eta Gtk+ theme</name>
+  <summary>Adapta-Eta Gtk+ theme (compact)</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta-Eta",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta-Eta",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--disable-dark",
+        "--enable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
+          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta-Eta.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta-Eta --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta-Eta"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta-Eta.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
-          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
+          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
-          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
+          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
-          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
+          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
-          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.109.tar.gz",
+          "sha256": "e075a16261c1d7aa35aed9f0e25b8a7aa831b7eaff9d141504d94ed26e910ab0"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
-          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
+          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta-Nokto</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta-Nokto Gtk+ theme</name>
+  <summary>Adapta-Nokto Gtk+ theme (dark)</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
-  <id>org.gtk.Gtk3theme.Adapta-Nokto</id>
+  <id>org.gtk.Gtk3theme.Adapta-Nokto-Eta</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Adapta-Nokto Gtk+ theme</name>
-  <summary>Adapta-Nokto Gtk+ theme (dark)</summary>
+  <name>Adapta-Nokto-Eta Gtk+ theme</name>
+  <summary>Adapta-Nokto-Eta Gtk+ theme (dark and compact)</summary>
   <description>
     <p>An adaptive Gtk+ theme based on Material Design</p>
   </description>

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
-          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
+          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
-          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
+          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
-          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
+          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
-          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.109.tar.gz",
+          "sha256": "e075a16261c1d7aa35aed9f0e25b8a7aa831b7eaff9d141504d94ed26e910ab0"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta-Nokto-Eta",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta-Nokto-Eta",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--enable-dark",
+        "--enable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
+          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta-Nokto-Eta --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta-Nokto-Eta"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta-Nokto-Eta.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto-Eta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
-          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
+          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta-Nokto</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta-Nokto Gtk+ theme</name>
+  <summary>Adapta-Nokto Gtk+ theme (dark)</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta-Nokto",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta-Nokto",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--enable-dark",
+        "--disable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
+          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta-Nokto.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta-Nokto --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta-Nokto"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta-Nokto.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
-          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
+          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
-          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
+          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
-          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
+          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
-          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.109.tar.gz",
+          "sha256": "e075a16261c1d7aa35aed9f0e25b8a7aa831b7eaff9d141504d94ed26e910ab0"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta-Nokto.json
+++ b/org.gtk.Gtk3theme.Adapta-Nokto.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
-          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
+          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta Gtk+ theme</name>
+  <summary>Adapta Gtk+ theme</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
-          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
+          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
-          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
+          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.64.tar.gz",
-          "sha256": "b681bf099d75fdb32d310bbb22c259fdb7d69a783353d1339abf3477c3bbf99f"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
+          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.86.tar.gz",
-          "sha256": "ead7797a42f58f33b1146687df813b570178bf8327bc6e1948b85c9e6c616ba5"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.109.tar.gz",
+          "sha256": "e075a16261c1d7aa35aed9f0e25b8a7aa831b7eaff9d141504d94ed26e910ab0"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--disable-dark",
+        "--disable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.15.tar.gz",
+          "sha256": "1271cd359b62fb63a35a385efb452f47bc63b59ceb32719ec4b0b92892a6b466"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.gtk.Gtk3theme.Adapta.json
+++ b/org.gtk.Gtk3theme.Adapta.json
@@ -18,8 +18,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.25.tar.gz",
-          "sha256": "abbef863c97c712973e516cb55e0422925bce456d3953e3f3000b5759a43f15b"
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.91.2.44.tar.gz",
+          "sha256": "fc787886d5b5a27f68627a3ba1c150509c9ffb787a2b0ef2a9baef4d56a7f6d9"
         }
       ]
     },


### PR DESCRIPTION
Hi, I'm an author of Adapta-gtk-theme.

Then I've created 8 files for 4 our theme variants (based on Arc's files)
  * Adapta (Light and standard widget size)
  * Adapta-Nokto (Dark and standard widget size)
  * Adapta-Eta (Light and compact widget size)
  * Adapta-Nokto-Eta (Dark and compact widget size)

Regards.