### PR TITLE
Add Hammond app.

### DIFF
--- a/org.gnome.Hammond.json
+++ b/org.gnome.Hammond.json
@@ -14,8 +14,7 @@
     "build-options" : {
         "env": {
             "CARGO_HOME": "/run/build/Hammond/cargo"
-        },
-        "build-args": [ "--share=network" ]
+        }
     },
     "modules": [
         {

--- a/org.gnome.Hammond.json
+++ b/org.gnome.Hammond.json
@@ -1,0 +1,37 @@
+{
+    "app-id": "org.gnome.Hammond",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+    "command": "hammond",
+    "finish-args": [
+        "--share=network",
+        "--socket=x11",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "build-options" : {
+        "env": {
+            "CARGO_HOME": "/run/build/Hammond/cargo"
+        },
+        "build-args": [ "--share=network" ]
+    },
+    "modules": [
+        {
+           "name": "Hammond",
+           "buildsystem": "simple",
+           "build-commands": [
+               "source /usr/lib/sdk/rust-stable/enable.sh && ./configure --prefix=/app && make && make install"
+            ],
+           "sources": [
+               {
+                   "type": "archive",
+                   "url": "https://gitlab.gnome.org/alatiera/Hammond/uploads/f294f8d4fcaded69b12ebd71c6c1b060/hammond-0.1.1.tar.gz",
+                   "sha256": "912de84b57395cb5a503aef04447c6b97eaaf95c38558b10d534743735e02890"
+               }
+           ]
+        }
+    ]
+}
+


### PR DESCRIPTION
There is not an Application Icon as of this moment.

The appdata.xml and .desktop file are distributed with the build system.