### PR TITLE
add fr.free.homebank flatpak

### DIFF
--- a/desktop-locale.patch
+++ b/desktop-locale.patch
@@ -1,0 +1,96 @@
+diff -ruN homebank-5.1.6/po/cs.po homebank-5.1.6-new/po/cs.po
+--- homebank-5.1.6/po/cs.po	2017-09-14 17:37:09.000000000 +0100
++++ homebank-5.1.6-new/po/cs.po	2017-09-28 11:39:39.749246430 +0100
+@@ -35,7 +35,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "finance,účetnictví,rozpočet,osobní,peníze"
++msgstr "finance,účetnictví,rozpočet,osobní,peníze;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/eu.po homebank-5.1.6-new/po/eu.po
+--- homebank-5.1.6/po/eu.po	2017-09-14 17:38:01.000000000 +0100
++++ homebank-5.1.6-new/po/eu.po	2017-09-28 11:40:31.270339021 +0100
+@@ -32,7 +32,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "finantza;kontuak;aurrekontua;pertsonala;dirua"
++msgstr "finantza;kontuak;aurrekontua;pertsonala;dirua;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/fa.po homebank-5.1.6-new/po/fa.po
+--- homebank-5.1.6/po/fa.po	2017-09-14 17:37:46.000000000 +0100
++++ homebank-5.1.6-new/po/fa.po	2017-09-28 11:49:18.530121987 +0100
+@@ -32,7 +32,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "امور مالی؛ حسابداری؛ بودجه؛ شخصی؛ پول؛"
++msgstr "امور مالی; حسابداری; بودجه; شخصی; پول;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/id.po homebank-5.1.6-new/po/id.po
+--- homebank-5.1.6/po/id.po	2017-09-14 17:37:59.000000000 +0100
++++ homebank-5.1.6-new/po/id.po	2017-09-28 11:40:41.870565170 +0100
+@@ -32,7 +32,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "Gratis, mudah, akuntansi pribadi untuk semua orang"
++msgstr "Gratis, mudah, akuntansi pribadi untuk semua orang;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/it.po homebank-5.1.6-new/po/it.po
+--- homebank-5.1.6/po/it.po	2017-09-14 17:37:04.000000000 +0100
++++ homebank-5.1.6-new/po/it.po	2017-09-28 11:40:36.802456988 +0100
+@@ -32,7 +32,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "finanza, contabilità, bilancio, personale, soldi"
++msgstr "finanza, contabilità, bilancio, personale, soldi;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/pl.po homebank-5.1.6-new/po/pl.po
+--- homebank-5.1.6/po/pl.po	2017-09-14 17:37:20.000000000 +0100
++++ homebank-5.1.6-new/po/pl.po	2017-09-28 11:41:37.467758788 +0100
+@@ -33,7 +33,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "finanse;księgowość,budżet;osobiste,pieniądze"
++msgstr "finanse;księgowość,budżet;osobiste,pieniądze;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/tr.po homebank-5.1.6-new/po/tr.po
+--- homebank-5.1.6/po/tr.po	2017-09-14 17:37:01.000000000 +0100
++++ homebank-5.1.6-new/po/tr.po	2017-09-28 11:42:01.524279130 +0100
+@@ -32,7 +32,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "finans;muhasebe;bütçe;kişisel;para"
++msgstr "finans;muhasebe;bütçe;kişisel;para;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""
+diff -ruN homebank-5.1.6/po/zh_CN.po homebank-5.1.6-new/po/zh_CN.po
+--- homebank-5.1.6/po/zh_CN.po	2017-09-14 17:36:56.000000000 +0100
++++ homebank-5.1.6-new/po/zh_CN.po	2017-09-28 11:42:16.524604761 +0100
+@@ -27,7 +27,7 @@
+ 
+ #: ../data/homebank.desktop.in.in.h:4
+ msgid "finance;accounting;budget;personal;money;"
+-msgstr "财务，会计，预算，个人，现金"
++msgstr "财务;会计;预算;个人;现金;"
+ 
+ #: ../data/homebank.appdata.xml.in.h:1
+ msgid ""

--- a/fr.free.Homebank.json
+++ b/fr.free.Homebank.json
@@ -32,6 +32,9 @@
                 "type": "patch",
                 "path": "desktop-locale.patch"
             }
+        ],
+        "post-install": [
+            "mv /app/share/mime/packages/homebank.xml /app/share/mime/packages/fr.free.Homebank.xml"
         ]
     }
     ]

--- a/fr.free.Homebank.json
+++ b/fr.free.Homebank.json
@@ -1,0 +1,38 @@
+{
+    "id": "fr.free.Homebank",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "homebank",
+    "rename-icon": "homebank",
+    "copy-icon": true,
+    "rename-desktop-file": "homebank.desktop",
+    "rename-appdata-file": "homebank.appdata.xml",
+    "finish-args": [
+            "--share=ipc", "--socket=x11",
+            "--device=dri",
+            "--socket=wayland",
+            "--filesystem=home",
+            "--talk-name=ca.desrt.dconf",
+            "--filesystem=xdg-run/dconf",
+            "--filesystem=~/.config/dconf:ro",
+            "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+            "--share=network"
+    ],
+    "modules": [
+    {
+        "name": "homebank",
+        "sources": [
+            {
+                "type": "archive",
+                "url": "http://homebank.free.fr/public/homebank-5.1.6.tar.gz",
+                "sha256": "2861e11590a00f5cbc505293821cb8caeabb74c26babe8a6a9d728f3404290e0"
+            },
+            {
+                "type": "patch",
+                "path": "desktop-locale.patch"
+            }
+        ]
+    }
+    ]
+}

--- a/fr.free.Homebank.json
+++ b/fr.free.Homebank.json
@@ -21,6 +21,56 @@
     ],
     "modules": [
     {
+        "name": "opensp",
+        "config-opts": [ "--disable-doc-build" ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://downloads.sourceforge.net/project/openjade/opensp/1.5.2/OpenSP-1.5.2.tar.gz",
+                "sha256": "57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce"
+            }
+        ]
+    },
+    {
+        "name": "gengetopt",
+        "config-opts": [ 
+            "--prefix=/app"
+            ],
+        "rm-configure": true,
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://ftp.gnu.org/gnu/gengetopt/gengetopt-2.22.6.tar.gz",
+                "sha256": "30b05a88604d71ef2a42a2ef26cd26df242b41f5b011ad03083143a31d9b01f7"
+            },
+            {
+                "type": "patch",
+                "path": "makefile.patch"
+            },
+            {
+                "type": "script",
+                "dest-filename": "autogen.sh",
+                "commands": [
+                    "autoreconf -vfi"
+                ]
+            }
+        ]
+    },
+    {
+        "name": "libofx",
+        "config-opts": [ 
+            "--with-opensp-includes=/app/include/OpenSP", 
+            "--with-opensp-libs=/lib"
+            ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://github.com/libofx/libofx/archive/0.9.12.tar.gz",
+                "sha256": "0288d0166b3e60e8ebbdcf4ac54b034082820d856a09912b748f2aec9b247130"
+            }
+        ]
+    },
+    {
         "name": "homebank",
         "sources": [
             {

--- a/fr.free.Homebank.json
+++ b/fr.free.Homebank.json
@@ -22,12 +22,20 @@
     "modules": [
     {
         "name": "opensp",
+        "rm-configure": true,
         "config-opts": [ "--disable-doc-build" ],
         "sources": [
             {
                 "type": "archive",
                 "url": "https://downloads.sourceforge.net/project/openjade/opensp/1.5.2/OpenSP-1.5.2.tar.gz",
                 "sha256": "57f4898498a368918b0d49c826aa434bb5b703d2c3b169beb348016ab25617ce"
+            },
+            {
+                "type": "script",
+                "dest-filename": "autogen.sh",
+                "commands": [
+                    "autoreconf -vfi"
+                ]
             }
         ]
     },
@@ -58,6 +66,7 @@
     },
     {
         "name": "libofx",
+        "no-parallel-make": true,
         "config-opts": [ 
             "--with-opensp-includes=/app/include/OpenSP", 
             "--with-opensp-libs=/lib"

--- a/makefile.patch
+++ b/makefile.patch
@@ -1,0 +1,12 @@
+diff -ruN gengetopt-2.22.6/src/Makefile.am gengetopt-2.22.6-new/src/Makefile.am
+--- gengetopt-2.22.6/src/Makefile.am	2012-11-02 13:26:54.000000000 +0000
++++ gengetopt-2.22.6-new/src/Makefile.am	2017-10-01 21:28:19.072113358 +0100
+@@ -51,7 +51,7 @@
+ 	@LTLIBOBJS@ \
+ 	skels/libgen.la
+ 
+-LDADD = $(top_builddir)/src/libgengetopt.la
++LDADD = libgengetopt.la
+ 
+ EXTRA_DIST = parser.h argsdef.h gengetopt.h ggos.h gm.h gnugetopt.h \
+ cmdline.c cmdline.h \


### PR DESCRIPTION
Everything works fine except the offline help which is distributed as HTML and fails with:

> Browser error:
> Could not display the URL 'file:/app/share/homebank/help/index.html'

Which I don't consider a blocker, but would be good to fix.