### PR TITLE
Create com.github.cassidyjames.dippi.json

### DIFF
--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -68,8 +68,8 @@
             "config-opts": ["--buildtype=release"],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/cassidyjames/dippi/archive/2.3.1.tar.gz",
-                "sha256": "3a2589bc30ad085d63e98ea67d1ce5e0e939b364203f3484ccbd0df2ea9f1e15"
+                "url": "https://github.com/cassidyjames/dippi/archive/2.3.3.tar.gz",
+                "sha256": "0839ff2d66121cd76f86abb77cd2535ae0d0840fc08354e388065f902df6c97d"
             }]
         }
     ]

--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -58,8 +58,8 @@
             },
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/elementary/granite/archive/0.4.1.tar.gz",
-                "sha256": "035a9b36ef73352ff8a76be06b876d9e2ea6633abb693fb67297d998c8d3a240"
+                "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
+                "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
             }]
         },
         {
@@ -68,8 +68,8 @@
             "config-opts": ["--buildtype=release"],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/cassidyjames/dippi/archive/2.3.3.tar.gz",
-                "sha256": "0839ff2d66121cd76f86abb77cd2535ae0d0840fc08354e388065f902df6c97d"
+                "url": "https://github.com/cassidyjames/dippi/archive/2.5.0.tar.gz",
+                "sha256": "271716e0b31c3a322574837cd10718ac052899ad00ea08dc137cb65594f3a113"
             }]
         }
     ]

--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -1,0 +1,76 @@
+{
+    "app-id": "com.github.cassidyjames.dippi",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "com.github.cassidyjames.dippi",
+    "build-options": {
+        "cflags": "-O2",
+        "cxxflags": "-O2"
+    },
+    "cleanup": [
+        "/bin/granite-demo",
+        "/share/applications/granite-demo.desktop",
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/debug",
+        "/share/vala",
+        "/man",
+        "*.a",
+        "*.la"
+    ],
+    "finish-args": [
+        /* X11 + XShm */
+        "--share=ipc", "--socket=x11",
+        /* Wayland */
+        "--socket=wayland",
+        /* Filesystem */
+        "--filesystem=host",
+        /* dconf */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [{
+            "name": "libgee",
+            "build-options": {
+                "env": {
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+                }
+            },
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/GNOME/libgee/archive/0.20.0.tar.gz",
+                "sha256": "42fe6d651910cb8b720167f71c5255a1b7b1afc82fecd3f31e61f9602b3b1335"
+            }]
+        },
+        {
+            "name": "granite",
+            "buildsystem": "cmake",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=/app",
+                "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+            ],
+            "build-options": {
+                "env": {
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+                }
+            },
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/elementary/granite/archive/0.4.1.tar.gz",
+                "sha256": "035a9b36ef73352ff8a76be06b876d9e2ea6633abb693fb67297d998c8d3a240"
+            }]
+        },
+        {
+            "name": "dippi",
+            "buildsystem": "meson",
+            "sources": [{
+                "type": "git",
+                "url": "https://github.com/bil-elmoussaoui/dippi"
+            }]
+        }
+    ]
+}

--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -4,6 +4,7 @@
     "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.cassidyjames.dippi",
+
     "build-options": {
         "cflags": "-O2",
         "cxxflags": "-O2"
@@ -24,8 +25,6 @@
         "--share=ipc", "--socket=x11",
         /* Wayland */
         "--socket=wayland",
-        /* Filesystem */
-        "--filesystem=host",
         /* dconf */
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
@@ -46,10 +45,9 @@
         },
         {
             "name": "granite",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_PREFIX=/app",
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib"
             ],
             "build-options": {
@@ -67,9 +65,11 @@
         {
             "name": "dippi",
             "buildsystem": "meson",
+            "config-opts": ["--buildtype=release"],
             "sources": [{
-                "type": "git",
-                "url": "https://github.com/bil-elmoussaoui/dippi"
+                "type": "archive",
+                "url": "https://github.com/cassidyjames/dippi/archive/2.3.1.tar.gz",
+                "sha256": "3a2589bc30ad085d63e98ea67d1ce5e0e939b364203f3484ccbd0df2ea9f1e15"
             }]
         }
     ]

--- a/com.github.cassidyjames.dippi.json
+++ b/com.github.cassidyjames.dippi.json
@@ -68,8 +68,8 @@
             "config-opts": ["--buildtype=release"],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/cassidyjames/dippi/archive/2.5.0.tar.gz",
-                "sha256": "271716e0b31c3a322574837cd10718ac052899ad00ea08dc137cb65594f3a113"
+                "url": "https://github.com/cassidyjames/dippi/archive/2.5.2.tar.gz",
+                "sha256": "907fbfae9ac22d953bd555d311816754323bd15a77841504ef125efa0a530dfd"
             }]
         }
     ]


### PR DESCRIPTION
The build requires this patch to be merged https://github.com/cassidyjames/dippi/pull/36
Don't really know why. As the `prefix` is correctly exported by flatpak-builder automatically?
And meson adds the prefix manually for the get_option I guess.

Anyway, this is more to check if an error I had on my machine with appstream-compose is reproducable on a "clean build machine".

