### PR TITLE
Add Freedoom Phase 1 manifest

### DIFF
--- a/io.github.Freedoom-Phase-1.json
+++ b/io.github.Freedoom-Phase-1.json
@@ -52,8 +52,8 @@
 				}
 			],
 			"build-commands": [
-				"mv freedoom1.wad doom.wad",
-				"install -Dm 644 doom.wad /app/share/games/doom",
+				"install -Dm 644 freedoom1.wad /app/share/games/doom",
+				"sed -i 's/Exec=freedoom1/Exec=gzdoom/g' freedoom1.desktop",
 				"install -Dm 644 freedoom1.desktop -t /app/share/applications",
 				"install -Dm 644 freedoom1.appdata.xml -t /app/share/appdata",
 				"mv playa2a8.png freedoom1.png",

--- a/io.github.Freedoom-Phase-1.json
+++ b/io.github.Freedoom-Phase-1.json
@@ -1,5 +1,5 @@
 {
-	"app-id": "io.github.Freedoom1",
+	"app-id": "io.github.Freedoom-Phase-1",
 	"runtime": "org.freedesktop.Platform",
 	"sdk": "org.freedesktop.Sdk",
 	"runtime-version": "1.6",

--- a/io.github.Freedoom1.json
+++ b/io.github.Freedoom1.json
@@ -1,0 +1,63 @@
+{
+	"app-id": "io.github.Freedoom1",
+	"runtime": "org.freedesktop.Platform",
+	"sdk": "org.freedesktop.Sdk",
+	"runtime-version": "1.6",
+	"command": "gzdoom",
+	"rename-desktop-file": "freedoom1.desktop",
+	"rename-icon": "freedoom1",
+	"finish-args": [
+		"--device=dri",
+		"--socket=wayland",
+		"--socket=x11",
+		"--socket=pulseaudio",
+		"--env=DOOMWADDIR=/app/share/games/doom"
+	],
+	"modules": [
+		{
+			"name": "gzdoom",
+			"buildsystem": "cmake",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/coelckers/gzdoom/archive/g3.1.0.tar.gz",
+					"sha256": "c011ce9a95b765da5b81cf723062379d585c57cb586848385a2319deba1996c3"
+				}
+			]
+		},
+		{
+			"name": "freedoom1",
+			"buildsystem": "simple",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/freedoom/freedoom/releases/download/v0.11.3/freedoom-0.11.3.zip",
+					"sha256": "28a5eafbb1285b78937bd408fcdd8f25f915432340eee79da692eae83bce5e8a"
+				},
+				{
+					"type": "file",
+					"url": "https://raw.githubusercontent.com/freedoom/freedoom/v0.11.3/dist/freedoom1.desktop",
+					"sha256": "e3f79848f4517fe02dca17ebb767bdfa53b600832c347bd62d6a30ed9a7c35a4"
+				},
+				{
+					"type": "file",
+					"url": "https://raw.githubusercontent.com/freedoom/freedoom/v0.11.3/dist/freedoom1.appdata.xml",
+					"sha256": "bdb0e08886306e5777eddb21fd93ae99125e57152f8b6a7f83f4e6e1cece1f58"
+				},
+				{
+					"type": "file",
+					"url": "https://raw.githubusercontent.com/freedoom/freedoom/9c6c68127672feee501d5e5cab9d5e15c3dbf8b3/sprites/playa2a8.png",
+					"sha256": "2814d1bc85b0994dc39926b26fb4c30b25556709255958500289c6d758ca8ce1"
+				}
+			],
+			"build-commands": [
+				"mv freedoom1.wad doom.wad",
+				"install -Dm 644 doom.wad /app/share/games/doom",
+				"install -Dm 644 freedoom1.desktop -t /app/share/applications",
+				"install -Dm 644 freedoom1.appdata.xml -t /app/share/appdata",
+				"mv playa2a8.png freedoom1.png",
+				"install -Dm 644 freedoom1.png -t /app/share/icons/hicolor/64x64/apps"
+			]
+		}
+	]
+}

--- a/io.github.Freedoom1.json
+++ b/io.github.Freedoom1.json
@@ -5,6 +5,7 @@
 	"runtime-version": "1.6",
 	"command": "gzdoom",
 	"rename-desktop-file": "freedoom1.desktop",
+	"rename-appdata-file": "freedoom1.appdata.xml",
 	"rename-icon": "freedoom1",
 	"finish-args": [
 		"--device=dri",


### PR DESCRIPTION
I tried to build the Freedoom WADs, which failed, but since that's just game data, simply downloading it fixed it.

The WAD can be used in a number of Doom source ports, but GZDoom is recommeded by Freedoom. I'm not sure if it'd make sense to bundle GZDoom as a base app and different WADs as extensions. Or one could ship the engine as a Flatpak and one could let users load levels from their home directoy. But that doesn't seem fitting for Flathub.