### PR TITLE
Add org.gnome.Hitori

### DIFF
--- a/org.gnome.Hitori.json
+++ b/org.gnome.Hitori.json
@@ -1,0 +1,47 @@
+{
+  "app-id": "org.gnome.Hitori",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.24",
+  "sdk": "org.gnome.Sdk",
+  "command": "hitori",
+  "finish-args":
+    [
+      /* X11 + XShm access */
+      "--share=ipc", "--socket=x11",
+      /* Wayland access */
+      "--socket=wayland",
+      /* Needed for dconf to work */
+      "--filesystem=xdg-run/dconf",
+      "--filesystem=~/.config/dconf:ro",
+      "--talk-name=ca.desrt.dconf",
+      "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+  "build-options" :
+    {
+      "cflags": "-O2 -g",
+      "cxxflags": "-O2 -g"
+    },
+  "cleanup":
+    [
+      "/include", "/lib/pkgconfig",
+      "/share/pkgconfig", "/share/aclocal",
+      "/man", "/share/man", "/share/gtk-doc",
+      "*.la", "*.a",
+      "/lib/girepository-1.0",
+      "/share/dbus-1", "/share/doc", "/share/gir-1.0"
+    ],
+  "modules":
+    [
+      {
+        "name": "hitori",
+        "sources":
+          [
+            {
+              "type": "git",
+              "url": "https://git.gnome.org/browse/hitori",
+              "commit": "4515af09f31b09e4d16b8b11b7b660d2f81bb351"
+            }
+          ]
+      }
+    ]
+}


### PR DESCRIPTION
This uses the 3.22.4 release (which is the latest stable release; we
don’t have a 3.24 release series yet).

Signed-off-by: Philip Withnall <withnall@endlessm.com>