### PR TITLE
Manifest for D-Feet

### DIFF
--- a/0001-Rename-the-icons-appdata-and-desktop-files.patch
+++ b/0001-Rename-the-icons-appdata-and-desktop-files.patch
@@ -1,0 +1,216 @@
+From 3bdb5e20b14385f089ba20d77baf30085b2cca9e Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <bochecha@daitauha.fr>
+Date: Mon, 9 Oct 2017 02:26:59 +0200
+Subject: [PATCH 1/3] Rename the icons, appdata and desktop files
+
+This is good practice, and it helps a lot with Flatpak.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=788693
+---
+ configure.ac                                          |   2 +-
+ data/Makefile.am                                      |   4 ++--
+ .../apps/{d-feet.svg => org.gnome.d-feet.svg}         |   0
+ data/icons/Makefile.am                                |  18 +++++++++---------
+ .../16x16/apps/{d-feet.png => org.gnome.d-feet.png}   | Bin
+ .../24x24/apps/{d-feet.png => org.gnome.d-feet.png}   | Bin
+ .../256x256/apps/{d-feet.png => org.gnome.d-feet.png} | Bin
+ .../32x32/apps/{d-feet.png => org.gnome.d-feet.png}   | Bin
+ .../48x48/apps/{d-feet.png => org.gnome.d-feet.png}   | Bin
+ .../apps/{d-feet.svg => org.gnome.d-feet.svg}         |   0
+ ...appdata.xml.in => org.gnome.d-feet.appdata.xml.in} |   2 +-
+ ...t.desktop.in.in => org.gnome.d-feet.desktop.in.in} |   2 +-
+ data/ui/bus.ui                                        |   2 +-
+ po/POTFILES.in                                        |   4 ++--
+ po/POTFILES.skip                                      |   2 +-
+ 15 files changed, 18 insertions(+), 18 deletions(-)
+ rename data/icons/HighContrast/scalable/apps/{d-feet.svg => org.gnome.d-feet.svg} (100%)
+ rename data/icons/hicolor/16x16/apps/{d-feet.png => org.gnome.d-feet.png} (100%)
+ rename data/icons/hicolor/24x24/apps/{d-feet.png => org.gnome.d-feet.png} (100%)
+ rename data/icons/hicolor/256x256/apps/{d-feet.png => org.gnome.d-feet.png} (100%)
+ rename data/icons/hicolor/32x32/apps/{d-feet.png => org.gnome.d-feet.png} (100%)
+ rename data/icons/hicolor/48x48/apps/{d-feet.png => org.gnome.d-feet.png} (100%)
+ rename data/icons/hicolor/scalable/apps/{d-feet.svg => org.gnome.d-feet.svg} (100%)
+ rename data/{d-feet.appdata.xml.in => org.gnome.d-feet.appdata.xml.in} (96%)
+ rename data/{d-feet.desktop.in.in => org.gnome.d-feet.desktop.in.in} (91%)
+
+diff --git a/configure.ac b/configure.ac
+index bba301b..bdeee4c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -48,7 +48,7 @@ AC_CONFIG_FILES([
+ 	src/dfeet/Makefile
+ 	src/tests/Makefile
+ 	data/Makefile
+-	data/d-feet.desktop.in
++	data/org.gnome.d-feet.desktop.in
+ 	data/icons/Makefile
+ 	data/ui/Makefile
+ 	help/Makefile
+diff --git a/data/Makefile.am b/data/Makefile.am
+index c47e922..98f3e23 100644
+--- a/data/Makefile.am
++++ b/data/Makefile.am
+@@ -6,7 +6,7 @@ gsettings_SCHEMAS = org.gnome.d-feet.gschema.xml
+ @INTLTOOL_DESKTOP_RULE@
+ 
+ desktopdir = $(datadir)/applications
+-desktop_in_files = d-feet.desktop.in
++desktop_in_files = org.gnome.d-feet.desktop.in
+ desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+ 
+ UPDATE_DESKTOP = if test -z "$(DESTDIR)"; then update-desktop-database $(datadir)/applications || :; fi
+@@ -14,7 +14,7 @@ UPDATE_DESKTOP = if test -z "$(DESTDIR)"; then update-desktop-database $(datadir
+ @INTLTOOL_XML_RULE@
+ appdatadir = $(datadir)/appdata
+ appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+-appdata_in_files = d-feet.appdata.xml.in
++appdata_in_files = org.gnome.d-feet.appdata.xml.in
+ 
+ 
+ install-data-hook:
+diff --git a/data/icons/HighContrast/scalable/apps/d-feet.svg b/data/icons/HighContrast/scalable/apps/org.gnome.d-feet.svg
+similarity index 100%
+rename from data/icons/HighContrast/scalable/apps/d-feet.svg
+rename to data/icons/HighContrast/scalable/apps/org.gnome.d-feet.svg
+diff --git a/data/icons/Makefile.am b/data/icons/Makefile.am
+index cb07dcc..4e7c21d 100644
+--- a/data/icons/Makefile.am
++++ b/data/icons/Makefile.am
+@@ -1,6 +1,6 @@
+ icon16dir = $(datadir)/icons/hicolor/16x16/apps
+ icon16_DATA = \
+-	hicolor/16x16/apps/d-feet.png \
++	hicolor/16x16/apps/org.gnome.d-feet.png \
+ 	hicolor/16x16/apps/dfeet-method-category.png \
+ 	hicolor/16x16/apps/dfeet-method.png \
+ 	hicolor/16x16/apps/dfeet-object.png \
+@@ -11,28 +11,28 @@ icon16_DATA = \
+ 	hicolor/16x16/apps/dfeet-icon-default-service.png
+ 
+ icon24dir = $(datadir)/icons/hicolor/24x24/apps
+-icon24_DATA = hicolor/24x24/apps/d-feet.png
++icon24_DATA = hicolor/24x24/apps/org.gnome.d-feet.png
+ 
+ icon32dir = $(datadir)/icons/hicolor/32x32/apps
+-icon32_DATA = hicolor/32x32/apps/d-feet.png
++icon32_DATA = hicolor/32x32/apps/org.gnome.d-feet.png
+ 
+ icon48dir = $(datadir)/icons/hicolor/48x48/apps
+-icon48_DATA = hicolor/48x48/apps/d-feet.png
++icon48_DATA = hicolor/48x48/apps/org.gnome.d-feet.png
+ 
+ #icon64dir = $(datadir)/icons/hicolor/64x64/apps
+-#icon64_DATA = hicolor/64x64/apps/d-feet.png
++#icon64_DATA = hicolor/64x64/apps/org.gnome.d-feet.png
+ 
+ #icon128dir = $(datadir)/icons/hicolor/128x128/apps
+-#icon128_DATA = hicolor/128x128/apps/d-feet.png
++#icon128_DATA = hicolor/128x128/apps/org.gnome.d-feet.png
+ 
+ icon256dir = $(datadir)/icons/hicolor/256x256/apps
+-icon256_DATA = hicolor/256x256/apps/d-feet.png
++icon256_DATA = hicolor/256x256/apps/org.gnome.d-feet.png
+ 
+ scalabledir = $(datadir)/icons/hicolor/scalable/apps
+-scalable_DATA = hicolor/scalable/apps/d-feet.svg
++scalable_DATA = hicolor/scalable/apps/org.gnome.d-feet.svg
+ 
+ scalablehcdir = $(datadir)/icons/HighContrast/scalable/apps
+-scalablehc_DATA = HighContrast/scalable/apps/d-feet.svg
++scalablehc_DATA = HighContrast/scalable/apps/org.gnome.d-feet.svg
+ 
+ 
+ gtk_update_icon_cache = gtk-update-icon-cache -f -t $(datadir)/icons/hicolor
+diff --git a/data/icons/hicolor/16x16/apps/d-feet.png b/data/icons/hicolor/16x16/apps/org.gnome.d-feet.png
+similarity index 100%
+rename from data/icons/hicolor/16x16/apps/d-feet.png
+rename to data/icons/hicolor/16x16/apps/org.gnome.d-feet.png
+diff --git a/data/icons/hicolor/24x24/apps/d-feet.png b/data/icons/hicolor/24x24/apps/org.gnome.d-feet.png
+similarity index 100%
+rename from data/icons/hicolor/24x24/apps/d-feet.png
+rename to data/icons/hicolor/24x24/apps/org.gnome.d-feet.png
+diff --git a/data/icons/hicolor/256x256/apps/d-feet.png b/data/icons/hicolor/256x256/apps/org.gnome.d-feet.png
+similarity index 100%
+rename from data/icons/hicolor/256x256/apps/d-feet.png
+rename to data/icons/hicolor/256x256/apps/org.gnome.d-feet.png
+diff --git a/data/icons/hicolor/32x32/apps/d-feet.png b/data/icons/hicolor/32x32/apps/org.gnome.d-feet.png
+similarity index 100%
+rename from data/icons/hicolor/32x32/apps/d-feet.png
+rename to data/icons/hicolor/32x32/apps/org.gnome.d-feet.png
+diff --git a/data/icons/hicolor/48x48/apps/d-feet.png b/data/icons/hicolor/48x48/apps/org.gnome.d-feet.png
+similarity index 100%
+rename from data/icons/hicolor/48x48/apps/d-feet.png
+rename to data/icons/hicolor/48x48/apps/org.gnome.d-feet.png
+diff --git a/data/icons/hicolor/scalable/apps/d-feet.svg b/data/icons/hicolor/scalable/apps/org.gnome.d-feet.svg
+similarity index 100%
+rename from data/icons/hicolor/scalable/apps/d-feet.svg
+rename to data/icons/hicolor/scalable/apps/org.gnome.d-feet.svg
+diff --git a/data/d-feet.appdata.xml.in b/data/org.gnome.d-feet.appdata.xml.in
+similarity index 96%
+rename from data/d-feet.appdata.xml.in
+rename to data/org.gnome.d-feet.appdata.xml.in
+index 6fb5689..87c4bb6 100644
+--- a/data/d-feet.appdata.xml.in
++++ b/data/org.gnome.d-feet.appdata.xml.in
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!-- Copyright 2013 Thomas Bechtold <thomasbechtold@jpberlin.de> -->
+ <component type="desktop">
+-  <id>d-feet.desktop</id>
++  <id>org.gnome.d-feet.desktop</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+   <_name>D-Feet</_name>
+diff --git a/data/d-feet.desktop.in.in b/data/org.gnome.d-feet.desktop.in.in
+similarity index 91%
+rename from data/d-feet.desktop.in.in
+rename to data/org.gnome.d-feet.desktop.in.in
+index 46f86c0..6581f0c 100644
+--- a/data/d-feet.desktop.in.in
++++ b/data/org.gnome.d-feet.desktop.in.in
+@@ -4,7 +4,7 @@ _GenericName=D-Bus Debugger
+ _Comment=Debug D-Bus applications
+ _Keywords=debug;d-bus;dbus;dfeet;
+ Exec=@PACKAGE@
+-Icon=@PACKAGE@
++Icon=org.gnome.d-feet
+ Terminal=false
+ Type=Application
+ Categories=GNOME;GTK;Development;Debugger;
+diff --git a/data/ui/bus.ui b/data/ui/bus.ui
+index 67aed2a..6708243 100644
+--- a/data/ui/bus.ui
++++ b/data/ui/bus.ui
+@@ -54,7 +54,7 @@
+         <property name="visible">True</property>
+         <property name="can_focus">False</property>
+         <property name="pixel_size">128</property>
+-        <property name="icon_name">d-feet</property>
++        <property name="icon_name">org.gnome.d-feet</property>
+       </object>
+       <packing>
+         <property name="expand">True</property>
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+index ea29e57..e73de53 100644
+--- a/po/POTFILES.in
++++ b/po/POTFILES.in
+@@ -1,7 +1,7 @@
+ # List of source files containing translatable strings.
+ # Please keep this file sorted alphabetically.
+-data/d-feet.appdata.xml.in
+-data/d-feet.desktop.in.in
++data/org.gnome.d-feet.appdata.xml.in
++data/org.gnome.d-feet.desktop.in.in
+ data/org.gnome.d-feet.gschema.xml
+ [type: gettext/glade]data/ui/addconnectiondialog.ui
+ [type: gettext/glade]data/ui/app-menu.ui
+diff --git a/po/POTFILES.skip b/po/POTFILES.skip
+index 138c665..45f9f4b 100644
+--- a/po/POTFILES.skip
++++ b/po/POTFILES.skip
+@@ -1 +1 @@
+-data/d-feet.desktop.in
++data/org.gnome.d-feet.desktop.in
+-- 
+2.14.3
+

--- a/0003-build-Install-appstream-metadata-to-non-deprecated-l.patch
+++ b/0003-build-Install-appstream-metadata-to-non-deprecated-l.patch
@@ -1,0 +1,27 @@
+From c92e31f540457c1696e60cfdccd19164f324dc12 Mon Sep 17 00:00:00 2001
+From: Jeremy Bicha <jbicha@ubuntu.com>
+Date: Sun, 26 Nov 2017 17:10:35 -0500
+Subject: [PATCH 3/3] build: Install appstream metadata to non-deprecated
+ location
+
+https://bugzilla.gnome.org/show_bug.cgi?id=790863
+---
+ data/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/Makefile.am b/data/Makefile.am
+index 98f3e23..4c7e363 100644
+--- a/data/Makefile.am
++++ b/data/Makefile.am
+@@ -12,7 +12,7 @@ desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+ UPDATE_DESKTOP = if test -z "$(DESTDIR)"; then update-desktop-database $(datadir)/applications || :; fi
+ 
+ @INTLTOOL_XML_RULE@
+-appdatadir = $(datadir)/appdata
++appdatadir = $(datadir)/metainfo
+ appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+ appdata_in_files = org.gnome.d-feet.appdata.xml.in
+ 
+-- 
+2.14.3
+

--- a/0004-Do-not-use-hyphen-for-the-reverse-DNS-names.patch
+++ b/0004-Do-not-use-hyphen-for-the-reverse-DNS-names.patch
@@ -1,0 +1,282 @@
+From 351c7dc9fa6fea65938f0de4e1cc445ad1771ec3 Mon Sep 17 00:00:00 2001
+From: Mathieu Bridon <bochecha@daitauha.fr>
+Date: Wed, 24 Jan 2018 18:37:15 +0100
+Subject: [PATCH] Do not use hyphen for the reverse-DNS names
+
+The convention for DBus and Flatpak is to not use hyphens in the last
+segment of a name.
+
+In fact, this is even illegal in object paths.
+
+This commit moves everything from org.gnome.d-feet to org.gnome.dfeet
+---
+ configure.ac                                          |   2 +-
+ data/Makefile.am                                      |   6 +++---
+ .../{org.gnome.d-feet.svg => org.gnome.dfeet.svg}     |   0
+ data/icons/Makefile.am                                |  18 +++++++++---------
+ .../{org.gnome.d-feet.png => org.gnome.dfeet.png}     | Bin
+ .../{org.gnome.d-feet.png => org.gnome.dfeet.png}     | Bin
+ .../{org.gnome.d-feet.png => org.gnome.dfeet.png}     | Bin
+ .../{org.gnome.d-feet.png => org.gnome.dfeet.png}     | Bin
+ .../{org.gnome.d-feet.png => org.gnome.dfeet.png}     | Bin
+ .../{org.gnome.d-feet.svg => org.gnome.dfeet.svg}     |   0
+ ....appdata.xml.in => org.gnome.dfeet.appdata.xml.in} |   2 +-
+ ...et.desktop.in.in => org.gnome.dfeet.desktop.in.in} |   2 +-
+ ...d-feet.gschema.xml => org.gnome.dfeet.gschema.xml} |   2 +-
+ data/ui/bus.ui                                        |   2 +-
+ po/POTFILES.in                                        |   6 +++---
+ po/POTFILES.skip                                      |   2 +-
+ src/dfeet/application.py                              |   2 +-
+ src/tests/tests.py                                    |   6 +++---
+ 19 files changed, 26 insertions(+), 26 deletions(-)
+ rename data/icons/HighContrast/scalable/apps/{org.gnome.d-feet.svg => org.gnome.dfeet.svg} (100%)
+ rename data/icons/hicolor/16x16/apps/{org.gnome.d-feet.png => org.gnome.dfeet.png} (100%)
+ rename data/icons/hicolor/24x24/apps/{org.gnome.d-feet.png => org.gnome.dfeet.png} (100%)
+ rename data/icons/hicolor/256x256/apps/{org.gnome.d-feet.png => org.gnome.dfeet.png} (100%)
+ rename data/icons/hicolor/32x32/apps/{org.gnome.d-feet.png => org.gnome.dfeet.png} (100%)
+ rename data/icons/hicolor/48x48/apps/{org.gnome.d-feet.png => org.gnome.dfeet.png} (100%)
+ rename data/icons/hicolor/scalable/apps/{org.gnome.d-feet.svg => org.gnome.dfeet.svg} (100%)
+ rename data/{org.gnome.d-feet.appdata.xml.in => org.gnome.dfeet.appdata.xml.in} (96%)
+ rename data/{org.gnome.d-feet.desktop.in.in => org.gnome.dfeet.desktop.in.in} (91%)
+ rename data/{org.gnome.d-feet.gschema.xml => org.gnome.dfeet.gschema.xml} (51%)
+ rename org.gnome.d-feet.json => org.gnome.dfeet.json (98%)
+
+diff --git a/configure.ac b/configure.ac
+index bdeee4c..48102ea 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -48,7 +48,7 @@ AC_CONFIG_FILES([
+ 	src/dfeet/Makefile
+ 	src/tests/Makefile
+ 	data/Makefile
+-	data/org.gnome.d-feet.desktop.in
++	data/org.gnome.dfeet.desktop.in
+ 	data/icons/Makefile
+ 	data/ui/Makefile
+ 	help/Makefile
+diff --git a/data/Makefile.am b/data/Makefile.am
+index 4c7e363..c50d1b6 100644
+--- a/data/Makefile.am
++++ b/data/Makefile.am
+@@ -1,12 +1,12 @@
+ SUBDIRS = icons ui
+ 
+-gsettings_SCHEMAS = org.gnome.d-feet.gschema.xml
++gsettings_SCHEMAS = org.gnome.dfeet.gschema.xml
+ @GSETTINGS_RULES@
+ 
+ @INTLTOOL_DESKTOP_RULE@
+ 
+ desktopdir = $(datadir)/applications
+-desktop_in_files = org.gnome.d-feet.desktop.in
++desktop_in_files = org.gnome.dfeet.desktop.in
+ desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+ 
+ UPDATE_DESKTOP = if test -z "$(DESTDIR)"; then update-desktop-database $(datadir)/applications || :; fi
+@@ -14,7 +14,7 @@ UPDATE_DESKTOP = if test -z "$(DESTDIR)"; then update-desktop-database $(datadir
+ @INTLTOOL_XML_RULE@
+ appdatadir = $(datadir)/metainfo
+ appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+-appdata_in_files = org.gnome.d-feet.appdata.xml.in
++appdata_in_files = org.gnome.dfeet.appdata.xml.in
+ 
+ 
+ install-data-hook:
+diff --git a/data/icons/HighContrast/scalable/apps/org.gnome.d-feet.svg b/data/icons/HighContrast/scalable/apps/org.gnome.dfeet.svg
+similarity index 100%
+rename from data/icons/HighContrast/scalable/apps/org.gnome.d-feet.svg
+rename to data/icons/HighContrast/scalable/apps/org.gnome.dfeet.svg
+diff --git a/data/icons/Makefile.am b/data/icons/Makefile.am
+index 4e7c21d..5439998 100644
+--- a/data/icons/Makefile.am
++++ b/data/icons/Makefile.am
+@@ -1,6 +1,6 @@
+ icon16dir = $(datadir)/icons/hicolor/16x16/apps
+ icon16_DATA = \
+-	hicolor/16x16/apps/org.gnome.d-feet.png \
++	hicolor/16x16/apps/org.gnome.dfeet.png \
+ 	hicolor/16x16/apps/dfeet-method-category.png \
+ 	hicolor/16x16/apps/dfeet-method.png \
+ 	hicolor/16x16/apps/dfeet-object.png \
+@@ -11,28 +11,28 @@ icon16_DATA = \
+ 	hicolor/16x16/apps/dfeet-icon-default-service.png
+ 
+ icon24dir = $(datadir)/icons/hicolor/24x24/apps
+-icon24_DATA = hicolor/24x24/apps/org.gnome.d-feet.png
++icon24_DATA = hicolor/24x24/apps/org.gnome.dfeet.png
+ 
+ icon32dir = $(datadir)/icons/hicolor/32x32/apps
+-icon32_DATA = hicolor/32x32/apps/org.gnome.d-feet.png
++icon32_DATA = hicolor/32x32/apps/org.gnome.dfeet.png
+ 
+ icon48dir = $(datadir)/icons/hicolor/48x48/apps
+-icon48_DATA = hicolor/48x48/apps/org.gnome.d-feet.png
++icon48_DATA = hicolor/48x48/apps/org.gnome.dfeet.png
+ 
+ #icon64dir = $(datadir)/icons/hicolor/64x64/apps
+-#icon64_DATA = hicolor/64x64/apps/org.gnome.d-feet.png
++#icon64_DATA = hicolor/64x64/apps/org.gnome.dfeet.png
+ 
+ #icon128dir = $(datadir)/icons/hicolor/128x128/apps
+-#icon128_DATA = hicolor/128x128/apps/org.gnome.d-feet.png
++#icon128_DATA = hicolor/128x128/apps/org.gnome.dfeet.png
+ 
+ icon256dir = $(datadir)/icons/hicolor/256x256/apps
+-icon256_DATA = hicolor/256x256/apps/org.gnome.d-feet.png
++icon256_DATA = hicolor/256x256/apps/org.gnome.dfeet.png
+ 
+ scalabledir = $(datadir)/icons/hicolor/scalable/apps
+-scalable_DATA = hicolor/scalable/apps/org.gnome.d-feet.svg
++scalable_DATA = hicolor/scalable/apps/org.gnome.dfeet.svg
+ 
+ scalablehcdir = $(datadir)/icons/HighContrast/scalable/apps
+-scalablehc_DATA = HighContrast/scalable/apps/org.gnome.d-feet.svg
++scalablehc_DATA = HighContrast/scalable/apps/org.gnome.dfeet.svg
+ 
+ 
+ gtk_update_icon_cache = gtk-update-icon-cache -f -t $(datadir)/icons/hicolor
+diff --git a/data/icons/hicolor/16x16/apps/org.gnome.d-feet.png b/data/icons/hicolor/16x16/apps/org.gnome.dfeet.png
+similarity index 100%
+rename from data/icons/hicolor/16x16/apps/org.gnome.d-feet.png
+rename to data/icons/hicolor/16x16/apps/org.gnome.dfeet.png
+diff --git a/data/icons/hicolor/24x24/apps/org.gnome.d-feet.png b/data/icons/hicolor/24x24/apps/org.gnome.dfeet.png
+similarity index 100%
+rename from data/icons/hicolor/24x24/apps/org.gnome.d-feet.png
+rename to data/icons/hicolor/24x24/apps/org.gnome.dfeet.png
+diff --git a/data/icons/hicolor/256x256/apps/org.gnome.d-feet.png b/data/icons/hicolor/256x256/apps/org.gnome.dfeet.png
+similarity index 100%
+rename from data/icons/hicolor/256x256/apps/org.gnome.d-feet.png
+rename to data/icons/hicolor/256x256/apps/org.gnome.dfeet.png
+diff --git a/data/icons/hicolor/32x32/apps/org.gnome.d-feet.png b/data/icons/hicolor/32x32/apps/org.gnome.dfeet.png
+similarity index 100%
+rename from data/icons/hicolor/32x32/apps/org.gnome.d-feet.png
+rename to data/icons/hicolor/32x32/apps/org.gnome.dfeet.png
+diff --git a/data/icons/hicolor/48x48/apps/org.gnome.d-feet.png b/data/icons/hicolor/48x48/apps/org.gnome.dfeet.png
+similarity index 100%
+rename from data/icons/hicolor/48x48/apps/org.gnome.d-feet.png
+rename to data/icons/hicolor/48x48/apps/org.gnome.dfeet.png
+diff --git a/data/icons/hicolor/scalable/apps/org.gnome.d-feet.svg b/data/icons/hicolor/scalable/apps/org.gnome.dfeet.svg
+similarity index 100%
+rename from data/icons/hicolor/scalable/apps/org.gnome.d-feet.svg
+rename to data/icons/hicolor/scalable/apps/org.gnome.dfeet.svg
+diff --git a/data/org.gnome.d-feet.appdata.xml.in b/data/org.gnome.dfeet.appdata.xml.in
+similarity index 96%
+rename from data/org.gnome.d-feet.appdata.xml.in
+rename to data/org.gnome.dfeet.appdata.xml.in
+index 87c4bb6..c4065c1 100644
+--- a/data/org.gnome.d-feet.appdata.xml.in
++++ b/data/org.gnome.dfeet.appdata.xml.in
+@@ -1,7 +1,7 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <!-- Copyright 2013 Thomas Bechtold <thomasbechtold@jpberlin.de> -->
+ <component type="desktop">
+-  <id>org.gnome.d-feet.desktop</id>
++  <id>org.gnome.dfeet.desktop</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+   <_name>D-Feet</_name>
+diff --git a/data/org.gnome.d-feet.desktop.in.in b/data/org.gnome.dfeet.desktop.in.in
+similarity index 91%
+rename from data/org.gnome.d-feet.desktop.in.in
+rename to data/org.gnome.dfeet.desktop.in.in
+index 6581f0c..134cf10 100644
+--- a/data/org.gnome.d-feet.desktop.in.in
++++ b/data/org.gnome.dfeet.desktop.in.in
+@@ -4,7 +4,7 @@ _GenericName=D-Bus Debugger
+ _Comment=Debug D-Bus applications
+ _Keywords=debug;d-bus;dbus;dfeet;
+ Exec=@PACKAGE@
+-Icon=org.gnome.d-feet
++Icon=org.gnome.dfeet
+ Terminal=false
+ Type=Application
+ Categories=GNOME;GTK;Development;Debugger;
+diff --git a/data/org.gnome.d-feet.gschema.xml b/data/org.gnome.dfeet.gschema.xml
+similarity index 51%
+rename from data/org.gnome.d-feet.gschema.xml
+rename to data/org.gnome.dfeet.gschema.xml
+index 297cd1f..d46272e 100644
+--- a/data/org.gnome.d-feet.gschema.xml
++++ b/data/org.gnome.dfeet.gschema.xml
+@@ -1,4 +1,4 @@
+ <schemalist gettext-domain="d-feet">
+-  <schema id="org.gnome.d-feet" path="/org/gnome/d-feet/">
++  <schema id="org.gnome.dfeet" path="/org/gnome/dfeet/">
+   </schema>
+ </schemalist>
+diff --git a/data/ui/bus.ui b/data/ui/bus.ui
+index 6708243..059e041 100644
+--- a/data/ui/bus.ui
++++ b/data/ui/bus.ui
+@@ -54,7 +54,7 @@
+         <property name="visible">True</property>
+         <property name="can_focus">False</property>
+         <property name="pixel_size">128</property>
+-        <property name="icon_name">org.gnome.d-feet</property>
++        <property name="icon_name">org.gnome.dfeet</property>
+       </object>
+       <packing>
+         <property name="expand">True</property>
+diff --git a/po/POTFILES.in b/po/POTFILES.in
+index e73de53..4e31d24 100644
+--- a/po/POTFILES.in
++++ b/po/POTFILES.in
+@@ -1,8 +1,8 @@
+ # List of source files containing translatable strings.
+ # Please keep this file sorted alphabetically.
+-data/org.gnome.d-feet.appdata.xml.in
+-data/org.gnome.d-feet.desktop.in.in
+-data/org.gnome.d-feet.gschema.xml
++data/org.gnome.dfeet.appdata.xml.in
++data/org.gnome.dfeet.desktop.in.in
++data/org.gnome.dfeet.gschema.xml
+ [type: gettext/glade]data/ui/addconnectiondialog.ui
+ [type: gettext/glade]data/ui/app-menu.ui
+ [type: gettext/glade]data/ui/bus.ui
+diff --git a/po/POTFILES.skip b/po/POTFILES.skip
+index 45f9f4b..d0845fe 100644
+--- a/po/POTFILES.skip
++++ b/po/POTFILES.skip
+@@ -1 +1 @@
+-data/org.gnome.d-feet.desktop.in
++data/org.gnome.dfeet.desktop.in
+diff --git a/src/dfeet/application.py b/src/dfeet/application.py
+index c8e02ee..9ddb66d 100644
+--- a/src/dfeet/application.py
++++ b/src/dfeet/application.py
+@@ -12,7 +12,7 @@ class DFeetApp(Gtk.Application):
+         self.package = package
+         self.version = version
+         self.data_dir = data_dir
+-        Gtk.Application.__init__(self, application_id="org.gnome.d-feet",
++        Gtk.Application.__init__(self, application_id="org.gnome.dfeet",
+                                  flags=Gio.ApplicationFlags.FLAGS_NONE)
+ 
+     # Note that the function in C activate() becomes do_activate() in Python
+diff --git a/src/tests/tests.py b/src/tests/tests.py
+index 4fb52d5..31a7292 100755
+--- a/src/tests/tests.py
++++ b/src/tests/tests.py
+@@ -16,7 +16,7 @@ import unittest
+ 
+ XML = """
+ <node>
+-  <interface name='org.gnome.d-feet.TestInterface'>
++  <interface name='org.gnome.dfeet.TestInterface'>
+     <method name='HelloWorld'>
+       <arg type='s' name='greeting' direction='in'/>
+       <arg type='s' name='response' direction='out'/>
+@@ -38,8 +38,8 @@ DATA_DIR = os.path.abspath("../../data/")
+ class IntrospectionHelperTest(unittest.TestCase):
+     """tests for the introspection helper classes"""
+     def setUp(self):
+-        self.name = "org.gnome.d-feet"
+-        self.object_path = "/org/gnome/d-feet"
++        self.name = "org.gnome.dfeet"
++        self.object_path = "/org/gnome/dfeet"
+         self.node_info = Gio.DBusNodeInfo.new_for_xml(XML)
+ 
+     def test_dbus_node_info(self):
+-- 
+2.14.3
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Flatpak for [D-Feet](https://wiki.gnome.org/Apps/DFeet)
+
+D-Feet is an easy to use D-Bus debugger. D-Feet can be used to inspect D-Bus interfaces of running programs and invoke methods on those interfaces.
+
+## Notes
+
+* `0001-Rename-the-icons-appdata-and-desktop-files.patch`,
+  `0003-build-Install-appstream-metadata-to-non-deprecated-l.patch`: already
+  merged upstream. We use `"rm-configure": true` in the manifest to cause
+  `autogen.sh` to be re-run.
+
+## Credits
+
+Derived from the [upstream manifest for D-Feet master](https://git.gnome.org/browse/d-feet/tree/org.gnome.d-feet.json), written by Mathieu Bridon.

--- a/org.gnome.d-feet.json
+++ b/org.gnome.d-feet.json
@@ -1,0 +1,76 @@
+{
+    "id": "org.gnome.d-feet",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "d-feet",
+    "finish-args": [
+        "--share=ipc", "--socket=x11",
+        "--socket=wayland",
+        "--socket=system-bus", "--socket=session-bus",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [
+        {
+            "name": "pycairo",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python2 setup.py install --prefix=/app"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/pygobject/pycairo/releases/download/v1.15.4/pycairo-1.15.4.tar.gz",
+                    "sha256": "ee4c3068c048230e5ce74bb8994a024711129bde1af1d76e3276c7acd81c4357"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/share/pkgconfig"
+            ]
+        },
+        {
+            "name": "pygobject",
+            "build-options" : {
+                "env": {
+                    "PYTHON": "/usr/bin/python2"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/pygobject/3.27/pygobject-3.27.1.tar.xz",
+                    "sha256": "40a62c479eed9aca6b2095b1650ab87981b7358880a0a07cacbdcbc250e155f1"
+                }
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/python2.7/site-packages/gi/*.la"
+            ]
+        },
+        {
+            "name": "d-feet",
+            "rm-configure": true,
+            "config-opts": [
+                "--disable-tests"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/d-feet/0.3/d-feet-0.3.13.tar.xz",
+                    "sha256": "941a2fda5a06deaeeb1eddd1e02c1eef6ddcaf8d6fb5647423e0e952f4a7a3d5"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Rename-the-icons-appdata-and-desktop-files.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0003-build-Install-appstream-metadata-to-non-deprecated-l.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.dfeet.json
+++ b/org.gnome.dfeet.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.gnome.d-feet",
+    "id": "org.gnome.dfeet",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.26",
     "sdk": "org.gnome.Sdk",
@@ -69,6 +69,10 @@
                 {
                     "type": "patch",
                     "path": "0003-build-Install-appstream-metadata-to-non-deprecated-l.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0004-Do-not-use-hyphen-for-the-reverse-DNS-names.patch"
                 }
             ]
         }


### PR DESCRIPTION
This is a work in progress, derived from an [upstream manifest](https://git.gnome.org/browse/d-feet/tree/org.gnome.d-feet.json) [added by](https://bugzilla.gnome.org/show_bug.cgi?id=788693) @bochecha.

The main thing I'm not sure about is the app ID: `org.gnome.d-feet`. I believe the convention is to use underscores in Flatpak app IDs, but the hyphenated name is used:

a. as the D-Bus well-known name in released versions of the app (objects are exposed below `/org/gnome/d_feet` since hyphens are illegal in object paths; I think this substitution is performed by GApplication)
b. as the name for `.desktop` files etc. upstream (on master, not released, as part of adding the flatpak manifest there)
c. as the upstream flatpak app ID in the nightly apps repo

`flatpak-builder` apparently replaces the hyphen with an underscore when generating names for the .Debug and .Locale extensions:

```console
% flatpak remote-ls gnome-nightly-apps -da | grep feet | grep x86_64
app/org.gnome.d-feet/x86_64/master                     1764458be0ac   2.1 MB       721.4 kB     
runtime/org.gnome.d_feet.Debug/x86_64/master           72013c290091   1.9 MB       847.3 kB     
runtime/org.gnome.d_feet.Locale/x86_64/master          6f3502a649c0  82.9 kB        38.8 kB     
```

To my surprise, `flatpak install` knew how to map one to the other:

```console
% flatpak install gnome-nightly-apps app/org.gnome.d-feet/x86_64/master
Installing: org.gnome.d-feet/x86_64/master from gnome-nightly-apps
[####################] 1 delta parts, 1 loose fetched; 387 KiB transferred in 19 seconds
Installing: org.gnome.d_feet.Locale/x86_64/master from gnome-nightly-apps
[####################] 1 delta parts, 1 loose fetched; 23 KiB transferred in 1 seconds
```

So maybe it's fine?