### PR TITLE
add org.kde.gcompris

### DIFF
--- a/org.kde.gcompris.json
+++ b/org.kde.gcompris.json
@@ -1,0 +1,29 @@
+{
+    "id": "org.kde.gcompris",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.9",
+    "sdk": "org.kde.Sdk",
+    "rename-icon": "gcompris-qt",
+    "command": "gcompris-qt",
+    "finish-args": [
+        "--socket=pulseaudio", 
+        "--share=ipc", 
+        "--socket=x11", 
+        "--socket=wayland", 
+        "--device=dri" 
+    ],
+    "modules": [
+        {
+            "name": "gcompris",
+            "buildsystem": "cmake",
+            "builddir": true,
+            "sources": [ 
+                { 
+                    "type": "git", 
+                    "url": "https://github.com/KDE/gcompris.git",
+                    "commit": "263b217f4bb41d7927d8666f5809beb7bfe73f6b"
+                } 
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This needs to use git in order to correctly pull in the qml box2d dependency. The commit corresponds to the 0.90 release.

The build doesn't work with cmake-ninja