### PR TITLE
Add com.github.lainsce.yishu

### DIFF
--- a/com.github.lainsce.yishu.json
+++ b/com.github.lainsce.yishu.json
@@ -1,0 +1,81 @@
+{
+    "app-id": "com.github.lainsce.yishu",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+    "command": "com.github.lainsce.yishu",
+    "build-options": {
+        "env": {
+            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+        }
+    },
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--talk-name=ca.desrt.dconf",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.la",
+        "/share/gir-1.0",
+        "/lib/girepository-1.0",
+        "/share/vala",
+        "/share/gtk-doc"
+    ],
+    "modules": [
+        {
+            "name": "libgee",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type":"archive",
+                    "url": "https://github.com/GNOME/libgee/archive/0.20.0.tar.gz",
+                    "sha256": "42fe6d651910cb8b720167f71c5255a1b7b1afc82fecd3f31e61f9602b3b1335"
+                }
+            ]
+        },
+        {
+            "name": "granite",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/share/vala",
+                "/share/gir-1.0",
+                "/share/applications",
+                "/lib/pkgconfig",
+                "/lib/girepository-1.0",
+                "/lib/*.la"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/elementary/granite/archive/0.5.zip",
+                    "sha256": "96ea42c8f7765d574eca62a68ae614b91bfa8e898fa450e3748e7711f879eb7f"
+                }
+            ]
+        },
+        {
+            "name": "yishu",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                  "type": "archive",
+                  "url": "https://github.com/lainsce/yishu/archive/1.0.5.tar.gz",
+                  "sha256": "794db5efb6675eceeb5f59690de319e7b325989ee7036e24ce323b8343c656d6"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is the file that makes possible to build a Flatpak for Yishu, my own todo.txt client application made for elementary OS, but now in Flatpak format.

It does not need the elementary Theme patch.