### PR TITLE
org.gnome.glabels-3

### DIFF
--- a/org.gnome.glabels-3.json
+++ b/org.gnome.glabels-3.json
@@ -86,6 +86,38 @@
             ]
         },
         {
+            "name": "gnubarcode",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnu.org/gnu/barcode/barcode-0.99.tar.gz",
+                    "sha256": "7c031cf3eb811242f53664379aebbdd9fae0b7b26b5e5d584c31a9f338154b64"
+                }
+            ]
+        },
+        {
+            "name": "libqrencode",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://fukuchi.org/works/qrencode/qrencode-4.0.0.tar.bz2",
+                    "sha256": "c90035e16921117d4086a7fdee65aab85be32beb4a376f6b664b8a425d327d0b"
+                }
+            ]
+        },
+        {
+            "name": "zint",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/zint/zint/2.6.3/zint-2.6.3.src.tar.gz",
+                    "sha256": "adcaebeb2931163a567073644c8e7952430ea31e08060363432d77cc599318d8"
+                }
+            ]
+        },
+        {
             "name": "glabels",
             "post-install": [
                 "for size in 64 128; do

--- a/org.gnome.glabels-3.json
+++ b/org.gnome.glabels-3.json
@@ -87,6 +87,12 @@
         },
         {
             "name": "glabels",
+            "post-install": [
+                "for size in 64 128; do
+                   rsvg-convert -w $size -h $size -f png -o $size.png /app/share/icons/hicolor/scalable/apps/glabels-3.0.svg
+                   install -Dm644 $size.png /app/share/icons/hicolor/${size}x${size}/apps/org.gnome.glabels-3.png
+                 done"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/org.gnome.glabels-3.json
+++ b/org.gnome.glabels-3.json
@@ -127,9 +127,9 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glabels/3.4/glabels-3.4.0.tar.xz",
-                    "sha256": "d40e079395d30adbcd8204f41d08f7a8da9ec130bffa4cb3c130fbe2322b6410"
+                    "type": "git",
+                    "url": "https://github.com/jimevins/glabels.git",
+                    "commit": "a391634d7efa143987c6f37204c7543bac67f03f"
                 }
             ]
         }

--- a/org.gnome.glabels-3.json
+++ b/org.gnome.glabels-3.json
@@ -1,0 +1,99 @@
+{
+    "app-id": "org.gnome.glabels-3",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "glabels-3",
+    "rename-appdata-file": "glabels-3.appdata.xml",
+    "rename-desktop-file": "glabels-3.0.desktop",
+    "rename-icon": "glabels-3.0",
+    "copy-icon": true,
+    "finish-args": [
+        "--share=ipc", "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/atkmm*", "/lib/cairomm*", "/lib/gdkmm*", "/lib/giomm*", "/lib/glibmm*", "/lib/gtkmm*", "/lib/pangomm*", "/lib/pkgconfig", "/lib/sigc++*",
+        "/share/devhelp", "/share/doc", "/share/gtk-doc", "/share/man",
+        "*.la", "*.a"
+    ],
+    "modules": [
+        {
+            "name": "sigc++",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/libsigc++/2.10/libsigc++-2.10.0.tar.xz",
+                    "sha256": "f843d6346260bfcb4426259e314512b99e296e8ca241d771d21ac64f28298d81"
+                }
+            ]
+        },
+        {
+            "name": "glibmm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glibmm/2.54/glibmm-2.54.1.tar.xz",
+                    "sha256": "7cc28c732b04d70ed34f0c923543129083cfb90580ea4a2b4be5b38802bf6a4a"
+                }
+            ]
+        },
+        {
+            "name": "cairomm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/cairomm/1.12/cairomm-1.12.0.tar.xz",
+                    "sha256": "a54ada8394a86182525c0762e6f50db6b9212a2109280d13ec6a0b29bfd1afe6"
+                }
+            ]
+        },
+        {
+            "name": "pangomm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/pangomm/2.40/pangomm-2.40.1.tar.xz",
+                    "sha256": "9762ee2a2d5781be6797448d4dd2383ce14907159b30bc12bf6b08e7227be3af"
+                }
+            ]
+        },
+        {
+            "name": "atkmm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/atkmm/2.24/atkmm-2.24.2.tar.xz",
+                    "sha256": "ff95385759e2af23828d4056356f25376cfabc41e690ac1df055371537e458bd"
+                }
+            ]
+        },
+        {
+            "name": "gtkmm",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/gtkmm/3.22/gtkmm-3.22.2.tar.xz",
+                    "sha256": "91afd98a31519536f5f397c2d79696e3d53143b80b75778521ca7b48cb280090"
+                }
+            ]
+        },
+        {
+            "name": "glabels",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/glabels/3.4/glabels-3.4.0.tar.xz",
+                    "sha256": "d40e079395d30adbcd8204f41d08f7a8da9ec130bffa4cb3c130fbe2322b6410"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Based off the GNotes manifest to get the gtkmm stuff done easily. I didn't enable any fancy barcode generation libs but there is basic support built-in which works fine. Works for my basic "text on a label" case - the printing and file portals seem to do basically the right thing.

@jimevins Would you be interested in maintaining the Flatpak together (basically pushing new tarball URLs/hashes when you make new releases). You can guide users to Flathub to download the latest version exactly how you've configured it and run on any distro.