### PR TITLE
Initial version of rust sdk extension

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-120.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-120.appdata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.rust-120</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Rust 1.20 Sdk extension</name>
+  <summary>Rust compiler and tools</summary>
+</component>

--- a/org.freedesktop.Sdk.Extension.rust-120.json
+++ b/org.freedesktop.Sdk.Extension.rust-120.json
@@ -7,6 +7,7 @@
     "runtime-version": "1.6",
     "sdk-extensions": [],
     "separate-locales": false,
+    "appstream-compose": false,
     "cleanup": [ "/share/info", "/share/man" ],
     "build-options" : {
         "cflags": "-O2 -g",
@@ -70,7 +71,21 @@
             "build-commands": [
                 "cp enable.sh /usr/lib/sdk/rust-120/"
             ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.rust-120.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose  --basename=org.freedesktop.Sdk.Extension.rust-120 --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.rust-120"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.rust-120.appdata.xml"
+                }
+            ]
         }
-
     ]
 }

--- a/org.freedesktop.Sdk.Extension.rust-120.json
+++ b/org.freedesktop.Sdk.Extension.rust-120.json
@@ -1,0 +1,76 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.rust-120",
+    "branch": "1.6",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "sdk-extensions": [],
+    "separate-locales": false,
+    "cleanup": [ "/share/info", "/share/man" ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "prefix": "/usr/lib/sdk/rust-120",
+        "env": {
+            "V": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "rust",
+            "buildsystem": "simple",
+            "cleanup": [
+                "/share/doc/rust/html"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "only-arches": ["i386"],
+                    "url": "https://static.rust-lang.org/dist/rust-1.20.0-i686-unknown-linux-gnu.tar.gz",
+                    "sha256": "abe592e06616cdc2fcca56ddbe482050dd49a1fada35e2af031c64fe6eb14668"
+                },
+                {
+                    "type": "archive",
+                    "only-arches": ["arm"],
+                    "url": "https://static.rust-lang.org/dist/rust-1.20.0-arm-unknown-linux-gnueabihf.tar.gz",
+                    "sha256": "d8282b04619acdcbb5259ba5a3c8677716a015cfef3ba68ba24211590c5bb5dc"
+                },
+                {
+                    "type": "archive",
+                    "only-arches": ["aarch64"],
+                    "url": "https://static.rust-lang.org/dist/rust-1.20.0-aarch64-unknown-linux-gnu.tar.gz",
+                    "sha256": "eaab3df489d4d8f976c4327d812b9870730eed6d0bbd52712767083d02be7472"
+                },
+                {
+                    "type": "archive",
+                    "only-arches": ["x86_64"],
+                    "url": "https://static.rust-lang.org/dist/rust-1.20.0-x86_64-unknown-linux-gnu.tar.gz",
+                    "sha256": "ca1cf3aed73ff03d065a7d3e57ecca92228d35dc36d9274a6597441319f18eb8"
+                }
+            ],
+            "build-commands": [
+                "./install.sh --help",
+                "./install.sh --list-components --verbose",
+                "./install.sh --prefix=/usr/lib/sdk/rust-120 --disable-ldconfig --verbose"
+            ]
+        },
+        {
+            "name": "scripts",
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        "export PATH=$PATH:/usr/lib/sdk/rust-120/bin"
+                    ],
+                    "dest-filename": "enable.sh"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp enable.sh /usr/lib/sdk/rust-120/"
+            ]
+        }
+
+    ]
+}


### PR DESCRIPTION
This is a Sdk extension with rust 1.2.0. It uses the upstream built binaries (MIT licensed, so this should be ok). There are binaries for all flathub arches.

To use it you can install it and then do e.g.:
```
$ flatpak run org.freedesktop.Sdk//1.6
sh-4.3$ cat > hello.rs
fn main() {                                 
    println!("Hello world!");
}
sh-4.3$ source /usr/lib/sdk/rust-120/enable.sh 
sh-4.3$ rustc hello.rs 
sh-4.3$ ./hello 
Hello world!
```

To use it in a builder manifest you would use:
```
 "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-120"]
```
Then you can source the script, or just manually set the path. The later is especially easy with the new append-path feature i added to flatpak-builder master.