### PR TITLE
Add org.gtk.Gtk3theme.Zukitre

### DIFF
--- a/org.gtk.Gtk3theme.Zukitre.appdata.xml
+++ b/org.gtk.Gtk3theme.Zukitre.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Zukitre</id>
+  <metadata_license>GPL3</metadata_license>
+  <name>Zukitre Gtk+ theme</name>
+  <summary>Zukitre Gtk+ theme</summary>
+  <description>
+    <p>Zukitre theme for GNOME, Xfce and more.</p>
+  </description>
+  <url type="homepage">https://github.com/lassekongo83/zuki-themes</url>
+</component>

--- a/org.gtk.Gtk3theme.Zukitre.appdata.xml
+++ b/org.gtk.Gtk3theme.Zukitre.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
   <id>org.gtk.Gtk3theme.Zukitre</id>
-  <metadata_license>GPL3</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <name>Zukitre Gtk+ theme</name>
   <summary>Zukitre Gtk+ theme</summary>
   <description>

--- a/org.gtk.Gtk3theme.Zukitre.json
+++ b/org.gtk.Gtk3theme.Zukitre.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Zukitre",
+  "branch": "3.28",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.28",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Zukitre",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -dm755 /usr/share/runtime/share/themes/Zukitre/gtk-3.0",
+        "cp -aL Zukitre/* /usr/share/runtime/share/themes/Zukitre"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/lassekongo83/zuki-themes/archive/v3.28-1.zip",
+          "sha256": "6fd192b26f90b29216ab6cb6e158fdf906ccf56d14a49e3ea03ece1bba234c08"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Zukitre.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Zukitre --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Zukitre"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Zukitre.appdata.xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the Zukitre theme. All credits go to the original author: https://github.com/lassekongo83/zuki-themes

Tagging @lassekongo83 here.

Signed-off-by: Yoshi2889 rick.2889@gmail.com