### PR TITLE
Add 6 Materia GTK+ theme variants

### DIFF
--- a/org.gtk.Gtk3theme.Materia-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-compact.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-compact</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia compact Gtk theme</name>
   <summary>Compact version of the Materia GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-compact.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-compact</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia compact Gtk theme</name>
-  <summary>Compact version of the Materia GTK+ theme</summary>
+  <name>Materia-compact GTK+ theme</name>
+  <summary>Materia-compact GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-compact.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia-compact</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia compact Gtk theme</name>
+  <summary>Compact version of the Materia GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia-compact.json
+++ b/org.gtk.Gtk3theme.Materia-compact.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia-compact.json
+++ b/org.gtk.Gtk3theme.Materia-compact.json
@@ -20,8 +20,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia-compact.json
+++ b/org.gtk.Gtk3theme.Materia-compact.json
@@ -1,0 +1,44 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia-compact",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia-compact",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-compact/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk-compact.css /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/gtk.css",
+        "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/gtk-dark.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia-compact.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia-compact --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia-compact"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia-compact.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia-compact.json
+++ b/org.gtk.Gtk3theme.Materia-compact.json
@@ -15,13 +15,13 @@
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-compact/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk-compact.css /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/gtk.css",
         "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/gtk-dark.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-compact/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-compact/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -39,6 +39,6 @@
           "path": "org.gtk.Gtk3theme.Materia-compact.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia-dark-compact</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia dark compact Gtk theme</name>
+  <summary>Compact version of the Materia dark GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-dark-compact</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia dark compact Gtk theme</name>
-  <summary>Compact version of the Materia dark GTK+ theme</summary>
+  <name>Materia-dark-compact GTK+ theme</name>
+  <summary>Materia-dark-compact GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-dark-compact</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia dark compact Gtk theme</name>
   <summary>Compact version of the Materia dark GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia-dark-compact.json
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia-dark-compact.json
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.json
@@ -14,13 +14,13 @@
       "build-commands": [
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0/gtk.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -38,6 +38,6 @@
           "path": "org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Materia-dark-compact.json
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.json
@@ -19,8 +19,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia-dark-compact.json
+++ b/org.gtk.Gtk3theme.Materia-dark-compact.json
@@ -1,0 +1,43 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia-dark-compact",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia-dark-compact",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0/gtk.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark-compact/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia-dark-compact --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia-dark-compact"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia-dark-compact.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia-dark.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-dark</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia dark Gtk theme</name>
   <summary>Materia dark GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia-dark.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia-dark</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia dark Gtk theme</name>
+  <summary>Materia dark GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia-dark.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-dark.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-dark</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia dark Gtk theme</name>
-  <summary>Materia dark GTK+ theme</summary>
+  <name>Materia-dark GTK+ theme</name>
+  <summary>Materia-dark GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia-dark.json
+++ b/org.gtk.Gtk3theme.Materia-dark.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia-dark.json
+++ b/org.gtk.Gtk3theme.Materia-dark.json
@@ -1,0 +1,43 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia-dark",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia-dark",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-dark/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia-dark/gtk-3.0/gtk.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia-dark.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia-dark --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia-dark"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia-dark.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia-dark.json
+++ b/org.gtk.Gtk3theme.Materia-dark.json
@@ -19,8 +19,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia-dark.json
+++ b/org.gtk.Gtk3theme.Materia-dark.json
@@ -14,13 +14,13 @@
       "build-commands": [
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-dark/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia-dark/gtk-3.0/gtk.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-dark/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -38,6 +38,6 @@
           "path": "org.gtk.Gtk3theme.Materia-dark.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-light-compact</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia light compact Gtk theme</name>
   <summary>Compact version of the Materia light GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia-light-compact</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia light compact Gtk theme</name>
+  <summary>Compact version of the Materia light GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light-compact.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-light-compact</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia light compact Gtk theme</name>
-  <summary>Compact version of the Materia light GTK+ theme</summary>
+  <name>Materia-light-compact GTK+ theme</name>
+  <summary>Materia-light-compact GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia-light-compact.json
+++ b/org.gtk.Gtk3theme.Materia-light-compact.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia-light-compact.json
+++ b/org.gtk.Gtk3theme.Materia-light-compact.json
@@ -20,8 +20,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia-light-compact.json
+++ b/org.gtk.Gtk3theme.Materia-light-compact.json
@@ -15,13 +15,13 @@
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk-light-compact.css /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/gtk.css",
         "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/gtk-dark.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -39,6 +39,6 @@
           "path": "org.gtk.Gtk3theme.Materia-light-compact.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Materia-light-compact.json
+++ b/org.gtk.Gtk3theme.Materia-light-compact.json
@@ -1,0 +1,44 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia-light-compact",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia-light-compact",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk-light-compact.css /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/gtk.css",
+        "cp src/gtk-3.0/3.22/gtk-dark-compact.css /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/gtk-dark.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light-compact/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia-light-compact.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia-light-compact --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia-light-compact"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia-light-compact.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia-light.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia-light</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia light Gtk theme</name>
+  <summary>Materia light GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia-light.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-light</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia light Gtk theme</name>
-  <summary>Materia light GTK+ theme</summary>
+  <name>Materia-light GTK+ theme</name>
+  <summary>Materia-light GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia-light.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia-light.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia-light</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia light Gtk theme</name>
   <summary>Materia light GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia-light.json
+++ b/org.gtk.Gtk3theme.Materia-light.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia-light.json
+++ b/org.gtk.Gtk3theme.Materia-light.json
@@ -1,0 +1,44 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia-light",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia-light",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-light/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk-light.css /usr/share/runtime/share/themes/Materia-light/gtk-3.0/gtk.css",
+        "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia-light/gtk-3.0/gtk-dark.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia-light.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia-light --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia-light"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia-light.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia-light.json
+++ b/org.gtk.Gtk3theme.Materia-light.json
@@ -15,13 +15,13 @@
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia-light/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk-light.css /usr/share/runtime/share/themes/Materia-light/gtk-3.0/gtk.css",
         "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia-light/gtk-3.0/gtk-dark.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia-light/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -39,6 +39,6 @@
           "path": "org.gtk.Gtk3theme.Materia-light.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }

--- a/org.gtk.Gtk3theme.Materia-light.json
+++ b/org.gtk.Gtk3theme.Materia-light.json
@@ -20,8 +20,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia.appdata.xml
@@ -2,10 +2,10 @@
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Materia Gtk theme</name>
+  <name>Materia GTK+ theme</name>
   <summary>Materia GTK+ theme</summary>
   <description>
-    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+    <p>A Material Design theme for GNOME/GTK+ based desktop environments</p>
   </description>
   <url type="homepage">https://github.com/nana-4/materia-theme</url>
 </component>

--- a/org.gtk.Gtk3theme.Materia.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Materia</id>
+  <metadata_license>GPL-2.0</metadata_license>
+  <name>Materia Gtk theme</name>
+  <summary>Materia GTK+ theme</summary>
+  <description>
+    <p> A Material Design theme for GNOME/GTK+ based desktop environments </p>
+  </description>
+  <url type="homepage">https://github.com/nana-4/materia-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Materia.appdata.xml
+++ b/org.gtk.Gtk3theme.Materia.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Materia</id>
-  <metadata_license>GPL-2.0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Materia Gtk theme</name>
   <summary>Materia GTK+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Materia.json
+++ b/org.gtk.Gtk3theme.Materia.json
@@ -4,7 +4,7 @@
   "runtime": "org.gnome.Sdk",
   "build-extension": true,
   "sdk": "org.gnome.Sdk",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "appstream-compose": false,
   "separate-locales": false,
   "modules": [

--- a/org.gtk.Gtk3theme.Materia.json
+++ b/org.gtk.Gtk3theme.Materia.json
@@ -1,0 +1,44 @@
+{
+  "id": "org.gtk.Gtk3theme.Materia",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.24",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Materia",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -pm 755 /usr/share/runtime/share/themes/Materia/gtk-3.0",
+        "cp src/gtk-3.0/3.22/gtk.css /usr/share/runtime/share/themes/Materia/gtk-3.0/gtk.css",
+        "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia/gtk-3.0/gtk-dark.css",
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia/gtk-3.0/"
+      ],
+      "sources": [
+        {
+            "type": "archive",
+            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Materia.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Materia --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Materia"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Materia.appdata.xml"
+        }
+      ]
+  }
+  ]
+}

--- a/org.gtk.Gtk3theme.Materia.json
+++ b/org.gtk.Gtk3theme.Materia.json
@@ -20,8 +20,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171213.tar.gz",
+          "sha256": "be1bd5c77339f5441be88b468212dfdc43d510ac7b3b876872dee1ecc77da864"
         }
       ]
     },

--- a/org.gtk.Gtk3theme.Materia.json
+++ b/org.gtk.Gtk3theme.Materia.json
@@ -15,13 +15,13 @@
         "mkdir -pm 755 /usr/share/runtime/share/themes/Materia/gtk-3.0",
         "cp src/gtk-3.0/3.22/gtk.css /usr/share/runtime/share/themes/Materia/gtk-3.0/gtk.css",
         "cp src/gtk-3.0/3.22/gtk-dark.css /usr/share/runtime/share/themes/Materia/gtk-3.0/gtk-dark.css",
-        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia/gtk-3.0/"
+        "cp -r src/gtk-3.0/gtk-common/assets /usr/share/runtime/share/themes/Materia/gtk-3.0"
       ],
       "sources": [
         {
-            "type": "archive",
-            "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
-            "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
+          "type": "archive",
+          "url": "https://github.com/nana-4/materia-theme/archive/v20171112.tar.gz",
+          "sha256": "e759b8fe922fc98727e039c44a2048595e387eaf102c9b30c703ed02decb8dc6"
         }
       ]
     },
@@ -39,6 +39,6 @@
           "path": "org.gtk.Gtk3theme.Materia.appdata.xml"
         }
       ]
-  }
+    }
   ]
 }


### PR DESCRIPTION
Hi, I'm an author of [Materia theme](https://github.com/nana-4/materia-theme) and I would like to request for adding Materia variants to Flathub.

Materia is a Material Design theme and it has 6 variants:

- Materia
- Materia-compact
- Materia-dark
- Materia-dark-compact
- Materia-light
- Materia-light-compact