### PR TITLE
Create org.gnome.Music.json

### DIFF
--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -1,15 +1,15 @@
 {
     "app-id": "org.gnome.Music",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "runtime-version": "3.28",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-music",
-    "rename-icon": "gnome-music",
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=wayland",
         "--share=network",
         "--talk-name=org.freedesktop.Tracker1",
+        "--env=TRACKER_SPARQL_BACKEND=bus",
         "--talk-name=org.gnome.OnlineAccounts",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
@@ -61,8 +61,8 @@
 
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/tracker/2.0/tracker-2.0.2.tar.xz",
-                "sha256": "ece71a56c29151a76fc1b6e43c15dd1b657b37162dc948fa2487faf5ddb47fda"
+                "url": "https://download.gnome.org/sources/tracker/2.0/tracker-2.0.3.tar.xz",
+                "sha256": "5a2fb274c128ec67a920944937b5147ceaf5db16fef6691ea22c4cb841e20580"
             }]
         },
         {
@@ -75,8 +75,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/gnome-online-accounts/3.26/gnome-online-accounts-3.26.2.tar.xz",
-                "sha256": "49f8760d86fe33057eaeeb4f1667bc7f6163e428591e7aed9575563be10b17d1"
+                "url": "https://download.gnome.org/sources/gnome-online-accounts/3.28/gnome-online-accounts-3.28.0.tar.xz",
+                "sha256": "87bc4ef307604f1ce4f09f6e5c9996ef8d37ca5e0a3bf76f6b27d71844adb40c"
             }]
         },
         {
@@ -116,18 +116,6 @@
                 "sha256": "2977827b8ecb3e15535236180e57dc35e85058d111349bdb6a1597e62a5068fb"
             }],
             "cleanup": ["/include"]
-        },
-        {
-            "name": "requests",
-            "buildsystem": "simple",
-            "build-commands": [
-                "python3 setup.py install --prefix=${FLATPAK_DEST}"
-            ],
-            "sources": [{
-                "type": "archive",
-                "url": "https://github.com/kennethreitz/requests/archive/v2.13.0.tar.gz",
-                "sha256": "48fd188aaa388b4193bf7b917cf861a00eafacad651148475bc65ffaef445627"
-            }]
         },
         {
             "name": "urllib3",
@@ -178,11 +166,24 @@
             }]
         },
         {
-            "name": "gnome-music",
+            "name": "requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=${FLATPAK_DEST}"
+            ],
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/gnome-music/3.26/gnome-music-3.26.1.tar.xz",
-                "sha256": "7197dff12f441a52b4011512bfe8ec926f2ce4ca511f79b078e0e612d612f8c3"
+                "url": "https://github.com/requests/requests/archive/v2.18.4.tar.gz",
+                "sha256": "b068ccce3b739a29cbf72148b0ff4be3d80198fb7cdbd63066f7384bb56ef917"
+            }]
+        },
+        {
+            "name": "gnome-music",
+            "buildsystem": "meson",
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gnome-music/3.28/gnome-music-3.28.0.1.tar.xz",
+                "sha256": "c5ccbc529b556329e7ab43cb24830ff4cd717eaf8bc1c7913d26ccca7bd5de7b"
 
             }]
         }

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -8,12 +8,15 @@
     "finish-args": [
         "--share=ipc", "--socket=x11",
         "--socket=wayland",
+        "--share=network",
         "--talk-name=org.freedesktop.Tracker1",
+        "--talk-name=org.gnome.OnlineAccounts",
         "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--talk-name=com.intel.dleyna-server",
         "--socket=pulseaudio",
-        "--filesystem=xdg-music"
+        "--filesystem=xdg-music",
+        "--filesystem=xdg-cache/media-art"
     ],
     "build-options": {
         "cflags": "-O2 -g",
@@ -49,17 +52,31 @@
                 "/etc",
                 "/libexec"
             ],
-            "config-opts": [
-                "--disable-miner-apps", "--disable-static",
+            "config-opts": ["--disable-miner-apps", "--disable-static",
                 "--disable-tracker-extract", "--disable-tracker-needle",
                 "--disable-tracker-preferences", "--disable-artwork",
                 "--disable-tracker-writeback", "--disable-miner-user-guides",
                 "--with-bash-completion-dir=no"
             ],
+
             "sources": [{
                 "type": "archive",
                 "url": "https://download.gnome.org/sources/tracker/2.0/tracker-2.0.2.tar.xz",
                 "sha256": "ece71a56c29151a76fc1b6e43c15dd1b657b37162dc948fa2487faf5ddb47fda"
+            }]
+        },
+        {
+            "name": "gnome-online-accounts",
+            "config-opts": ["--enable-introspection",
+                "--disable-telepathy",
+                "--disable-documentation",
+                "--disable-backend",
+                "--disable-Werror"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gnome-online-accounts/3.26/gnome-online-accounts-3.26.2.tar.xz",
+                "sha256": "49f8760d86fe33057eaeeb4f1667bc7f6163e428591e7aed9575563be10b17d1"
             }]
         },
         {
@@ -79,7 +96,7 @@
             "config-opts": [
                 "--enable-tracker",
                 "--enable-dleyna",
-                "--enable-goa=no",
+                "--enable-goa",
                 "--enable-filesystem=no",
                 "--enable-optical-media=no",
                 "--enable-youtube=no",
@@ -110,6 +127,54 @@
                 "type": "archive",
                 "url": "https://github.com/kennethreitz/requests/archive/v2.13.0.tar.gz",
                 "sha256": "48fd188aaa388b4193bf7b917cf861a00eafacad651148475bc65ffaef445627"
+            }]
+        },
+        {
+            "name": "urllib3",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=/app --root=/"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/shazow/urllib3/archive/1.22.tar.gz",
+                "sha256": "dd60d4104b871943e06be69e296e97ede9d42edf6ba534f0268aee932a601e2a"
+            }]
+        },
+        {
+            "name": "chardet",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=/app --root=/"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/chardet/chardet/archive/3.0.4.tar.gz",
+                "sha256": "d5620025cfca430f6c2e28ddbc87c3c66a5c82fa65570ae975c92911c2190189"
+            }]
+        },
+        {
+            "name": "certifi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=/app --root=/"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/certifi/python-certifi/archive/2018.01.18.tar.gz",
+                "sha256": "4912338503a14ff784f602177389e488a5814afa08db00425d175201fdbd6994"
+            }]
+        },
+        {
+            "name": "idna",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=/app --root=/"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/kjd/idna/archive/v2.6.tar.gz",
+                "sha256": "53c722c4b7908dfdf2e5db2b79982f1084494db7b34fd31ff6a296e9fddfceaa"
             }]
         },
         {

--- a/org.gnome.Music.json
+++ b/org.gnome.Music.json
@@ -1,0 +1,125 @@
+{
+    "app-id": "org.gnome.Music",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-music",
+    "rename-icon": "gnome-music",
+    "finish-args": [
+        "--share=ipc", "--socket=x11",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.Tracker1",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=com.intel.dleyna-server",
+        "--socket=pulseaudio",
+        "--filesystem=xdg-music"
+    ],
+    "build-options": {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [{
+            "name": "libmediaart",
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/libmediaart/1.9/libmediaart-1.9.4.tar.xz",
+                "sha256": "a57be017257e4815389afe4f58fdacb6a50e74fd185452b23a652ee56b04813d"
+            }]
+        },
+        {
+            "name": "tracker",
+            "cleanup": [
+                "/bin",
+                "/etc",
+                "/libexec"
+            ],
+            "config-opts": [
+                "--disable-miner-apps", "--disable-static",
+                "--disable-tracker-extract", "--disable-tracker-needle",
+                "--disable-tracker-preferences", "--disable-artwork",
+                "--disable-tracker-writeback", "--disable-miner-user-guides",
+                "--with-bash-completion-dir=no"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/tracker/2.0/tracker-2.0.2.tar.xz",
+                "sha256": "ece71a56c29151a76fc1b6e43c15dd1b657b37162dc948fa2487faf5ddb47fda"
+            }]
+        },
+        {
+            "name": "grilo",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/grilo/0.3/grilo-0.3.4.tar.xz",
+                "sha256": "7c6964053b42574c2f14715d2392a02ea5cbace955eb73e067c77aa3e43b066e"
+            }],
+            "cleanup": ["/include", "/bin"]
+        },
+        {
+            "name": "grilo-plugins",
+            "config-opts": [
+                "--enable-tracker",
+                "--enable-dleyna",
+                "--enable-goa=no",
+                "--enable-filesystem=no",
+                "--enable-optical-media=no",
+                "--enable-youtube=no",
+                "--enable-bookmarks=no",
+                "--enable-lua-factory=no",
+                "--enable-metadata-store=no",
+                "--enable-vimeo=no",
+                "--enable-localmetadata=no",
+                "--enable-thetvdb=no",
+                "--enable-tmdb=no",
+                "--enable-freebox=no",
+                "--enable-opensubtitles=no"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/grilo-plugins/0.3/grilo-plugins-0.3.5.tar.xz",
+                "sha256": "2977827b8ecb3e15535236180e57dc35e85058d111349bdb6a1597e62a5068fb"
+            }],
+            "cleanup": ["/include"]
+        },
+        {
+            "name": "requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=${FLATPAK_DEST}"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/kennethreitz/requests/archive/v2.13.0.tar.gz",
+                "sha256": "48fd188aaa388b4193bf7b917cf861a00eafacad651148475bc65ffaef445627"
+            }]
+        },
+        {
+            "name": "gnome-music",
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/gnome-music/3.26/gnome-music-3.26.1.tar.xz",
+                "sha256": "7197dff12f441a52b4011512bfe8ec926f2ce4ca511f79b078e0e612d612f8c3"
+
+            }]
+        }
+    ]
+}


### PR DESCRIPTION
Based on the original flatpak build file from the gnome music devs! 
Just switched the dependencies from git to a stable tarball

Not sure why gnome music requires this? ` +        "--talk-name=com.intel.dleyna-server", `
It compiles without any issues, but it seems that it can create a database file?
```
Tracker-Message: Could not get mtime for 'file:///home/bilal/.var/app/org.gnome.Music/cache/tracker/meta.db': Error when getting information for file “/home/bilal/.var/app/org.gnome.Music/cache/tracker/meta.db”: No such file or directory

(gnome-music:3): Tracker-WARNING **: Falling back to bus backend, the direct backend failed to initialize: Could not open sqlite3 database:'/home/bilal/.var/app/org.gnome.Music/cache/tracker/meta.db': unable to open database file

(gnome-music:3): GdkPixbuf-CRITICAL **: gdk_pixbuf_composite: assertion 'dest_x >= 0 && dest_x + dest_width <= dest->width' failed

(gnome-music:3): Tracker-CRITICAL **: tracker_bus_fd_cursor_real_get_string: assertion 'column < n_columns && data != null' failed

(gnome-music:3): Tracker-CRITICAL **: tracker_bus_fd_cursor_real_get_string: assertion 'column < n_columns && data != null' failed
12:57:40 WARNING	Error: <class 'GLib.GError'>, tracker_sparql_error-quark: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database (6)

(gnome-music:3): Grilo-WARNING **: [tracker-source-request] grl-tracker-source-api.c:504: Could not execute sparql query id=1: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database

(gnome-music:3): Grilo-WARNING **: [tracker-source-request] grl-tracker-source-api.c:504: Could not execute sparql query id=2: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database

(gnome-music:3): Grilo-WARNING **: [tracker-source-request] grl-tracker-source-api.c:504: Could not execute sparql query id=3: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database

(gnome-music:3): Grilo-WARNING **: [tracker-source-request] grl-tracker-source-api.c:504: Could not execute sparql query id=4: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database

(gnome-music:3): Grilo-WARNING **: [tracker-source-request] grl-tracker-source-api.c:504: Could not execute sparql query id=5: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database

(gnome-music:3): Grilo-WARNING **: [tracker-notif] grl-tracker-source-notif.c:216: Error: GDBus.Error:org.freedesktop.Tracker1.SparqlError.Internal: file is not a database
```
My Tracker knowledge is close to 0. So any help how to debug this would be really nice :)