### PR TITLE
Add MuseScore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/appdata.xml
+++ b/appdata.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop-application">
-  <id>org.musescore.MuseScore</id>
-  <metadata_license>CC0</metadata_license>
-  <project_license>GPL-2.0</project_license>
+<application>
+  <id type="desktop">mscore.desktop</id>
   <name>MuseScore</name>
+  <metadata_license>CC0-1.0</metadata_license>
   <summary>Free music composition and notation software</summary>
+  <project_license>GPL-2.0</project_license>
 
   <description>
     <p>
@@ -31,5 +31,6 @@
   </screenshots>
 
   <url type="homepage">https://musescore.org/</url>
+  <updatecontact>jurf_AT_riseup.net</updatecontact>
 
-</component>
+</application>

--- a/org.musescore.MuseScore.appdata.xml
+++ b/org.musescore.MuseScore.appdata.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.musescore.MuseScore</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <name>MuseScore</name>
+  <summary>Free music composition and notation software</summary>
+
+  <description>
+    <p>
+      MuseScore is an open source and free music notation software. For support, contribution &amp; bug reports, visit MuseScore.org.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>WYSIWYG design, notes are entered on a "virtual notepaper"</li>
+      <li>TrueType font(s) for printing &amp; display allows for high quality scaling to all sizes</li>
+      <li>Easy &amp; fast note entry</li>
+      <li>Many editing functions</li>
+      <li>MusicXML, Midi (SMF) import/export, MuseData import</li>
+      <li>Midi input for note entry</li>
+      <li>Integrated sequencer and software synthesizer to play the score</li>
+      <li>Print or create PDF files</li>
+    </ul>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main UI</caption>
+      <image>https://upload.wikimedia.org/wikipedia/commons/thumb/7/7c/MuseScore_2.0_in_full_screen.png/1280px-MuseScore_2.0_in_full_screen.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://musescore.org/</url>
+
+</component>

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -47,10 +47,6 @@
         {
           "type": "file",
           "path": "org.musescore.MuseScore.appdata.xml"
-        },
-        {
-          "type": "shell",
-          "commands": [ ]
         }
       ]
     }

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -5,6 +5,7 @@
   "sdk": "org.kde.Sdk",
   "command": "musescore",
   "rename-desktop-file": "mscore.desktop",
+  "rename-appdata-file": "mscore.appdata.xml",
   "rename-icon": "mscore",
   "finish-args": [
     "--device=dri",
@@ -43,7 +44,7 @@
       "post-install": [
         "mv /app/share/mime/packages/musescore.xml /app/share/mime/packages/org.musescore.MuseScore.xml",
         "mkdir -p /app/share/appdata",
-        "install -Dm644 org.musescore.MuseScore.appdata.xml /app/share/appdata/org.musescore.MuseScore.appdata.xml",
+        "install -Dm644 appdata.xml /app/share/appdata/mscore.appdata.xml",
         "sed -i 's|<!--  <generic-icon name=\"audio-x-generic\"/> Uncomment to use generic audio file icon -->|<generic-icon name=\"audio-x-generic\"/>|' /app/share/mime/packages/org.musescore.MuseScore.xml"
       ],
       "sources": [
@@ -54,7 +55,7 @@
         },
         {
           "type": "file",
-          "path": "org.musescore.MuseScore.appdata.xml"
+          "path": "appdata.xml"
         }
       ]
     }

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -25,6 +25,33 @@
     }
   },
   "modules": [
+    {
+      "name": "qtwebkit",
+      "buildsystem": "simple",
+      "cleanup-platform": [
+        "/bin",
+        "/mkspecs"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/qt/qtwebkit/archive/v5.212.0-alpha2.tar.gz",
+          "sha256": "6db43b931f64857cfda7bcf89914e2730b82164871a8c24c1881620e6bfdeca1"
+        }
+      ],
+      "build-commands": [
+        "qmake",
+        "grep -rl '/usr/local' . | xargs sed -i 's|/usr/local|/app|g'",
+        "make",
+        "find . -name \"cmake_install.cmake\" | xargs sed -i 's|/usr|/app|g'",
+        "make install"
+      ],
+      "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig"
+      ]
+    },
     "shared-modules/lame/lame-3.99.5.json",
     {
       "name": "musescore",
@@ -33,8 +60,7 @@
         "-DCMAKE_BUILD_TYPE=RELEASE",
         "-DBUILD_ALSA=OFF",
         "-DBUILD_JACK=OFF",
-        "-DBUILD_PORTAUDIO=OFF",
-        "-DBUILD_WEBKIT=OFF"
+        "-DBUILD_PORTAUDIO=OFF"
       ],
       "build-commands": [
         "make lrelease",

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -11,10 +11,18 @@
     "--share=network",
     "--share=ipc",
     "--socket=x11",
-    "--socket=wayland",
     "--socket=pulseaudio",
-    "--filesystem=home"
+    "--filesystem=home",
+    "--env=QT_QPA_PLATFORM=flatpak",
+    "--env=QT_QPA_FLATPAK_PLATFORM=xcb"
   ],
+  "build-options": {
+    "cflags": "-O2 -g",
+    "cxxflags": "-O2 -g",
+    "env": {
+      "V": "1"
+    }
+  },
   "modules": [
     "shared-modules/lame/lame-3.99.5.json",
     {
@@ -36,7 +44,7 @@
         "mv /app/share/mime/packages/musescore.xml /app/share/mime/packages/org.musescore.MuseScore.xml",
         "mkdir -p /app/share/appdata",
         "install -Dm644 org.musescore.MuseScore.appdata.xml /app/share/appdata/org.musescore.MuseScore.appdata.xml",
-        "sed -i 's|<!--  <generic-icon name=\"audio-x-generic\"/> Uncomment to use generic audio file icon -->|<generic-icon name=\"audio-x-generic\"/>|' /app/share/mime/packages/org.musescore.MuseScore.xml" 
+        "sed -i 's|<!--  <generic-icon name=\"audio-x-generic\"/> Uncomment to use generic audio file icon -->|<generic-icon name=\"audio-x-generic\"/>|' /app/share/mime/packages/org.musescore.MuseScore.xml"
       ],
       "sources": [
         {

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -63,9 +63,7 @@
         "-DBUILD_PORTAUDIO=OFF"
       ],
       "build-commands": [
-        "make lrelease",
-        "make",
-        "make install PREFIX=/app"
+        "make lrelease"
       ],
       "post-install": [
         "mv /app/share/mime/packages/musescore.xml /app/share/mime/packages/org.musescore.MuseScore.xml",

--- a/org.musescore.MuseScore.json
+++ b/org.musescore.MuseScore.json
@@ -1,0 +1,58 @@
+{
+  "app-id": "org.musescore.MuseScore",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.9",
+  "sdk": "org.kde.Sdk",
+  "command": "musescore",
+  "rename-desktop-file": "mscore.desktop",
+  "rename-icon": "mscore",
+  "finish-args": [
+    "--device=dri",
+    "--share=network",
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--filesystem=home"
+  ],
+  "modules": [
+    "shared-modules/lame/lame-3.99.5.json",
+    {
+      "name": "musescore",
+      "buildsystem": "cmake",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=RELEASE",
+        "-DBUILD_ALSA=OFF",
+        "-DBUILD_JACK=OFF",
+        "-DBUILD_PORTAUDIO=OFF",
+        "-DBUILD_WEBKIT=OFF"
+      ],
+      "build-commands": [
+        "make lrelease",
+        "make",
+        "make install PREFIX=/app"
+      ],
+      "post-install": [
+        "mv /app/share/mime/packages/musescore.xml /app/share/mime/packages/org.musescore.MuseScore.xml",
+        "mkdir -p /app/share/appdata",
+        "install -Dm644 org.musescore.MuseScore.appdata.xml /app/share/appdata/org.musescore.MuseScore.appdata.xml",
+        "sed -i 's|<!--  <generic-icon name=\"audio-x-generic\"/> Uncomment to use generic audio file icon -->|<generic-icon name=\"audio-x-generic\"/>|' /app/share/mime/packages/org.musescore.MuseScore.xml" 
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/musescore/MuseScore/archive/v2.1.0.tar.gz",
+          "sha256": "0581b8dd4e9bef51f863baf5b7f03b518f9784c79c0d92d6f0e33b180dd63c47"
+        },
+        {
+          "type": "file",
+          "path": "org.musescore.MuseScore.appdata.xml"
+        },
+        {
+          "type": "shell",
+          "commands": [ ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`org.musescore.MuseScore` in flatpak-speak.

This is not a flawless build however, but the issues are mostly design-related:

 * ~~QtWebKit is not present, since I didn’t have 2 hours to spare and it’s only used to showcase community sheet music in the start page, but I guess we should add it, but it can be done later~~ done
 * ~~Mimetype icons aren’t exported and instead, generic icons are used. I– I don’t know, I’m torn. Should we ship custom icons, use the MuseScore icon or just use generic ones?~~ generic ones until flatpak/flatpak-builder#1
 * Opening links does not work (using the Flatpak QtPlatform from the KDE Runtime crashes the portal, I think it’s still broken)
 * The AppData is incomplete, but, TBH, MuseScore people should fill it out, this one is really just a replacement until a proper one is present, but hey, it does the job quite well

Of course a lot of thanks to @Alexander-Wilms for the initial version of the manifest and AppData.