### PR TITLE
Create org.flarerpg.Flare manifest

### DIFF
--- a/org.flarerpg.Flare.json
+++ b/org.flarerpg.Flare.json
@@ -1,0 +1,81 @@
+{
+	"app-id": "org.flarerpg.Flare",
+	"rename-desktop-file": "flare.desktop",
+	"rename-icon": "flare",
+	"runtime": "org.freedesktop.Platform",
+	"runtime-version": "1.6",
+	"sdk": "org.freedesktop.Sdk",
+	"command": "flare.sh",
+	"finish-args": [
+		"--socket=wayland",
+		"--socket=x11",
+		"--share=ipc",
+		"--socket=pulseaudio",
+		"--device=dri"
+	],
+	"build-options": {
+		"cflags": "-O2",
+		"cxxflags": "-O2"
+	},
+	"cleanup": [
+		"/app/games",
+		"/lib/debug",
+		"/share/man"
+	],
+	"modules": [
+		{
+			"name": "flare-engine",
+			"buildsystem": "cmake-ninja",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/clintbellanger/flare-engine/archive/v1.0.tar.gz",
+					"sha256": "4bbd4674513b643be6294188904665c53f0ef2912e803212c05e8fd22a44d74d"
+				}
+			],
+			"post-install": [
+				"mkdir /app/bin",
+				"mv /app/games/flare /app/bin"
+			]
+		},
+		{
+			"name": "flare-game",
+			"buildsystem": "cmake-ninja",
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://github.com/clintbellanger/flare-game/archive/837407a156fb16ec3e4be18d497bae6005d5f946.zip",
+					"sha256": "da06d73d2b3cab3d39fdf947ab886e9aa8068740f562604b953536f3091fc3d8"
+				}
+			],
+			"post-install": [
+				"echo \"flare --mods=fantasycore,empyrean_campaign --data-path=/app/share/games/flare\" > /app/bin/flare.sh",
+				"chmod +x /app/bin/flare.sh",
+				"desktop-file-edit --set-key=Exec --set-value=flare.sh /app/share/applications/flare.desktop"
+				
+			]
+		},
+		{
+			"name": "SDL2",
+			"config-opts": ["--enable-sdl-dlopen",
+					"--disable-arts",
+					"--disable-esd",
+					"--disable-nas",
+					"--enable-pulseaudio",
+					"--disable-alsa",
+					"--disable-oss",
+					"--disable-sndio",
+					"--disable-libudev",
+					"--enable-video-wayland",
+					"--enable-wayland-shared=no"],
+			"cleanup-platform": ["/bin/sdl2-config"],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "http://www.libsdl.org/release/SDL2-2.0.7.tar.gz",
+					"sha256": "ee35c74c4313e2eda104b14b1b86f7db84a04eeab9430d56e001cea268bf4d5e"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
The flare-game archive is the 1.0 release from 3 days ago + some appdata commits: https://github.com/clintbellanger/flare-game/commit/837407a156fb16ec3e4be18d497bae6005d5f946

I'm bundling SDL2 2.0.7 until it's updated in the Freedesktop Sdk, since 2.0.6 causes a segfault.