### PR TITLE
Add ZevDocs

### DIFF
--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -8,6 +8,7 @@
     ],
     "command" : "zevdocs",
     "rename-icon": "zevdocs",
+    "copy-icon" : true,
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",
@@ -49,7 +50,7 @@
                     "type" : "git",
                     "url" : "https://github.com/jkozera/zevdocs.git",
                     "tag" : "0.1.0",
-                    "commit": "da2a5a3c10bbc664c5c26ecf50145247c69a389c"
+                    "commit": "8f6391f4222aa932b7f1fca27d6446cec4537952"
                 }
             ]
         },

--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -49,7 +49,7 @@
                     "type" : "git",
                     "url" : "ssh://git@github.com/jkozera/zevdocs.git",
                     "tag" : "0.1.0",
-                    "commit": "17f79dfbff8f2c8a90be4c7431ba5d2ed91c3c8c"
+                    "commit": "da2a5a3c10bbc664c5c26ecf50145247c69a389c"
                 }
             ]
         },

--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -47,7 +47,7 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "ssh://git@github.com/jkozera/zevdocs.git",
+                    "url" : "https://github.com/jkozera/zevdocs.git",
                     "tag" : "0.1.0",
                     "commit": "da2a5a3c10bbc664c5c26ecf50145247c69a389c"
                 }

--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -1,0 +1,74 @@
+{
+    "app-id" : "io.github.jkozera.ZevDocs",
+    "runtime" : "org.gnome.Sdk",
+    "runtime-version" : "3.28",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.golang"
+    ],
+    "command" : "zevdocs",
+    "rename-icon": "zevdocs",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        /* Needs to talk to the network: */
+        "--share=network",
+        "--filesystem=host:ro",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options" : {
+        "cflags" : "-O2",
+        "cxxflags" : "-O2",
+        "env" : {
+            "V" : "1"
+        },
+        "build-args": ["--share=network"]
+    },
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "zevdocs",
+            "config-opts" : [
+                "--enable-flatpak-build"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "ssh://git@github.com/jkozera/zevdocs.git",
+                    "tag" : "0.1.0",
+		    "commit": "17f79dfbff8f2c8a90be4c7431ba5d2ed91c3c8c"
+                }
+            ]
+        },
+        {
+            "name": "zealcore",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "ssh://git@github.com/jkozera/zealcore.git",
+                    "commit" : "83166e99106f3a3edb0e235e7f482078eaf682d9",
+                    "dest": "go/src/github.com/zealdocs/zealcore"
+                }
+            ],
+            "build-commands": [
+                "GOPATH=$(pwd)/go sh -c '/usr/lib/sdk/golang/bin/go get -u github.com/golang/dep/cmd/dep && cd go/src/github.com/zealdocs/zealcore && $GOPATH/bin/dep ensure && /usr/lib/sdk/golang/bin/go build'",
+                "install -D go/src/github.com/zealdocs/zealcore/zealcore /app/bin/zealcore"
+            ]
+        }
+    ]
+}

--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -132,7 +132,7 @@
                 },
                 {
                     "type": "git",
-                    "url": "ssh://git@github.com/jkozera/zealcore.git",
+                    "url": "https://github.com/jkozera/zealcore.git",
                     "commit" : "83166e99106f3a3edb0e235e7f482078eaf682d9",
                     "dest": "go/src/github.com/zealdocs/zealcore"
                 }

--- a/io.github.jkozera.ZevDocs.json
+++ b/io.github.jkozera.ZevDocs.json
@@ -26,8 +26,7 @@
         "cxxflags" : "-O2",
         "env" : {
             "V" : "1"
-        },
-        "build-args": ["--share=network"]
+        }
     },
     "cleanup" : [
         "/include",
@@ -50,14 +49,87 @@
                     "type" : "git",
                     "url" : "ssh://git@github.com/jkozera/zevdocs.git",
                     "tag" : "0.1.0",
-		    "commit": "17f79dfbff8f2c8a90be4c7431ba5d2ed91c3c8c"
+                    "commit": "17f79dfbff8f2c8a90be4c7431ba5d2ed91c3c8c"
                 }
             ]
         },
         {
-            "name": "zealcore",
+            "name" : "zealcore",
             "buildsystem": "simple",
-            "sources": [
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url": "https://github.com/gin-contrib/sse",
+                    "commit": "22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae",
+                    "dest": "go/src/github.com/gin-contrib/sse"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/gin-gonic/gin",
+                    "commit": "d459835d2b077e44f7c9b453505ee29881d5d12d",
+                    "tag": "v1.2",
+                    "dest": "go/src/github.com/gin-gonic/gin"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/golang/protobuf",
+                    "commit": "925541529c1fa6821df4e44ce2723319eb2be768",
+                    "tag": "v1.0.0",
+                    "dest": "go/src/github.com/golang/protobuf"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/kyoh86/xdg",
+                    "commit": "8db68a8ea76a47f1f677f533df8b125b464d5210",
+                    "dest": "go/src/github.com/kyoh86/xdg"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/mattn/go-isatty",
+                    "commit": "0360b2af4f38e8d38c7fce2a9f4e702702d73a39",
+                    "tag": "v0.0.3",
+                    "dest": "go/src/github.com/mattn/go-isatty"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/mattn/go-sqlite3",
+                    "commit": "6c771bb9887719704b210e87e934f08be014bdb1",
+                    "tag": "v1.6.0",
+                    "dest": "go/src/github.com/mattn/go-sqlite3"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/ugorji/go",
+                    "commit": "9831f2c3ac1068a78f50999a30db84270f647af6",
+                    "tag": "v1.1",
+                    "dest": "go/src/github.com/ugorji/go"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/golang/net",
+                    "commit": "e0c57d8f86c17f0724497efcb3bc617e82834821",
+                    "dest": "go/src/golang.org/x/net"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://github.com/golang/sys",
+                    "commit": "cc7307a45468e49eaf2997c890f14aa03a26917b",
+                    "dest": "go/src/golang.org/x/sys"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://gopkg.in/go-playground/validator.v8",
+                    "commit": "5f1438d3fca68893a817e4a66806cea46a9e4ebf",
+                    "tag": "v8.18.2",
+                    "dest": "go/src/gopkg.in/go-playground/validator.v8"
+                },
+                {
+                    "type" : "git",
+                    "url": "https://gopkg.in/yaml.v2",
+                    "commit": "7f97868eec74b32b0982dd158a51a446d1da7eb5",
+                    "tag": "v2.1.1",
+                    "dest": "go/src/gopkg.in/yaml.v2"
+                },
                 {
                     "type": "git",
                     "url": "ssh://git@github.com/jkozera/zealcore.git",
@@ -66,7 +138,7 @@
                 }
             ],
             "build-commands": [
-                "GOPATH=$(pwd)/go sh -c '/usr/lib/sdk/golang/bin/go get -u github.com/golang/dep/cmd/dep && cd go/src/github.com/zealdocs/zealcore && $GOPATH/bin/dep ensure && /usr/lib/sdk/golang/bin/go build'",
+                "GOPATH=$(pwd)/go sh -c 'cd go/src/github.com/zealdocs/zealcore && /usr/lib/sdk/golang/bin/go build'",
                 "install -D go/src/github.com/zealdocs/zealcore/zealcore /app/bin/zealcore"
             ]
         }


### PR DESCRIPTION
This is a first public release of ZevDocs, exclusively on Flathub.

ZevDocs is a Devhelp fork, which allows browsing more sets of documentation, in particular the ones from [Dash](https://kapeli.com/dash), thanks to usage of "[zealcore](https://github.com/jkozera/zealcore)" search backend. In addition to browsing more sets, it also uses less memory, thanks to offloading the index to the external (though executing on local machine) backend.

To resolve potential concerns about forking or using 3rd party resources, it was discussed separately with:
- @swilmet (Devhelp's maintainer, over personal emails), who agreed that for now Devhelp goals are different from this app, hence the fork,
- @Kapeli (Dash's maintainer), who agreed to distribute his documentation sets through ZevDocs,
- @trollixx (Zeal's maintainer), who agreed that zealcore is a good idea (see also [relevant Medium post by me](https://medium.com/@jerzy.kozera/zeal-1-0-0-golang-plans-8f011ac18933)), and even though he didn't want to release it so early, he agreed for me to release the ZevDocs GNOME app as an experiment,
- some people on #gnome-hackers on Freenode, who encouraged the release.