### PR TITLE
Add Othman Flatpak

### DIFF
--- a/amiri-fontconfig.conf
+++ b/amiri-fontconfig.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+        <alias>
+          <family>serif</family>
+            <prefer>
+              <family>Amiri</family>
+            </prefer>
+        </alias>
+        <alias>
+          <family>Amiri</family>
+            <default>
+              <family>serif</family>
+            </default>
+        </alias>
+</fontconfig>

--- a/amiri-quran-fontconfig.conf
+++ b/amiri-quran-fontconfig.conf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fontconfig SYSTEM "../fonts.dtd">
+<fontconfig>
+        <alias>
+          <family>serif</family>
+            <prefer>
+              <family>Amiri Quran</family>
+            </prefer>
+        </alias>
+        <alias>
+          <family>Amiri Quran</family>
+            <default>
+              <family>serif</family>
+            </default>
+        </alias>
+</fontconfig>

--- a/com.github.ojubaorg.Othman.appdata.xml
+++ b/com.github.ojubaorg.Othman.appdata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2017 Mosaab Alzoubi <moceap@hotmail.com> -->
+<!--
+EmailAddress: moceap@hotmail.com
+SentUpstream: 2017-1-8
+-->
+<application>
+  <id type="desktop">Othman.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <summary>Electronic Quran Browser</summary>
+  <summary xml:lang="ar">مصحف إلكتروني</summary>
+  <description>
+    <p>
+	Electronic Quran Browser
+    </p>
+  </description>
+  <description xml:lang="ar">
+    <p>
+	مصحف إلكتروني.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/ojuba-org/othman</url>
+  <screenshots>
+    <screenshot type="default">http://ojuba.org/_media/othman/othman.png</screenshot>
+  </screenshots>
+  <updatecontact>moceap@hotmail.com</updatecontact>
+</application>

--- a/com.github.ojubaorg.Othman.json
+++ b/com.github.ojubaorg.Othman.json
@@ -75,8 +75,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://www.imagemagick.org/download/ImageMagick-7.0.6-7.tar.xz",
-          "sha256": "732332a76cb62f067d680a90d85dd05a2f2592e0017af83becb639d05681106d"
+          "url": "https://www.imagemagick.org/download/ImageMagick-7.0.7-0.tar.xz",
+          "sha256": "77e2a309edebd1389e5a16e8f3c3cd919b43f0b0df04a614ec6f8697032674d8"
         }
       ]
     },

--- a/com.github.ojubaorg.Othman.json
+++ b/com.github.ojubaorg.Othman.json
@@ -1,0 +1,150 @@
+{
+    "id": "com.github.ojubaorg.Othman",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.24",
+    "sdk": "org.gnome.Sdk",
+    "command": "othman-browser",
+    "rename-icon": "Othman",
+    "copy-icon": true,
+    "rename-desktop-file": "Othman.desktop",
+    "finish-args": [
+            "--share=ipc", "--socket=x11",
+            "--device=dri",
+            "--socket=wayland",
+            "--share=network"
+    ],
+    "modules": [
+    {
+        "name": "amiri-quran-fonts",
+        "buildsystem":"simple",
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://github.com/alif-type/amiri/archive/0.109.tar.gz",
+                "sha256": "bbfd6edbcad28607903322bd5d1feb61d0d8202191e6f1a6d7d357c831612ed4"
+            },
+            {
+                "type": "file",
+                "path": "amiri-fontconfig.conf"
+            },
+            {
+                "type": "file",
+                "path": "amiri-quran-fontconfig.conf"
+            }
+        ],
+        "build-commands": [
+            "mkdir -p /app/share/fonts/",
+            "cp *.ttf /app/share/fonts/",
+            "mkdir -p /app/etc/fonts/conf.d/",
+            "cp amiri-fontconfig.conf /app/etc/fonts/conf.d/",
+            "cp amiri-quran-fontconfig.conf /app/etc/fonts/conf.d/",
+            "fc-cache -fs"
+        ]
+    },
+    {
+      "name": "imagemagick",
+      "config-opts": [
+        "--enable-static=no",
+        "--disable-docs",
+        "--disable-deprecated",
+        "--without-autotrace",
+        "--without-bzlib",
+        "--without-djvu",
+        "--without-dps",
+        "--without-fftw",
+        "--without-fontconfig",
+        "--without-fpx",
+        "--without-freetype",
+        "--without-gvc",
+        "--without-jbig",
+        "--without-jpeg",
+        "--without-lcms",
+        "--without-lzma",
+        "--without-magick-plus-plus",
+        "--without-openexr",
+        "--without-openjp2",
+        "--without-pango",
+        "--without-raqm",
+        "--without-tiff",
+        "--without-webp",
+        "--without-wmf",
+        "--without-x",
+        "--without-xml",
+        "--without-zlib"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.imagemagick.org/download/ImageMagick-7.0.6-7.tar.xz",
+          "sha256": "732332a76cb62f067d680a90d85dd05a2f2592e0017af83becb639d05681106d"
+        }
+      ]
+    },
+    {
+        "name": "pycairo",
+        "build-options" : {
+            "env": {
+                "PYTHON": "/usr/bin/python"
+            }
+        },
+        "buildsystem": "simple",
+        "build-commands": [
+            "python ./setup.py build",
+            "python ./setup.py install --prefix=/app"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://github.com/pygobject/pycairo/releases/download/v1.12.0/pycairo-1.12.0.tar.gz",
+                "sha256": "243c351d7abcef41ac1fa984d2c753f3d065336a0fcf4c20fafb191b23423095"
+            }
+        ]
+    },
+    {
+        "name": "pygobject",
+        "build-options" : {
+                "env": {
+                    "PYTHON": "/usr/bin/python"
+                }
+        },
+        "sources": [
+            {
+                "type": "archive",
+                "url": "http://ftp.acc.umu.se/pub/GNOME/sources/pygobject/3.24/pygobject-3.24.1.tar.xz",
+                "sha256": "a628a95aa0909e13fb08230b1b98fc48adef10b220932f76d62f6821b3fdbffd"
+        }
+        ]
+    },
+    {
+        "name": "othman",
+        "buildsystem": "simple",
+        "build-options" : {
+                "env": {
+                    "PYTHON": "/usr/bin/python"
+                }
+        },
+        "sources": [
+            {
+                "type": "git",
+                "url": "https://github.com/ojuba-org/othman.git",
+                "commit": "4296155d967a40726fc7177ac6f6156cc6284036"
+        },
+        {
+                "type": "patch",
+                "path": "othman-flatpak-path.patch"
+        },
+        {
+                "type": "file",
+                "path": "com.github.ojubaorg.Othman.appdata.xml"
+        }
+        ],
+        "build-commands": [
+                "make PREFIX=/app install"
+        ],
+            "post-install": [
+                "mkdir -p /app/share/appdata",
+                "cp com.github.ojubaorg.Othman.appdata.xml /app/share/appdata"
+        ]
+    }
+    ]
+}

--- a/othman-flatpak-path.patch
+++ b/othman-flatpak-path.patch
@@ -1,0 +1,20 @@
+diff --git a/Makefile b/Makefile
+index 8e3d328..acd05b7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+ DESTDIR?=/
+-datadir?=$(DESTDIR)/usr/share
++datadir?=/app/share
+ INSTALL=install
+ 
+ SOURCES=$(wildcard *.desktop.in)
+@@ -25,7 +25,7 @@ pos:
+ 
+ install: all
+ 	rm othman-data/quran-kareem.png || :
+-	python setup.py install -O2 --root $(DESTDIR)
++	python setup.py install --prefix=/app
+ 	$(INSTALL) -d $(datadir)/applications/
+ 	$(INSTALL) -m 0644 Othman.desktop $(datadir)/applications/
+ 	for i in 96 72 64 48 36 32 24 22 16; do \


### PR DESCRIPTION
Adds a flatpak of the [Othman]( https://github.com/ojuba-org/othman) Quran browser and search engine.

This app doesn't work properly with python 3, thus the py-g-i rebuild and requires a specific arabic typeface for rendering. It needs this specific commit from the tree to get a number of app data improvements that the Fedora community have made.