### PR TITLE
Add org.supertux.SuperTux-Milestone1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*~
+/.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "shared-modules"]
 	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git
+	url = https://github.com/Grumbel/shared-modules.git

--- a/org.supertux.SuperTux-Milestone1.json
+++ b/org.supertux.SuperTux-Milestone1.json
@@ -1,0 +1,32 @@
+{
+    "app-id": "org.supertux.SuperTux-Milestone1",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "supertux",
+    "rename-icon": "supertux",
+    "rename-desktop-file": "supertux.desktop",
+    "rename-appdata-file": "supertux.appdata.xml",
+    "finish-args": [
+        "--device=all",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=pulseaudio"
+    ],
+    "modules": [
+        "shared-modules/SDL/SDL-1.2.15.json",
+        "shared-modules/SDL/SDL_mixer-1.2.12.json",
+        "shared-modules/SDL/SDL_image-1.2.12.json",
+        {
+            "name": "supertux-milestone1",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/SuperTux/supertux.git",
+                    "commit": "1fafb1f9705ef045d77d7b1afd095ae73696e185"
+                }
+            ]
+        }
+    ]
+}

--- a/org.supertux.SuperTux-Milestone1.json
+++ b/org.supertux.SuperTux-Milestone1.json
@@ -14,6 +14,7 @@
         "--socket=pulseaudio"
     ],
     "modules": [
+        "shared-modules/glu/glu-9.0.0.json",
         "shared-modules/SDL/SDL-1.2.15.json",
         "shared-modules/SDL/SDL_mixer-1.2.12.json",
         "shared-modules/SDL/SDL_image-1.2.12.json",

--- a/org.supertux.SuperTux-Milestone1.json
+++ b/org.supertux.SuperTux-Milestone1.json
@@ -14,9 +14,10 @@
         "--socket=pulseaudio"
     ],
     "modules": [
+        "shared-modules/mikmod/mikmod-3.3.11.json",
         "shared-modules/glu/glu-9.0.0.json",
         "shared-modules/SDL/SDL-1.2.15.json",
-        "shared-modules/SDL/SDL_mixer-1.2.12.json",
+        "shared-modules/SDL/SDL_mixer-1.2.12-1.json",
         "shared-modules/SDL/SDL_image-1.2.12.json",
         {
             "name": "supertux-milestone1",
@@ -25,7 +26,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/SuperTux/supertux.git",
-                    "commit": "1fafb1f9705ef045d77d7b1afd095ae73696e185"
+                    "commit": "9c6f46fc8c81f7a86f33366e95fce1692f9069fd"
                 }
             ]
         }

--- a/org.supertux.SuperTux-Milestone1.json
+++ b/org.supertux.SuperTux-Milestone1.json
@@ -17,7 +17,8 @@
         "shared-modules/mikmod/mikmod-3.3.11.json",
         "shared-modules/glu/glu-9.0.0.json",
         "shared-modules/SDL/SDL-1.2.15.json",
-        "shared-modules/SDL/SDL_mixer-1.2.12-1.json",
+        "shared-modules/smpeg/smpeg-0.4.5.json",
+        "shared-modules/SDL/SDL_mixer-1.2.12.json",
         "shared-modules/SDL/SDL_image-1.2.12.json",
         {
             "name": "supertux-milestone1",


### PR DESCRIPTION
This is the classic SuperMarioBros1 inspired version of SuperTux, which is separate from the already existing `org.supertuxproject.SuperTux`, which is the modern one.

I am using the proper `org.supertux` prefix here, `org.supertuxproject` should be renamed at some point (will fill a separate issue for that).

