### PR TITLE
Add org.keepassxc.KeePassXC

### DIFF
--- a/keepassxc-id-fix.patch
+++ b/keepassxc-id-fix.patch
@@ -1,0 +1,192 @@
+diff --git a/release-tool b/release-tool
+index 10c6a14c..42cd3a1d 100755
+--- a/release-tool
++++ b/release-tool
+@@ -264,13 +264,13 @@ checkChangeLog() {
+ }
+ 
+ checkAppStreamInfo() {
+-    if [ ! -f share/linux/org.keepassxc.appdata.xml ]; then
++    if [ ! -f share/linux/org.keepassxc.KeePassXC.appdata.xml ]; then
+         exitError "No AppStream info file found!"
+     fi
+ 
+-    grep -qPzo "<release version=\"${RELEASE_NAME}\" date=\"\d{4}-\d{2}-\d{2}\">" share/linux/org.keepassxc.appdata.xml
++    grep -qPzo "<release version=\"${RELEASE_NAME}\" date=\"\d{4}-\d{2}-\d{2}\">" share/linux/org.keepassxc.KeePassXC.appdata.xml
+     if [ $? -ne 0 ]; then
+-        exitError "'share/linux/org.keepassxc.appdata.xml' has not been updated to the '${RELEASE_NAME}' release!"
++        exitError "'share/linux/org.keepassxc.KeePassXC.appdata.xml' has not been updated to the '${RELEASE_NAME}' release!"
+     fi
+ }
+ 
+diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
+index 6323ece8..81bb2693 100644
+--- a/share/CMakeLists.txt
++++ b/share/CMakeLists.txt
+@@ -30,8 +30,8 @@ if(UNIX AND NOT APPLE)
+     install(DIRECTORY icons/application/ DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor
+             FILES_MATCHING PATTERN "application-x-keepassxc.png" PATTERN "application-x-keepassxc.svgz"
+             PATTERN "status" EXCLUDE PATTERN "actions" EXCLUDE PATTERN "categories" EXCLUDE)
+-    install(FILES linux/org.keepassxc.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+-    install(FILES linux/org.keepassxc.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
++    install(FILES linux/org.keepassxc.KeePassXC.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
++    install(FILES linux/org.keepassxc.KeePassXC.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+     install(FILES linux/keepassxc.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
+ endif(UNIX AND NOT APPLE)
+ 
+diff --git a/share/linux/org.keepassxc.appdata.xml b/share/linux/org.keepassxc.KeePassXC.appdata.xml
+similarity index 89%
+rename from share/linux/org.keepassxc.appdata.xml
+rename to share/linux/org.keepassxc.KeePassXC.appdata.xml
+index 563450a4..b2a4de6e 100644
+--- a/share/linux/org.keepassxc.appdata.xml
++++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
+@@ -1,16 +1,15 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!-- Copyright 2017 KeePassXC Team <team@keepassxc.org> -->
+ <component type="desktop-application">
+-    <id>org.keepassxc</id>
++    <id>org.keepassxc.KeePassXC.desktop</id>
+     <name>KeePassXC</name>
+     <metadata_license>CC-BY-3.0</metadata_license>
+     <project_license>GPL-3.0+</project_license>
+-    <icon type="stock">keepassxc</icon>
+-    <url type="homepage">https://keepassxc.org</url>
+     <mimetypes>
+         <mimetype>application/x-keepass2</mimetype>
+     </mimetypes>
+     <summary>Community-driven port of the Windows application “KeePass Password Safe”</summary>
++    <developer_name>KeePassXC Team</developer_name>
+     <description>
+         <p>
+             KeePassXC is an application for people with extremely high demands on secure
+@@ -19,56 +18,41 @@
+         </p>
+     </description>
+ 
+-    <launchable type="desktop-id">org.keepassxc.desktop</launchable>
++    <launchable type="desktop-id">org.keepassxc.KeePassXC.desktop</launchable>
++
++    <url type="homepage">https://keepassxc.org</url>
++    <url type="bugtracker">https://github.com/keepassxreboot/keepassxc/issues</url>
++    <url type="faq">https://keepassxc.org/docs#faq</url>
++    <url type="help">https://keepassxc.org/docs</url>
++    <url type="translate">https://www.transifex.com/keepassxc/keepassxc</url>
+ 
+     <screenshots>
+         <screenshot type="default">
+             <image>https://keepassxc.org/images/screenshots/linux/screen_001.png</image>
++            <caption>Create, Import or Open Databases</caption>
+         </screenshot>
+         <screenshot>
+             <image>https://keepassxc.org/images/screenshots/linux/screen_002.png</image>
++            <caption>Organize with Groups and Entries</caption>
+         </screenshot>
+         <screenshot>
+             <image>https://keepassxc.org/images/screenshots/linux/screen_003.png</image>
++            <caption>Database Entry</caption>
+         </screenshot>
+         <screenshot>
+             <image>https://keepassxc.org/images/screenshots/linux/screen_004.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_005.png</image>
++            <caption>Icon Selection for Entry</caption>
+         </screenshot>
+         <screenshot>
+             <image>https://keepassxc.org/images/screenshots/linux/screen_006.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_007.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_008.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_009.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_010.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_011.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_012.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_013.png</image>
+-        </screenshot>
+-        <screenshot>
+-            <image>https://keepassxc.org/images/screenshots/linux/screen_014.png</image>
++            <caption>Password Generator</caption>
+         </screenshot>
+     </screenshots>
+ 
+     <releases>
+         <release version="2.2.2" date="2017-10-22">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Fixed entries with empty URLs being reported to KeePassHTTP clients [#1031]</li>
+                     <li>Fixed YubiKey detection and enabled CLI tool for AppImage binary [#1100]</li>
+@@ -87,6 +71,7 @@
+             </description>
+         </release><release version="2.2.1" date="2017-10-01">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Corrected multiple snap issues [#934, #1011]</li>
+                     <li>Corrected multiple custom icon issues [#708, #719, #994]</li>
+@@ -103,6 +88,7 @@
+         </release>
+         <release version="2.2.0" date="2017-06-23">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Added YubiKey 2FA integration for unlocking databases [#127]</li>
+                     <li>Added TOTP support [#519]</li>
+@@ -138,6 +124,7 @@
+         </release>
+         <release version="2.1.4" date="2017-04-09">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Bumped KeePassHTTP version to 1.8.4.2</li>
+                     <li>KeePassHTTP confirmation window comes to foreground [#466]</li>
+@@ -146,6 +133,7 @@
+         </release>
+         <release version="2.1.3" date="2017-03-03">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Fix possible overflow in zxcvbn library [#363]</li>
+                     <li>Revert HiDPI setting to avoid problems on laptop screens [#332]</li>
+@@ -160,6 +148,7 @@
+         </release>
+         <release version="2.1.2" date="2017-02-17">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Ask for save location when creating a new database [#302]</li>
+                     <li>Remove Libmicrohttpd dependency to clean up the code and ensure better OS X compatibility [#317, #265]</li>
+@@ -177,6 +166,7 @@
+         </release>
+         <release version="2.1.1" date="2017-02-06">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Enabled HTTP plugin build; plugin is disabled by default and limited to localhost [#147]</li>
+                     <li>Escape HTML in dialog boxes [#247]</li>
+@@ -189,6 +179,7 @@
+         </release>
+         <release version="2.1.0" date="2017-01-22">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Show unlock dialog when using autotype on a closed database [#10, #89]</li>
+                     <li>Show different tray icon when database is locked [#37, #46]</li>
+diff --git a/share/linux/org.keepassxc.desktop b/share/linux/org.keepassxc.KeePassXC.desktop
+similarity index 100%
+rename from share/linux/org.keepassxc.desktop
+rename to share/linux/org.keepassxc.KeePassXC.desktop

--- a/keepassxc-id-fix.patch
+++ b/keepassxc-id-fix.patch
@@ -1,49 +1,10 @@
-diff --git a/release-tool b/release-tool
-index 10c6a14c..42cd3a1d 100755
---- a/release-tool
-+++ b/release-tool
-@@ -264,13 +264,13 @@ checkChangeLog() {
- }
- 
- checkAppStreamInfo() {
--    if [ ! -f share/linux/org.keepassxc.appdata.xml ]; then
-+    if [ ! -f share/linux/org.keepassxc.KeePassXC.appdata.xml ]; then
-         exitError "No AppStream info file found!"
-     fi
- 
--    grep -qPzo "<release version=\"${RELEASE_NAME}\" date=\"\d{4}-\d{2}-\d{2}\">" share/linux/org.keepassxc.appdata.xml
-+    grep -qPzo "<release version=\"${RELEASE_NAME}\" date=\"\d{4}-\d{2}-\d{2}\">" share/linux/org.keepassxc.KeePassXC.appdata.xml
-     if [ $? -ne 0 ]; then
--        exitError "'share/linux/org.keepassxc.appdata.xml' has not been updated to the '${RELEASE_NAME}' release!"
-+        exitError "'share/linux/org.keepassxc.KeePassXC.appdata.xml' has not been updated to the '${RELEASE_NAME}' release!"
-     fi
- }
- 
-diff --git a/share/CMakeLists.txt b/share/CMakeLists.txt
-index 6323ece8..81bb2693 100644
---- a/share/CMakeLists.txt
-+++ b/share/CMakeLists.txt
-@@ -30,8 +30,8 @@ if(UNIX AND NOT APPLE)
-     install(DIRECTORY icons/application/ DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor
-             FILES_MATCHING PATTERN "application-x-keepassxc.png" PATTERN "application-x-keepassxc.svgz"
-             PATTERN "status" EXCLUDE PATTERN "actions" EXCLUDE PATTERN "categories" EXCLUDE)
--    install(FILES linux/org.keepassxc.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
--    install(FILES linux/org.keepassxc.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
-+    install(FILES linux/org.keepassxc.KeePassXC.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-+    install(FILES linux/org.keepassxc.KeePassXC.appdata.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
-     install(FILES linux/keepassxc.xml DESTINATION ${CMAKE_INSTALL_DATADIR}/mime/packages)
- endif(UNIX AND NOT APPLE)
- 
-diff --git a/share/linux/org.keepassxc.appdata.xml b/share/linux/org.keepassxc.KeePassXC.appdata.xml
-similarity index 89%
-rename from share/linux/org.keepassxc.appdata.xml
-rename to share/linux/org.keepassxc.KeePassXC.appdata.xml
-index 563450a4..b2a4de6e 100644
---- a/share/linux/org.keepassxc.appdata.xml
+diff --git a/share/linux/org.keepassxc.KeePassXC.appdata.xml b/share/linux/org.keepassxc.KeePassXC.appdata.xml
+index bde79416..856ed479 100644
+--- a/share/linux/org.keepassxc.KeePassXC.appdata.xml
 +++ b/share/linux/org.keepassxc.KeePassXC.appdata.xml
 @@ -1,16 +1,15 @@
  <?xml version="1.0" encoding="UTF-8"?>
- <!-- Copyright 2017 KeePassXC Team <team@keepassxc.org> -->
+ <!--Copyright 2017 KeePassXC Team <team@keepassxc.org> -->
  <component type="desktop-application">
 -    <id>org.keepassxc</id>
 +    <id>org.keepassxc.KeePassXC.desktop</id>
@@ -124,21 +85,29 @@ index 563450a4..b2a4de6e 100644
      </screenshots>
  
      <releases>
+         <release version="2.2.4" date="2017-12-13">
+             <description>
++                <p>Changes included in this release:</p>
+                 <ul>
+                     <li>Prevent database corruption when locked [#1219]</li>
+                     <li>Fixes apply button not saving new entries [#1141]</li>
+@@ -81,6 +65,7 @@
+         </release>
          <release version="2.2.2" date="2017-10-22">
              <description>
 +                <p>Changes included in this release:</p>
                  <ul>
                      <li>Fixed entries with empty URLs being reported to KeePassHTTP clients [#1031]</li>
                      <li>Fixed YubiKey detection and enabled CLI tool for AppImage binary [#1100]</li>
-@@ -87,6 +71,7 @@
-             </description>
-         </release><release version="2.2.1" date="2017-10-01">
+@@ -100,6 +85,7 @@
+         </release>
+         <release version="2.2.1" date="2017-10-01">
              <description>
 +                <p>Changes included in this release:</p>
                  <ul>
                      <li>Corrected multiple snap issues [#934, #1011]</li>
                      <li>Corrected multiple custom icon issues [#708, #719, #994]</li>
-@@ -103,6 +88,7 @@
+@@ -116,6 +102,7 @@
          </release>
          <release version="2.2.0" date="2017-06-23">
              <description>
@@ -146,7 +115,7 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Added YubiKey 2FA integration for unlocking databases [#127]</li>
                      <li>Added TOTP support [#519]</li>
-@@ -138,6 +124,7 @@
+@@ -151,6 +138,7 @@
          </release>
          <release version="2.1.4" date="2017-04-09">
              <description>
@@ -154,7 +123,7 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Bumped KeePassHTTP version to 1.8.4.2</li>
                      <li>KeePassHTTP confirmation window comes to foreground [#466]</li>
-@@ -146,6 +133,7 @@
+@@ -159,6 +147,7 @@
          </release>
          <release version="2.1.3" date="2017-03-03">
              <description>
@@ -162,7 +131,7 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Fix possible overflow in zxcvbn library [#363]</li>
                      <li>Revert HiDPI setting to avoid problems on laptop screens [#332]</li>
-@@ -160,6 +148,7 @@
+@@ -173,6 +162,7 @@
          </release>
          <release version="2.1.2" date="2017-02-17">
              <description>
@@ -170,7 +139,7 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Ask for save location when creating a new database [#302]</li>
                      <li>Remove Libmicrohttpd dependency to clean up the code and ensure better OS X compatibility [#317, #265]</li>
-@@ -177,6 +166,7 @@
+@@ -190,6 +180,7 @@
          </release>
          <release version="2.1.1" date="2017-02-06">
              <description>
@@ -178,7 +147,7 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Enabled HTTP plugin build; plugin is disabled by default and limited to localhost [#147]</li>
                      <li>Escape HTML in dialog boxes [#247]</li>
-@@ -189,6 +179,7 @@
+@@ -202,6 +193,7 @@
          </release>
          <release version="2.1.0" date="2017-01-22">
              <description>
@@ -186,7 +155,3 @@ index 563450a4..b2a4de6e 100644
                  <ul>
                      <li>Show unlock dialog when using autotype on a closed database [#10, #89]</li>
                      <li>Show different tray icon when database is locked [#37, #46]</li>
-diff --git a/share/linux/org.keepassxc.desktop b/share/linux/org.keepassxc.KeePassXC.desktop
-similarity index 100%
-rename from share/linux/org.keepassxc.desktop
-rename to share/linux/org.keepassxc.KeePassXC.desktop

--- a/org.keepassxc.KeePassXC.json
+++ b/org.keepassxc.KeePassXC.json
@@ -1,0 +1,123 @@
+{
+  "id": "org.keepassxc.KeePassXC",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.9",
+  "sdk": "org.kde.Sdk",
+  "command": "keepassxc",
+  "rename-icon": "keepassxc",
+  "finish-args": [
+    /* X11 + XShm access */
+    "--share=ipc", "--socket=x11",
+    /* Notification access */
+    "--talk-name=org.freedesktop.Notifications",
+    /* Screen Lock Listener */
+    "--talk-name=org.freedesktop.login1.Manager",
+    "--talk-name=org.freedesktop.ScreenSaver",
+    "--talk-name=org.gnome.SessionManager",
+    "--talk-name=org.gnome.SessionManager.Presence",
+    "--talk-name=com.canonical.Unity.Session",
+    /* KeePassHTTP */
+    "--share=network",
+    /* YubiKey USB access */
+    "--device=all"
+  ],
+  "cleanup": [
+    "*.a",
+    "*.h",
+    "*.la",
+    "/include",
+    "/lib/pkgconfig"
+  ],
+  "modules": [
+    {
+      "name": "keepassxc",
+      "buildsystem": "cmake",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DWITH_TESTS=OFF",
+        "-DWITH_XC_AUTOTYPE=ON",
+        "-DWITH_XC_HTTP=ON",
+        "-DWITH_XC_YUBIKEY=ON"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.2.2/keepassxc-2.2.2-src.tar.xz",
+          "sha256": "2f55784f7e6d3a840575e1768a3e5ae03986c2f6a70029dd6b9f9bb0fa443473"
+        },
+        {
+          /* Backport of upstream patch */
+          "type": "patch",
+          "path": "keepassxc-id-fix.patch"
+        }
+      ],
+      "post-install": [
+        "for f in COPYING LICENSE*; do install -Dm644 $f /app/share/licenses/org.keepassxc.KeePassXC/$f; done"
+      ],
+      "cleanup": [ "keepassxc-cli" ],
+      "modules": [
+        {
+          "name": "libusb",
+          "config-opts": [ "--disable-static", "--disable-udev", "--prefix=/app" ],
+          "sources": [{
+            "type": "git",
+            "url": "https://github.com/libusb/libusb.git",
+            "branch": "v1.0.21"
+          }],
+          "post-install": [
+            "install -Dm644 COPYING /app/share/licenses/libusb/COPYING"
+          ]
+        },
+        {
+          "name": "libyubikey",
+          "sources": [
+            {
+              "type": "git",
+              "url": "https://github.com/Yubico/yubico-c.git",
+              "branch": "libyubikey-1.13"
+            },
+            {
+              "type": "script",
+              "dest-filename": "autogen.sh",
+              "commands": [ "autoreconf --install" ]
+            }
+          ],
+          "post-install": [
+            "install -Dm644 COPYING /app/share/licenses/libyubikey/COPYING"
+          ],
+          "cleanup": [ "/bin", "/share/man" ],
+          "modules": [
+            {
+              "name": "a2x",
+              "sources": [{
+                "type": "archive",
+                "url": "https://downloads.sourceforge.net/project/asciidoc/asciidoc/8.6.9/asciidoc-8.6.9.tar.gz",
+                "sha256": "78db9d0567c8ab6570a6eff7ffdf84eadd91f2dfc0a92a2d0105d323cab4e1f0"
+              }],
+              "cleanup": [ "*" ]
+            }
+          ]
+        },
+        {
+          "name": "libykpers-1",
+          "sources": [
+            {
+              "type": "git",
+              "url": "https://github.com/Yubico/yubikey-personalization.git",
+              "branch": "v1.18.0"
+            },
+            {
+              "type": "script",
+              "dest-filename": "autogen.sh",
+              "commands": [ "autoreconf --install" ]
+            }
+          ],
+          "post-install": [
+            "install -Dm644 COPYING /app/share/licenses/libykpers-1/COPYING"
+          ],
+          "cleanup": [ "/bin", "/share/man" ]
+        }
+      ]
+    }
+  ]
+}

--- a/org.keepassxc.KeePassXC.json
+++ b/org.keepassxc.KeePassXC.json
@@ -42,11 +42,11 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.2.2/keepassxc-2.2.2-src.tar.xz",
-          "sha256": "2f55784f7e6d3a840575e1768a3e5ae03986c2f6a70029dd6b9f9bb0fa443473"
+          "url": "https://github.com/keepassxreboot/keepassxc/releases/download/2.2.4/keepassxc-2.2.4-src.tar.xz",
+          "sha256": "e52fa32cb39af3c64ddd651481b7963b1206830687fb7d4c9f20ad5d6ac0d3dd"
         },
         {
-          /* Backport of upstream patch */
+          /* id is still broken in appdata */
           "type": "patch",
           "path": "keepassxc-id-fix.patch"
         }

--- a/org.keepassxc.KeePassXC.json
+++ b/org.keepassxc.KeePassXC.json
@@ -34,7 +34,6 @@
       "buildsystem": "cmake",
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DWITH_TESTS=OFF",
         "-DWITH_XC_AUTOTYPE=ON",
         "-DWITH_XC_HTTP=ON",
         "-DWITH_XC_YUBIKEY=ON"


### PR DESCRIPTION
Everything works well. I made sure to test every feature, paying extra attention to things like the yubikey support and browser integration.

The patch based upon this [pull request](https://github.com/keepassxreboot/keepassxc/pull/1132). I back-ported it to 2.2.2 so that I could make this pull request without having to wait for the next release.