### PR TITLE
Add org.kde.elisa

### DIFF
--- a/0001-hardcode-icon-theme-name-to-breeze-to-ensure-consist.patch
+++ b/0001-hardcode-icon-theme-name-to-breeze-to-ensure-consist.patch
@@ -1,0 +1,25 @@
+From b6d11363efac9ddeb0e48dd7baa7621e9c74ca08 Mon Sep 17 00:00:00 2001
+From: Matthieu Gallien <matthieu_gallien@yahoo.fr>
+Date: Wed, 18 Apr 2018 10:05:19 +0200
+Subject: [PATCH] hardcode icon theme name to breeze to ensure consistent look
+
+---
+ src/main.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/main.cpp b/src/main.cpp
+index 4600f6d..1f27e0f 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -126,6 +126,8 @@ int main(int argc, char *argv[])
+ 
+     KLocalizedString::setApplicationDomain("elisa");
+ 
++    QIcon::setThemeName(QStringLiteral("breeze"));
++
+ #if defined UPNPQT_FOUND && UPNPQT_FOUND
+     qmlRegisterType<UpnpSsdpEngine>("org.kde.elisa", 1, 0, "UpnpSsdpEngine");
+     qmlRegisterType<UpnpDiscoverAllMusic>("org.kde.elisa", 1, 0, "UpnpDiscoverAllMusic");
+-- 
+2.17.0
+

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -25,8 +25,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/frameworks/5.44/kdeclarative-5.44.0.tar.xz",
-          "sha256": "40d2108b28c59ca0e486b1a7540d6b46a43b5177e0a40b298e40d9e9ba7acf2f"
+          "url": "https://download.kde.org/stable/frameworks/5.45/kdeclarative-5.45.0.tar.xz",
+          "sha256": "f4f6f49392ba7dfaba0971c61b29fb0cfc1a16d26fb7b2b36fae7a5d14b50441"
         }
       ]
     },
@@ -53,8 +53,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/frameworks/5.44/kfilemetadata-5.44.0.tar.xz",
-          "sha256": "6f9dd7ab57ff4465736272973a2f064fc68ff5dfbf7f56f8f4c7dcc7016d1d6d"
+          "url": "https://download.kde.org/stable/frameworks/5.45/kfilemetadata-5.45.0.tar.xz",
+          "sha256": "467166170082f09d9e6a27933a11a687362406239f08f893a617c53defd28f71"
         }
       ]
     },
@@ -84,8 +84,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/frameworks/5.44/baloo-5.44.0.tar.xz",
-          "sha256": "3eae55b5fa31f695da4145f8505637f6d8d5f77a0472d6f23fd367690ba07d79"
+          "url": "https://download.kde.org/stable/frameworks/5.45/baloo-5.45.0.tar.xz",
+          "sha256": "ba4157e0f8fd6c33aa373a373719e2907aa058bdcf2e0d97617c6043d2bb227f"
         }
       ]
     },

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -95,6 +95,9 @@
     {
       "name": "elisa",
       "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+      ],
       "sources": [
         {
           "type": "archive",

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -1,0 +1,80 @@
+{
+    "id": "org.kde.elisa",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.9",
+    "sdk": "org.kde.Sdk",
+    "command": "elisa",
+    "finish-args": ["--share=ipc", "--socket=x11", "--socket=wayland", "--filesystem=home:ro", "--socket=pulseaudio", "--device=dri", "--socket=session-bus", "--env=BALOO_DB_PATH=.local/share/baloo" ],
+
+    "modules": [
+        {
+            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"],
+            "name": "kdeclarative",
+            "buildsystem": "cmake-ninja",
+            "sources":
+                [
+                    {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/frameworks/5.44/kdeclarative-5.44.0.tar.xz",
+                    "sha256": "40d2108b28c59ca0e486b1a7540d6b46a43b5177e0a40b298e40d9e9ba7acf2f"
+                    }
+                ]
+        },
+        {
+            "config-opts": [ "-DBUILD_SHARED_LIBS=ON" ],
+            "name": "taglib",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://taglib.github.io/releases/taglib-1.11.1.tar.gz",
+                    "sha256": "b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b"
+                }
+            ]
+        },
+        {
+            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib" ],
+            "name": "kfilemetadata",
+            "buildsystem": "cmake-ninja",
+            "sources":
+                [
+                    {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/frameworks/5.44/kfilemetadata-5.44.0.tar.xz",
+                    "sha256": "6f9dd7ab57ff4465736272973a2f064fc68ff5dfbf7f56f8f4c7dcc7016d1d6d"
+                    }
+                ]
+        },
+        {
+            "name": "lmdb",
+            "sources": [ { "type": "git", "url": "git://github.com/LMDB/lmdb.git", "branch": "LMDB_0.9.18", "commit": "ad8488cfac644d7a289e428ab3c403c859d844cb" }],
+            "no-autogen": true,
+            "make-install-args": ["prefix=/app"],
+            "subdir" : "libraries/liblmdb"
+        },
+        {
+            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib", "-DLMDB_DIR=/app"],
+            "name": "baloo",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/frameworks/5.44/baloo-5.44.0.tar.xz",
+                    "sha256": "3eae55b5fa31f695da4145f8505637f6d8d5f77a0472d6f23fd367690ba07d79"
+                }
+            ]
+        },
+        {
+            "name": "elisa",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/elisa/0.1/elisa-0.1.tar.xz",
+                    "sha256": "dbf6d2d3991c2b1ea3bc34e07b6e6450bb47a6f8518907be851d57d429e45eed"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -101,8 +101,12 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://download.kde.org/stable/elisa/0.1/elisa-0.1.tar.xz",
-          "sha256": "dbf6d2d3991c2b1ea3bc34e07b6e6450bb47a6f8518907be851d57d429e45eed"
+          "url": "https://download.kde.org/stable/elisa/0.1.1/elisa-0.1.1.tar.xz",
+          "sha256": "3ca7dce9092de422cea82f37fa16613e5aa969cfdae016dce87d38a46d8c463b"
+        },
+        {
+          "type": "patch",
+          "path": "0001-hardcode-icon-theme-name-to-breeze-to-ensure-consist.patch"
         }
       ]
     }

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -95,7 +95,6 @@
     {
       "name": "elisa",
       "buildsystem": "cmake-ninja",
-      "config-opts": [],
       "sources": [
         {
           "type": "archive",

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -18,8 +18,7 @@
   "modules": [
     {
       "config-opts": [
-        "-DENABLE_TESTING=OFF",
-        "-DCMAKE_INSTALL_LIBDIR=lib"
+        "-DENABLE_TESTING=OFF"
       ],
       "name": "kdeclarative",
       "buildsystem": "cmake-ninja",
@@ -47,8 +46,7 @@
     },
     {
       "config-opts": [
-        "-DENABLE_TESTING=OFF",
-        "-DCMAKE_INSTALL_LIBDIR=lib"
+        "-DENABLE_TESTING=OFF"
       ],
       "name": "kfilemetadata",
       "buildsystem": "cmake-ninja",
@@ -79,7 +77,6 @@
     {
       "config-opts": [
         "-DENABLE_TESTING=OFF",
-        "-DCMAKE_INSTALL_LIBDIR=lib",
         "-DLMDB_DIR=/app"
       ],
       "name": "baloo",

--- a/org.kde.elisa.json
+++ b/org.kde.elisa.json
@@ -1,80 +1,108 @@
 {
-    "id": "org.kde.elisa",
-    "runtime": "org.kde.Platform",
-    "runtime-version": "5.9",
-    "sdk": "org.kde.Sdk",
-    "command": "elisa",
-    "finish-args": ["--share=ipc", "--socket=x11", "--socket=wayland", "--filesystem=home:ro", "--socket=pulseaudio", "--device=dri", "--socket=session-bus", "--env=BALOO_DB_PATH=.local/share/baloo" ],
-
-    "modules": [
+  "id": "org.kde.elisa",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.9",
+  "sdk": "org.kde.Sdk",
+  "command": "elisa",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--filesystem=home:ro",
+    "--socket=pulseaudio",
+    "--device=dri",
+    "--talk-name=org.kde.baloo",
+    "--own-name=org.mpris.MediaPlayer2.elisa",
+    "--env=BALOO_DB_PATH=.local/share/baloo"
+  ],
+  "modules": [
+    {
+      "config-opts": [
+        "-DENABLE_TESTING=OFF",
+        "-DCMAKE_INSTALL_LIBDIR=lib"
+      ],
+      "name": "kdeclarative",
+      "buildsystem": "cmake-ninja",
+      "sources": [
         {
-            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib"],
-            "name": "kdeclarative",
-            "buildsystem": "cmake-ninja",
-            "sources":
-                [
-                    {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/frameworks/5.44/kdeclarative-5.44.0.tar.xz",
-                    "sha256": "40d2108b28c59ca0e486b1a7540d6b46a43b5177e0a40b298e40d9e9ba7acf2f"
-                    }
-                ]
-        },
-        {
-            "config-opts": [ "-DBUILD_SHARED_LIBS=ON" ],
-            "name": "taglib",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "http://taglib.github.io/releases/taglib-1.11.1.tar.gz",
-                    "sha256": "b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b"
-                }
-            ]
-        },
-        {
-            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib" ],
-            "name": "kfilemetadata",
-            "buildsystem": "cmake-ninja",
-            "sources":
-                [
-                    {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/frameworks/5.44/kfilemetadata-5.44.0.tar.xz",
-                    "sha256": "6f9dd7ab57ff4465736272973a2f064fc68ff5dfbf7f56f8f4c7dcc7016d1d6d"
-                    }
-                ]
-        },
-        {
-            "name": "lmdb",
-            "sources": [ { "type": "git", "url": "git://github.com/LMDB/lmdb.git", "branch": "LMDB_0.9.18", "commit": "ad8488cfac644d7a289e428ab3c403c859d844cb" }],
-            "no-autogen": true,
-            "make-install-args": ["prefix=/app"],
-            "subdir" : "libraries/liblmdb"
-        },
-        {
-            "config-opts": ["-DENABLE_TESTING=OFF", "-DCMAKE_INSTALL_LIBDIR=lib", "-DLMDB_DIR=/app"],
-            "name": "baloo",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/frameworks/5.44/baloo-5.44.0.tar.xz",
-                    "sha256": "3eae55b5fa31f695da4145f8505637f6d8d5f77a0472d6f23fd367690ba07d79"
-                }
-            ]
-        },
-        {
-            "name": "elisa",
-            "buildsystem": "cmake-ninja",
-            "config-opts": [],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/elisa/0.1/elisa-0.1.tar.xz",
-                    "sha256": "dbf6d2d3991c2b1ea3bc34e07b6e6450bb47a6f8518907be851d57d429e45eed"
-                }
-            ]
+          "type": "archive",
+          "url": "https://download.kde.org/stable/frameworks/5.44/kdeclarative-5.44.0.tar.xz",
+          "sha256": "40d2108b28c59ca0e486b1a7540d6b46a43b5177e0a40b298e40d9e9ba7acf2f"
         }
-    ]
+      ]
+    },
+    {
+      "config-opts": [
+        "-DBUILD_SHARED_LIBS=ON"
+      ],
+      "name": "taglib",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://taglib.github.io/releases/taglib-1.11.1.tar.gz",
+          "sha256": "b6d1a5a610aae6ff39d93de5efd0fdc787aa9e9dc1e7026fa4c961b26563526b"
+        }
+      ]
+    },
+    {
+      "config-opts": [
+        "-DENABLE_TESTING=OFF",
+        "-DCMAKE_INSTALL_LIBDIR=lib"
+      ],
+      "name": "kfilemetadata",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.kde.org/stable/frameworks/5.44/kfilemetadata-5.44.0.tar.xz",
+          "sha256": "6f9dd7ab57ff4465736272973a2f064fc68ff5dfbf7f56f8f4c7dcc7016d1d6d"
+        }
+      ]
+    },
+    {
+      "name": "lmdb",
+      "sources": [
+        {
+          "type": "git",
+          "url": "git://github.com/LMDB/lmdb.git",
+          "branch": "LMDB_0.9.18",
+          "commit": "ad8488cfac644d7a289e428ab3c403c859d844cb"
+        }
+      ],
+      "no-autogen": true,
+      "make-install-args": [
+        "prefix=/app"
+      ],
+      "subdir": "libraries/liblmdb"
+    },
+    {
+      "config-opts": [
+        "-DENABLE_TESTING=OFF",
+        "-DCMAKE_INSTALL_LIBDIR=lib",
+        "-DLMDB_DIR=/app"
+      ],
+      "name": "baloo",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.kde.org/stable/frameworks/5.44/baloo-5.44.0.tar.xz",
+          "sha256": "3eae55b5fa31f695da4145f8505637f6d8d5f77a0472d6f23fd367690ba07d79"
+        }
+      ]
+    },
+    {
+      "name": "elisa",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.kde.org/stable/elisa/0.1/elisa-0.1.tar.xz",
+          "sha256": "dbf6d2d3991c2b1ea3bc34e07b6e6450bb47a6f8518907be851d57d429e45eed"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
json file to build stable version 0.1.0 of Elisa music player. This is heavily inspired from the files in KDE repo that builds nightly versions of this application.
I am not sure how to give the minimal authorization for access of dbus session bus for Mpris2 support. There is also a need to access baloo dbus service on the session bus.
I have another not ideal permission. In order to provide access to music files located in other places than xdg-music, I have added full read-only access to home. As far as I have understood, the current portal interface does not allow to give access to full directory but only to individual files. This the reason to give this broad permission.