### PR TITLE
Create org.gnome.meld.json

### DIFF
--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -56,7 +56,7 @@
             "name": "pycairo",
             "buildsystem": "simple",
             "build-commands": [
-                "python2 setup.py install --prefix=${FLATPAK_DEST}"
+                "python3 setup.py install --prefix=${FLATPAK_DEST}"
             ],
             "sources": [{
                     "type": "archive",
@@ -67,11 +67,6 @@
         },
         {
             "name": "pygobject",
-            "build-options": {
-                "env": {
-                    "PYTHON": "python2"
-                }
-            },
             "sources": [{
                 "type": "archive",
                 "url": "https://ftp.gnome.org/pub/GNOME/sources/pygobject/3.26/pygobject-3.26.1.tar.xz",

--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -43,34 +43,14 @@
             "name": "gtksourceview",
             "build-options": {
                 "config-opts": [
-                    "--enable-vala=no"
+                    "--enable-vala=no",
+                    "--enable-gtk-doc=no"
                 ]
             },
             "sources": [{
                 "type": "archive",
                 "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.6.tar.xz",
                 "sha256": "7aa6bdfebcdc73a763dddeaa42f190c40835e6f8495bb9eb8f78587e2577c188"
-            }]
-        },
-        {
-            "name": "pycairo",
-            "buildsystem": "simple",
-            "build-commands": [
-                "python3 setup.py install --prefix=${FLATPAK_DEST}"
-            ],
-            "sources": [{
-                    "type": "archive",
-                    "url": "https://github.com/pygobject/pycairo/releases/download/v1.15.4/pycairo-1.15.4.tar.gz",
-                    "sha256": "ee4c3068c048230e5ce74bb8994a024711129bde1af1d76e3276c7acd81c4357"
-                }
-            ]
-        },
-        {
-            "name": "pygobject",
-            "sources": [{
-                "type": "archive",
-                "url": "https://ftp.gnome.org/pub/GNOME/sources/pygobject/3.26/pygobject-3.26.1.tar.xz",
-                "sha256": "f5577b9b9c70cabb9a60d81b855d488b767c66f867432e7fb64aa7269b04d1a9"
             }]
         },
         {

--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -1,0 +1,91 @@
+{
+    "app-id": "org.gnome.meld",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "meld",
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/vala",
+        "*.la",
+        "*.a",
+        "*.pyc",
+        "*.pyo"
+    ],
+    "build-options": {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "rename-appdata-file": "meld.appdata.xml",
+    "rename-desktop-file": "meld.desktop",
+    "rename-icon": "meld",
+    "finish-args": [
+        /* X11 + XShm */
+        "--share=ipc", "--socket=x11",
+        /* Wayland */
+        "--socket=wayland",
+        /* Filesystem */
+        "--filesystem=host",
+        /* dconf */
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [{
+            "name": "gtksourceview",
+            "build-options": [
+                "--enable-vala=no"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.6.tar.xz",
+                "sha256": "7aa6bdfebcdc73a763dddeaa42f190c40835e6f8495bb9eb8f78587e2577c188"
+            }]
+        },
+        {
+            "name": "pycairo",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python2 setup.py install --prefix=${FLATPAK_DEST}"
+            ],
+            "sources": [{
+                    "type": "archive",
+                    "url": "https://github.com/pygobject/pycairo/releases/download/v1.15.4/pycairo-1.15.4.tar.gz",
+                    "sha256": "ee4c3068c048230e5ce74bb8994a024711129bde1af1d76e3276c7acd81c4357"
+                }
+            ]
+        },
+        {
+            "name": "pygobject",
+            "build-options": {
+                "env": {
+                    "PYTHON": "python2"
+                }
+            },
+            "sources": [{
+                "type": "archive",
+                "url": "https://ftp.gnome.org/pub/GNOME/sources/pygobject/3.26/pygobject-3.26.1.tar.xz",
+                "sha256": "f5577b9b9c70cabb9a60d81b855d488b767c66f867432e7fb64aa7269b04d1a9"
+            }]
+        },
+        {
+            "name": "meld",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=${FLATPAK_DEST}"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/meld/3.18/meld-3.18.0.tar.xz",
+                "sha256": "848158b1e5c7473b9da3ddc16e057aad8951ec82979beb5914b8b4acdf97223e"
+            }]
+        }
+    ]
+}

--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -40,9 +40,11 @@
     ],
     "modules": [{
             "name": "gtksourceview",
-            "build-options": [
-                "--enable-vala=no"
-            ],
+            "build-options": {
+                "config-opts": [
+                    "--enable-vala=no"
+                ]
+            },
             "sources": [{
                 "type": "archive",
                 "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.6.tar.xz",

--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -36,6 +36,7 @@
         /* Filesystem */
         "--filesystem=host",
         /* dconf */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "modules": [{

--- a/org.gnome.meld.json
+++ b/org.gnome.meld.json
@@ -14,9 +14,7 @@
         "/share/gtk-doc",
         "/share/vala",
         "*.la",
-        "*.a",
-        "*.pyc",
-        "*.pyo"
+        "*.a"
     ],
     "build-options": {
         "cflags": "-O2 -g",


### PR DESCRIPTION
Based on the initial manifest file of meld. 
Updated to work with GNOME runtime 3.26
