### PR TITLE
Add Geary

### DIFF
--- a/org.gnome.Geary.json
+++ b/org.gnome.Geary.json
@@ -5,7 +5,6 @@
     "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "geary",
-    "tags": [],
     "rename-icon": "geary",
     "copy-icon": true,
     "finish-args": [
@@ -17,9 +16,6 @@
 
         /* OpenGL access for WK2 */
         "--device=dri",
-
-        /* Bus access */
-        "--socket=session-bus",
 
         /* Pulseaudio */
         "--socket=pulseaudio",
@@ -37,7 +33,7 @@
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
 
-        /* Let view source keep on working as-sis for now. Bug 779311. */
+        /* Let view source keep on working as-is for now. Bug 779311. */
         "--filesystem=/tmp"
     ],
     "build-options" : {

--- a/org.gnome.Geary.json
+++ b/org.gnome.Geary.json
@@ -1,0 +1,113 @@
+/* flatpak-builder config for Geary. */
+{
+    "app-id": "org.gnome.Geary",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "geary",
+    "tags": [],
+    "rename-icon": "geary",
+    "copy-icon": true,
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+
+        /* Wayland access */
+        "--socket=wayland",
+
+        /* OpenGL access for WK2 */
+        "--device=dri",
+
+        /* Bus access */
+        "--socket=session-bus",
+
+        /* Pulseaudio */
+        "--socket=pulseaudio",
+
+        /* Needs to talk to the network: */
+        "--share=network",
+
+        /* Notification access */
+        "--talk-name=org.freedesktop.Notifications",
+
+        /* Secrets access */
+        "--talk-name=org.freedesktop.secrets",
+
+        /* Needed for dconf to work */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+
+        /* Let view source keep on working as-sis for now. Bug 779311. */
+        "--filesystem=/tmp"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": ["/include", "/lib/pkgconfig",
+                "/share/pkgconfig", "/share/aclocal",
+                "/man", "/share/man", "/share/gtk-doc",
+                "/share/vala",
+                "*.la", "*.a"],
+    "modules": [
+        {
+            "name": "gnome-doc-utils",
+            "build-options": {
+                "arch" : {
+                    /* Lie about our arch - no actual compilation happens here. */
+                    "arm": {
+                        "config-opts": [ "--build=amd64" ]
+                    },
+                    "aarch64": {
+                        "config-opts": [ "--build=amd64" ]
+                    }
+                }            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-doc-utils/0.20/gnome-doc-utils-0.20.10.tar.xz",
+                    "sha256": "cb0639ffa9550b6ddf3b62f3b1add92fb92ab4690d351f2353cffe668be8c4a6"
+                }
+            ]
+        },
+        {
+            "name": "libgee",
+            "build-options" : {
+                "env": {
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+                }
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.gnome.org/browse/libgee",
+                    "tag": "0.20.0"
+                }
+            ]
+        },
+        {
+            "name": "gmime",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.gnome.org/browse/gmime",
+                    "tag": "2.6.9"
+                }
+            ]
+        },
+        {
+            "name": "geary",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://git.gnome.org/browse/geary",
+                    "branch": "geary-0.12"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.Geary.json
+++ b/org.gnome.Geary.json
@@ -95,7 +95,7 @@
                 {
                     "type": "git",
                     "url": "https://git.gnome.org/browse/gmime",
-                    "tag": "2.6.9"
+                    "branch": "gmime-2-6"
                 }
             ]
         },


### PR DESCRIPTION
New Geary 0.12 release no longer depends on WebKit1GTK, so it would be good to get some wider coverage.