### PR TITLE
Initial version of ffmpeg extension

### DIFF
--- a/org.freedesktop.Platform.ffmpeg.appdata.xml
+++ b/org.freedesktop.Platform.ffmpeg.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
-  <id>org.freedesktop.Sdk.Extension.rust-stable</id>
+  <id>org.freedesktop.Platform.ffmpeg</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <name>Rust stable Sdk extension</name>
-  <summary>Rust compiler and tools</summary>
+  <name>FFmpeg extension</name>
+  <summary>Add support for aac, mpeg4 and h264</summary>
 </component>

--- a/org.freedesktop.Platform.ffmpeg.appdata.xml
+++ b/org.freedesktop.Platform.ffmpeg.appdata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.rust-stable</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Rust stable Sdk extension</name>
+  <summary>Rust compiler and tools</summary>
+</component>

--- a/org.freedesktop.Platform.ffmpeg.json
+++ b/org.freedesktop.Platform.ffmpeg.json
@@ -1,0 +1,95 @@
+{
+    "id": "org.freedesktop.Platform.ffmpeg",
+    "branch": "1.6",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "sdk-extensions": [],
+    "separate-locales": false,
+    "appstream-compose": false,
+    "cleanup": [
+        "/bin/ffmpeg",
+        "/lib/*.so",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/ffmpeg/examples",
+        "/share/ffmpeg"
+    ],
+    "build-options": {
+        "cflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+        "cxxflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+        "ldflags": "-fstack-protector-strong -Wl,-z,relro,-z,now",
+        "prefix": "/usr/lib/ffmpeg",
+        "env": {
+            "V": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "ffmpeg",
+            "config-opts": [
+                /* Copied from runtiem */
+                "--disable-debug",
+                "--disable-doc",
+                "--disable-static",
+                "--enable-gpl",
+                "--enable-optimizations",
+                "--enable-libvpx",
+                "--enable-shared",
+                "--disable-ffplay",
+                "--disable-ffprobe",
+                "--disable-ffserver",
+                "--disable-everything",
+                "--enable-gnutls",
+                "--enable-libfontconfig",
+                "--enable-libfreetype",
+                "--enable-libopus",
+                "--enable-libpulse",
+                "--enable-libspeex",
+                "--enable-libtheora",
+                "--enable-libvorbis",
+                "--enable-libvpx",
+                "--enable-libwebp",
+                "--enable-openal",
+                "--enable-opengl",
+                "--enable-sdl2",
+                "--enable-decoder=pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw",
+                "--enable-decoder=pcm_u8,pcm_s16le,pcm_s24le,pcm_f32le",
+                "--enable-decoder=theora,vorbis,vp8,vp9,mp3,flac,webp",
+                "--enable-decoder=rawvideo,png,gif",
+                "--enable-parser=opus,vp3,vorbis,vp8,mpegaudio,flac",
+                "--enable-demuxer=ogg,matroska,wav,mp3,gif,flac",
+                "--enable-filter=crop,scale",
+                "--enable-protocol=file"
+                , /* These are specific to the extension */
+                "--enable-decoder=aac,h264,h263,ac3,mpeg4",
+                "--enable-hwaccel=h264_vaapi,h264_vdpau",
+                "--enable-parser=aac,h264,ac3,mpeg4video",
+                "--enable-demuxer=avi,aac,h264,mov,ac3,m4v,m4a"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ffmpeg.org/releases/ffmpeg-3.4.1.tar.xz",
+                    "sha256": "5a77278a63741efa74e26bf197b9bb09ac6381b9757391b922407210f0f991c0"
+                }
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Platform.ffmpeg.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose  --basename=org.freedesktop.Platform.ffmpeg --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Platform.ffmpeg"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Platform.ffmpeg.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This matches the build in the freedesktop 1.6 sdk, but adds
support for some codes like aac, mpeg4 and h264