### PR TITLE
Add mono SDK extension

### DIFF
--- a/org.freedesktop.Sdk.Extension.mono5.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.mono5.appdata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.mono5</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Mono 5.x Sdk extension</name>
+  <summary>Mono runtime, compiler and tools</summary>
+</component>

--- a/org.freedesktop.Sdk.Extension.mono5.json
+++ b/org.freedesktop.Sdk.Extension.mono5.json
@@ -1,0 +1,76 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.mono5",
+    "branch": "1.6",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "sdk-extensions": [],
+    "separate-locales": false,
+    "appstream-compose": false,
+    "cleanup": [ ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "prefix": "/usr/lib/sdk/mono5",
+        "env": {
+            "V": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "mono",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.mono-project.com/sources/mono/mono-5.4.0.201.tar.bz2",
+                    "sha256": "2a2f5c2a214a9980c086ac7561a5dd106f13d823a630de218eabafe1d995c5b4"
+                }
+            ]
+        },
+        {
+            "name": "scripts",
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/lib",
+                        "mkdir -p /app/bin",
+                        "cp /usr/lib/sdk/mono5/bin/mono /app/bin/mono",
+                        "cp -ar /usr/lib/sdk/mono5/lib/mono /app/lib/mono"
+                    ],
+                    "dest-filename": "install.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "export PATH=$PATH:/usr/lib/sdk/mono5/bin",
+                        "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/sdk/mono5/lib",
+                        "export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}/usr/lib/sdk/mono5/lib/pkgconfig",
+                        "export MONO_GAC_PREFIX=/app"
+                    ],
+                    "dest-filename": "use.sh"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp use.sh install.sh /usr/lib/sdk/mono5/"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.mono5.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose  --basename=org.freedesktop.Sdk.Extension.mono5 --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.mono5"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.mono5.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is an initial version of an SDK for mono.
For testing I used this build of gbrainy:

[org.gnome.gbrainy.json](https://github.com/flathub/flathub/files/1461816/org.gnome.gbrainy.json.txt)

For the record, I don't know shit about mono, so I would appreciate some feedback on this, maybe @directhex can take a look?

Some outstanding issues:
 * It seems the binaries are not stripped which makes the extension unnecessary large.
 * `install.sh` copies the entire GAC, which is like 170 meg. There must be a way to find a smaller set of dependencies and only install those.
