### PR TITLE
org.tordini.flavio.Minitube

### DIFF
--- a/org.tordini.flavio.Minitube.json
+++ b/org.tordini.flavio.Minitube.json
@@ -22,30 +22,26 @@
     "modules": [
      {
         "name": "ffmpeg",
-        "build-options" : {
-            "arch" : {
-                "i386" : {
-                    "config-opts" : [
-                        "--arch=x86"
-                        ]
-                    },
-                "arm" : {
-                    "config-opts" : [
-                        "--arch=arm"
-                        ]
-                    }
-                }
-        },
         "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
         "config-opts": [
+            "--disable-all",
             "--enable-shared",
             "--disable-static",
-            "--enable-gnutls",
             "--disable-doc",
             "--disable-programs",
-            "--disable-encoders",
-            "--disable-muxers",
-            "--disable-devices"
+            "--enable-gnutls",
+            "--enable-avfilter",
+            "--enable-avcodec",
+            "--enable-avformat",
+            "--enable-swscale",
+            "--enable-hwaccels",
+            "--enable-decoder=vp9",
+            "--enable-decoder=vp9_cuvid",
+            "--enable-decoder=opus",
+            "--enable-decoder=h264",
+            "--enable-decoder=h264_vdpau",
+            "--enable-decoder=h264_cuvid",
+            "--enable-decoder=aac"
         ],
         "sources": [{
             "type": "archive",

--- a/org.tordini.flavio.Minitube.json
+++ b/org.tordini.flavio.Minitube.json
@@ -1,0 +1,83 @@
+{
+    "app-id": "org.tordini.flavio.Minitube",
+    "branch": "stable",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.9",
+    "sdk": "org.kde.Sdk",
+    "command": "minitube",
+    "rename-desktop-file": "minitube.desktop",
+    "rename-appdata-file": "minitube.appdata.xml",
+    "rename-icon": "minitube",
+    "copy-icon": true,	
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--share=ipc",
+        "--share=network",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--env=QT_QPA_PLATFORM=flatpak"
+    ],
+    "modules": [
+     {
+        "name": "ffmpeg",
+        "build-options" : {
+            "arch" : {
+                "i386" : {
+                    "config-opts" : [
+                        "--arch=x86"
+                        ]
+                    },
+                "arm" : {
+                    "config-opts" : [
+                        "--arch=arm"
+                        ]
+                    }
+                }
+        },
+        "cleanup": [ "/include", "/lib/pkgconfig", "/share/ffmpeg/examples" ],
+        "config-opts": [
+            "--enable-shared",
+            "--disable-static",
+            "--enable-gnutls",
+            "--disable-doc",
+            "--disable-programs",
+            "--disable-encoders",
+            "--disable-muxers",
+            "--disable-devices"
+        ],
+        "sources": [{
+            "type": "archive",
+            "url": "https://ffmpeg.org/releases/ffmpeg-3.3.4.tar.xz",
+            "sha256": "98b97e1b908dfeb6aeb6d407e5a5eacdfc253a40c2d195f5867ed2d1d46ea957"
+        }]
+    },
+    {
+        "name": "gst-libav",
+        "config-opts": [ "--disable-gtk-doc", "--with-system-libav" ],
+        "cleanup": [ "*.la", "/share/gtk-doc" ],
+        "sources": [{
+            "type": "archive",
+            "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.10.4.tar.xz",
+            "sha256": "6ca0feca75e3d48315e07f20ec37cf6260ed1e9dde58df355febd5016246268b"
+        }]
+    },
+    {
+        "name": "minitube",
+        "buildsystem": "simple",
+        "build-commands": [
+            "qmake \"DEFINES += APP_GOOGLE_API_KEY=AIzaSyAyTdYPI-xHdBFeKx7eFyHFlR7dhuph9jY\" PREFIX=/app",
+            "make",
+            "make install"
+        ],
+        "sources": [
+            {
+                "type": "git",
+                "url": "https://github.com/flaviotordini/minitube/",
+                "commit": "130ab4f8f300ae14ebf0d624ee1e73abdb32d58e"
+            }
+        ]
+    }
+    ] 
+}


### PR DESCRIPTION
As noted in https://github.com/flathub/flathub/issues/134 we're going to leave the API key in the clear for now and will address it if there's abuse.

I'm keeping the simple buildsystem rather than qmake because I don't have a new enough flatpak-builder on endless os for now. I'll migrate when we update.

Screensaver permission required for inhibiting sleep.