### PR TITLE
add org.kde.ktuberling

### DIFF
--- a/org.kde.ktuberling.appdata.xml
+++ b/org.kde.ktuberling.appdata.xml
@@ -107,6 +107,39 @@
       <image>https://www.kde.org/images/screenshots/ktuberling.png</image>
     </screenshot>
   </screenshots>
+  <releases>
+    <release date="2018-03-06" version="17.12.3">
+    </release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
   <project_group>KDE</project_group>
   <update_contact>kdeedu@kde.org</update_contact>
 </component>

--- a/org.kde.ktuberling.appdata.xml
+++ b/org.kde.ktuberling.appdata.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.kde.ktuberling.desktop</id>
+  <name>Potato Guy</name>
+  <name xml:lang="af">Aartappel Man</name>
+  <name xml:lang="be">Бульбяш</name>
+  <name xml:lang="bn">পটেটো গাই</name>
+  <name xml:lang="br">Paotr ar patatez</name>
+  <name xml:lang="bs">Krompirko</name>
+  <name xml:lang="ca">Home Patata</name>
+  <name xml:lang="ca@valencia">Home Patata</name>
+  <name xml:lang="cs">Bramborový chlapík</name>
+  <name xml:lang="da">Kartoffelfyren</name>
+  <name xml:lang="de">Kartoffelknülch</name>
+  <name xml:lang="el">Πατατάνθρωπος</name>
+  <name xml:lang="eo">Terpomulo</name>
+  <name xml:lang="es">Señor Patata</name>
+  <name xml:lang="et">Kartulimees</name>
+  <name xml:lang="eu">Patata jauna</name>
+  <name xml:lang="fa">مرد سیب زمینی</name>
+  <name xml:lang="fi">Perunamies</name>
+  <name xml:lang="fr">Monsieur Patate</name>
+  <name xml:lang="gl">O home pataca</name>
+  <name xml:lang="he">מר תפוח אדמה</name>
+  <name xml:lang="hne">आलू परसाद</name>
+  <name xml:lang="hr">Krumpirko</name>
+  <name xml:lang="hu">Krumpli bácsi</name>
+  <name xml:lang="is">Kartöflukall</name>
+  <name xml:lang="it">Uomo patata</name>
+  <name xml:lang="ja">ポテトマン</name>
+  <name xml:lang="kk">Картопбай</name>
+  <name xml:lang="km">មនុស្ស​ដំឡូង</name>
+  <name xml:lang="ko">감자돌이</name>
+  <name xml:lang="lt">Bulvinis Vyrukas</name>
+  <name xml:lang="lv">Kartupeļu vīrs</name>
+  <name xml:lang="mk">Компирко</name>
+  <name xml:lang="mr">बटाटा व्यक्ति</name>
+  <name xml:lang="nb">Potetfyren</name>
+  <name xml:lang="nds">Kantüffelfips</name>
+  <name xml:lang="ne">पोट्याटो गाइ</name>
+  <name xml:lang="nl">Aardappelmannetje</name>
+  <name xml:lang="nn">Potetfyren</name>
+  <name xml:lang="pa">ਆਲੂ ਮੁੰਡਾ</name>
+  <name xml:lang="pl">Ziemniaczany facet</name>
+  <name xml:lang="pt">Homem Batata</name>
+  <name xml:lang="pt_BR">Homem-Batata</name>
+  <name xml:lang="ro">Domnul Cartof</name>
+  <name xml:lang="ru">Картофельный парень</name>
+  <name xml:lang="se">Buđetolmmái</name>
+  <name xml:lang="sk">Zemiakový chlapec</name>
+  <name xml:lang="sl">Krompirček</name>
+  <name xml:lang="sr">Кромпирко</name>
+  <name xml:lang="sr@ijekavian">Кромпирко</name>
+  <name xml:lang="sr@ijekavianlatin">Krompirko</name>
+  <name xml:lang="sr@latin">Krompirko</name>
+  <name xml:lang="sv">Potatismannen</name>
+  <name xml:lang="ta">உருளைகிழங்கு வீரர்</name>
+  <name xml:lang="tg">Писараки Картошкагин</name>
+  <name xml:lang="tr">Patates Adam</name>
+  <name xml:lang="uk">Картопляний хлопець</name>
+  <name xml:lang="wa">Monsieu Crompire</name>
+  <name xml:lang="xh">Umfana wetapile </name>
+  <name xml:lang="zh_CN">土豆小子</name>
+  <name xml:lang="zh_TW">馬鈴薯小子</name>
+  <summary>A simple constructor game suitable for children and adults alike</summary>
+  <summary xml:lang="ca">Un joc de construcció senzill, adequat per nens i també per adults</summary>
+  <summary xml:lang="ca@valencia">Un joc de construcció senzill, adequat per nens i també per adults</summary>
+  <summary xml:lang="da">En simpelt byggeprogram til børn i alle aldre</summary>
+  <summary xml:lang="de">Ein einfaches Aufbauspiel für Kinder und Erwachsene</summary>
+  <summary xml:lang="el">Ένα απλό παιχνίδι κατασκευών κατάλληλο για παιδιά και μεγάλους</summary>
+  <summary xml:lang="es">Un sencillo juego de construcción adecuado para niños y para adultos</summary>
+  <summary xml:lang="et">Lihtne konstrueerimismäng, mis sobib nii lastele kui ka täiskasvanutele</summary>
+  <summary xml:lang="fi">Yksinkertainen rakennuspeli, joka sopii niin lapsille kuin aikuisille</summary>
+  <summary xml:lang="fr">Un jeu d'assemblage simple qui convient aussi bien aux enfants qu'aux adultes</summary>
+  <summary xml:lang="gl">Un construtor de xogos sinxelo que poden usar tanto nenos como adultos</summary>
+  <summary xml:lang="hu">Egyszerű építőjátéknak gyerekeknek és felnőtteknek egyaránt</summary>
+  <summary xml:lang="it">Un semplice gioco di costruzioni adatto sia ai bambini, sia agli adulti</summary>
+  <summary xml:lang="nl">Een eenvoudig aannemerspel geschikt voor zowel kinderen als volwassenen</summary>
+  <summary xml:lang="nn">Eit enkelt biletbyggjespel for både store og små</summary>
+  <summary xml:lang="pl">Prosta gra twórcza kierowana dla dzieci i dorosłych</summary>
+  <summary xml:lang="pt">Um jogo de construção simples, adequado tanto para crianças como adultos</summary>
+  <summary xml:lang="pt_BR">Um jogo de construção simples, adequado para crianças e adultos</summary>
+  <summary xml:lang="ru">Игра-конструктор для детей, а также взрослых, впадающих в детство</summary>
+  <summary xml:lang="sk">Jednoduchá výstavbová hra vhodná pre deti a dospelých</summary>
+  <summary xml:lang="sl">Preprosta igra sestavljanja primerna za mlajše in starejše otroke</summary>
+  <summary xml:lang="sr">Једноставна игра конструисања погодна и за децу и за одрасле</summary>
+  <summary xml:lang="sr@ijekavian">Једноставна игра конструисања погодна и за децу и за одрасле</summary>
+  <summary xml:lang="sr@ijekavianlatin">Jednostavna igra konstruisanja pogodna i za decu i za odrasle</summary>
+  <summary xml:lang="sr@latin">Jednostavna igra konstruisanja pogodna i za decu i za odrasle</summary>
+  <summary xml:lang="sv">Ett enkelt byggspel lika lämpligt för barn som vuxna</summary>
+  <summary xml:lang="tr">Çocukların ve yetişkinlerin hoşlanacağı basit bir inşaat oyunu</summary>
+  <summary xml:lang="uk">Проста гра-складанка для дітей та дорослих</summary>
+  <summary xml:lang="zh_CN">一个简单的建造游戏，适合儿童和成人</summary>
+  <summary xml:lang="zh_TW">適合小孩與童心未泯的大人們的簡單遊戲</summary>
+  <developer_name>XXX: Insert Company or Developer Name</developer_name>
+  <description>
+    <p>KTuberling a simple constructor game suitable for children and adults alike. The idea of the game is based around a once popular doll making concept.</p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=ktuberling</url>
+  <url type="donation">https://kde.org/donate/</url>
+  <url type="help">https://docs.kde.org/stable5/en/kdegames/ktuberling/index.html</url>
+  <url type="homepage">https://www.kde.org/applications/games/ktuberling/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.kde.org/images/screenshots/ktuberling.png</image>
+    </screenshot>
+  </screenshots>
+  <project_group>KDE</project_group>
+  <update_contact>kdeedu@kde.org</update_contact>
+</component>

--- a/org.kde.ktuberling.json
+++ b/org.kde.ktuberling.json
@@ -1,0 +1,78 @@
+{
+    "id": "org.kde.ktuberling",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.9",
+    "sdk": "org.kde.Sdk",
+    "command": "ktuberling",
+    "rename-icon": "ktuberling",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri"
+    ],
+    "modules": [
+        {
+            "name": "libkdegames",
+            "buildsystem": "cmake-ninja",
+            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"],
+            "sources": [ 
+                { 
+                    "type": "archive", 
+                    "url": "https://download.kde.org/stable/applications/17.12.3/src/libkdegames-17.12.3.tar.xz",
+                    "sha256": "6d12bf8f389e07dc8cd8681e61757c817082ffb5e9e409e488a17da9dae501ce"
+                } 
+            ]
+        },
+        {
+            "name": "openal",
+            "buildsystem": "cmake-ninja",
+            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"],
+            "sources": [ 
+                    { 
+                        "type": "archive", 
+                        "url": "https://github.com/kcat/openal-soft/archive/openal-soft-1.17.2.tar.gz", 
+                        "sha256": "11ea176f6cbf9763dbce0953dd77ab72d032b4ad95f07afffb91844abb174033" 
+                    } 
+                ]
+        },
+        {
+            "name": "kdelibs4support",
+            "config-opts": ["-DCMAKE_BUILD_TYPE=Release", "-DCMAKE_INSTALL_LIBDIR=lib"],
+            "buildsystem": "cmake-ninja",
+            "sources": [ 
+                { 
+                    "type": "archive", 
+                    "url": "https://download.kde.org/stable/frameworks/5.44/portingAids/kdelibs4support-5.44.0.tar.xz", 
+                    "sha256": "564e1ccb196119ab29c44cd606d0633a13875259576205a7608b5a9c80cfddb3" 
+                } 
+            ]
+        },
+        {
+            "name": "ktuberling",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [ 
+                { 
+                    "type": "archive", 
+                    "url": "https://download.kde.org/stable/applications/17.12.3/src/ktuberling-17.12.3.tar.xz",
+                    "sha256": "247b165bd38edf83e46be1982aa8750fd4a3d9ba129b29b3b5e3fb68bf4b16e7"
+                }
+            ]
+        },
+        {
+            "name": "ktuberling-appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 org.kde.ktuberling.appdata.xml /app/share/appdata/org.kde.ktuberling.appdata.xml"
+            ],
+            "sources": [ 
+                {
+                    "type": "file",
+                    "path": "org.kde.ktuberling.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Adds the awesome Potato Guy application from KDE. The manifest is basically the unstable testing version from the kde-flatpak-apps but linked against stable releases and formatted a bit more in the flathub style.

I've copied the appdata that's been merged upstream but not yet released in a stable version. I've added OARS and version tags so we'll need to get those upstream as well.

@aleixpol and I think probably @tsdgeos represent upstream here (do let me know if I've got it wrong). What do you guys think? Would you want or be able to maintain the app on Flathub as well? (you'd certainly both have access)
