### PR TITLE
Filezilla

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -1,6 +1,5 @@
 {
     "id": "org.filezillaproject.Filezilla",
-    "base-version": "master",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
@@ -20,25 +19,7 @@
             "--share=network"
     ],
     "modules": [
-        {
-        "name": "libglu",
-        "config-opts": [
-            "--enable-shared",
-            "--disable-static"
-        ],
-        "sources": [
-        {
-            "type": "archive",
-            "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2",
-            "sha256": "1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12"
-        }
-        ],
-        "cleanup": [
-            "/include",
-            "/lib/*.la",
-            "/lib/pkgconfig"
-        ]
-    },
+        "shared-modules/glu/glu-9.0.0.json",
         {
         "name": "wxWidgets",
         "config-opts": [

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -23,11 +23,13 @@
     {
         "name": "wxWidgets",
         "rm-configure": true,
+        "cleanup": [
+            "/bin",
+            "/share/bakefile"
+        ],
         "config-opts": [
-            "--with-gtk=3",
             "--with-opengl", 
             "--with-libjpeg", 
-            "--enable-monolithic",
             "--with-libtiff",
             "--with-libpng",
             "--with-zlib",
@@ -48,7 +50,15 @@
                 "type": "archive", 
                 "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3.1/wxWidgets-3.0.3.1.tar.bz2",
                 "sha256":"3164ad6bc5f61c48d2185b39065ddbe44283eb834a5f62beb13f1d0923e366e4" 
-            } 
+            },
+            {
+                "type": "script",
+                "path": "autogen.sh",
+                "commands": [
+                    "cp -p /usr/share/automake-*/config.{sub,guess} .",
+                    "autoconf -f -B build/autoconf_prepend-include"
+                ]
+            }
         ]
     },
     {

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -19,7 +19,7 @@
     ],
     "modules": [
         "shared-modules/glu/glu-9.0.0.json",
-        {
+    {
         "name": "wxWidgets",
         "config-opts": [
             "--with-opengl", 
@@ -37,10 +37,9 @@
             "--disable-webviewwebkit",
             "--with-expat=builtin",
             "--with-libiconv=/usr" ],
-        "make-args": ["-j4"],
         "build-options" : {
             "cxxflags":"-std=c++0x"
-        },
+    },
         "sources": [ 
             {  
                 "type": "archive", 
@@ -51,7 +50,6 @@
         },
     {
         "name": "libfilezilla",
-        "buildsystem": "autotools",
         "sources": [
             {
                 "type": "archive",
@@ -62,7 +60,6 @@
     },
     {
         "name": "filezilla",
-        "buildsystem": "autotools",
         "config-opts": [
             "--with-pugixml=builtin"
         ],

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -1,0 +1,96 @@
+{
+    "id": "org.filezillaproject.Filezilla",
+    "base-version": "master",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "sdk": "org.gnome.Sdk",
+    "command": "filezilla",
+    "rename-icon": "filezilla",
+    "copy-icon": true,
+    "rename-desktop-file": "filezilla.desktop",
+    "rename-appdata-file": "filezilla.appdata.xml",
+    "finish-args": [
+            "--share=ipc", "--socket=x11",
+            "--device=dri",
+            "--socket=wayland",
+            "--socket=session-bus",
+            "--filesystem=home",
+            "--share=network"
+    ],
+    "modules": [
+        {
+        "name": "libglu",
+        "config-opts": [
+            "--enable-shared",
+            "--disable-static"
+        ],
+        "sources": [
+        {
+            "type": "archive",
+            "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2",
+            "sha256": "1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12"
+        }
+        ],
+        "cleanup": [
+            "/include",
+            "/lib/*.la",
+            "/lib/pkgconfig"
+        ]
+    },
+        {
+        "name": "wxWidgets",
+        "config-opts": [
+            "--with-opengl", 
+            "--with-libjpeg", 
+            "--enable-monolithic",
+            "--with-libtiff",
+            "--with-libpng",
+            "--with-zlib",
+            "--disable-sdltest",
+            "--enable-unicode",
+            "--enable-display",
+            "--enable-propgrid",
+            "--disable-webkit",
+            "--disable-webview",
+            "--disable-webviewwebkit",
+            "--with-expat=builtin",
+            "--with-libiconv=/usr" ],
+        "make-args": ["-j4"],
+        "build-options" : {
+            "cxxflags":"-std=c++0x"
+        },
+        "sources": [ 
+            {  
+                "type": "archive", 
+                "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3.1/wxWidgets-3.0.3.1.tar.bz2",
+                "sha256":"3164ad6bc5f61c48d2185b39065ddbe44283eb834a5f62beb13f1d0923e366e4" 
+            } 
+        ]
+        },
+    {
+        "name": "libfilezilla",
+        "buildsystem": "autotools",
+        "sources": [
+            {
+                "type": "archive",
+                "url": "http://download.filezilla-project.org/libfilezilla/libfilezilla-0.10.1.tar.bz2",
+                "sha256": "a097536689f92320f8ee03eed68fe0b82457a53a7f4d287d7c03f60bc16a29fa"
+            }
+        ]
+    },
+    {
+        "name": "filezilla",
+        "buildsystem": "autotools",
+        "config-opts": [
+            "--with-pugixml=builtin"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "http://download.filezilla-project.org/client/FileZilla_3.27.0.1_src.tar.bz2",
+                "sha256": "2061b3d23a95e600d46913cc8b12b701da1b1f6b309fa6f6c7affa21261d3afa"
+            }
+        ]
+    }
+    ]
+}

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -1,6 +1,5 @@
 {
     "id": "org.filezillaproject.Filezilla",
-    "base-version": "master",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -39,7 +39,6 @@
             "--disable-webviewwebkit",
             "--with-expat=builtin",
             "--with-libiconv=/usr" ],
-        "make-args": ["-j4"],
         "build-options" : {
             "cxxflags":"-std=c++0x"
         },
@@ -53,7 +52,6 @@
         },
     {
         "name": "libfilezilla",
-        "buildsystem": "autotools",
         "sources": [
             {
                 "type": "archive",
@@ -64,7 +62,6 @@
     },
     {
         "name": "filezilla",
-        "buildsystem": "autotools",
         "config-opts": [
             "--with-pugixml=builtin"
         ],

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -1,5 +1,6 @@
 {
     "id": "org.filezillaproject.Filezilla",
+    "base-version": "master",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
@@ -12,15 +13,36 @@
             "--share=ipc", "--socket=x11",
             "--device=dri",
             "--socket=wayland",
-            "--socket=session-bus",
+	    "--talk-name=org.freedesktop.PowerManagement",
+	    "--talk-name=org.freedesktop.Notifications",
+	    "--talk-name=org.gnome.SessionManager",
             "--filesystem=home",
             "--share=network"
     ],
     "modules": [
-        "shared-modules/glu/glu-9.0.0.json",
-    {
+        {
+        "name": "libglu",
+        "config-opts": [
+            "--enable-shared",
+            "--disable-static"
+        ],
+        "sources": [
+        {
+            "type": "archive",
+            "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2",
+            "sha256": "1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12"
+        }
+        ],
+        "cleanup": [
+            "/include",
+            "/lib/*.la",
+            "/lib/pkgconfig"
+        ]
+    },
+        {
         "name": "wxWidgets",
         "config-opts": [
+            "--with-gtk=3",
             "--with-opengl", 
             "--with-libjpeg", 
             "--enable-monolithic",
@@ -36,9 +58,10 @@
             "--disable-webviewwebkit",
             "--with-expat=builtin",
             "--with-libiconv=/usr" ],
+        "make-args": ["-j4"],
         "build-options" : {
             "cxxflags":"-std=c++0x"
-    },
+        },
         "sources": [ 
             {  
                 "type": "archive", 
@@ -49,6 +72,7 @@
         },
     {
         "name": "libfilezilla",
+        "buildsystem": "autotools",
         "sources": [
             {
                 "type": "archive",
@@ -59,13 +83,14 @@
     },
     {
         "name": "filezilla",
+        "buildsystem": "autotools",
         "config-opts": [
             "--with-pugixml=builtin"
         ],
         "sources": [
             {
                 "type": "archive",
-                "url": "http://download.filezilla-project.org/client/FileZilla_3.27.0.1_src.tar.bz2",
+                "url": "https://downloads.sourceforge.net/project/filezilla/FileZilla_Client/3.27.0.1/FileZilla_3.27.0.1_src.tar.bz2",
                 "sha256": "2061b3d23a95e600d46913cc8b12b701da1b1f6b309fa6f6c7affa21261d3afa"
             }
         ]

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -12,9 +12,9 @@
             "--share=ipc", "--socket=x11",
             "--device=dri",
             "--socket=wayland",
-	    "--talk-name=org.freedesktop.PowerManagement",
-	    "--talk-name=org.freedesktop.Notifications",
-	    "--talk-name=org.gnome.SessionManager",
+            "--talk-name=org.freedesktop.PowerManagement",
+            "--talk-name=org.freedesktop.Notifications",
+            "--talk-name=org.gnome.SessionManager",
             "--filesystem=home",
             "--share=network"
     ],
@@ -22,6 +22,7 @@
         "shared-modules/glu/glu-9.0.0.json",
     {
         "name": "wxWidgets",
+        "rm-configure": true,
         "config-opts": [
             "--with-gtk=3",
             "--with-opengl", 

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -18,25 +18,7 @@
             "--share=network"
     ],
     "modules": [
-        {
-        "name": "libglu",
-        "config-opts": [
-            "--enable-shared",
-            "--disable-static"
-        ],
-        "sources": [
-        {
-            "type": "archive",
-            "url": "https://mesa.freedesktop.org/archive/glu/glu-9.0.0.tar.bz2",
-            "sha256": "1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12"
-        }
-        ],
-        "cleanup": [
-            "/include",
-            "/lib/*.la",
-            "/lib/pkgconfig"
-        ]
-    },
+        "shared-modules/glu/glu-9.0.0.json",
         {
         "name": "wxWidgets",
         "config-opts": [

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -69,8 +69,8 @@
         "sources": [
             {
                 "type": "archive",
-                "url": "https://downloads.sourceforge.net/project/filezilla/FileZilla_Client/3.27.0.1/FileZilla_3.27.0.1_src.tar.bz2",
-                "sha256": "2061b3d23a95e600d46913cc8b12b701da1b1f6b309fa6f6c7affa21261d3afa"
+                "url": "https://downloads.sourceforge.net/project/filezilla/FileZilla_Client/3.27.1/FileZilla_3.27.1_src.tar.bz2",
+                "sha256": "4389fa81b62b7c816674a01f030592e44f2d8d5423f2cbcca4c7bb7417bd9a92"
             }
         ]
     }

--- a/org.filezillaproject.Filezilla.json
+++ b/org.filezillaproject.Filezilla.json
@@ -20,7 +20,7 @@
     ],
     "modules": [
         "shared-modules/glu/glu-9.0.0.json",
-        {
+    {
         "name": "wxWidgets",
         "config-opts": [
             "--with-gtk=3",
@@ -49,7 +49,7 @@
                 "sha256":"3164ad6bc5f61c48d2185b39065ddbe44283eb834a5f62beb13f1d0923e366e4" 
             } 
         ]
-        },
+    },
     {
         "name": "libfilezilla",
         "sources": [


### PR DESCRIPTION
Adds the FileZilla file transfer application.

Home r/w permissions would be required for normal use - I don't think it's usual to use the tool outside home but would take feedback on this, perhaps as a r/o permission.

The session bus is for inhibit, notifications and session management. Not totally sure if I should rebuild with just those interfaces whitelisted, feedback welcomed.