### PR TITLE
Add com.github.birros.WebArchives

### DIFF
--- a/com.github.birros.WebArchives.json
+++ b/com.github.birros.WebArchives.json
@@ -7,6 +7,7 @@
     "finish-args": [
         "--socket=wayland",
         "--socket=x11",
+        "--share=ipc",
         "--device=dri",
         "--socket=pulseaudio",
         "--talk-name=org.freedesktop.Tracker1",

--- a/com.github.birros.WebArchives.json
+++ b/com.github.birros.WebArchives.json
@@ -211,6 +211,12 @@
         },
         {
             "name": "libgee",
+            "build-options": {
+                "env": {
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+                }
+            },
             "cleanup": [
                 "/include",
                 "/lib/girepository-1.0",
@@ -223,13 +229,6 @@
                     "type": "archive",
                     "url": "http://http.debian.net/debian/pool/main/libg/libgee-0.8/libgee-0.8_0.20.0.orig.tar.xz",
                     "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
-                },
-                {
-                    "type": "shell",
-                    "commands": [
-                        "sed -i 's/@INTROSPECTION_GIRDIR@/$(datadir)\\/gir-1.0/' gee/Makefile.in",
-                        "sed -i 's/@INTROSPECTION_TYPELIBDIR@/$(libdir)\\/girepository-1.0/' gee/Makefile.in"
-                    ]
                 }
             ]
         },

--- a/com.github.birros.WebArchives.json
+++ b/com.github.birros.WebArchives.json
@@ -1,0 +1,276 @@
+{
+    "id": "com.github.birros.WebArchives",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "web-archives",
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--device=dri",
+        "--socket=pulseaudio",
+        "--talk-name=org.freedesktop.Tracker1",
+        "--filesystem=home",
+        "--share=network"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "modules": [
+        {
+            "name": "xapian-core",
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/cmake",
+                "/lib/*.la",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://oligarchy.co.uk/xapian/1.4.5/xapian-core-1.4.5.tar.xz",
+                    "sha256": "85b5f952de9df925fd13e00f6e82484162fd506d38745613a50b0a2064c6b02b"
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   xapian-core
+             */
+            "name": "libzim",
+            "buildsystem": "meson",
+            "builddir": true,
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/openzim/libzim/archive/3.0.0.tar.gz",
+                    "sha256": "eb2abc7cb99ba67e74004ded48c02fe4c2de40ee19f56896ee79e533af11159c"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "mkdir -p subprojects/packagecache"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/google/googletest/archive/release-1.8.0.zip",
+                    "sha256": "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",
+                    "dest-filename": "subprojects/packagecache/gtest-1.8.0.zip"
+                },
+                {
+                    "type": "file",
+                    "url": "https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.0/4/get_zip",
+                    "sha256": "0b90fe055acbdb002a37dfb035184b306008b763931158497ef5dbaa8c7925af",
+                    "dest-filename": "subprojects/packagecache/gtest-1.8.0-4-wrap.zip"
+                }
+            ]
+        },
+        {
+            "name": "pugixml",
+            "buildsystem": "cmake",
+            "builddir": true,
+            "config-opts": [
+                "-DBUILD_PKGCONFIG=ON",
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/cmake"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/zeux/pugixml/releases/download/v1.8.1/pugixml-1.8.1.tar.gz",
+                    "sha256": "00d974a1308e85ca0677a981adc1b2855cb060923181053fb0abf4e2f37b8f39"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's/${CMAKE_INSTALL_LIBDIR}${INSTALL_SUFFIX}/${CMAKE_INSTALL_LIBDIR}/g' CMakeLists.txt",
+                        "sed -i 's/lib\\/pugixml-@PUGIXML_VERSION_STRING@/lib/g' scripts/pugixml.pc.in"
+                    ]
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   libzim, pugixml
+             */
+            "name": "libkiwix",
+            "buildsystem": "meson",
+            "builddir": true,
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/kiwix/kiwix-lib/archive/1.0.1.tar.gz",
+                    "sha256": "a7973f741e9ac70ce0bb430c46833584e2c4c261eb15549d077a3b3349cbbac2"
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   libzim
+             */
+            "name": "libzim-glib",
+            "buildsystem": "meson",
+            "builddir": true,
+            "cleanup": [
+                "/include",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/birros/libzim-glib/archive/v3.0.0.tar.gz",
+                    "sha256": "9caea46469afa6ab02f02f10ead90da57c9991afbed74e1c674c6138d99878d0"
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   libkiwix
+             */
+            "name": "libkiwix-glib",
+            "buildsystem": "meson",
+            "builddir": true,
+            "cleanup": [
+                "/include",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/birros/libkiwix-glib/archive/v1.0.1.tar.gz",
+                    "sha256": "dc6459d03e367bab08c721cee5196e27786a8bdfe0539a6bb1d3719732cddb89"
+                }
+            ]
+        },
+        {
+            "name": "tracker",
+            "config-opts": [
+                "--disable-miner-apps",
+                "--disable-static",
+                "--disable-tracker-extract",
+                "--disable-tracker-needle",
+                "--disable-tracker-preferences",
+                "--disable-artwork",
+                "--disable-tracker-writeback",
+                "--disable-miner-user-guides",
+                "--with-bash-completion-dir=no"
+            ],
+            "cleanup": [
+                "/etc",
+                "/include",
+                "/lib/libtracker-control*",
+                "/lib/libtracker-mine*",
+                "/lib/*.la",
+                "/lib/tracker-2.0/*.la",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/lib/systemd",
+                "/libexec",
+                "/share/dbus-1",
+                "/share/gir-1.0",
+                "/share/glib-2.0",
+                "/share/gtk-doc",
+                "/share/man",
+                "/share/runtime",
+                "/share/vala"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/tracker/2.0/tracker-2.0.1.tar.xz",
+                    "sha256": "ac5c9f4dbb0741af5877ae2818d8c053aa9a431477a924a17976bb7e44411e47"
+                }
+            ]
+        },
+        {
+            "name": "libgee",
+            "cleanup": [
+                "/include",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/lib/*.la",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://http.debian.net/debian/pool/main/libg/libgee-0.8/libgee-0.8_0.20.0.orig.tar.xz",
+                    "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's/@INTROSPECTION_GIRDIR@/$(datadir)\\/gir-1.0/' gee/Makefile.in",
+                        "sed -i 's/@INTROSPECTION_TYPELIBDIR@/$(libdir)\\/girepository-1.0/' gee/Makefile.in"
+                    ]
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   libgee
+             */
+            "name": "libisocodes",
+            "cleanup": [
+                "/include",
+                "/lib/girepository-1.0",
+                "/lib/pkgconfig",
+                "/lib/*.la",
+                "/lib/*.a",
+                "/share/gir-1.0",
+                "/share/vala"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://http.debian.net/debian/pool/main/libi/libisocodes/libisocodes_1.2.2.orig.tar.xz",
+                    "sha256": "4cdf2c02486bb44902d95e2b86356ef348c65b5edff75925d6878fe5e5f038de"
+                }
+            ]
+        },
+        {
+            /*
+             * require
+             *   libzim-glib, libkiwix-glib, tracker, libisocodes
+             */
+            "name": "web-archives",
+            "buildsystem": "meson",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/birros/web-archives/archive/v0.0.1.tar.gz",
+                    "sha256": "f613b7e500fe8791e2c1ceeaf3633aa0617c96bbece5249af491031cd726a0fc"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
It's a Web archive reader to open [ZIM](https://en.wikipedia.org/wiki/ZIM_(file_format)) files.
It's an alternative to the desktop version of the [Kiwix](https://en.wikipedia.org/wiki/Kiwix) application.
It's a free software.

This is an amateur project, so it is being developed sporadically at the moment.
I think it may be useful for some people, so i decide to push it on Flathub.
If you feel that it is not enough in order to be present in your market, i would understand if it's not published.

On the sandboxing side, for the moment home directory access is required to open files listed by Tracker.
In addition, as long as the printing mechanism of WebKitGTK+ does not support portals, write access is necessary to save PDFs.

In any case, thanks a lot for this great tool which greatly simplifies the development of an application, at least for me.
I hope i don't make too many mistakes for a first pull request.