### PR TITLE
Add org.electronjs.Electron2.BaseApp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-appstream-check": true
+}

--- a/io.electronjs.Electron2.BaseApp.yml
+++ b/io.electronjs.Electron2.BaseApp.yml
@@ -91,6 +91,12 @@ modules:
         commands: [autoreconf -vfi]
         dest-filename: autogen.sh
 
+  - name: libxkbfile
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/releases/individual/lib/libxkbfile-1.0.9.tar.bz2
+        sha256: 51817e0530961975d9513b773960b4edd275f7d5c72293d5a151ed4f42aeb16a
+
   - name: nss
     buildsystem: simple
     subdir: nss

--- a/io.electronjs.Electron2.BaseApp.yml
+++ b/io.electronjs.Electron2.BaseApp.yml
@@ -107,6 +107,9 @@ modules:
       - type: archive
         url: https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_36_1_RTM/src/nss-3.36.1.tar.gz
         sha256: 6025441d528ff6a7f1a4b673b6ee7d3540731ada3f78d5acd5c3b3736b222bff
+      - type: patch
+        path: nss-i386-no-parallel.patch
+        only-arches: [i386]
     modules:
       - name: gyp
         buildsystem: simple

--- a/io.electronjs.Electron2.BaseApp.yml
+++ b/io.electronjs.Electron2.BaseApp.yml
@@ -1,0 +1,114 @@
+id: io.electronjs.Electron2.BaseApp
+branch: stable
+runtime: org.freedesktop.Platform
+sdk: org.freedesktop.Sdk
+runtime-version: '1.6'
+separate-locales: false
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /man
+  - /share/aclocal
+  - /share/devhelp
+  - /share/gir-1.0
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - /share/vala
+  - /lib/systemd
+  - '*.la'
+  - '*.a'
+modules:
+  - shared-modules/udev/udev-175.json
+
+  - name: dbus-glib
+    cleanup:
+      - /bin
+      - /libexec
+      - /etc/bash_completion.d
+    config-opts:
+      - --disable-static
+      - --disable-gtk-doc
+    sources:
+      - type: archive
+        url: https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.106.tar.gz
+        sha256: b38952706dcf68bad9c302999ef0f420b8cf1a2428227123f0ac4764b689c046
+
+  - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+
+  - name: gconf
+    cleanup:
+      - /bin
+      - /libexec
+      - /share
+      - /etc
+    config-opts:
+      - --disable-static
+      - --disable-gtk-doc
+      - --disable-orbit
+      - --disable-introspection
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/GConf/3.2/GConf-3.2.6.tar.xz
+        sha256: 1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c
+
+  - name: libnotify
+    cleanup:
+      - /bin
+    config-opts:
+      - --disable-static
+      - --disable-tests
+      - --disable-introspection
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.7.tar.xz
+        sha256: 9cb4ce315b2655860c524d46b56010874214ec27e854086c1a1d0260137efc04
+
+  - name: gvfs-trash
+    buildsystem: simple
+    build-commands:
+      - install -m755 gvfs-trash /app/bin/gvfs-trash
+    sources:
+    - type: script
+      dest-filename: gvfs-trash
+      commands:
+        - exec rm -r "$@"
+
+  - name: libgnome-keyring
+    config-opts:
+      - --disable-static
+      - --disable-gtk-doc
+      - --disable-coverage
+      - --disable-introspection
+    rm-configure: true
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz
+        sha256: c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783
+      - type: patch
+        path: libgnome-keyring-detect-gcrypt.patch
+      - type: script
+        commands: [autoreconf -vfi]
+        dest-filename: autogen.sh
+
+  - name: nss
+    buildsystem: simple
+    subdir: nss
+    build-commands:
+      - ./build.sh --system-sqlite --system-nspr --enable-libpkix --disable-tests -v -o
+      - install -D ../dist/Release/lib/*.so /app/lib
+    sources:
+      - type: archive
+        url: https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_36_1_RTM/src/nss-3.36.1.tar.gz
+        sha256: 6025441d528ff6a7f1a4b673b6ee7d3540731ada3f78d5acd5c3b3736b222bff
+    modules:
+      - name: gyp
+        buildsystem: simple
+        cleanup: ['*']
+        build-commands:
+          - python2 setup.py install --prefix=/app
+        sources:
+          - type: git
+            url: https://chromium.googlesource.com/external/gyp
+            branch: master
+            commit: 4d467626b0b9f59a85fb81ca4d7ea9eca99b9d8f

--- a/libgnome-keyring-detect-gcrypt.patch
+++ b/libgnome-keyring-detect-gcrypt.patch
@@ -1,0 +1,29 @@
+diff -pur libgnome-keyring-3.12.0.orig/configure.ac libgnome-keyring-3.12.0/configure.ac
+--- libgnome-keyring-3.12.0.orig/configure.ac	2014-03-23 00:48:24.000000000 -0700
++++ libgnome-keyring-3.12.0/configure.ac	2016-11-07 16:58:37.063601464 -0800
+@@ -127,24 +127,13 @@ LIBRARY_LIBS="$LIBRARY_LIBS $DBUS_LIBS"
+ #
+ 
+ GCRYPT_VERSION=1.2.2
+-GCRYPT_LIBVER=1
+ 
+-AM_PATH_LIBGCRYPT($GCRYPT_LIBVER:$GCRYPT_VERSION,,
+-	AC_MSG_ERROR([[
+-***
+-*** libgcrypt was not found. You may want to get it from
+-*** ftp://ftp.gnupg.org/gcrypt/libgcrypt/
+-***
+-]]))
+-libgcrypt=yes
++PKG_CHECK_MODULES(LIBGCRYPT, [libgcrypt >= $GCRYPT_VERSION])
+ AC_DEFINE_UNQUOTED(LIBGCRYPT_VERSION, "$GCRYPT_VERSION", [Version of GCRYPT we expect])
+ 
+ LIBRARY_CFLAGS="$LIBRARY_CFLAGS $LIBGCRYPT_CFLAGS"
+ LIBRARY_LIBS="$LIBRARY_LIBS $LIBGCRYPT_LIBS"
+ 
+-AC_SUBST([LIBGCRYPT_CFLAGS])
+-AC_SUBST([LIBGCRYPT_LIBS])
+-
+ # --------------------------------------------------------------------
+ # Debug mode
+ #

--- a/nss-i386-no-parallel.patch
+++ b/nss-i386-no-parallel.patch
@@ -1,0 +1,12 @@
+diff -up a/nss/build.sh.orig b/nss/build.sh
+--- a/nss/build.sh.orig	2017-10-13 11:24:47.436647729 +0200
++++ b/nss/build.sh	2017-10-13 11:25:25.141116333 +0200
+@@ -196,7 +196,7 @@ if [ "$rebuild_gyp" = 1 ]; then
+         set_nspr_path "$obj_dir/include/nspr:$obj_dir/lib"
+     fi
+ 
+-    run_verbose run_scanbuild ${GYP} -f ninja "${gyp_params[@]}" "$cwd"/nss.gyp
++    run_verbose run_scanbuild ${GYP} --no-parallel -f ninja "${gyp_params[@]}" "$cwd"/nss.gyp
+ 
+     mv -f "$gyp_config".new "$gyp_config"
+ fi


### PR DESCRIPTION
Since Electron 2.0 hit stable we might as well add this.

Changes:

- New app-id to better reflect upstreams domain
- Remove Gtk2
- Build Gtk3 version of appindicator
- Convert to yaml
- Add NSS and libxkbfile

(**I've not actually tested this against any Electron 2 application**)