### PR TITLE
Add org.gnome.Podcasts manifest.

### DIFF
--- a/org.gnome.Podcasts.json
+++ b/org.gnome.Podcasts.json
@@ -1,0 +1,41 @@
+{
+    "app-id" : "org.gnome.Podcasts",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.28",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "command" : "gnome-podcasts",
+    "finish-args" : [
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--share=network",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--talk-name=org.freedesktop.Desktop"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/rust-stable/bin",
+        "env" : {
+            "CARGO_HOME" : "/run/build/Podcasts/cargo"
+        }
+    },
+    "modules" : [
+        {
+            "name" : "gnome-podcasts",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+		    "url" : "https://gitlab.gnome.org/World/podcasts/uploads/306c5f5bafbf1ebc54c9f17bd4881e8a/gnome-podcasts-0.4.4.tar.xz",
+                    "sha256" : "6424a05637909593aee6f5672149e37cc0203210ea06a1731eda196312d2876d"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
I am the upstream maintainer, we've been working on this app for about year now.

It assumes the `org.gnome.Podcasts` ID since the intention is to be part of the GNOME eventually, along with [`Fractal`][1], once the inclusion policy is established. Currently the [repo][2] is under the World/ namespace in the GNOME Gitlab instance.

[1]: https://gitlab.gnome.org/World/fractal
[2]: https://gitlab.gnome.org/World/podcasts