### PR TITLE
add Numix Circle/Square(Light) icon themes

### DIFF
--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.appdata.xml
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.appdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Platform.Icontheme.NumixCircleLight</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Numix Circle icon theme (Light variant)</name>
+  <summary>Circle version of the Numix icon theme</summary>
+  <description>
+    <p>
+      Circle is an icon theme for Linux from the Numix project.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/numixproject/numix-icon-theme-circle</url>
+  <url type="bugtracker">https://github.com/numixproject/numix-core</url>
+</component>

--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.json
@@ -1,0 +1,61 @@
+{
+    "id": "org.freedesktop.Platform.Icontheme.NumixCircleLight",
+    "branch": "1.0",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/share/runtime"
+    },
+    "modules": [{
+            "name": "numix-icon-theme-circle",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Circle",
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Light",
+                "tar -xzf numix-icon-theme-circle.tar.gz",
+                "cp -r numix-icon-theme-circle-17-12-25/Numix-Circle/* ${FLATPAK_DEST}/share/icons/Numix-Circle/",
+                "cp -r numix-icon-theme-circle-17-12-25/Numix-Circle-Light/* ${FLATPAK_DEST}/share/icons/Numix-Circle-Light/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme-circle/archive/17-12-25.tar.gz",
+                "sha256": "01e3bf9ef5531578440bcfc4a3ffd75671cfc3e9a68738226fb6a4ce7138660f",
+                "dest-filename": "numix-icon-theme-circle.tar.gz"
+            }]
+        },
+        {
+            "name": "numix-icon-theme",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix",
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Light",
+                "tar -xzf numix-icon-theme.tar.gz",
+                "cp -r numix-icon-theme-17-12-25/Numix/* ${FLATPAK_DEST}/share/icons/Numix/",
+                "cp -r numix-icon-theme-17-12-25/Numix-Light/* ${FLATPAK_DEST}/share/icons/Numix-Light/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme/archive/17-12-25.tar.gz",
+                "sha256": "768b9bcd77ecf51765683ecaf9aa77c220a92af3e5b19f89830ac0b5f7ffef49",
+                "dest-filename": "numix-icon-theme.tar.gz"
+            }]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Platform.Icontheme.Numix.Circle.Light.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Platform.Icontheme.NumixCircleLight --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Platform.Icontheme.NumixCircleLight"
+            ],
+            "sources": [{
+                "type": "file",
+                "path": "org.freedesktop.Platform.Icontheme.Numix.Circle.Light.appdata.xml"
+            }]
+        }
+    ]
+}

--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.Light.json
@@ -7,9 +7,6 @@
     "runtime-version": "1.6",
     "separate-locales": false,
     "appstream-compose": false,
-    "build-options": {
-        "prefix": "/usr/share/runtime"
-    },
     "modules": [{
             "name": "numix-icon-theme-circle",
             "buildsystem": "simple",

--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.appdata.xml
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.appdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Platform.Icontheme.NumixCircle</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Numix Circle icon theme</name>
+  <summary>Circle version of the Numix icon theme</summary>
+  <description>
+    <p>
+      Circle is an icon theme for Linux from the Numix project.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/numixproject/numix-icon-theme-circle</url>
+  <url type="bugtracker">https://github.com/numixproject/numix-core</url>
+</component>

--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.json
@@ -7,9 +7,6 @@
     "runtime-version": "1.6",
     "separate-locales": false,
     "appstream-compose": false,
-    "build-options": {
-        "prefix": "/usr/share/runtime"
-    },
     "modules": [{
             "name": "numix-icon-theme-circle",
             "buildsystem": "simple",

--- a/org.freedesktop.Platform.Icontheme.Numix.Circle.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Circle.json
@@ -1,0 +1,57 @@
+{
+    "id": "org.freedesktop.Platform.Icontheme.NumixCircle",
+    "branch": "1.0",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/share/runtime"
+    },
+    "modules": [{
+            "name": "numix-icon-theme-circle",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Circle",
+                "tar -xzf numix-icon-theme-circle.tar.gz",
+                "cp -r numix-icon-theme-circle-17-12-25/Numix-Circle/* ${FLATPAK_DEST}/share/icons/Numix-Circle/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme-circle/archive/17-12-25.tar.gz",
+                "sha256": "01e3bf9ef5531578440bcfc4a3ffd75671cfc3e9a68738226fb6a4ce7138660f",
+                "dest-filename": "numix-icon-theme-circle.tar.gz"
+            }]
+        },
+        {
+            "name": "numix-icon-theme",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix",
+                "tar -xzf numix-icon-theme.tar.gz",
+                "cp -r numix-icon-theme-17-12-25/Numix/* ${FLATPAK_DEST}/share/icons/Numix/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme/archive/17-12-25.tar.gz",
+                "sha256": "768b9bcd77ecf51765683ecaf9aa77c220a92af3e5b19f89830ac0b5f7ffef49",
+                "dest-filename": "numix-icon-theme.tar.gz"
+            }]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Platform.Icontheme.Numix.Circle.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Platform.Icontheme.NumixCircle --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Platform.Icontheme.NumixCircle"
+            ],
+            "sources": [{
+                "type": "file",
+                "path": "org.freedesktop.Platform.Icontheme.Numix.Circle.appdata.xml"
+            }]
+        }
+    ]
+}

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.Light.appdata.xml
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.Light.appdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Platform.Icontheme.NumixSquareLight</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Numix Square icon theme (Light variant)</name>
+  <summary>Square version of the Numix icon theme</summary>
+  <description>
+    <p>
+      Square is an icon theme for Linux from the Numix project.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/numixproject/numix-icon-theme-square</url>
+  <url type="bugtracker">https://github.com/numixproject/numix-core</url>
+</component>

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.Light.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.Light.json
@@ -1,0 +1,61 @@
+{
+    "id": "org.freedesktop.Platform.Icontheme.NumixSquareLight",
+    "branch": "1.0",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/share/runtime"
+    },
+    "modules": [{
+            "name": "numix-icon-theme-square",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Square",
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Square-Light",
+                "tar -xzf numix-icon-theme-square.tar.gz",
+                "cp -r numix-icon-theme-square-17-12-25/Numix-Square/* ${FLATPAK_DEST}/share/icons/Numix-Square/",
+                "cp -r numix-icon-theme-square-17-12-25/Numix-Square-Light/* ${FLATPAK_DEST}/share/icons/Numix-Square-Light/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme-square/archive/17-12-25.tar.gz",
+                "sha256": "ac6b031afd9ff6bf65902447949fa432bb8074c21979d0622ac4a35a60329167",
+                "dest-filename": "numix-icon-theme-square.tar.gz"
+            }]
+        },
+        {
+            "name": "numix-icon-theme",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix",
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Light",
+                "tar -xzf numix-icon-theme.tar.gz",
+                "cp -r numix-icon-theme-17-12-25/Numix/* ${FLATPAK_DEST}/share/icons/Numix/",
+                "cp -r numix-icon-theme-17-12-25/Numix-Light/* ${FLATPAK_DEST}/share/icons/Numix-Light/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme/archive/17-12-25.tar.gz",
+                "sha256": "768b9bcd77ecf51765683ecaf9aa77c220a92af3e5b19f89830ac0b5f7ffef49",
+                "dest-filename": "numix-icon-theme.tar.gz"
+            }]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Platform.Icontheme.Numix.Square.Light.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Platform.Icontheme.NumixSquareLight --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Platform.Icontheme.NumixSquareLight"
+            ],
+            "sources": [{
+                "type": "file",
+                "path": "org.freedesktop.Platform.Icontheme.Numix.Square.Light.appdata.xml"
+            }]
+        }
+    ]
+}

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.Light.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.Light.json
@@ -7,9 +7,6 @@
     "runtime-version": "1.6",
     "separate-locales": false,
     "appstream-compose": false,
-    "build-options": {
-        "prefix": "/usr/share/runtime"
-    },
     "modules": [{
             "name": "numix-icon-theme-square",
             "buildsystem": "simple",

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.appdata.xml
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.appdata.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Platform.Icontheme.NumixSquare</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Numix Square icon theme</name>
+  <summary>Square version of the Numix icon theme</summary>
+  <description>
+    <p>
+      Square is an icon theme for Linux from the Numix project.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/numixproject/numix-icon-theme-square</url>
+  <url type="bugtracker">https://github.com/numixproject/numix-core</url>
+</component>

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.json
@@ -1,0 +1,57 @@
+{
+    "id": "org.freedesktop.Platform.Icontheme.NumixSquare",
+    "branch": "1.0",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/share/runtime"
+    },
+    "modules": [{
+            "name": "numix-icon-theme-square",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix-Square",
+                "tar -xzf numix-icon-theme-square.tar.gz",
+                "cp -r numix-icon-theme-square-17-12-25/Numix-Square/* ${FLATPAK_DEST}/share/icons/Numix-Square/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme-square/archive/17-12-25.tar.gz",
+                "sha256": "ac6b031afd9ff6bf65902447949fa432bb8074c21979d0622ac4a35a60329167",
+                "dest-filename": "numix-icon-theme-square.tar.gz"
+            }]
+        },
+        {
+            "name": "numix-icon-theme",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/icons/Numix",
+                "tar -xzf numix-icon-theme.tar.gz",
+                "cp -r numix-icon-theme-17-12-25/Numix/* ${FLATPAK_DEST}/share/icons/Numix/"
+            ],
+            "sources": [{
+                "type": "file",
+                "url": "https://github.com/numixproject/numix-icon-theme/archive/17-12-25.tar.gz",
+                "sha256": "768b9bcd77ecf51765683ecaf9aa77c220a92af3e5b19f89830ac0b5f7ffef49",
+                "dest-filename": "numix-icon-theme.tar.gz"
+            }]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Platform.Icontheme.Numix.Square.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Platform.Icontheme.NumixSquare --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Platform.Icontheme.NumixSquare"
+            ],
+            "sources": [{
+                "type": "file",
+                "path": "org.freedesktop.Platform.Icontheme.Numix.Square.appdata.xml"
+            }]
+        }
+    ]
+}

--- a/org.freedesktop.Platform.Icontheme.Numix.Square.json
+++ b/org.freedesktop.Platform.Icontheme.Numix.Square.json
@@ -7,9 +7,6 @@
     "runtime-version": "1.6",
     "separate-locales": false,
     "appstream-compose": false,
-    "build-options": {
-        "prefix": "/usr/share/runtime"
-    },
     "modules": [{
             "name": "numix-icon-theme-square",
             "buildsystem": "simple",


### PR DESCRIPTION
This PR adds:
- Numix Circle (the app icons + the base theme)
- Numix Circle Light (the app icons + the light version of the base theme)
- Numix Square (the app icons + the base theme)
- Numix Square Light (the app icons + the light version of the base theme)

The Gtk theme will be added in a different PR in 2018. 