### PR TITLE
Add an OpenJDK 10 SDK Extension

### DIFF
--- a/org.freedesktop.Sdk.Extension.openjdk10.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk10.appdata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.openjdk10</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>OpenJDK 10 SDK extension</name>
+  <summary>OpenJDK 10 SDK extension</summary>
+  <description>
+    <p>
+      This SDK extension allows you to build java apps.
+    </p>
+  </description>
+</component>

--- a/org.freedesktop.Sdk.Extension.openjdk10.json
+++ b/org.freedesktop.Sdk.Extension.openjdk10.json
@@ -1,0 +1,159 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.openjdk10",
+    "branch": "1.6",
+    "runtime": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [ "org.freedesktop.Sdk.Extension.openjdk9" ],
+    "separate-locales": false,
+    "appstream-compose": false,
+    "cleanup": [ "/share/info", "/share/man" ],
+    "build-options" : {
+        "no-debuginfo": true,
+        "strip": true,
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "prefix": "/usr/lib/sdk/openjdk10",
+        "env": {
+        }
+    },
+    "modules": [
+        {
+            "name": "bootstrap",
+            "cleanup": [ "*" ],
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "file",
+                    "only-arches": ["i386"],
+                    "url": "https://fedorapeople.org/~mbooth/bootstrap_jdk/java-openjdk-10.0.1.10-3.fc28.i686.tar.gz",
+                    "dest-filename": "java-openjdk.tar.gz",
+                    "sha512": "cd8f477cef231dfdb292bef4b68c7d9dfa87b6a5c8f3fcdc8fa989ddbd8d6186b786759b4190ce12a4acafca4b8679abed59f03b7409e52a4805cebe7b15c9c3"
+                },
+                {
+                    "type": "file",
+                    "only-arches": ["x86_64"],
+                    "url": "https://fedorapeople.org/~mbooth/bootstrap_jdk/java-openjdk-10.0.1.10-3.fc28.x86_64.tar.gz",
+                    "dest-filename": "java-openjdk.tar.gz",
+                    "sha512": "3a342fff57fafea63667491f99a3358f74600d8bbdd4b6a73258449890937978fce3a86750b8299e9f4e31f404a6c5480f6db6f645e371f90ba34a3c9a22a8a8"
+                },
+                {
+                    "type": "file",
+                    "only-arches": ["arm"],
+                    "url": "https://fedorapeople.org/~mbooth/bootstrap_jdk/java-openjdk-10.0.1.10-3.fc28.armv7hl.tar.gz",
+                    "dest-filename": "java-openjdk.tar.gz",
+                    "sha512": "67cbf9f4901bea70e21bb9813644e8618a6d9078131429c77e0ac8b3fc72bb36be5a09fb4fa417944a906f0dd288d5f59e02b8d52aa9773e78cc04eef7c3e158"
+                },
+                {
+                    "type": "file",
+                    "only-arches": ["aarch64"],
+                    "url": "https://fedorapeople.org/~mbooth/bootstrap_jdk/java-openjdk-10.0.1.10-3.fc28.aarch64.tar.gz",
+                    "dest-filename": "java-openjdk.tar.gz",
+                    "sha512": "5b22c39ca63746d297a1fc61fe087d885680b066a1f1fdc18e80b7d1321c88af33d6e9ae443c5802479797a4ee6537615b5a4254f2d825f788cf04a623ae8fbe"
+                }
+            ],
+            "build-commands": [
+                "tar xf java-openjdk.tar.gz",
+                "mkdir -p $FLATPAK_DEST/bootstrap-java",
+                "cp -dr usr/lib/jvm/java-*/* $FLATPAK_DEST/bootstrap-java"
+            ]
+        },
+        {
+            "name": "java",
+            "buildsystem": "autotools",
+            "no-parallel-make": true,
+            "config-opts": [
+                "--with-boot-jdk=/usr/lib/sdk/openjdk10/bootstrap-java",
+                "--with-version-build=10",
+                "--with-version-pre=",
+                "--with-version-opt=",
+                "--with-debug-level=release",
+                "--with-native-debug-symbols=internal",
+                "--enable-unlimited-crypto",
+                "--with-zlib=system",
+                "--with-libjpeg=system",
+                "--with-giflib=system",
+                "--with-libpng=system",
+                "--with-lcms=system",
+                "--with-stdc++lib=dynamic",
+                "--with-extra-cxxflags=-Wno-error -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse",
+                "--with-extra-cflags=-fstack-protector-strong -Wno-error -std=gnu++98  -fno-delete-null-pointer-checks -fno-lifetime-dse -fpermissive",
+                "--with-extra-ldflags=-Wl,-z,relro  -Wl,-z,now",
+                "--disable-javac-server",
+                "--disable-warnings-as-errors"
+            ],
+            "make-args": [
+                "JAVAC_FLAGS=-g",
+                "LOG=trace",
+                "WARNINGS_ARE_ERRORS=-Wno-error",
+                "CFLAGS_WARNINGS_ARE_ERRORS=-Wno-error",
+                "all"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://src.fedoraproject.org/repo/pkgs/java-openjdk/jdk-updates-jdk10u-jdk-10.0.1+10.tar.xz/sha512/e57810a4208bb12a6b37f5e8313e30c489e6611ec6be8e7a8fb3c0ae9f1842803a3775bc7cc1f597064444fb4fabae5798a4447712fbf547f7021dd0da384613/jdk-updates-jdk10u-jdk-10.0.1+10.tar.xz",
+                    "sha512": "e57810a4208bb12a6b37f5e8313e30c489e6611ec6be8e7a8fb3c0ae9f1842803a3775bc7cc1f597064444fb4fabae5798a4447712fbf547f7021dd0da384613"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "chmod a+x configure"
+                    ]
+		}
+            ]
+        },
+        {
+            "name": "scripts",
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/jre/bin",
+                        "cd /usr/lib/sdk/openjdk10/jvm/openjdk-10.0.1",
+                        "cp -ra conf lib /app/jre/",
+                        "rm /app/jre/lib/src.zip /app/jre/lib/ct.sym",
+			"cp -ra bin/{java,jjs,keytool,orbd,pack200,rmid,rmiregistry,servertool,tnameserv,unpack200} /app/jre/bin"
+                    ],
+                    "dest-filename": "install.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/jdk/",
+                        "cd /usr/lib/sdk/openjdk10/jvm/openjdk-10.0.1",
+                        "cp -ra bin conf include jmods lib /app/jdk/"
+                    ],
+                    "dest-filename": "installjdk.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "export PATH=$PATH:/usr/lib/sdk/openjdk10/bin"
+                    ],
+                    "dest-filename": "enable.sh"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk10/"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.openjdk10.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk10 --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.openjdk10"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.openjdk10.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is an SDK extension for Java 10.

I wanted to use the Java 9 extension to build this extension (a bootstrap JDK is required) but I am blocked by the inability to use extensions to build extensions. I filed a bug against flatpak-builder here: https://github.com/flatpak/flatpak-builder/issues/156

For now we continue to rely on pre-built binaries hosted externally :-(