### PR TITLE
org.flightgear.FlightGear

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-arches": ["aarch64", "arm"]
+}

--- a/flightgear.sh
+++ b/flightgear.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-FG_ROOT=/app/share/flightgear LD_LIBRARY_PATH=/app/lib64 FG_AIRCRAFT=~/.fgfs/Aircraft/ FG_SCENERY=~/.fgfs/Scenery fgfs "$@"
+FG_ROOT=/app/share/flightgear FG_AIRCRAFT=$XDG_DATA_HOME/fgfs/Aircraft/ FG_SCENERY=$XDG_DATA_HOME/fgfs/Scenery fgfs "$@"

--- a/flightgear.sh
+++ b/flightgear.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+FG_ROOT=/app/share/flightgear LD_LIBRARY_PATH=/app/lib64 FG_AIRCRAFT=~/.fgfs/Aircraft/ FG_SCENERY=~/.fgfs/Scenery fgfs "$@"

--- a/org.flightgear.FlightGear.appdata.xml
+++ b/org.flightgear.FlightGear.appdata.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
-
 <!-- HOUSEKEEPING, REMOVE THIS COMMENT WHEN THIS GOES UPSTREAM
 BugReportURL: https://sourceforge.net/p/fgrun/support-requests/9/
 SentUpstream: 2014-09-17
 -->
-
-<application>
-  <id type="desktop">org.flightgear.FlightGear</id>
+<component type="desktop">
+  <id>org.flightgear.FlightGear</id>
   <metadata_license>CC0-1.0</metadata_license>
   <description>
     <p>
@@ -19,25 +17,25 @@ SentUpstream: 2014-09-17
     </p>
     <p>
       The FlightGear landscape covers the entire world and is downloaded as you
-      fly.
-      Visit any of the 20,000 airports with an accurate representation of
+      fly. Visit any of the 20,000 airports with an accurate representation of
       airport buildings on many of the larger, international airports.
     </p>
     <p>
-      Most popular flight control hardware, such as yokes and sticks are
-      supported.
-      Multiple monitor setup and multiplayer is also featured.
+      Most popular flight control hardware, such as yokes and sticks are     supported. Multiple monitor setup and multiplayer is also featured.
     </p>
   </description>
   <url type="homepage">http://www.flightgear.org/</url>
   <screenshots>
-    <screenshot type="default">http://wiki.flightgear.org/images/b/b3/SOTM-Feb18.jpg</screenshot>
-    <screenshot>http://wiki.flightgear.org/images/3/37/SOTY-2017.jpeg</screenshot>
-    <screenshot>http://wiki.flightgear.org/images/2/27/SOTM-Oct17.png</screenshot>
+    <screenshot type="default">
+      <image>http://wiki.flightgear.org/images/b/b3/SOTM-Feb18.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://wiki.flightgear.org/images/3/37/SOTY-2017.jpeg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://wiki.flightgear.org/images/2/27/SOTM-Oct17.png</image>
+    </screenshot>
   </screenshots>
-  <!-- FIXME: change this to an upstream email address for spec updates
-  <updatecontact>someone_who_cares@upstream_project.org</updatecontact>
-   -->
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>
     <content_attribute id="violence-fantasy">none</content_attribute>
@@ -67,4 +65,23 @@ SentUpstream: 2014-09-17
     <content_attribute id="money-purchasing">none</content_attribute>
     <content_attribute id="money-gambling">none</content_attribute>
   </content_rating>
-</application>
+  <project_license>GPL-2.0</project_license>
+  <developer_name>FlightGear Developers</developer_name>
+  <url type="bugtracker">https://sourceforge.net/p/flightgear/codetickets/</url>
+  <url type="donation">http://store.flightgear.org/</url>
+  <url type="help">http://flightgear.sourceforge.net/getstart-en/getstart-en.html</url>
+  <url type="translate">http://wiki.flightgear.org/Howto:Translate_FlightGear</url>
+  <releases>
+    <release date="2017-09-20" version="2017.3"/>
+    <release date="2017-05-25" version="2017.2"/>
+    <release date="2017-05-21" version="2017.1"/>
+    <release date="2016-12-28" version="2016.4"/>
+    <release date="2016-09-08" version="2016.3"/>
+    <release date="2016-05-21" version="2016.2"/>
+    <release date="2016-05-07" version="2016.3"/>
+  </releases>
+
+  <!--FIXME: this is optional, but recommended-->
+  <update_contact/>
+  <launchable type="desktop-id">org.flightgear.FlightGear.desktop</launchable>
+</component>

--- a/org.flightgear.FlightGear.appdata.xml
+++ b/org.flightgear.FlightGear.appdata.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
+
+<!-- HOUSEKEEPING, REMOVE THIS COMMENT WHEN THIS GOES UPSTREAM
+BugReportURL: https://sourceforge.net/p/fgrun/support-requests/9/
+SentUpstream: 2014-09-17
+-->
+
+<application>
+  <id type="desktop">org.flightgear.FlightGear</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <description>
+    <p>
+      FlightGear allows you to control over 400 aircraft, small and large in a
+      range of situations, types of weather, seasons, day and night cycle.
+      This includes single-engine propeller aircraft, large 4-engine passenger
+      liners, experimental aircraft, classic and vintage aircraft and
+      helicopters.
+    </p>
+    <p>
+      The FlightGear landscape covers the entire world and is downloaded as you
+      fly.
+      Visit any of the 20,000 airports with an accurate representation of
+      airport buildings on many of the larger, international airports.
+    </p>
+    <p>
+      Most popular flight control hardware, such as yokes and sticks are
+      supported.
+      Multiple monitor setup and multiplayer is also featured.
+    </p>
+  </description>
+  <url type="homepage">http://www.flightgear.org/</url>
+  <screenshots>
+    <screenshot type="default">http://wiki.flightgear.org/images/b/b3/SOTM-Feb18.jpg</screenshot>
+    <screenshot>http://wiki.flightgear.org/images/3/37/SOTY-2017.jpeg</screenshot>
+    <screenshot>http://wiki.flightgear.org/images/2/27/SOTM-Oct17.png</screenshot>
+  </screenshots>
+  <!-- FIXME: change this to an upstream email address for spec updates
+  <updatecontact>someone_who_cares@upstream_project.org</updatecontact>
+   -->
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</application>

--- a/org.flightgear.FlightGear.appdata.xml
+++ b/org.flightgear.FlightGear.appdata.xml
@@ -78,7 +78,7 @@ SentUpstream: 2014-09-17
     <release date="2016-12-28" version="2016.4"/>
     <release date="2016-09-08" version="2016.3"/>
     <release date="2016-05-21" version="2016.2"/>
-    <release date="2016-05-07" version="2016.3"/>
+    <release date="2016-05-07" version="2016.1"/>
   </releases>
 
   <!--FIXME: this is optional, but recommended-->

--- a/org.flightgear.FlightGear.json
+++ b/org.flightgear.FlightGear.json
@@ -1,81 +1,65 @@
 {
-	"id":"org.flightgear.FlightGear",
-	"runtime":"org.kde.Platform",
-	"runtime-version":"5.10",
-	"sdk":"org.kde.Sdk",
-	"command":"flightgear.sh",
-	"rename-icon":"flightgear",
-	"finish-args":[
+	"id": "org.flightgear.FlightGear",
+	"runtime": "org.kde.Platform",
+	"runtime-version": "5.10",
+	"sdk": "org.kde.Sdk",
+	"command": "flightgear.sh",
+	"rename-icon": "flightgear",
+	"finish-args": [
 		"--share=ipc",
 		"--socket=x11",
-		"--socket=wayland",
 		"--device=dri",
 		"--socket=pulseaudio",
 		"--share=network",
-		"--filesystem=~/.fgfs/"
+		"--persist=~/.fgfs/"
 	],
 	"build-options": {
 		"cflags": "-O2",
 		"cxxflags": "-O2"
 	},
-	"cleanup":[
+	"cleanup": [
 		"/include",
 		"/lib/pkgconfig",
 		"/lib64/pkgconfig",
 		"/lib/cmake",
 		"/share/doc",
+		"/share/ffmpeg",
 		"/share/man",
 		"*.a",
 		"*.la",
 		"*.cmake"
 	],
-	"modules":[
+	"modules": [
 		{
-			"name":"boost",
-			"buildsystem":"simple",
-			"build-commands":[
+			"name": "boost",
+			"buildsystem": "simple",
+			"build-commands": [
 				"./bootstrap.sh --prefix=/app",
 				"./b2 headers",
 				"./b2 install"
 			],
-			"sources":[
+			"sources": [
 				{
-					"sha256":"5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9",
-					"type":"archive",
-					"url":"https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.bz2"
+					"sha256": "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9",
+					"type": "archive",
+					"url": "https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.bz2"
 				}
 			],
-			"cleanup":[
+			"cleanup": [
 				"/include"
-			]
-		},
-		{
-			"name":"flightgear-data",
-			"buildsystem":"simple",
-			"sources":[
-				{
-					"type":"archive",
-					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/FlightGear-2017.3.1-data.tar.bz2",
-					"sha256":"df08b06e88a29a9f80f29186afd54d278636a663281a1b68e8f484bbb403d898",
-					"dest": "fgdata"
-				}
-			],
-			"build-commands": [
-				"mkdir --parents /app/share/flightgear",
-				"mv fgdata/* /app/share/flightgear/"
 			]
 		},
 		"shared-modules/glu/glu-9.0.0.json",
 		{
-			"name":"mesa",
-			"config-opts":[
+			"name": "mesa",
+			"config-opts": [
 				"--enable-osmesa"
 			],
-			"sources":[
+			"sources": [
 				{
-					"type":"archive",
-					"url":"https://mesa.freedesktop.org/archive/mesa-17.2.0-rc6.tar.gz",
-					"sha256":"ce25345b7da886cdc730299065e2f27ac285eddc75c89595be16cb8ec8497fcc"
+					"type": "archive",
+					"url": "https://mesa.freedesktop.org/archive/mesa-17.2.0-rc6.tar.gz",
+					"sha256": "ce25345b7da886cdc730299065e2f27ac285eddc75c89595be16cb8ec8497fcc"
 				}
 			]
 		},
@@ -104,35 +88,33 @@
 			]
 		},
 		{
-			"name":"openscenegraph",
-			"buildsystem":"cmake-ninja",
+			"name": "openscenegraph",
+			"buildsystem": "cmake-ninja",
 			"config-opts": [
-				"-DBUILD_OSG_PLUGINS_BY_DEFAULT=0",
-				"-DBUILD_OSG_PLUGIN_OSG=1",
-				"-DBUILD_OSG_PLUGIN_DDS=1",
-				"-DBUILD_OSG_PLUGIN_TGA=1",
-				"-DBUILD_OSG_PLUGIN_BMP=1",
-				"-DBUILD_OSG_PLUGIN_JPEG=1",
-				"-DBUILD_OSG_PLUGIN_PNG=1",
-				"-DBUILD_OSG_DEPRECATED_SERIALIZERS=0",
-				"-DBUILD_OSG_APPLICATIONS=0",
 				"-DCMAKE_BUILD_TYPE=Release"
 			],
-			"sources":[
+			"sources": [
 				{
 					"type":"archive",
-					"url":"https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.2.3.tar.gz",
-					"sha256":"a1ecc6524197024834e1277916922b32f30246cb583e27ed19bf3bf889534362"
+					"url":"https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.2.1.tar.gz",
+					"sha256":"2083b632b764438727e07289845992d41757582e571e3133ca259a6514cf72b2"
+				},
+				{
+					"type": "shell",
+					"commands": [
+						"sed 's|SET(LIB_POSTFIX \"64\" CACHE|SET(LIB_POSTFIX \"\" CACHE|' -i CMakeLists.txt",
+						"sed 's|DGifCloseFile(giffile)|DGifCloseFile(giffile,0)|' -i src/osgPlugins/gif/ReaderWriterGIF.cpp"
+					]
 				}
 			]
 		},
 		{
-			"name":"simgear",
-			"buildsystem":"cmake-ninja",
-			"config-opts":[
+			"name": "simgear",
+			"buildsystem": "cmake-ninja",
+			"config-opts": [
 				"-DCMAKE_BUILD_TYPE=Release"
 			],
-			"sources":[
+			"sources": [
 				{
 					"type":"archive",
 					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/simgear-2017.3.1.tar.bz2",
@@ -141,52 +123,68 @@
 			]
 		},
 		{
-			"name":"xmu",
-			"sources":[
+			"name": "xmu",
+			"sources": [
 				{
-					"type":"archive",
-					"url":"https://www.x.org/archive//individual/lib/libXmu-1.1.2.tar.bz2",
-					"sha256":"756edc7c383254eef8b4e1b733c3bf1dc061b523c9f9833ac7058378b8349d0b"
+					"type": "archive",
+					"url": "https://www.x.org/archive//individual/lib/libXmu-1.1.2.tar.bz2",
+					"sha256": "756edc7c383254eef8b4e1b733c3bf1dc061b523c9f9833ac7058378b8349d0b"
 				}
 			]
 		},
 		{
-			"name":"plib",
-			"sources":[
+			"name": "plib",
+			"sources": [
 				{
-					"type":"archive",
-					"url":"http://plib.sourceforge.net/dist/plib-1.8.5.tar.gz",
-					"sha256":"485b22bf6fdc0da067e34ead5e26f002b76326f6371e2ae006415dea6a380a32"
+					"type": "archive",
+					"url": "http://plib.sourceforge.net/dist/plib-1.8.5.tar.gz",
+					"sha256": "485b22bf6fdc0da067e34ead5e26f002b76326f6371e2ae006415dea6a380a32"
 				}
 			]
 		},
 		{
-			"name":"flightgear",
-			"buildsystem":"cmake-ninja",
-			"config-opts":[
+			"name": "flightgear",
+			"buildsystem": "cmake-ninja",
+			"config-opts": [
 				/*"-DENABLE_QT=ON",*/
 				"-DCMAKE_BUILD_TYPE=Release",
 				"-DFG_BUILD_TYPE=Release"
 			],
 			"builddir": true,
-			"sources":[
+			"sources": [
 				{
 					"type":"archive",
 					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/flightgear-2017.3.1.tar.bz2",
 					"sha256":"6f2e1d992e2f202b8f9c918c9fb19124ef06824ea0e767e2f4dff6ba43728ccd"
 				},
 				{
-					"type":"file",
+					"type": "file",
 					"path": "org.flightgear.FlightGear.appdata.xml"
 				},
 				{
-					"type":"file",
+					"type": "file",
 					"path": "flightgear.sh"
 				}
 			],
 			"build-commands": [
 				"install -Dm644 ../org.flightgear.FlightGear.appdata.xml /app/share/appdata/org.flightgear.FlightGear.appdata.xml",
 				"install -Dm744 ../flightgear.sh /app/bin/flightgear.sh"
+			]
+		},
+				{
+			"name": "flightgear-data",
+			"buildsystem": "simple",
+			"sources": [
+				{
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/FlightGear-2017.3.1-data.tar.bz2",
+					"sha256":"df08b06e88a29a9f80f29186afd54d278636a663281a1b68e8f484bbb403d898",
+					"dest": "fgdata"
+				}
+			],
+			"build-commands": [
+				"mkdir --parents /app/share/flightgear",
+				"mv fgdata/* /app/share/flightgear/"
 			]
 		}
 	]

--- a/org.flightgear.FlightGear.json
+++ b/org.flightgear.FlightGear.json
@@ -1,0 +1,193 @@
+{
+	"id":"org.flightgear.FlightGear",
+	"runtime":"org.kde.Platform",
+	"runtime-version":"5.10",
+	"sdk":"org.kde.Sdk",
+	"command":"flightgear.sh",
+	"rename-icon":"flightgear",
+	"finish-args":[
+		"--share=ipc",
+		"--socket=x11",
+		"--socket=wayland",
+		"--device=dri",
+		"--socket=pulseaudio",
+		"--share=network",
+		"--filesystem=~/.fgfs/"
+	],
+	"build-options": {
+		"cflags": "-O2",
+		"cxxflags": "-O2"
+	},
+	"cleanup":[
+		"/include",
+		"/lib/pkgconfig",
+		"/lib64/pkgconfig",
+		"/lib/cmake",
+		"/share/doc",
+		"/share/man",
+		"*.a",
+		"*.la",
+		"*.cmake"
+	],
+	"modules":[
+		{
+			"name":"boost",
+			"buildsystem":"simple",
+			"build-commands":[
+				"./bootstrap.sh --prefix=/app",
+				"./b2 headers",
+				"./b2 install"
+			],
+			"sources":[
+				{
+					"sha256":"5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9",
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/boost/files/boost/1.66.0/boost_1_66_0.tar.bz2"
+				}
+			],
+			"cleanup":[
+				"/include"
+			]
+		},
+		{
+			"name":"flightgear-data",
+			"buildsystem":"simple",
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/FlightGear-2017.3.1-data.tar.bz2",
+					"sha256":"df08b06e88a29a9f80f29186afd54d278636a663281a1b68e8f484bbb403d898",
+					"dest": "fgdata"
+				}
+			],
+			"build-commands": [
+				"mkdir --parents /app/share/flightgear",
+				"mv fgdata/* /app/share/flightgear/"
+			]
+		},
+		"shared-modules/glu/glu-9.0.0.json",
+		{
+			"name":"mesa",
+			"config-opts":[
+				"--enable-osmesa"
+			],
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://mesa.freedesktop.org/archive/mesa-17.2.0-rc6.tar.gz",
+					"sha256":"ce25345b7da886cdc730299065e2f27ac285eddc75c89595be16cb8ec8497fcc"
+				}
+			]
+		},
+		{
+			"name": "ffmpeg",
+			"config-opts": [
+				"--disable-everything",
+				"--disable-static",
+				"--enable-shared",
+				"--disable-programs",
+				"--disable-doc",
+				"--disable-avdevice",
+				"--disable-avfilter",
+				"--disable-postproc",
+
+				/* Enough to run the base game, might need extending for mod content */
+				"--enable-decoder=bink,binkaudio_rdft,mp3,pcm_s16le,vorbis",
+				"--enable-demuxer=bink,mp3,ogg,pcm_s16le,wav"
+			],
+			"sources": [
+				{
+				"type": "archive",
+				"url": "http://ffmpeg.org/releases/ffmpeg-2.8.14.tar.xz",
+				"sha256": "ef061d9a6cdde8628d00613d17b467fb5ad75e7404ef523dc842e192c511a116"
+				}
+			]
+		},
+		{
+			"name":"openscenegraph",
+			"buildsystem":"cmake-ninja",
+			"config-opts": [
+				"-DBUILD_OSG_PLUGINS_BY_DEFAULT=0",
+				"-DBUILD_OSG_PLUGIN_OSG=1",
+				"-DBUILD_OSG_PLUGIN_DDS=1",
+				"-DBUILD_OSG_PLUGIN_TGA=1",
+				"-DBUILD_OSG_PLUGIN_BMP=1",
+				"-DBUILD_OSG_PLUGIN_JPEG=1",
+				"-DBUILD_OSG_PLUGIN_PNG=1",
+				"-DBUILD_OSG_DEPRECATED_SERIALIZERS=0",
+				"-DBUILD_OSG_APPLICATIONS=0",
+				"-DCMAKE_BUILD_TYPE=Release"
+			],
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://github.com/openscenegraph/OpenSceneGraph/archive/OpenSceneGraph-3.2.3.tar.gz",
+					"sha256":"a1ecc6524197024834e1277916922b32f30246cb583e27ed19bf3bf889534362"
+				}
+			]
+		},
+		{
+			"name":"simgear",
+			"buildsystem":"cmake-ninja",
+			"config-opts":[
+				"-DCMAKE_BUILD_TYPE=Release"
+			],
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/simgear-2017.3.1.tar.bz2",
+					"sha256":"0ee08550b737b249dcc91590ec0cb9c5dc9080998f6ba66a7d7209cdfce6e1f4"
+				}
+			]
+		},
+		{
+			"name":"xmu",
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://www.x.org/archive//individual/lib/libXmu-1.1.2.tar.bz2",
+					"sha256":"756edc7c383254eef8b4e1b733c3bf1dc061b523c9f9833ac7058378b8349d0b"
+				}
+			]
+		},
+		{
+			"name":"plib",
+			"sources":[
+				{
+					"type":"archive",
+					"url":"http://plib.sourceforge.net/dist/plib-1.8.5.tar.gz",
+					"sha256":"485b22bf6fdc0da067e34ead5e26f002b76326f6371e2ae006415dea6a380a32"
+				}
+			]
+		},
+		{
+			"name":"flightgear",
+			"buildsystem":"cmake-ninja",
+			"config-opts":[
+				/*"-DENABLE_QT=ON",*/
+				"-DCMAKE_BUILD_TYPE=Release",
+				"-DFG_BUILD_TYPE=Release"
+			],
+			"builddir": true,
+			"sources":[
+				{
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/flightgear-2017.3.1.tar.bz2",
+					"sha256":"6f2e1d992e2f202b8f9c918c9fb19124ef06824ea0e767e2f4dff6ba43728ccd"
+				},
+				{
+					"type":"file",
+					"path": "org.flightgear.FlightGear.appdata.xml"
+				},
+				{
+					"type":"file",
+					"path": "flightgear.sh"
+				}
+			],
+			"build-commands": [
+				"install -Dm644 ../org.flightgear.FlightGear.appdata.xml /app/share/appdata/org.flightgear.FlightGear.appdata.xml",
+				"install -Dm744 ../flightgear.sh /app/bin/flightgear.sh"
+			]
+		}
+	]
+}

--- a/org.flightgear.FlightGear.json
+++ b/org.flightgear.FlightGear.json
@@ -171,7 +171,7 @@
 				"install -Dm744 ../flightgear.sh /app/bin/flightgear.sh"
 			]
 		},
-				{
+		{
 			"name": "flightgear-data",
 			"buildsystem": "simple",
 			"sources": [

--- a/org.flightgear.FlightGear.json
+++ b/org.flightgear.FlightGear.json
@@ -143,6 +143,22 @@
 			]
 		},
 		{
+			"name": "flightgear-data",
+			"buildsystem": "simple",
+			"sources": [
+				{
+					"type":"archive",
+					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/FlightGear-2017.3.1-data.tar.bz2",
+					"sha256":"df08b06e88a29a9f80f29186afd54d278636a663281a1b68e8f484bbb403d898",
+					"dest": "fgdata"
+				}
+			],
+			"build-commands": [
+				"mkdir --parents /app/share/flightgear",
+				"mv fgdata/* /app/share/flightgear/"
+			]
+		},
+		{
 			"name": "flightgear",
 			"buildsystem": "cmake-ninja",
 			"config-opts": [
@@ -168,23 +184,12 @@
 			],
 			"build-commands": [
 				"install -Dm644 ../org.flightgear.FlightGear.appdata.xml /app/share/appdata/org.flightgear.FlightGear.appdata.xml",
-				"install -Dm744 ../flightgear.sh /app/bin/flightgear.sh"
-			]
-		},
-		{
-			"name": "flightgear-data",
-			"buildsystem": "simple",
-			"sources": [
-				{
-					"type":"archive",
-					"url":"https://sourceforge.net/projects/flightgear/files/release-2017.3/FlightGear-2017.3.1-data.tar.bz2",
-					"sha256":"df08b06e88a29a9f80f29186afd54d278636a663281a1b68e8f484bbb403d898",
-					"dest": "fgdata"
-				}
+				"install -Dm744 ../flightgear.sh /app/bin/flightgear.sh",
+				"chmod +x /app/bin/flightgear.sh"
 			],
-			"build-commands": [
-				"mkdir --parents /app/share/flightgear",
-				"mv fgdata/* /app/share/flightgear/"
+			"post-install": [
+				"desktop-file-edit --set-key=Exec --set-value=flightgear.sh /app/share/applications/org.flightgear.FlightGear.desktop",
+				"desktop-file-edit --set-key=StartupWMClass --set-value=osgViewer /app/share/applications/org.flightgear.FlightGear.desktop"
 			]
 		}
 	]


### PR DESCRIPTION
Additional aircraft & scenery can be downloaded from flightgear.org and must be placed in ~/.fgfs/Aircraft, respective ~/.fgfs/Scenery.

I'm using the KDE Sdk, since FlightGear offers a Qt GUI, which I've disabled for now. The FlightGear code makes an assertion in the Qt code fail, but the root cause itself is not fatal. But since the Qt contained in the KDE Platform is build with the -debug flag, this causes a crash.

Upstream bug report: https://sourceforge.net/p/flightgear/codetickets/2012/