### PR TITLE
Add io.github.gillesdegottex.FMIT

### DIFF
--- a/io.github.gillesdegottex.FMIT.json
+++ b/io.github.gillesdegottex.FMIT.json
@@ -11,7 +11,6 @@
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",
-        "--socket=wayland",
         "--socket=pulseaudio"
     ],
     "modules" : [

--- a/io.github.gillesdegottex.FMIT.json
+++ b/io.github.gillesdegottex.FMIT.json
@@ -47,9 +47,9 @@
             ],
             "sources" : [
                 {
-                    "type" : "archive",
-                    "url" : "https://github.com/gillesdegottex/fmit/archive/v1.1.13.tar.gz",
-                    "sha512" : "e1febcd15c2425cda451cd4c4ca8396fe1651788f672f5d38ae4190691b3c2457fdfd8bb7aeb813e3f4c30ce29e6d435861f5df289b3839c9401aab1a607da8b"
+                    "type" : "git",
+                    "url" : "https://github.com/gillesdegottex/fmit.git",
+                    "commit" : "584e58b55916b57b944e40c3140a3f112dd04f73"
                 },
                 {
                     "type" : "shell",

--- a/io.github.gillesdegottex.FMIT.json
+++ b/io.github.gillesdegottex.FMIT.json
@@ -1,0 +1,66 @@
+{
+    "id" : "io.github.gillesdegottex.FMIT",
+    "branch" : "stable",
+    "runtime" : "org.kde.Platform",
+    "sdk" : "org.kde.Sdk",
+    "runtime-version" : "5.10",
+    "command" : "fmit",
+    "rename-icon" : "fmit",
+    "rename-desktop-file" : "fmit.desktop",
+    "rename-appdata-file" : "fmit.appdata.xml",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio"
+    ],
+    "modules" : [
+        {
+            "name": "fftw",
+            "config-opts" : [
+                "--enable-shared",
+                "--disable-static"
+            ],
+            "cleanup" : [
+            	"/bin",
+                "/include",
+                "/lib/*.la",
+                "/lib/cmake",
+                "/lib/pkgconfig",
+                "/share/info",
+                "/share/man"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://www.fftw.org/fftw-3.3.7.tar.gz",
+                    "sha1": "2ae980a8d44c161ce4a09c6e2d1c79243ecbabb2"
+                }
+            ]
+        },
+        {
+            "name" : "fmit",
+            "buildsystem" : "qmake",
+            "config-opts" : [
+                "PREFIXSHORTCUT=/app",
+                "FFT_LIBDIR=/app",
+                "CONFIG+=acs_alsa"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/gillesdegottex/fmit/archive/v1.1.13.tar.gz",
+                    "sha512" : "e1febcd15c2425cda451cd4c4ca8396fe1651788f672f5d38ae4190691b3c2457fdfd8bb7aeb813e3f4c30ce29e6d435861f5df289b3839c9401aab1a607da8b"
+                },
+                {
+                    "type" : "shell",
+                    "commands" : [ "sed -i -e 's/CONFIG += acs_qt//g' fmit.pro" ]
+                },
+                {
+                    "type" : "shell",
+                    "commands" : [ "lrelease fmit.pro" ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi. It is my first flatpak manifest, but I hope it won't be too bad a first try. I could build, install and run it fine locally, but I'm having an issue: the only file being put in the `export/` folder is the flatpak-created executable under `bin/`. The desktop, appdata and icons files are all missing, despite being correctly renamed and installed under the `files/share/` folder. I have been building/installing the bundle with the following command:

```
$ flatpak-builder --verbose --install --force-clean test io.github.gillesdegottex.FMIT.json
```

Am I missing something?