### PR TITLE
Add net.mediaarea.MediaInfo

### DIFF
--- a/net.mediaarea.MediaInfo.json
+++ b/net.mediaarea.MediaInfo.json
@@ -9,7 +9,7 @@
   "rename-appdata-file": "mediainfo-gui.metainfo.xml",
   "rename-icon": "mediainfo",
   "finish-args": [
-    "--filesystem=host",
+    "--filesystem=host:ro",
     "--socket=wayland",
     "--socket=x11",
     "--share=network",

--- a/net.mediaarea.MediaInfo.json
+++ b/net.mediaarea.MediaInfo.json
@@ -1,0 +1,82 @@
+{
+  "app-id": "net.mediaarea.MediaInfo",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.26",
+  "branch": "stable",
+  "sdk": "org.gnome.Sdk",
+  "command": "mediainfo-gui",
+  "rename-desktop-file": "mediainfo-gui.desktop",
+  "rename-appdata-file": "mediainfo-gui.metainfo.xml",
+  "rename-icon": "mediainfo",
+  "finish-args": [
+    "--filesystem=host",
+    "--socket=wayland",
+    "--socket=x11",
+    "--share=network",
+    "--share=ipc"
+  ],
+  "build-options": {
+    "cflags": "-O2 -g",
+    "cxxflags": "-O2 -g"
+  },
+  "modules": [
+    {
+      "name": "wxwidgets",
+      "cleanup": [ "/bin", "/include", "/share", "/lib/wx" ],
+      "rm-configure": true,
+      "config-opts": [ "--enable-shared", "--disable-static", "--enable-unicode" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.3.1/wxWidgets-3.0.3.1.tar.bz2",
+          "sha256": "3164ad6bc5f61c48d2185b39065ddbe44283eb834a5f62beb13f1d0923e366e4"
+        },
+        {
+          "type": "script",
+          "commands": [
+            "cp -p /usr/share/automake-*/config.{sub,guess} .",
+            "autoconf -f -B build/autoconf_prepend-include"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "libzen",
+      "subdir": "Project/GNU/Library",
+      "config-opts": [ "--enable-shared", "--disable-static" ],
+      "cleanup": [ "/bin", "/include", "/lib/pkgconfig", "/lib/*.la" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://mediaarea.net/download/source/libzen/0.4.37/libzen_0.4.37.tar.xz",
+          "sha256": "401c34d93056a95f8392982f856d1371c5de6aec373d84dcbb356e1f473d0452"
+        }
+      ]
+    },
+    {
+      "name": "libmediainfo",
+      "subdir": "Project/GNU/Library",
+      "config-opts": [ "--enable-shared", "--disable-static" ],
+      "cleanup": [ "/bin", "/include", "/lib/pkgconfig", "/lib/*.la" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://mediaarea.net/download/source/libmediainfo/17.10/libmediainfo_17.10.tar.xz",
+          "sha256": "60b018fcd8acd249c5316670bdf1c85abc166fb9c340e84da834b1332a59a102"
+        }
+      ]
+    },
+    {
+      "name": "mediainfo-gui",
+      "subdir": "Project/GNU/GUI",
+      "cleanup": [ "share/pixmaps", "/share/apps", "/share/kde4", "/share/kservices5" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://mediaarea.net/download/source/mediainfo/17.10/mediainfo_17.10.tar.xz",
+          "sha256": "0c1130cfa1878592f1225097a1814126378abbcc33926cdfff6bcc99422670fb"
+        }
+      ]
+    }
+  ]
+}

--- a/net.mediaarea.MediaInfo.json
+++ b/net.mediaarea.MediaInfo.json
@@ -56,7 +56,7 @@
     {
       "name": "libmediainfo",
       "subdir": "Project/GNU/Library",
-      "config-opts": [ "--enable-shared", "--disable-static" ],
+      "config-opts": [ "--enable-shared", "--disable-static", "--with-libcurl" ],
       "cleanup": [ "/bin", "/include", "/lib/pkgconfig", "/lib/*.la" ],
       "sources": [
         {


### PR DESCRIPTION
MediaInfo provide a unified display of the most relevant technical and tag data for video and audio files.

Tested with flatpak-builder v0.10.3 on Gentoo x86_64