### PR TITLE
Add edu.stanford.Almond

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build/

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -252,10 +252,7 @@
                     "npm_config_sqlite_libname" : "sqlcipher",
                     "npm_config_build_from_source" : "true",
                     "PYTHONDONTWRITEBYTECODE" : "1"
-                },
-                "build-args" : [
-                    "--share=network"
-                ]
+                }
             },
             "sources" : [
                 {

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -253,6 +253,7 @@
                 "--disable-tcl",
                 "--disable-readline"
             ],
+            "rm-configure": true,
             "build-options" : {
                 "env" : {
                     "CFLAGS" : "-g -O2 -DSQLITE_HAS_CODEC",
@@ -264,6 +265,13 @@
                     "type" : "archive",
                     "url" : "https://github.com/sqlcipher/sqlcipher/archive/v3.4.2.tar.gz",
                     "sha256" : "69897a5167f34e8a84c7069f1b283aba88cdfa8ec183165c4a5da2c816cfaadb"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                    ]
                 }
             ]
         },

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -94,6 +94,7 @@
                 "--disable-antlrdebug",
                 "--with-pic"
             ],
+            "rm-configure": true,
             "build-options" : {
                 "arch" : {
                     "x86_64" : {
@@ -112,6 +113,13 @@
                     "type" : "archive",
                     "url" : "http://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz",
                     "sha256" : "ca914a97f1a2d2f2c8e1fca12d3df65310ff0286d35c48b7ae5f11dcc8b2eb52"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                    ]
                 }
             ]
         },

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -14,7 +14,6 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=dri",
-        "--filesystem=home",
         "--filesystem=host",
         "--talk-name=ca.desrt.dconf",
         "--system-talk-name=org.bluez",
@@ -88,23 +87,6 @@
             ]
         },
         {
-            "name" : "antlr3",
-            "buildsystem" : "simple",
-            "build-commands" : [
-                "install -m 0755 -d /app/share/java",
-                "install -m 0644 antlr-3.4-complete.jar /app/share/java",
-                "echo 'java -cp /app/share/java/antlr-3.4-complete.jar org.antlr.Tool \"\\$@\"' > /app/bin/antlr3",
-                "chmod 0755 /app/bin/antlr3"
-            ],
-            "sources" : [
-                {
-                    "type" : "file",
-                    "url" : "http://www.antlr3.org/download/antlr-3.4-complete.jar",
-                    "sha256" : "9d3e866b610460664522520f73b81777b5626fb0a282a5952b9800b751550bf7"
-                }
-            ]
-        },
-        {
             "name" : "libantlr3",
             "config-opts" : [
                 "--disable-static",
@@ -138,7 +120,7 @@
             "buildsystem" : "simple",
             "build-commands" : [
                 "./bootstrap.sh",
-                "./b2 -j8 link=shared runtime-link=shared threading=multi variant=release --without-math --without-python install --prefix=/app"
+                "./b2 -j $FLATPAK_BUILDER_N_JOBS link=shared runtime-link=shared threading=multi variant=release --without-math --without-python install --prefix=/app"
             ],
             "sources" : [
                 {
@@ -264,9 +246,5 @@
                 "yarn.json"
             ]
         }
-    ],
-    "build-options" : {
-        "env" : {
-        }
-    }
+    ]
 }

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -78,6 +78,7 @@
         },
         {
             "name" : "cln",
+            "skip-arches": ["arm"],
             "sources" : [
                 {
                     "type" : "archive",
@@ -98,6 +99,15 @@
             "build-options" : {
                 "arch" : {
                     "x86_64" : {
+                        "config-opts" : [
+                            "--enable-64bit",
+                            "--disable-static",
+                            "--enable-shared",
+                            "--disable-antlrdebug",
+                            "--with-pic"
+                        ]
+                    },
+                    "aarch64" : {
                         "config-opts" : [
                             "--enable-64bit",
                             "--disable-static",
@@ -148,6 +158,21 @@
                 "--enable-gpl",
                 "--without-compat"
             ],
+            "build-options" : {
+                "arch" : {
+                    "arm" : {
+                        "config-opts" : [
+                            "--with-build=production",
+                            "--enable-optimized",
+                            "--without-cln",
+                            "--with-gmp",
+                            "--without-readline",
+                            "--enable-gpl",
+                            "--without-compat"
+                        ]
+                    }
+                }
+            },
             "sources" : [
                 {
                     "type" : "archive",

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -110,6 +110,16 @@
                     "aarch64" : {
                         "config-opts" : [
                             "--enable-64bit",
+                            "--disable-abiflags",
+                            "--disable-static",
+                            "--enable-shared",
+                            "--disable-antlrdebug",
+                            "--with-pic"
+                        ]
+                    },
+                    "arm": {
+                        "config-opts" : [
+                            "--disable-abiflags",
                             "--disable-static",
                             "--enable-shared",
                             "--disable-antlrdebug",

--- a/edu.stanford.Almond.json
+++ b/edu.stanford.Almond.json
@@ -1,0 +1,275 @@
+{
+    "app-id" : "edu.stanford.Almond",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.28",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.gfortran-62"
+    ],
+    "command" : "/app/bin/edu.stanford.Almond",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--share=network",
+        "--device=dri",
+        "--filesystem=home",
+        "--filesystem=host",
+        "--talk-name=ca.desrt.dconf",
+        "--system-talk-name=org.bluez",
+        "--system-talk-name=org.freedesktop.login1",
+        "--talk-name=org.gtk.vfs.Daemon",
+        "--talk-name=org.gtk.vfs.mountpoint_http",
+        "--talk-name=org.gnome.Shell.Screenshot",
+        "--talk-name=org.freedesktop.secrets"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/lib/cmake",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/vala",
+        "/bin/npm",
+        "/bin/cvc4",
+        "/bin/antlr3",
+        "/bin/pi",
+        "/lib/yarn",
+        "/bin/yarn",
+        "/bin/mimic*",
+        "/bin/lfsc-checker",
+        "/bin/compile_regexes",
+        "/bin/t2p",
+        "*.la",
+        "*.a",
+        "Makefile",
+        "binding.gyp",
+        "*.o",
+        "*.d"
+    ],
+    "modules" : [
+        {
+            "name" : "lapack",
+            "buildsystem" : "cmake",
+            "builddir" : true,
+            "config-opts" : [
+                "-DBUILD_SHARED_LIBS=ON",
+                "-DCBLAS=ON",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "build-options" : {
+                "env" : {
+                    "FC" : "/usr/lib/sdk/gfortran-62/bin/gfortran"
+                }
+            },
+            "build-commands" : [
+                "/usr/lib/sdk/gfortran-62/install.sh"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://www.netlib.org/lapack/lapack-3.8.0.tar.gz",
+                    "sha256" : "deb22cc4a6120bff72621155a9917f485f96ef8319ac074a7afbc68aab88bcf6"
+                }
+            ]
+        },
+        {
+            "name" : "cln",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://www.ginac.de/CLN/cln-1.3.4.tar.bz2",
+                    "sha256" : "2d99d7c433fb60db1e28299298a98354339bdc120d31bb9a862cafc5210ab748"
+                }
+            ]
+        },
+        {
+            "name" : "antlr3",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "install -m 0755 -d /app/share/java",
+                "install -m 0644 antlr-3.4-complete.jar /app/share/java",
+                "echo 'java -cp /app/share/java/antlr-3.4-complete.jar org.antlr.Tool \"\\$@\"' > /app/bin/antlr3",
+                "chmod 0755 /app/bin/antlr3"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url" : "http://www.antlr3.org/download/antlr-3.4-complete.jar",
+                    "sha256" : "9d3e866b610460664522520f73b81777b5626fb0a282a5952b9800b751550bf7"
+                }
+            ]
+        },
+        {
+            "name" : "libantlr3",
+            "config-opts" : [
+                "--disable-static",
+                "--enable-shared",
+                "--disable-antlrdebug",
+                "--with-pic"
+            ],
+            "build-options" : {
+                "arch" : {
+                    "x86_64" : {
+                        "config-opts" : [
+                            "--enable-64bit",
+                            "--disable-static",
+                            "--enable-shared",
+                            "--disable-antlrdebug",
+                            "--with-pic"
+                        ]
+                    }
+                }
+            },
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://www.antlr3.org/download/C/libantlr3c-3.4.tar.gz",
+                    "sha256" : "ca914a97f1a2d2f2c8e1fca12d3df65310ff0286d35c48b7ae5f11dcc8b2eb52"
+                }
+            ]
+        },
+        {
+            "name" : "boost",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "./bootstrap.sh",
+                "./b2 -j8 link=shared runtime-link=shared threading=multi variant=release --without-math --without-python install --prefix=/app"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.bz2",
+                    "sha256" : "5721818253e6a0989583192f96782c4a98eb6204965316df9f5ad75819225ca9"
+                }
+            ]
+        },
+        {
+            "name" : "cvc4",
+            "config-opts" : [
+                "--with-build=production",
+                "--enable-optimized",
+                "--with-cln",
+                "--without-readline",
+                "--enable-gpl",
+                "--without-compat"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://cvc4.cs.stanford.edu/downloads/builds/src/cvc4-1.5.tar.gz",
+                    "sha256" : "5d6b4f8ee8420f85e3f804181341cedf6ea32342c48f355a5be87754152b14e9"
+                }
+            ]
+        },
+        {
+            "name" : "mimic",
+            "config-opts" : [
+                "--enable-shared",
+                "--disable-static",
+                "--with-audio=no"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/MycroftAI/mimic",
+                    "tag" : "1.2.0.2",
+                    "commit" : "67e43bf0fa56008276b878ec3790aa5f32eb2a16"
+                }
+            ]
+        },
+        {
+            "name" : "node",
+            "config-opts" : [
+                "--openssl-use-def-ca-store",
+                "--shared-openssl",
+                "--shared-zlib",
+                "--with-intl=full-icu"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "sha256" : "577c751fdca91c46c60ffd8352e5b465881373bfdde212c17c3a3c1bd2616ee0",
+                    "url" : "https://nodejs.org/dist/v8.11.3/node-v8.11.3.tar.xz"
+                },
+                {
+                    "type" : "archive",
+                    "sha256" : "9542bd97abeaf3ac2f260b6ccaac36eff7dd2d3122e2efe6ca365c3e457489b4",
+                    "url" : "https://ssl.icu-project.org/files/icu4c/60.2/icu4c-60_2-src.zip",
+                    "dest" : "deps/icu"
+                }
+            ]
+        },
+        {
+            "name" : "yarn",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "cp -r . /app/lib/yarn",
+                "ln -s /app/lib/yarn/bin/yarn /app/bin/yarn"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/yarnpkg/yarn/releases/download/v1.7.0/yarn-v1.7.0.tar.gz",
+                    "sha256" : "e7720ee346b2bd7ec32b7e04517643c38648f5022c7981168321ba1636f2dca3"
+                }
+            ]
+        },
+        {
+            "name" : "sqlcipher",
+            "config-opts" : [
+                "--enable-tempstore=yes",
+                "--enable-releasemode",
+                "--disable-static",
+                "--disable-tcl",
+                "--disable-readline"
+            ],
+            "build-options" : {
+                "env" : {
+                    "CFLAGS" : "-g -O2 -DSQLITE_HAS_CODEC",
+                    "LDFLAGS" : "-lcrypto"
+                }
+            },
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/sqlcipher/sqlcipher/archive/v3.4.2.tar.gz",
+                    "sha256" : "69897a5167f34e8a84c7069f1b283aba88cdfa8ec183165c4a5da2c816cfaadb"
+                }
+            ]
+        },
+        {
+            "name" : "almond-gnome",
+            "buildsystem" : "meson",
+            "build-options" : {
+                "env" : {
+                    "npm_config_nodedir" : "/app",
+                    "npm_config_sqlite" : "/app",
+                    "npm_config_sqlite_libname" : "sqlcipher",
+                    "npm_config_build_from_source" : "true",
+                    "PYTHONDONTWRITEBYTECODE" : "1"
+                },
+                "build-args" : [
+                    "--share=network"
+                ]
+            },
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/Stanford-Mobisocial-IoT-Lab/almond-gnome",
+                    "tag" : "v1.0.0",
+                    "commit" : "4b13ca6d3744491141fd00c30a3808284edda58b"
+                },
+                "yarn.json"
+            ]
+        }
+    ],
+    "build-options" : {
+        "env" : {
+        }
+    }
+}

--- a/yarn.json
+++ b/yarn.json
@@ -1,0 +1,1486 @@
+[
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.0.2.tgz#833d163680a151d2441a2489f5fe5fa87ac87726",
+        "sha256": "d48174f59046d9dbb93abe110db9e562594a80f5e6f6e303ef763670a14b4ce8",
+        "dest": "service/deps",
+        "dest-filename": "@yarnpkg-lockfile-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8",
+        "sha256": "0cc19d22a5f9a54ff45f64509c56c7aedb358215a41be9a9c7c0be8c8673ba6d",
+        "dest": "service/deps",
+        "dest-filename": "abbrev-1.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/abstract-socket/-/abstract-socket-2.0.0.tgz#d83c93e7df30d27e23f3e82a763e7f5e78d916f9",
+        "sha256": "da48f8e58382d95cde46a141765f64f391fe6ba67adc9b2b902bb4b68d075edc",
+        "dest": "service/deps",
+        "dest-filename": "abstract-socket-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/adt/-/adt-0.7.2.tgz#824bb725fe3632c8c35ec24985df610f97d98244",
+        "sha256": "f1a60ad12e5486857bd588892aa2f719ef9701a19fd6c38ecf9f8d33e00c4603",
+        "dest": "service/deps",
+        "dest-filename": "adt-0.7.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536",
+        "sha256": "5e645008a327dfa21293ea60d2e2b9aaa383b44553da1b4126a7dc5a2034fcb7",
+        "dest": "service/deps",
+        "dest-filename": "ajv-4.11.8.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965",
+        "sha256": "0caf0ce6ce6c773345b1ea3d34f67280ea6f16f883a4552f63c04a9eb2f0902f",
+        "dest": "service/deps",
+        "dest-filename": "ajv-5.5.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/almond-dialog-agent/-/almond-dialog-agent-1.0.2.tgz#32ec3abf6be0b59ef6e35d5c9dfc728bca294dc0",
+        "sha256": "f0074163eac6cbe7df1cf663443f593f118d63686c73efe93d7b223d27824044",
+        "dest": "service/deps",
+        "dest-filename": "almond-dialog-agent-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/another-json/-/another-json-0.2.0.tgz#b5f4019c973b6dd5c6506a2d93469cb6d32aeedc",
+        "sha256": "34c7d7e578ccce71e254aad3fcc0beec2f80e4e8aa0579f8cb5673edc5dbb5c4",
+        "dest": "service/deps",
+        "dest-filename": "another-json-0.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df",
+        "sha256": "52b8ab148865eeaf538e630a937fa153d5af21232f014a5d4e38491937be8037",
+        "dest": "service/deps",
+        "dest-filename": "ansi-regex-2.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998",
+        "sha256": "bdadb0d036d35d54a71c47d94b2abfedb595775f41b8137bec044dc5efe43d35",
+        "dest": "service/deps",
+        "dest-filename": "ansi-regex-3.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a",
+        "sha256": "5af368c71e05db3f69f4f7f892156ceaecaf5ae2eaf464cf6ae37809f0e8e09d",
+        "dest": "service/deps",
+        "dest-filename": "aproba-1.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21",
+        "sha256": "c5c1b6012946bf0d4074ba07f5ead07266f87835f25a6616ee95779dc6a962c5",
+        "dest": "service/deps",
+        "dest-filename": "are-we-there-yet-1.1.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asn1/-/asn1-0.2.3.tgz#dac8787713c9966849fc8180777ebe9c1ddf3b86",
+        "sha256": "45ab08e7614dfe11caeda2b869602a5cd7fc777a01968ac101f239db0c9ea19c",
+        "dest": "service/deps",
+        "dest-filename": "asn1-0.2.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525",
+        "sha256": "47ab5c4571504bdee569f03e3423af5b51aa17d6a94866ddcae353ed2d9033eb",
+        "dest": "service/deps",
+        "dest-filename": "assert-plus-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234",
+        "sha256": "73031b3f39d0f0785e6a39f896067abf50d4283dcde4527835e5eacdf3bbc2fd",
+        "dest": "service/deps",
+        "dest-filename": "assert-plus-0.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8",
+        "sha256": "de423275efc992846d5b987788120bf479de94d08636ec5cf808f5f2d8c2ef6a",
+        "dest": "service/deps",
+        "dest-filename": "async-limiter-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79",
+        "sha256": "8c254f30f70792645042e4d71f590ec49f8e386a475772f7430c73b964b57dcf",
+        "dest": "service/deps",
+        "dest-filename": "asynckit-0.4.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f",
+        "sha256": "592829a38e2ffca197ae26799e7e635981d16bb5bba252074f4e333ad4aa9f3a",
+        "dest": "service/deps",
+        "dest-filename": "aws-sign2-0.6.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8",
+        "sha256": "a8f9f4956c5951460f7298586ff35776fbabf4a686ef13bb7716c07703e07289",
+        "dest": "service/deps",
+        "dest-filename": "aws-sign2-0.7.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289",
+        "sha256": "150d1855c0e1f6874569b111e170eb149612390a96601cfdea3e58591d986138",
+        "dest": "service/deps",
+        "dest-filename": "aws4-1.7.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe",
+        "sha256": "14d2488946744b70c47999b48b1989aa3b85d828181b3c61f35818be9033946b",
+        "dest": "service/deps",
+        "dest-filename": "babel-runtime-6.26.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767",
+        "sha256": "2896602c12d3cef566bfbed7ccdef79232f4f1e00622fc5c9b40737465baffad",
+        "dest": "service/deps",
+        "dest-filename": "balanced-match-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d",
+        "sha256": "da5811c666dfbb44633116cb2698a0619da7514f77e03879ff9c38ce549a1679",
+        "dest": "service/deps",
+        "dest-filename": "bcrypt-pbkdf-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7",
+        "sha256": "ad802579ff385984482661989d1ae56c3a22a648dbdc9648c49aa77aff5b2650",
+        "dest": "service/deps",
+        "dest-filename": "bindings-1.3.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c",
+        "sha256": "cab3c710500fd5eafb954d3652b3aefe1c55d3fdea21a5378a840fe07c3a8fac",
+        "dest": "service/deps",
+        "dest-filename": "bl-1.2.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a",
+        "sha256": "d900ce261c297442a61c9791211c622e42d292b5478d9408221e19ff810d717b",
+        "dest": "service/deps",
+        "dest-filename": "block-stream-0.0.9.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9",
+        "sha256": "b72913a58374c9b1b0610b86bbd3b304adee5b73f592b0707ef60e9926716890",
+        "dest": "service/deps",
+        "dest-filename": "bluebird-3.5.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f",
+        "sha256": "a61cb4df27252b2945f69cdfcbe4bc879bf57ea1a4a7ec5838ef7fa56294cedc",
+        "dest": "service/deps",
+        "dest-filename": "boom-2.10.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd",
+        "sha256": "84bd645925eb665a04c19c66eb9da8499d9c17d0d62b4b979d085dcae99695da",
+        "dest": "service/deps",
+        "dest-filename": "brace-expansion-1.1.11.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/browser-request/-/browser-request-0.3.3.tgz#9ece5b5aca89a29932242e18bf933def9876cc17",
+        "sha256": "35cf70fbe4d5b5e913b45dce46e7d2076096526f114aa0ebe6bdd2c0308612e8",
+        "dest": "service/deps",
+        "dest-filename": "browser-request-0.3.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0",
+        "sha256": "7edd593f063d0e46d8dacc4f47dbe0ac77fcca161beea9c8e1948293ea5d8092",
+        "dest": "service/deps",
+        "dest-filename": "buffer-alloc-unsafe-1.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec",
+        "sha256": "98bdbfedcf3375f1d60ecbc715a2ea8b6ed37cf82d4f05f8517cbb3d16599d8c",
+        "dest": "service/deps",
+        "dest-filename": "buffer-alloc-1.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c",
+        "sha256": "8177e3071eb122bf82db0c85130c063dd7341ff18a53d5dcf045b492b17b97ee",
+        "dest": "service/deps",
+        "dest-filename": "buffer-fill-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1",
+        "sha256": "abe62dcdcf47e1fe889df05aeab6c9ece6b1135b14301c710bad9dec0e389f04",
+        "dest": "service/deps",
+        "dest-filename": "byline-5.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc",
+        "sha256": "4d7eb172144890213264deda324bd94a7654302265d18e66bfaa63a351fdae98",
+        "dest": "service/deps",
+        "dest-filename": "caseless-0.12.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181",
+        "sha256": "5d2ecf3af8b7b4068aa4d53507b7e91afa4ea16de46e4f2d69fcbdec003ae8d3",
+        "dest": "service/deps",
+        "dest-filename": "chownr-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184",
+        "sha256": "21d4362a4a3822e68fe1852409381dd0be9851756eabfbf6d0723ef51e39cf98",
+        "dest": "service/deps",
+        "dest-filename": "co-4.6.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77",
+        "sha256": "5279ca78986d6381852ac1b02592ae2dc5cc979317284b8aa1d7554107770b3d",
+        "dest": "service/deps",
+        "dest-filename": "code-point-at-1.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818",
+        "sha256": "b293da68c7f54cf581abc9a512892c7d2ef41ad5bbc460f390aa2b82d57a14b4",
+        "dest": "service/deps",
+        "dest-filename": "combined-stream-1.0.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b",
+        "sha256": "35902dd620cf0058c49ea614120f18a889d984269a90381b7622e79c2cfe4261",
+        "dest": "service/deps",
+        "dest-filename": "concat-map-0.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e",
+        "sha256": "f0d49b480cfabcf86c98b729e4dca966d17d187152b9458983b889473a128336",
+        "dest": "service/deps",
+        "dest-filename": "console-control-strings-1.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/consumer-queue/-/consumer-queue-1.0.1.tgz#be0a8efcf9e3aa7e1ab0248d5c07f817c45b5276",
+        "sha256": "9543939863272617cb8471fb647466b59fe784819a8d7e8a39da90e52a696d56",
+        "dest": "service/deps",
+        "dest-filename": "consumer-queue-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b",
+        "sha256": "db3e3f71df10b2b226a4e9abdc95a47aaa725e499dcee72099beddedcf9e1948",
+        "dest": "service/deps",
+        "dest-filename": "content-type-1.0.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e",
+        "sha256": "dd0af25180bca0d2e186fb31723e76f2a16cbe88ff8018b56d15d6ce164cd5a4",
+        "dest": "service/deps",
+        "dest-filename": "core-js-2.5.7.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7",
+        "sha256": "a4a44dab6579ede3e06ade58d26f8fd642eae09153fd59c608fcb7951a499398",
+        "dest": "service/deps",
+        "dest-filename": "core-util-is-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8",
+        "sha256": "dac94398339bad4fcefe7212915171d1838ccf989ac1053910f10b778daa1238",
+        "dest": "service/deps",
+        "dest-filename": "cryptiles-2.0.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/cvc4/-/cvc4-0.1.1.tgz#053b5536778cadb163c6341471860374e3c081de",
+        "sha256": "8fcd7e4638b6d52a4d8152d2ee5dd5a2310e246626a3aec41b812833cdbffad0",
+        "dest": "service/deps",
+        "dest-filename": "cvc4-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0",
+        "sha256": "8b79ebde18aa8f10aba37e32dcecbe376023c79776510e06e9a53f5e68555340",
+        "dest": "service/deps",
+        "dest-filename": "dashdash-1.14.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://codeload.github.com/gcampax/node-dbus/tar.gz/d65449cd0d5ddf4fd35c2cc36ef769fa2e0979ce",
+        "sha256": "4992054981ab04d04483de375e476045ddb78d226b52f7b3b209615ef7bf10a1",
+        "dest": "service/deps",
+        "dest-filename": "d65449cd0d5ddf4fd35c2cc36ef769fa2e0979ce"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f",
+        "sha256": "34ae48c66698f1f81e2a2e6e322f34e8a88b0986a3fa7b74bb5ea14c0edb1c98",
+        "dest": "service/deps",
+        "dest-filename": "debug-2.6.9.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3",
+        "sha256": "d9a56b26543e99e9d84048ba99071b11264af16d4efe58d86ad26887955341ff",
+        "dest": "service/deps",
+        "dest-filename": "decompress-response-3.3.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5",
+        "sha256": "679226cbc8173a807e1985410f71a06092f25bea729da142d9fda15a8e085ed0",
+        "dest": "service/deps",
+        "dest-filename": "deep-equal-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac",
+        "sha256": "0dcc5f34920c23f5da2916d1d42e53ae5574913dfb78c406902b7189cf0b1386",
+        "dest": "service/deps",
+        "dest-filename": "deep-extend-0.6.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619",
+        "sha256": "ac38fce4217dfb1d772427c7d8d0d073e35ecd832915e97a61d9ab5c504129d3",
+        "dest": "service/deps",
+        "dest-filename": "delayed-stream-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a",
+        "sha256": "bfefdbf411ed50a94c7befbdd75fc49c4ff53b063d481e05bbac2f670acf6461",
+        "dest": "service/deps",
+        "dest-filename": "delegates-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b",
+        "sha256": "7a2af298b85cb36f877693318e157e4d20719ce8dca02b34d68c12142b71218b",
+        "dest": "service/deps",
+        "dest-filename": "detect-libc-1.0.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1",
+        "sha256": "e970de93b55944f514569a97b5d134163db45fee7814315ff4ce9fa2f0a6312e",
+        "dest": "service/deps",
+        "dest-filename": "duplexer-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505",
+        "sha256": "9296acf374d7488b07e9466c03098cc9e6b90aa6bfdd9c614c6ee63975642c4c",
+        "dest": "service/deps",
+        "dest-filename": "ecc-jsbn-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43",
+        "sha256": "3fccf9867cbecb7a355e43d9c9d5c2cbe216bd7b35532d52b6d9cc12b0ba385e",
+        "dest": "service/deps",
+        "dest-filename": "end-of-stream-1.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571",
+        "sha256": "cd4198c30c9deb0d3c5044b230116305539a45b46174a5e8030a3f2d50deed80",
+        "dest": "service/deps",
+        "dest-filename": "event-stream-3.3.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd",
+        "sha256": "915a49a7f6a7c93b0d16b791b317619ce16b380ec57a068a185c1da7d79fd4da",
+        "dest": "service/deps",
+        "dest-filename": "expand-template-1.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444",
+        "sha256": "945da184c09e2fb0d920a73bac25a747b41eb8da99fa456c80e907f3cdfa2eba",
+        "dest": "service/deps",
+        "dest-filename": "extend-3.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05",
+        "sha256": "cf9b392605f59c195d1d44f20162170a4e44bcedc01dddf3cbe6bc594faed044",
+        "dest": "service/deps",
+        "dest-filename": "extsprintf-1.3.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f",
+        "sha256": "b567ce8a7571941a3b0b2eae6e67992c4e47fee9301c47d07fa11f9cfb62f0d2",
+        "dest": "service/deps",
+        "dest-filename": "extsprintf-1.4.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614",
+        "sha256": "4862f3bec17c5a9be48b23e0d1278fce7c0f5020ca879625558f9973075f591d",
+        "dest": "service/deps",
+        "dest-filename": "fast-deep-equal-1.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2",
+        "sha256": "c0fdc9166f441026aedca007c1497dfed2b44e95f93071c2123670c5b451f7ca",
+        "dest": "service/deps",
+        "dest-filename": "fast-json-stable-stringify-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91",
+        "sha256": "eca862e1fd07bf54ff68ccf70450a64dc3d6b807ee9e3ddeb5d96773a3c806c5",
+        "dest": "service/deps",
+        "dest-filename": "forever-agent-0.6.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1",
+        "sha256": "f1292eb8ecd656db1e05bd9879282b961a9d8f30a703a745ebf7784b05a25a2d",
+        "dest": "service/deps",
+        "dest-filename": "form-data-2.1.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099",
+        "sha256": "e42323e14e39e24873d2edc18aeca738b44c4f10481f7b619a5e21f9fefd78cd",
+        "dest": "service/deps",
+        "dest-filename": "form-data-2.3.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe",
+        "sha256": "ae329ea8fbe235040ad598b3de62aad5e53cc84dc7e2391d9c0edf3726bbc504",
+        "dest": "service/deps",
+        "dest-filename": "from-0.1.7.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad",
+        "sha256": "e7936d7e1b24475bd59312c4005f30d42539627dfc1c4f5dfe2326d7b7c7c5fa",
+        "dest": "service/deps",
+        "dest-filename": "fs-constants-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f",
+        "sha256": "9e80cb8713125aa53df81a29626f7b81f26a9be1cd41840b3ccdcae4d52e8f9c",
+        "dest": "service/deps",
+        "dest-filename": "fs.realpath-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105",
+        "sha256": "30acfaf7aa9875a241c7c8e9398b060c9ae7c31adad48a46af47a6070175e04d",
+        "dest": "service/deps",
+        "dest-filename": "fstream-ignore-1.0.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171",
+        "sha256": "c662581e8e2837bf9b81b42651242d300c6b9031bd6788adc5f51f6d270f1971",
+        "dest": "service/deps",
+        "dest-filename": "fstream-1.0.11.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7",
+        "sha256": "98d904d5d0987cf0f4f54ce033934c81bdb93a8b7d75e4fb6912b843c1496676",
+        "dest": "service/deps",
+        "dest-filename": "gauge-2.7.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa",
+        "sha256": "8f0312ba10766d6c13bf71bae5168ca26191f6eed5c47ac5fa7c4df85b3ed445",
+        "dest": "service/deps",
+        "dest-filename": "getpass-0.1.7.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce",
+        "sha256": "3e46f185e0772ae9b83a3383a2bc7182b9facaef63c247a76b0ffc91114443fa",
+        "dest": "service/deps",
+        "dest-filename": "github-from-package-0.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15",
+        "sha256": "cf3d3e47a1308b512fd707f1df593737cb569079d04bf975e1fc48de6a629ed1",
+        "dest": "service/deps",
+        "dest-filename": "glob-7.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658",
+        "sha256": "6ab070270ef8dd8edd446df87425829ed31091dc7e5f30787f5abb9cb5c2b6b8",
+        "dest": "service/deps",
+        "dest-filename": "graceful-fs-4.1.11.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e",
+        "sha256": "8ff4058be48bb686d115490fcfeee71c9bbec44e994f962bc0deb195f71016f8",
+        "dest": "service/deps",
+        "dest-filename": "har-schema-1.0.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92",
+        "sha256": "2e7b84af0567ad7c6a5ddcb5f4c1bcc2bd29d4b089d734f628ac08517081be26",
+        "dest": "service/deps",
+        "dest-filename": "har-schema-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a",
+        "sha256": "b102d4b47fc28822809210e6035870d580daccb86f50f4130ad1de61a1978561",
+        "dest": "service/deps",
+        "dest-filename": "har-validator-4.2.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd",
+        "sha256": "c7e53308bae7ddb691ac13f951eb2028f857909a71529cd6977d9b9c5b3a0c3f",
+        "dest": "service/deps",
+        "dest-filename": "har-validator-5.0.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9",
+        "sha256": "d061dd9f29aa7e063efe6bae9906e8111a8e2b9b69876cf4e9e2337b7335ecac",
+        "dest": "service/deps",
+        "dest-filename": "has-unicode-2.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4",
+        "sha256": "25a9c9d9755c48a1b2a9c69ee5d678796584d0f4464610277136d10098b1b283",
+        "dest": "service/deps",
+        "dest-filename": "hawk-3.1.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hexy/-/hexy-0.2.11.tgz#9939c25cb6f86a91302f22b8a8a72573518e25b4",
+        "sha256": "70d297823f1f03f70ea1fef391de5f6261b1de5b3d4702c7a7b24dfda6122b72",
+        "dest": "service/deps",
+        "dest-filename": "hexy-0.2.11.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed",
+        "sha256": "b203a87561b58b0c712cf1df4a5b362d3709b851c5e6cc4bfa7c020bd372672d",
+        "dest": "service/deps",
+        "dest-filename": "hoek-2.16.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf",
+        "sha256": "e14761a7b61ac7e7b32582d62fced7438983e65dd800138e33363d3b78041f15",
+        "dest": "service/deps",
+        "dest-filename": "http-signature-1.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1",
+        "sha256": "66be6d6fddeaf39acc4fb1437af28ff6a0401a740c479f183718f649d03205f9",
+        "dest": "service/deps",
+        "dest-filename": "http-signature-1.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9",
+        "sha256": "5a9fdcf59874af6ad3b413b6815d5afaaea34939a3bee20e1e50f7830031889b",
+        "dest": "service/deps",
+        "dest-filename": "inflight-1.0.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de",
+        "sha256": "7f5f58e9b54e87e264786e7e84d9e078aaf68c1003de9fa68945101e02356cdf",
+        "dest": "service/deps",
+        "dest-filename": "inherits-2.0.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927",
+        "sha256": "fe8ebd87cc87404eeb3ec89880bc49d83df337f8b95a504366c4674f3646785d",
+        "dest": "service/deps",
+        "dest-filename": "ini-1.3.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a",
+        "sha256": "a8f688da4c42c598ef772c608103fdf1ea0abec15ba082456fba2bdc32224259",
+        "dest": "service/deps",
+        "dest-filename": "ip-1.1.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb",
+        "sha256": "77ed656a130d47cc804c1d8fdae8f0fc4ad355625552fcde37703ca5f8b3686c",
+        "dest": "service/deps",
+        "dest-filename": "is-fullwidth-code-point-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f",
+        "sha256": "4cd0d0edee6bf328b641662054d69e9faf91262beee6f158eb974220ceaba06b",
+        "dest": "service/deps",
+        "dest-filename": "is-fullwidth-code-point-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a",
+        "sha256": "0d5c97ab733832aa006929b933decd71af74d92dcc857637840cb47496c83845",
+        "dest": "service/deps",
+        "dest-filename": "is-typedarray-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11",
+        "sha256": "e23c76f14f5222e07e39d89858b61e8e33f96956de9e0df3659cbdf8db950c87",
+        "dest": "service/deps",
+        "dest-filename": "isarray-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a",
+        "sha256": "79ae4378a2a3446fb72177b57138c1382565ad75e50baba2909731ebb5c90b44",
+        "dest": "service/deps",
+        "dest-filename": "isstream-0.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513",
+        "sha256": "5ac44bc9490a2d7da45ebb7028ff9b86bf17944741e7c449573d7a147ae72323",
+        "dest": "service/deps",
+        "dest-filename": "jsbn-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340",
+        "sha256": "42e2cd66a58b0eef52156985138c363704602c391f1d4a1962b5daa1b95ddcf1",
+        "dest": "service/deps",
+        "dest-filename": "json-schema-traverse-0.3.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13",
+        "sha256": "e3163c53fbc030cb6ac9bd9652f20a62d3d0580e4eeafe9cb36571ca2bee933f",
+        "dest": "service/deps",
+        "dest-filename": "json-schema-0.2.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af",
+        "sha256": "70e228b750bf40ab69dda437f284992f1ea4c4bf9e788dc7fc586a6956256150",
+        "dest": "service/deps",
+        "dest-filename": "json-stable-stringify-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb",
+        "sha256": "b7fbbf65c0bff6d47f516c98638229dff0e981d0edfffecbcf971d7fe361928a",
+        "dest": "service/deps",
+        "dest-filename": "json-stringify-safe-5.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73",
+        "sha256": "030f926cb3d18933c9bce7fe3d1dddbde73b91532dc4cada98214337e811c89c",
+        "dest": "service/deps",
+        "dest-filename": "jsonify-0.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2",
+        "sha256": "1df307cc675650ee56c4a5f7c87860dd56d7e42f6350e715c1a92a280322ec46",
+        "dest": "service/deps",
+        "dest-filename": "jsprim-1.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/keytar/-/keytar-4.2.1.tgz#8a06a6577fdf6373e0aa6b112277e63dec77fd12",
+        "sha256": "e42ff63cc765321a9d22499a921fcd48904badb60d14bc68c28512df6f30d841",
+        "dest": "service/deps",
+        "dest-filename": "keytar-4.2.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99",
+        "sha256": "df4deba1b8156cffe8360b08f04de11b78d3f31ebdde90bef0a053a59848a49b",
+        "dest": "service/deps",
+        "dest-filename": "lodash.get-4.4.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b",
+        "sha256": "a5b10daf8eaa2e6507a3e9e648016cdc9777857ad501917316a5228aa5f3d9cb",
+        "dest": "service/deps",
+        "dest-filename": "long-3.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194",
+        "sha256": "2a72c6e4d972decd6d9fc3fe803b7bfd963ad0b84f601e79fa10f700c8b563ba",
+        "dest": "service/deps",
+        "dest-filename": "map-stream-0.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-0.9.2.tgz#2a521bddcf637cbefde9138784e627ea43645b77",
+        "sha256": "1335136d2f7121ad39523ea10e3d113d598d509d68c90d7210a71e671a209614",
+        "dest": "service/deps",
+        "dest-filename": "matrix-js-sdk-0.9.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db",
+        "sha256": "937420f33b7c3beccba66e48d8b3a48a02d5b8006478a94c54a9a4d0cfbc9559",
+        "dest": "service/deps",
+        "dest-filename": "mime-db-1.33.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8",
+        "sha256": "aea571e6a1f2b6b42fea40e670c704883639928e15d6ff8961e832dfbee474b4",
+        "dest": "service/deps",
+        "dest-filename": "mime-types-2.1.18.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e",
+        "sha256": "763dd728ed8c39615523f3b7e25a69110024ec86ecff82fe5c2666c8cc5d67d9",
+        "dest": "service/deps",
+        "dest-filename": "mimic-response-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083",
+        "sha256": "426a24d79bb6f0d3bb133e62cec69021836d254b39d931c104ddd7c464adea71",
+        "dest": "service/deps",
+        "dest-filename": "minimatch-3.0.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d",
+        "sha256": "7953afa208b921faf59c1fa5693764ca2be03e261ef91c88717ef20c8c474a33",
+        "dest": "service/deps",
+        "dest-filename": "minimist-0.0.8.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284",
+        "sha256": "ec0d0bdf71837612eea9fa61e5689e14856807946d499ce6ebf062ba09a5f270",
+        "dest": "service/deps",
+        "dest-filename": "minimist-1.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf",
+        "sha256": "73e03ee5fba64f3ee864fa90aacd4fc799e427a0555e27b41dd1988a35ffcb76",
+        "dest": "service/deps",
+        "dest-filename": "minimist-0.0.10.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903",
+        "sha256": "77b52870e8dedc68e1e7afcdadba34d3da6debe4f3aae36453ba151f1638bf24",
+        "dest": "service/deps",
+        "dest-filename": "mkdirp-0.5.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8",
+        "sha256": "362152ab8864181fc3359a3c440eec58ce3e18f773b0dde4d88a84fe13d73ecb",
+        "dest": "service/deps",
+        "dest-filename": "ms-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a",
+        "sha256": "ff996fb5ae80b617933e9e68fd67a4aeff445dfaa80ece48ecc9235e142d83d1",
+        "dest": "service/deps",
+        "dest-filename": "nan-2.8.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f",
+        "sha256": "600305681aa0bdebcffc5b89529f39bcf2d56f953b8c50f54226d0ca78ba1b84",
+        "dest": "service/deps",
+        "dest-filename": "nan-2.10.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46",
+        "sha256": "745eb03ca51a191bae27022f286ad2392669ce4b242f3bb67973c7f6266a48ab",
+        "dest": "service/deps",
+        "dest-filename": "nan-2.7.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923",
+        "sha256": "f729e5d5f67c3eccc6fc998a4c8a8aec7dc16b68d6a604ac4245a01132bca9ff",
+        "dest": "service/deps",
+        "dest-filename": "node-abi-2.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-gettext/-/node-gettext-2.0.0.tgz#f1dc1237cdc546f51593da340304b8beba5b8525",
+        "sha256": "39073d99812e394052fe47421acd7a38e75bf584c529883bd37e7fe4645f28cb",
+        "dest": "service/deps",
+        "dest-filename": "node-gettext-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-mimic/-/node-mimic-1.0.0.tgz#87a6b5fb29c1568ff643d83c8098d8f952ee22c5",
+        "sha256": "dbb2c2a46444e8f3e08ef50dbe8ba42520afe2a328545818ff32041dad08f8df",
+        "dest": "service/deps",
+        "dest-filename": "node-mimic-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649",
+        "sha256": "6e30e2fc489a6f597935e3917b8ba05becdfc5e11ec606f8e450cdc3d16d01bd",
+        "dest": "service/deps",
+        "dest-filename": "node-pre-gyp-0.6.39.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/node-ssdp/-/node-ssdp-2.9.1.tgz#2d6ba8e7eff9bf5b338564f91f7ac5d5cdddc55b",
+        "sha256": "01ed92772d16a1537d6db07b3b833c976d72cd2af513bc0a317c237e1cd6b795",
+        "dest": "service/deps",
+        "dest-filename": "node-ssdp-2.9.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2",
+        "sha256": "909fd6649ffdc2b2c885680f9a4e30db04eaca80bf26341acfa68e75ef788aeb",
+        "dest": "service/deps",
+        "dest-filename": "noop-logger-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d",
+        "sha256": "a700f2b6615e0825409dd5e83e5f200847fa84ad2b71cf083bd51b926ed5f8b7",
+        "dest": "service/deps",
+        "dest-filename": "nopt-4.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b",
+        "sha256": "6812a94724c1379c7d57500949afa319d26baa1ee777325f472571d965770759",
+        "dest": "service/deps",
+        "dest-filename": "npmlog-4.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d",
+        "sha256": "896ec5dd2269a0f219b0e46dd24b5532cdfd1648f1e5156078854b912d619f3c",
+        "dest": "service/deps",
+        "dest-filename": "number-is-nan-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43",
+        "sha256": "231d83cb7925718cae32662f274a4c753644b45e1a4f90f3844f7ce234a37eba",
+        "dest": "service/deps",
+        "dest-filename": "oauth-sign-0.8.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/oauth/-/oauth-0.9.15.tgz#bd1fefaf686c96b75475aed5196412ff60cfb9c1",
+        "sha256": "ef7b24bb1f4e82e4ff5d116baa176ca27e10d79c4b09f759123463eb90903d73",
+        "dest": "service/deps",
+        "dest-filename": "oauth-0.9.15.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863",
+        "sha256": "782d726a263ba7b26cced612af97b80035516df4b0cd788524e7b2cebc4e29ed",
+        "dest": "service/deps",
+        "dest-filename": "object-assign-4.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://matrix.org/packages/npm/olm/olm-2.2.2.tgz#7e217d862ab0fd189565e0aea3337efda2dadce4",
+        "sha256": "345d8695ad761c91063a603e17c01f11d953b38ede33e1fa11e59c2c0e0d82da",
+        "dest": "service/deps",
+        "dest-filename": "olm-2.2.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1",
+        "sha256": "cf51460ba370c698f68b976e514d113497339ba018b6003e8e8eb569c6fccfcf",
+        "dest": "service/deps",
+        "dest-filename": "once-1.4.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686",
+        "sha256": "56425fd38177f312912848ff242a684e0c69a03a4c370f49269e1411e031a1a5",
+        "dest": "service/deps",
+        "dest-filename": "optimist-0.6.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3",
+        "sha256": "0ee885c8afec352b70b7b65f7ab8e54a912f8ba4c309ae1c106aa4b67cb24475",
+        "dest": "service/deps",
+        "dest-filename": "os-homedir-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274",
+        "sha256": "13e722c2d777c084983e2e1e1150a496aa25685791a71244e61a605ec892ad89",
+        "dest": "service/deps",
+        "dest-filename": "os-tmpdir-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410",
+        "sha256": "7d19469a119cf35262531ed0729a67a0eacb55baea57f257e7f2801341516448",
+        "dest": "service/deps",
+        "dest-filename": "osenv-0.1.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae",
+        "sha256": "effd84e09e1330542a84a243f1f4da21a700d459b83761eaca16070eb1fb8841",
+        "dest": "service/deps",
+        "dest-filename": "p-finally-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f",
+        "sha256": "6e6d709f1a56942514e4e2c2709b30c7b1ffa46fbed70e714904a3d63b01f75c",
+        "dest": "service/deps",
+        "dest-filename": "path-is-absolute-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445",
+        "sha256": "66df1b1aad8eed88f70cfa06ed541252215a8b725cfcad893a58bfc93f45ebe6",
+        "dest": "service/deps",
+        "dest-filename": "pause-stream-0.0.11.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5",
+        "sha256": "41193d639761077b384832fa53a3d9e4d36008afe7588894ff80059fda75de08",
+        "dest": "service/deps",
+        "dest-filename": "performance-now-0.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b",
+        "sha256": "068f99ddeff11741bd1ebbbe3ee4c6f782731bd9ae0a2d598536cce74e289045",
+        "dest": "service/deps",
+        "dest-filename": "performance-now-2.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/posix/-/posix-4.1.2.tgz#a382ee09dc7bf712f8683b3104d09d5b7909ebe9",
+        "sha256": "d1df7909d1314aaef2f796f4acfb270eb04c4b7446414a1a5a68e1dd3addc479",
+        "dest": "service/deps",
+        "dest-filename": "posix-4.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-2.5.3.tgz#9f65f242782d370296353710e9bc843490c19f69",
+        "sha256": "9f0a7408526806763333ab443af8f9ea5aace8dd050c41117d75250bc19ff4ad",
+        "dest": "service/deps",
+        "dest-filename": "prebuild-install-2.5.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa",
+        "sha256": "8eec271b7af29443e9bc816d5645a1cf8dd744e4ce9d7d929bbcdc2bd49e9c4e",
+        "dest": "service/deps",
+        "dest-filename": "process-nextick-args-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://bitbucket.org/gcampax/node-pulseaudio/get/03ea5ac1a6db16d6bae9cec2faf88d154d249b4e.tar.gz",
+        "sha256": "e82bf9fce75440d6a983686d3c94c5baea90fa09d4d1327310d4ba7a9101a754",
+        "dest": "service/deps",
+        "dest-filename": "03ea5ac1a6db16d6bae9cec2faf88d154d249b4e.tar.gz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954",
+        "sha256": "0ae3d4aa9b9d33b3944b045bb038816af354b7bb9e638ae9b1288c3eee0a7a89",
+        "dest": "service/deps",
+        "dest-filename": "pump-1.0.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909",
+        "sha256": "550d8a15c10582a099dff1a369081106d7954a5a5f6a8d6f47aa12bc9c4b76ab",
+        "dest": "service/deps",
+        "dest-filename": "pump-2.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e",
+        "sha256": "452bca7369ca14bc47711c79063f5f0f3939095918508ca7400f5859448ded89",
+        "dest": "service/deps",
+        "dest-filename": "punycode-1.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/put/-/put-0.0.6.tgz#30f5f60bd6e4389bd329e16a25386cbb2e4a00a3",
+        "sha256": "1ad397439fffc983bb40b1655f46a68f8d1b07fbe4b05b9e09bf3e6e7df999cb",
+        "dest": "service/deps",
+        "dest-filename": "put-0.0.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7",
+        "sha256": "757b4915ac02f13b4c450a517892518bd84e170d52f627798b5577af00cd15f2",
+        "dest": "service/deps",
+        "dest-filename": "q-1.5.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e",
+        "sha256": "545b428eb6dbb457148564b3c033b5e7f3f8495b785cd7f1ddc4813926e84115",
+        "dest": "service/deps",
+        "dest-filename": "q-1.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233",
+        "sha256": "a166db939dbf2e14b115b1fb3c9406fea7fe582c27b64011db1f41235814c19d",
+        "dest": "service/deps",
+        "dest-filename": "qs-6.4.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36",
+        "sha256": "539349384f28c64d970ee897379839967dcc2a9c5b03a4db49cb1c0e5e2e16f0",
+        "dest": "service/deps",
+        "dest-filename": "qs-6.5.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed",
+        "sha256": "03a5fae485203eb424dd3e9b1c4cf9ce3d04c03b154cb4fb6604497815cae93b",
+        "dest": "service/deps",
+        "dest-filename": "rc-1.2.8.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf",
+        "sha256": "0f205b60dc0fb300f05bbbf1d1583b3f87cca8cecc0b6a8673910c9519c45c77",
+        "dest": "service/deps",
+        "dest-filename": "readable-stream-2.3.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9",
+        "sha256": "cdd8985b84b3b6b08fe5dcb39b9506d70ddddffda9f9d703dd33534c60bc373b",
+        "dest": "service/deps",
+        "dest-filename": "regenerator-runtime-0.11.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0",
+        "sha256": "bc392db88ba9386af1f4dd86aea46dfbe35441d3fea891cc008ccea4b669adcf",
+        "dest": "service/deps",
+        "dest-filename": "request-2.81.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e",
+        "sha256": "1cab7365b91df37101a7372b267285e223049741089b1a1183a2d8ef28211359",
+        "dest": "service/deps",
+        "dest-filename": "request-2.87.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36",
+        "sha256": "e6ee2251037935e6e6734f91acee17a5cc405f1011107b8fecd0f7f9685929de",
+        "dest": "service/deps",
+        "dest-filename": "rimraf-2.6.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d",
+        "sha256": "e09206c60fccafb952c854af7629cbb031a98d6da2e143fb3aa3c8a48402aa22",
+        "dest": "service/deps",
+        "dest-filename": "safe-buffer-5.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a",
+        "sha256": "78812f65ae3b98071ce1c9bacbe0666f4220d0b2753c2a11530eb27df440a3b3",
+        "dest": "service/deps",
+        "dest-filename": "safer-buffer-2.1.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9",
+        "sha256": "adc442e017041cffca4d4418d06006ae5f17a9984557fa80c3a6cd8859021cf2",
+        "dest": "service/deps",
+        "dest-filename": "sax-1.2.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab",
+        "sha256": "bd93bdd068b190bfe1deb9f68bc37458e2425b4c3e230284732b5b6dad66a36e",
+        "dest": "service/deps",
+        "dest-filename": "semver-5.5.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7",
+        "sha256": "d934aee7db9e09da09e87724743315ffe888130aa6e04fbbdecac985f6ae693d",
+        "dest": "service/deps",
+        "dest-filename": "set-blocking-2.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d",
+        "sha256": "d8900ed050db9f8e5c27529d43c025d0bbbb16737ca199d86bd50fdc8c5bd2d8",
+        "dest": "service/deps",
+        "dest-filename": "signal-exit-3.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6",
+        "sha256": "2e467ab880395831e6b731ef4f43fe87a2dd6173471b562323189a11f97361ce",
+        "dest": "service/deps",
+        "dest-filename": "simple-concat-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d",
+        "sha256": "e026e2c1a94efb361f81151231b7cedaf297421ce581a2da94094817354bc6ab",
+        "dest": "service/deps",
+        "dest-filename": "simple-get-2.8.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/smtlib/-/smtlib-0.1.1.tgz#7aae56f12d14e3e370ffc8d1c5c8e4fe01bae950",
+        "sha256": "08217e7f0ca199336d920811733e8faac3cac785b24efe2fc3b311f03ee1519b",
+        "dest": "service/deps",
+        "dest-filename": "smtlib-0.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/snowboy/-/snowboy-1.3.1.tgz#220f23f026096fe5290d7919a9f0da93ccd253f2",
+        "sha256": "b3554d6e76e3cf166ef22fbf14c1a6d1e3cee514429df7f1b270442df3b1ac4e",
+        "dest": "service/deps",
+        "dest-filename": "snowboy-1.3.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198",
+        "sha256": "6913bd03125d36dd741d4ffac1620170b568c655a1751bfb7e2ebb3ffa3edcf0",
+        "dest": "service/deps",
+        "dest-filename": "sntp-1.0.9.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f",
+        "sha256": "895e07fb8896a97ca6cd0981d5b4cd7644407486f1654bc7aeedc0a1fb06df86",
+        "dest": "service/deps",
+        "dest-filename": "split-0.3.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sqlite3/-/sqlite3-3.1.13.tgz#d990a05627392768de6278bafd1a31fdfe907dd9",
+        "sha256": "bcf0ac1b10e2e4bcf0bed4a07478e14260ae396097b5efc09e72a44697701ba6",
+        "dest": "service/deps",
+        "dest-filename": "sqlite3-3.1.13.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.2.tgz#c6fc61648a3d9c4e764fd3fcdf4ea105e492ba98",
+        "sha256": "fd0b31959f5cb2ee84b7c8326a35c823a01bcd66d829d46e20a9f0917f406adf",
+        "dest": "service/deps",
+        "dest-filename": "sshpk-1.14.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14",
+        "sha256": "94c833174d0e1f4bcd8040239c151aa27bc07b37688f579024ff3cc6617c0bf4",
+        "dest": "service/deps",
+        "dest-filename": "stream-combiner-0.0.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+        "sha256": "97e54ded8cca6d24a58e8d0650fcfe80fb4094894c2078136b4ad0f24059e25d",
+        "dest": "service/deps",
+        "dest-filename": "string-width-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e",
+        "sha256": "227cdc0ce920900ba08c9c53bdfbd36ab22d78d9657dbb6108e4f9b9ae59792c",
+        "dest": "service/deps",
+        "dest-filename": "string-width-2.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8",
+        "sha256": "af8262434508fa8292407f7fef4690d19eabb73387ca230b41f2a1155216963a",
+        "dest": "service/deps",
+        "dest-filename": "string_decoder-1.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72",
+        "sha256": "dab308bef13617e40126db3709229a2cbb848d3996d97da3fef0e138099a2465",
+        "dest": "service/deps",
+        "dest-filename": "stringstream-0.0.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf",
+        "sha256": "1c9d385a4118959514f84dce8d7bb2dafc802f0272dd00348aa18d17b95b793a",
+        "dest": "service/deps",
+        "dest-filename": "strip-ansi-3.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f",
+        "sha256": "aab0a8473699e01692bac2bb83d5460e295a3dad0e6653e0dd6af57e8ff6202d",
+        "dest": "service/deps",
+        "dest-filename": "strip-ansi-4.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a",
+        "sha256": "dbe45febaf1bf7265c25733242bc0e7ac38b632db6a8e19f0341af4770425899",
+        "dest": "service/deps",
+        "dest-filename": "strip-json-comments-2.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.2.tgz#17e5239747e399f7e77344f5f53365f04af53577",
+        "sha256": "f3c7de02a84c87cd170babf4905caa48e7691bd85e81f81f4d98cc87810a864c",
+        "dest": "service/deps",
+        "dest-filename": "tar-fs-1.16.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.1.tgz#e1dbc03a9b9d3ba07e896ad027317eb679a10a1f",
+        "sha256": "ed8e0f05894021c7bfda1a17e5de5ab0eff196f164b2398128c79d51f2b31647",
+        "dest": "service/deps",
+        "dest-filename": "tar-pack-3.4.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395",
+        "sha256": "48b8793e2a028dc3986b6363f94765ba0b55427207f912299b59f4ae9ff60311",
+        "dest": "service/deps",
+        "dest-filename": "tar-stream-1.6.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1",
+        "sha256": "1f187a298c96f42a825117e9e40a986749133ce1f7fd05d9aa70ba581c131f37",
+        "dest": "service/deps",
+        "dest-filename": "tar-2.2.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/thingengine-core/-/thingengine-core-1.0.1.tgz#8377c3b702e964876bcb24a8d54bd33c0c8edf96",
+        "sha256": "0123f00c59ddfd0e684b8d43ad6817d1dce8df37c2b18891ebfff8100f9c503d",
+        "dest": "service/deps",
+        "dest-filename": "thingengine-core-1.0.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/thingpedia-discovery/-/thingpedia-discovery-1.0.0.tgz#8f56f22419cc20ddce638ade986410066fc707dc",
+        "sha256": "e9ffa59587fd5038fc690168f1032452093070fb2078e854dabad4bd6d467358",
+        "dest": "service/deps",
+        "dest-filename": "thingpedia-discovery-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/thingpedia/-/thingpedia-2.2.2.tgz#a2622a5d0bcea3a7722dd1c11205b89f90e7e816",
+        "sha256": "713d487c263679cde9cc6af5468bfeb73b51a5f7118b74a8128a981bbf260943",
+        "dest": "service/deps",
+        "dest-filename": "thingpedia-2.2.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.1.0.tgz#b713d85b455dcaef2e29ec5766b653224d8f9800",
+        "sha256": "f628ae982fa105f3a84c12bf16680b50e44cf6c7a8e5e9e768819e00ff23acbc",
+        "dest": "service/deps",
+        "dest-filename": "thingtalk-1.1.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5",
+        "sha256": "16b27a8c0fb13e5727356b328d72dbbc5f20bd909252f14d19da344e9354573e",
+        "dest": "service/deps",
+        "dest-filename": "through-2.3.8.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9",
+        "sha256": "d23b215e6ce454f076e163a3feb7a1b548ddf44be3a41353f74837722b11d6c5",
+        "dest": "service/deps",
+        "dest-filename": "tmp-0.0.33.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80",
+        "sha256": "8175b2ad900524d5f8a13d92ede85e531b5babfa109e6a6cd58dc57f39e47a54",
+        "dest": "service/deps",
+        "dest-filename": "to-buffer-1.1.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655",
+        "sha256": "910b8acbe1ae08f9598b331ac952860aef61618d603620ca24a0b1df0df78683",
+        "dest": "service/deps",
+        "dest-filename": "tough-cookie-2.3.4.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd",
+        "sha256": "d3e3c04a50d6d2fa40654bf764fa1792f797bd5a62c69d03dceaa7d4a85c5012",
+        "dest": "service/deps",
+        "dest-filename": "tunnel-agent-0.6.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64",
+        "sha256": "6cea33d67a9bd83f8bd250655c78a2c89ea912bcc6be91c8e65807ce69cfdfd6",
+        "dest": "service/deps",
+        "dest-filename": "tweetnacl-0.14.5.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81",
+        "sha256": "409e8ad409e79122539f440ae0bb2e494453e7584edeb5907d2c64d3a8eb8544",
+        "dest": "service/deps",
+        "dest-filename": "uid-number-0.0.6.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf",
+        "sha256": "79a1de983c1b393180c47456d6b73caab278a00ea6e37d5c6675f2dcdec2a3e5",
+        "dest": "service/deps",
+        "dest-filename": "util-deprecate-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14",
+        "sha256": "917d0c22a3268506a2b5061722916aa3982497ee5e879ade8f726e14324f0664",
+        "dest": "service/deps",
+        "dest-filename": "uuid-3.2.1.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400",
+        "sha256": "019b4544dc60b21b7f325205967d0aafb72c618570499933ed25e16d0d799e6b",
+        "dest": "service/deps",
+        "dest-filename": "verror-1.10.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb",
+        "sha256": "6b0bc6154fbe70a30e9d2364eeb13ebbc1ba5f7fd7578351f72b99c91e38dac8",
+        "dest": "service/deps",
+        "dest-filename": "which-pm-runs-1.0.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457",
+        "sha256": "7da7041b2b221dd750e17f2c01c92d24439c5792876d672875d6412130dbb0f5",
+        "dest": "service/deps",
+        "dest-filename": "wide-align-1.1.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107",
+        "sha256": "419fcd999c644377c678ea8315aacf9bda442cd75bdfa50aee3918dd917ae274",
+        "dest": "service/deps",
+        "dest-filename": "wordwrap-0.0.3.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f",
+        "sha256": "aff3730d91b7b1e143822956d14608f563163cf11b9d0ae602df1fe1e430fdfb",
+        "dest": "service/deps",
+        "dest-filename": "wrappy-1.0.2.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/ws/-/ws-5.2.0.tgz#9fd95e3ac7c76f6ae8bcc868a0e3f11f1290c33e",
+        "sha256": "c19fac44c57204093e261e57a275212725ff120e26467a1c2a0c7dc1ee29b5f2",
+        "dest": "service/deps",
+        "dest-filename": "ws-5.2.0.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.1.14.tgz#5274e67f5a64c5f92974cd85139e0332adc6b90c",
+        "sha256": "1282f9941d1e5fe0951fd7315b1e7e163d52efe884c20ae9a7a0c1a21dd71896",
+        "dest": "service/deps",
+        "dest-filename": "xml2js-0.1.14.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7",
+        "sha256": "7e7e391591d3d933ec64a92b2dd2a08714ef02d053723d79ad62e41cfe254bf2",
+        "dest": "service/deps",
+        "dest-filename": "xml2js-0.4.19.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d",
+        "sha256": "4a57018577d44b055666ea271939524355579a79df8e5e12b01f8d29c3f281ca",
+        "dest": "service/deps",
+        "dest-filename": "xmlbuilder-9.0.7.tgz"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af",
+        "sha256": "e8cf61040c95fcc1b6b707d76d54365fb646e8e7ac9bdf6e1f794e8790dfa872",
+        "dest": "service/deps",
+        "dest-filename": "xtend-4.0.1.tgz"
+    }
+]


### PR DESCRIPTION
Almond is a virtual assistant that support natural language commands against web and IoT APIs, similar to Cortana on Windows, Siri on Mac and Alexa on the Echo.

This submission includes the GNOME/desktop version of Almond, which includes a typing interface with a chat view, and a voice interface activatable with the "almond" hotword.
Screenshots are provided in the app's appdata, which show more or less how the app works.

Website: https://almond.stanford.edu
Programming platform: nodejs (the background service and VA engine), gjs (the Gtk UI)
License: GPL 3+ with exceptions for OpenSSL and Snowboy (the hotword detection library)

The nightly version of the app is hosted here:
https://crowdie.stanford.edu/flatpak/edu.stanford.Almond.flatpakref
