### PR TITLE
Add org.flatpak.qtdemo

### DIFF
--- a/org.flatpak.demo.json
+++ b/org.flatpak.demo.json
@@ -9,7 +9,6 @@
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
-        "--filesystem=host",
         "--device=dri"
     ],
     "build-options" : {

--- a/org.flatpak.demo.json
+++ b/org.flatpak.demo.json
@@ -11,17 +11,11 @@
         "--socket=wayland",
         "--device=dri"
     ],
-    "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
-        "env": {
-            "V": "1"
-        }
-    },
     "modules": [
         {
             "name": "flatpak-demo",
-            "cmake": true,
+            "buildsystem": "cmake-ninja",
+            "config-opts": ["-DCMAKE_BUILD_TYPE=RelWithDebInfo"],
             "sources": [
                 {
                     "type": "archive",

--- a/org.flatpak.demo.json
+++ b/org.flatpak.demo.json
@@ -1,0 +1,36 @@
+{
+    "app-id": "org.flatpak.demo",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.10",
+    "sdk": "org.kde.Sdk",
+    "command": "flatpak-demo",
+    "rename-icon": "flatpak",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=host",
+        "--device=dri"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "flatpak-demo",
+            "cmake": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/grulja/flatpak-demo/archive/v1.0.0.tar.gz",
+                    "sha256": "8cb2ed5f957cf7be0c95fe8bf7fc7b0a4fc5441ff2a20643c1a7e5a2483632cf"
+                }
+            ]
+        }
+    ]
+}
+

--- a/org.flatpak.qtdemo.json
+++ b/org.flatpak.qtdemo.json
@@ -1,14 +1,14 @@
 {
-    "app-id": "org.flatpak.demo",
+    "app-id": "org.flatpak.qtdemo",
     "runtime": "org.kde.Platform",
     "runtime-version": "5.10",
     "sdk": "org.kde.Sdk",
     "command": "flatpak-demo",
-    "rename-icon": "flatpak",
     "finish-args": [
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
+        "--filesystem=host",
         "--device=dri"
     ],
     "modules": [
@@ -19,8 +19,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/grulja/flatpak-demo/archive/v1.0.0.tar.gz",
-                    "sha256": "8cb2ed5f957cf7be0c95fe8bf7fc7b0a4fc5441ff2a20643c1a7e5a2483632cf"
+                    "url": "https://github.com/flatpak/qt-flatpak-demo/archive/v1.1.0.tar.gz",
+                    "sha256": "8eb6d9fbfa585f9a9f380a52f7ca5a54b08b476397829363857c7ad02527b28e"
                 }
             ]
         }


### PR DESCRIPTION
The demo application is supposed to demonstrate portals and be used as an example for Flatpak documentation.