### PR TITLE
Add io.elementary.Loki.BaseApp

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-appstream-check": true
+}

--- a/io.elementary.BaseApp.json
+++ b/io.elementary.BaseApp.json
@@ -27,6 +27,18 @@
     },
 
     "modules": [{
+            "name": "vala",
+            "cleanup-platform": ["*"],
+            "config-opts": [
+                "--enable-vapigen", "--enable-unversioned"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/vala/0.36/vala-0.36.3.tar.xz",
+                "sha256": "ac8a4ecd01f62d0c5f62ba50b7290d8c5a1edb308eec772a65b8e79be68f061c"
+            }]
+        },
+        {
             "name": "libgee",
             "config-opts": [
                 "--disable-static"

--- a/io.elementary.BaseApp.json
+++ b/io.elementary.BaseApp.json
@@ -4,7 +4,8 @@
     "sdk": "org.freedesktop.Sdk",
     "runtime-version": "1.6",
     "separate-locales": false,
-    "cleanup": ["/cache",
+    "cleanup": [
+        "/cache",
         "/include",
         "/lib/pkgconfig",
         "/man",
@@ -40,7 +41,7 @@
             "name": "granite",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_BUILD_TYPE=Release"
             ],
             "cleanup": [
                 "/bin",
@@ -51,7 +52,7 @@
                 "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
                 "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
             }]
-        }, ,
+        },
         {
             "name": "elementary-theme",
             "buildsystem": "simple",

--- a/io.elementary.BaseApp.json
+++ b/io.elementary.BaseApp.json
@@ -1,0 +1,71 @@
+{
+    "id": "io.elementary.BaseApp",
+    "runtime": "org.freedesktop.Platform",
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "separate-locales": false,
+    "cleanup": ["/cache",
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/devhelp",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "/lib/systemd",
+        "*.la", "*.a"
+    ],
+    "build-options": {
+        "env": {
+            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+            "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+        }
+    },
+
+    "modules": [{
+            "name": "libgee",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://download.gnome.org/sources/libgee/0.20/libgee-0.20.0.tar.xz",
+                "sha256": "21308ba3ed77646dda2e724c0e8d5a2f8d101fb05e078975a532d7887223c2bb"
+            }]
+        },
+        {
+            "name": "granite",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+            ],
+            "cleanup": [
+                "/bin",
+                "/share/applications"
+            ],
+            "sources": [{
+                "type": "archive",
+                "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
+                "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
+            }]
+        }, ,
+        {
+            "name": "elementary-theme",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -dm755 /app/share/themes/elementary/gtk-3.0",
+                "cp -aL gtk-3.22/* /app/share/themes/elementary/gtk-3.0",
+                "cp -a index.theme /app/share/themes/elementary"
+            ],
+            "sources": [{
+                "type": "git",
+                "url": "git://github.com/elementary/stylesheet.git",
+                "branch": "5.1.1",
+                "commit": "6a96d0f3227f15533c11e136b101ee44052eb750"
+            }]
+        }
+    ]
+}

--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -1,5 +1,5 @@
 {
-    "id": "io.elementary.BaseApp",
+    "id": "io.elementary.Loki.BaseApp",
     "runtime": "org.freedesktop.Platform",
     "sdk": "org.freedesktop.Sdk",
     "runtime-version": "1.6",

--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -61,8 +61,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/elementary/granite/archive/5.0.tar.gz",
-                "sha256": "62dd9a8ddef61d42bb77fdc6626e235d3129bd438533a1575652f7a15fd186c8"
+                "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
+                "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
             }]
         },
         {

--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -34,8 +34,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/vala/0.36/vala-0.36.3.tar.xz",
-                "sha256": "ac8a4ecd01f62d0c5f62ba50b7290d8c5a1edb308eec772a65b8e79be68f061c"
+                "url": "https://download.gnome.org/sources/vala/0.40/vala-0.40.6.tar.xz",
+                "sha256": "6da450f1a73e0f1e17506e68cce5b9e8996349e576d3f8cb6b0b73ee22e44be2"
             }]
         },
         {
@@ -61,8 +61,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
-                "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
+                "url": "https://github.com/elementary/granite/archive/5.0.tar.gz",
+                "sha256": "62dd9a8ddef61d42bb77fdc6626e235d3129bd438533a1575652f7a15fd186c8"
             }]
         },
         {

--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -53,7 +53,7 @@
             "name": "granite",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
             ],
             "cleanup": [
                 "/bin",

--- a/io.elementary.Loki.BaseApp.json
+++ b/io.elementary.Loki.BaseApp.json
@@ -34,8 +34,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/vala/0.40/vala-0.40.6.tar.xz",
-                "sha256": "6da450f1a73e0f1e17506e68cce5b9e8996349e576d3f8cb6b0b73ee22e44be2"
+                "url": "https://download.gnome.org/sources/vala/0.36/vala-0.36.14.tar.xz",
+                "sha256": "31df542f37f78d8847c3675a76f691df9e8a6ccfd93045ca3a33cd25db3aa4d2"
             }]
         },
         {


### PR DESCRIPTION
This is a work in progress. The BaseApp includes for now just the most important stuff: granite, libgee and the elementary Gtk theme. 
@codygarver Do you think you can help with providing the list of the packages that are required to build basic elementary Gtk Apps. This will allow elementary app to be published pretty easily on all the platforms using Flatpak.
