### PR TITLE
Add work.openpaper.Paperwork.json

### DIFF
--- a/pip-Makefile
+++ b/pip-Makefile
@@ -1,0 +1,5 @@
+all:
+	python3 setup.py build
+
+install:
+	python3 setup.py install --prefix=/app ${ARGS}

--- a/python-paperwork-backend-fix-flatpak-support.diff
+++ b/python-paperwork-backend-fix-flatpak-support.diff
@@ -1,0 +1,14 @@
+diff --git a/paperwork_backend/__init__.py b/paperwork_backend/__init__.py
+index d89b3e0..c6585a2 100644
+--- a/paperwork_backend/__init__.py
++++ b/paperwork_backend/__init__.py
+@@ -16,7 +16,8 @@ def init_flatpak():
+     """
+     tessdata_files = glob.glob("/app/share/locale/*/*.traineddata")
+     if len(tessdata_files) <= 0:
+-        return False
++        logger.info("Is Flatpak enabled ? %s", str(os.path.exists("/app")))
++        return os.path.exists("/app")
+ 
+     localdir = os.path.expanduser("~/.local")
+     base_data_dir = os.getenv(

--- a/python-pillow-disable-multithreaded-compilation.diff
+++ b/python-pillow-disable-multithreaded-compilation.diff
@@ -1,0 +1,11 @@
+--- setup.py	2017-11-16 21:02:44.002328167 +0100
++++ setup.py	2017-11-16 21:03:48.353489990 +0100
+@@ -22,7 +22,7 @@
+ 
+ # monkey patch import hook. Even though flake8 says it's not used, it is.
+ # comment this out to disable multi threaded builds.
+-import mp_compile
++# import mp_compile
+ 
+ _IMAGING = ("decode", "encode", "map", "display", "outline", "path")
+ 

--- a/shared-modules/noop-Makefile
+++ b/shared-modules/noop-Makefile
@@ -1,0 +1,7 @@
+all:
+	@echo no-op
+
+install:
+	@echo no-op
+
+.PHONY: all

--- a/shared-modules/sane-backends-1.0.27.json
+++ b/shared-modules/sane-backends-1.0.27.json
@@ -1,0 +1,20 @@
+{
+    "name": "sane-backends",
+    "buildsystem": "autotools",
+    "config-opts": [
+        "--disable-saned"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://ftp.osuosl.org/.1/blfs/conglomeration/sane-backends/sane-backends-1.0.27.tar.gz",
+            "sha256": "293747bf37275c424ebb2c833f8588601a60b2f9653945d5a3194875355e36c9"
+        }
+    ],
+    "post-install": [
+        "rm /app/etc/sane.d/dll.conf",
+        "rm /app/etc/sane.d/net.conf",
+        "echo 127.0.0.1 > /app/etc/sane.d/net.conf",
+        "echo net > /app/etc/sane.d/dll.conf"
+    ]
+}

--- a/shared-modules/tesseract-3.05.01.json
+++ b/shared-modules/tesseract-3.05.01.json
@@ -1,0 +1,96 @@
+{
+    "name": "tesseract-bundle",
+    "no-autogen": true,
+    "sources": [
+        {
+            "type": "file",
+            "path": "noop-Makefile",
+            "dest-filename": "Makefile"
+        }
+    ],
+    "modules": [
+        {
+            "name": "libleptonica",
+            "buildsystem": "autotools",
+            "config-opts": [
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/DanBloomberg/leptonica/releases/download/1.74.4/leptonica-1.74.4.tar.gz",
+                    "sha256": "29c35426a416bf454413c6fec24c24a0b633e26144a17e98351b6dffaa4a833b"
+                }
+            ]
+        },
+        {
+            "name": "tesseract",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-graphics"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/tesseract-ocr/tesseract/archive/3.05.01.tar.gz",
+                    "sha256": "05898f93c5d057fada49b9a116fc86ad9310ff1726a0f499c3e5211b3af47ec1"
+                }
+            ]
+        },
+        {
+            "name": "tessdata",
+            "no-autogen": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/tesseract-ocr/tessdata/archive/3.04.00.tar.gz",
+                    "sha256": "5dcb37198336b6953843b461ee535df1401b41008d550fc9e43d0edabca7adb1"
+                },
+                {
+                    "type": "file",
+                    "path": "noop-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ],
+            "post-install": [
+                "mkdir -p /app/share/tessdata",
+                "cp eng.traineddata /app/share/tessdata",
+                "cp osd.traineddata /app/share/tessdata",
+
+                "mkdir -p /app/share/locale/bg",
+                "cp bul.traineddata /app/share/locale/bg",
+                "mkdir -p /app/share/locale/da",
+                "cp dan.traineddata /app/share/locale/da",
+                "mkdir -p /app/share/locale/de",
+                "cp deu.traineddata /app/share/locale/de",
+                "mkdir -p /app/share/locale/eo",
+                "cp epo.traineddata /app/share/locale/eo",
+                "mkdir -p /app/share/locale/fi",
+                "cp fin.traineddata /app/share/locale/fi",
+                "mkdir -p /app/share/locale/fr",
+                "cp fra.traineddata /app/share/locale/fr",
+                "mkdir -p /app/share/locale/gl",
+                "cp glg.traineddata /app/share/locale/gl",
+                "mkdir -p /app/share/locale/hu",
+                "cp hun.traineddata /app/share/locale/hu",
+                "mkdir -p /app/share/locale/it",
+                "cp ita.traineddata /app/share/locale/it",
+                "mkdir -p /app/share/locale/ja",
+                "cp jpn.traineddata /app/share/locale/ja",
+                "mkdir -p /app/share/locale/nl",
+                "cp nld.traineddata /app/share/locale/nl",
+                "mkdir -p /app/share/locale/nb",
+                "cp nor.traineddata /app/share/locale/nb",
+                "mkdir -p /app/share/locale/pt",
+                "cp por.traineddata /app/share/locale/pt",
+                "mkdir -p /app/share/locale/ru",
+                "cp rus.traineddata /app/share/locale/ru",
+                "mkdir -p /app/share/locale/es",
+                "cp spa.traineddata /app/share/locale/es",
+                "mkdir -p /app/share/locale/sv",
+                "cp swe.traineddata /app/share/locale/sv",
+                "mkdir -p /app/share/locale/uk",
+                "cp ukr.traineddata /app/share/locale/uk"
+            ]
+        }
+    ]
+}

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -22,7 +22,7 @@
         "shared-modules/tesseract-3.05.01.json",
         "shared-modules/sane-backends-1.0.27.json",
         {
-            "name" :"six",
+            "name" :"python-six",
             "no-autogen": true,
             "sources": [
                 {
@@ -72,7 +72,7 @@
             ]
         },
         {
-            "name" :"Pillow",
+            "name" :"python-pillow",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -96,7 +96,7 @@
             ],
             "modules": [
                 {
-                    "name" :"olefile",
+                    "name" :"python-olefile",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -115,7 +115,7 @@
             ]
         },
         {
-            "name" :"pycountry",
+            "name" :"python-pycountry",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -132,7 +132,7 @@
             ]
         },
         {
-            "name" :"nose",
+            "name" :"python-nose",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -149,7 +149,7 @@
             ]
         },
         {
-            "name" :"pyinsane2",
+            "name" :"python-pyinsane2",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -166,7 +166,7 @@
             ]
         },
         {
-            "name" :"pyocr",
+            "name" :"python-pyocr",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -183,7 +183,7 @@
             ]
         },
         {
-            "name" :"pypillowfight",
+            "name" :"python-pypillowfight",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
             "sources": [
@@ -200,7 +200,7 @@
             ]
         },
         {
-            "name" :"pyxdg",
+            "name" :"python-pyxdg",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
             "sources": [
@@ -217,7 +217,7 @@
             ]
         },
         {
-            "name" :"pydbus",
+            "name" :"python-pydbus",
             "no-autogen": true,
             "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
             "sources": [
@@ -234,7 +234,7 @@
             ]
         },
         {
-            "name" :"paperwork-backend",
+            "name" :"python-paperwork-backend",
             "no-autogen": true,
             "ensure-writable": [
                     "/lib/python*/site-packages/easy-install.pth",
@@ -254,7 +254,7 @@
             ],
             "modules": [
                 {
-                    "name" :"natsort",
+                    "name" :"python-natsort",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -271,7 +271,7 @@
                     ]
                 },
                 {
-                    "name" :"pyenchant",
+                    "name" :"python-pyenchant",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -288,7 +288,7 @@
                     ]
                 },
                 {
-                    "name" :"simplebayes",
+                    "name" :"python-simplebayes",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -305,7 +305,7 @@
                     ]
                 },
                 {
-                    "name" :"whoosh",
+                    "name" :"python-whoosh",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -322,7 +322,7 @@
                     ]
                 },
                 {
-                    "name" :"termcolor",
+                    "name" :"python-termcolor",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
                     "sources": [
@@ -339,7 +339,7 @@
                     ]
                 },
                 {
-                    "name" :"setuptools",
+                    "name" :"python-setuptools",
                     "no-autogen": true,
                     "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
                     "sources": [
@@ -370,7 +370,6 @@
         },
         {
             "name": "poppler",
-            "buildsystem": "autotools",
             "config-opts": [
                 "--enable-libopenjpeg=none",
                 "--enable-xpdf-headers"
@@ -384,7 +383,7 @@
             ]
         },
         {
-            "name": "paperwork",
+            "name": "python-paperwork",
             "make-install-args": ["prefix=/app"],
             "no-autogen": true,
             "ensure-writable": [

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -85,6 +85,13 @@
                     "type": "file",
                     "path": "pip-Makefile",
                     "dest-filename": "Makefile"
+                },
+                {
+                    "type": "patch",
+                    "path": "python-pillow-disable-multithreaded-compilation.diff",
+                    "strip-components": 0,
+                    "dest": ".",
+                    "use-git": false
                 }
             ],
             "modules": [

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -15,7 +15,6 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.DBus",
         "--socket=session-bus",
-        "--socket=system-bus",
         "--own-name=work.openpaper.paperwork"
     ],
     "modules": [

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -1,0 +1,402 @@
+{
+    "app-id": "work.openpaper.Paperwork",
+    "branch": "stable",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "paperwork",
+    "copy-icon": true,
+    "finish-args": [
+        "--share=ipc",
+        "--share=network",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=home",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.DBus",
+        "--socket=session-bus",
+        "--socket=system-bus",
+        "--own-name=work.openpaper.paperwork"
+    ],
+    "modules": [
+        "shared-modules/tesseract-3.05.01.json",
+        "shared-modules/sane-backends-1.0.27.json",
+        {
+            "name" :"six",
+            "no-autogen": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz",
+                    "sha256": "105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"python-dateutil",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/51/fc/39a3fbde6864942e8bb24c93663734b74e281b984d1b8c4f95d64b0c21f6/python-dateutil-2.6.0.tar.gz",
+                    "sha256": "62a2f8df3d66f878373fd0072eacf4ee52194ba302e00082828e0d263b0418d2"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name": "python-Levenshtein",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/42/a9/d1785c85ebf9b7dfacd08938dd028209c34a0ea3b1bcdb895208bd40a67d/python-Levenshtein-0.12.0.tar.gz",
+                    "sha256": "033a11de5e3d19ea25c9302d11224e1a1898fe5abd23c61c7c360c25195e3eb1"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"Pillow",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/93/73/66854f63b1941aad9af18a1de59f9cf95ad1a87c801540222e332f6688d7/Pillow-4.1.1.tar.gz",
+                    "sha256": "00b6a5f28d00f720235a937ebc2f50f4292a5c7e2d6ab9a8b26153b625c4f431"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ],
+            "modules": [
+                {
+                    "name" :"olefile",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/35/17/c15d41d5a8f8b98cc3df25eb00c5cee76193114c78e5674df6ef4ac92647/olefile-0.44.zip",
+                            "sha256": "61f2ca0cd0aa77279eb943c07f607438edf374096b66332fae1ee64a6f0f73ad"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name" :"pycountry",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/4b/51/9155a48faed108db64a0ff45227c752fda8126f3585475cef30b7abaa536/pycountry-17.1.8.tar.gz",
+                    "sha256": "c5ccad49e47caee92779bf83da81565159b1fe3d8f48b063068ac118b73dd1f8"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"nose",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz",
+                    "sha256": "f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"pyinsane2",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/89/02/d516f6676ce668626275207e1bb4567404c900854157ea2d1b9b1f2bc2b6/pyinsane2-2.0.9.tar.gz",
+                    "sha256": "879cecc7679acac0129b5e3e297236197cbd6991a89faa6dadfae89ce10f8abc"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"pyocr",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/6b/5e/0eaa5c939426b0f6a51f9fc883a1d756ad54ac9568faab129440a1dbca24/pyocr-0.4.6.tar.gz",
+                    "sha256": "3626ea30ca3d52c8282da672692b216f28cca62fe0e5f97e58f57b7b1d38d56f"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"pypillowfight",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/c6/89/a32d817e56314ca8c1532bce4553ba2ca8c93d75766bfd748730841f2cf5/pypillowfight-0.2.1.tar.gz",
+                    "sha256": "57bb003ff66979b9b3d5e1e32189f6cd23bb63f2a659f3b97c84ad05ba07992a"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"pyxdg",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/26/28/ee953bd2c030ae5a9e9a0ff68e5912bd90ee50ae766871151cd2572ca570/pyxdg-0.25.tar.gz",
+                    "sha256": "81e883e0b9517d624e8b0499eb267b82a815c0b7146d5269f364988ae031279d"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"pydbus",
+            "no-autogen": true,
+            "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/58/56/3e84f2c1f2e39b9ea132460183f123af41e3b9c8befe222a35636baa6a5a/pydbus-0.6.0.tar.gz",
+                    "sha256": "4207162eff54223822c185da06c1ba8a34137a9602f3da5a528eedf3f78d0f2c"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name" :"paperwork-backend",
+            "no-autogen": true,
+            "ensure-writable": [
+                    "/lib/python*/site-packages/easy-install.pth",
+                    "/lib/python*/site-packages/setuptools.pth"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/05/36/08c1f5ff9ade9611be788455ed6cac50b3779353d0e8c5594b73df2afe57/paperwork-backend-1.2.2.tar.gz",
+                    "sha256": "2d7a957b33592c9bf3107103ed129c81188ca4a1c9052e38cbe583452f0fee0a"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ],
+            "modules": [
+                {
+                    "name" :"natsort",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/8e/6b/a4e3031e573ef29a251984ac0a6bd26cedac6f5e67a7607c9746bd64b3fe/natsort-5.0.3.tar.gz",
+                            "sha256": "d57b7a0156f16f49c6c010c9ce97e2125956697846f31bba7cd544cd24b007c1"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                },
+                {
+                    "name" :"pyenchant",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/73/73/49f95fe636ab3deed0ef1e3b9087902413bcdf74ec00298c3059e660cfbb/pyenchant-1.6.8.tar.gz",
+                            "sha256": "7ead2ee74f1a4fc2a7199b3d6012eaaaceea03fbcadcb5df67d2f9d0d51f050a"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                },
+                {
+                    "name" :"simplebayes",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/b9/73/764578df72934940d95a8941cbd374b56319562dda72630fc8bfeaefc350/simplebayes-1.5.8.tar.gz",
+                            "sha256": "363418c0ef185ac2158ebbd6d8afb45aa997254fcb809a73ed20a7d5dccf8b85"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                },
+                {
+                    "name" :"whoosh",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/25/2b/6beed2107b148edc1321da0d489afc4617b9ed317ef7b72d4993cad9b684/Whoosh-2.7.4.tar.gz",
+                            "sha256": "7ca5633dbfa9e0e0fa400d3151a8a0c4bec53bd2ecedc0a67705b17565c31a83"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                },
+                {
+                    "name" :"termcolor",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/8a/48/a76be51647d0eb9f10e2a4511bf3ffb8cc1e6b14e9e4fab46173aa79f981/termcolor-1.1.0.tar.gz",
+                            "sha256": "1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                },
+                {
+                    "name" :"setuptools",
+                    "no-autogen": true,
+                    "ensure-writable": ["/lib/python*/site-packages/easy-install.pth","/lib/python*/site-packages/setuptools.pth"],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://pypi.python.org/packages/a9/23/720c7558ba6ad3e0f5ad01e0d6ea2288b486da32f053c73e259f7c392042/setuptools-36.0.1.zip",
+                            "sha256": "e17c4687fddd6d70a6604ac0ad25e33324cec71b5137267dd5c45e103c4b288a"
+                        },
+                        {
+                            "type": "file",
+                            "path": "pip-Makefile",
+                            "dest-filename": "Makefile"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "poppler-data",
+            "buildsystem": "cmake",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.7.tar.gz",
+                    "sha256": "e752b0d88a7aba54574152143e7bf76436a7ef51977c55d6bd9a48dccde3a7de"
+                }
+            ]
+        },
+        {
+            "name": "poppler",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--enable-libopenjpeg=none",
+                "--enable-xpdf-headers"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://poppler.freedesktop.org/poppler-0.55.0.tar.xz",
+                    "sha256": "537f2bc60d796525705ad9ca8e46899dcc99c2e9480b80051808bae265cdc658"
+                }
+            ]
+        },
+        {
+            "name": "paperwork",
+            "make-install-args": ["prefix=/app"],
+            "no-autogen": true,
+            "ensure-writable": [
+                    "/lib/python*/site-packages/easy-install.pth",
+                    "/lib/python*/site-packages/setuptools.pth"
+            ],
+            "post-install": ["paperwork-shell install_system /app/share/icons /app/share"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/11/c9/7027fd39165666236faffa3a5a6ebc9d9c4732df36684b0c5e9b6a675e56/paperwork-1.2.2.tar.gz",
+                    "sha256": "18fe3bccd5f9ad16e920baa88985b7e9ba36858b83cdf43cb3591be59cbfc50f"
+                },
+                {
+                    "type": "file",
+                    "path": "pip-Makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        }
+    ]
+}

--- a/work.openpaper.Paperwork.json
+++ b/work.openpaper.Paperwork.json
@@ -246,6 +246,13 @@
                     "sha256": "2d7a957b33592c9bf3107103ed129c81188ca4a1c9052e38cbe583452f0fee0a"
                 },
                 {
+                    "type": "patch",
+                    "path": "python-paperwork-backend-fix-flatpak-support.diff",
+                    "strip-components": 1,
+                    "dest": ".",
+                    "use-git": true
+                },
+                {
                     "type": "file",
                     "path": "pip-Makefile",
                     "dest-filename": "Makefile"


### PR DESCRIPTION
Hello,

Paperwork is a personal document manager ( https://openpaper.work/ ).

Note that this Flatpak package [requires some small configuration changes on the host system to work](https://github.com/openpaperwork/paperwork/tree/master/flatpak#readme) :(

It has a been a little bit tricky to package:
- Python modules relies on setuptools instead of Makefile. So a small Makefile has been added to make the bridge (`pip-Makefile`).
- [Access to scanner is done assuming that Saned is running on the host system](https://github.com/openpaperwork/paperwork/tree/master/flatpak#readme)
- I was hoping to make Tesseract and its data files shared for other projects. Unfortunately Tesseract data files (for the OCR) have been split across `/app/share/locale` (all of them together make about 400MB). I would have used symlinks to merge them together in `/app/share/tessdata`, but unfortunately Tesseract assumes that all files in `tessdata` are always valid and list all the languages as installed (`tesseract --list-langs`). So [I had to make Paperwork create a `tessdata` folder at runtime](https://github.com/openpaperwork/paperwork-backend/blob/master/paperwork_backend/__init__.py#L12).
- Tesseract data files have no Makefile (nor have the need for one), so an empty Makefile has been added too (`noop-Makefile`).
- I still kept them in `shared-modules/` because I share them between [many variant of Paperwork](https://github.com/openpaperwork/paperwork/tree/master/flatpak) and I was hoping I could keep on Flathub a file organization similar to the one I have in my Git repository. 

I just hope it's not too much of a mess :/

With regards,