### PR TITLE
Initial manifest for org.laptop.TurtleArtActivity

### DIFF
--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -125,6 +125,10 @@
                     "type": "archive",
                     "url": "https://telepathy.freedesktop.org/releases/telepathy-python/telepathy-python-0.15.19.tar.gz",
                     "sha256": "244c0e1bf4bbd78ae298ea659fe10bf3a73738db550156767cc2477aedf72376"
+                },
+                {
+                    "type": "patch",
+                    "path": "telepathy-python-fix-build.patch"
                 }
             ]
         },

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -120,6 +120,7 @@
         {
             "name": "telepathy-python",
             "no-parallel-make": true,
+            "rm-configure": true,
             "sources": [
                 {
                     "type": "archive",
@@ -129,6 +130,13 @@
                 {
                     "type": "patch",
                     "path": "telepathy-python-fix-build.patch"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "autoreconf -vif"
+                    ]
                 }
             ]
         },

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -161,6 +161,10 @@
                 {
                     "type": "patch",
                     "path": "turtleblock-add-screenshots-appdata.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-add-oars.patch"
                 }
             ],
             "post-install": [

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -169,6 +169,10 @@
                 {
                     "type": "patch",
                     "path": "turtleblock-add-releases.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblocks-fix-expand.patch"
                 }
             ],
             "post-install": [

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -165,6 +165,10 @@
                 {
                     "type": "patch",
                     "path": "turtleblock-add-oars.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-add-releases.patch"
                 }
             ],
             "post-install": [

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -16,7 +16,11 @@
     "finish-args": [
         "--socket=x11",
         "--share=ipc",
-        "--device=dri"
+        "--device=dri",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=ca.desrt.dconf"
     ],
     "cleanup": [
         "/include",

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -32,6 +32,7 @@
     "modules": [
         {
             "name": "sugar-toolkit-gtk3",
+            "no-parallel-make": true,
             "sources": [
                 {
                     "type": "archive",
@@ -118,6 +119,7 @@
         },
         {
             "name": "telepathy-python",
+            "no-parallel-make": true,
             "sources": [
                 {
                     "type": "archive",

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -1,0 +1,173 @@
+{
+    "app-id": "org.laptop.TurtleArtActivity",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
+    "rename-desktop-file": "turtleblocks.desktop",
+    "rename-icon": "turtleart",
+    "build-options": {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "command": "turtleblocks",
+    "finish-args": [
+        "--socket=x11",
+        "--share=ipc",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/aclocal",
+        "/share/info",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name": "sugar-toolkit-gtk3",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.112.tar.xz",
+                    "sha256": "333051814b5d16b34ae33a2ed6e12ed7044aaf3749fa5e2ac9bc7ce0f3aa2e1b"
+                }
+            ]
+        },
+        {
+            "name": "dbus-glib",
+            "cleanup": [
+                "/bin",
+                "/libexec",
+                "/etc/bash_completion.d"
+            ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-gtk-doc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.106.tar.gz",
+                    "sha256": "b38952706dcf68bad9c302999ef0f420b8cf1a2428227123f0ac4764b689c046"
+
+                }
+            ]
+        },
+        {
+            "name": "python-dbus",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip2 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" dbus-python"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz",
+                    "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
+                }
+            ]
+        },
+        {
+            "name": "decorator",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip2 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" decorator"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://pypi.python.org/packages/70/f1/cb9373195639db13063f55eb06116310ad691e1fd125e6af057734dc44ea/decorator-4.2.1.tar.gz",
+                    "sha256": "7d46dd9f3ea1cf5f06ee0e4e1277ae618cf48dfb10ada7c8427cd46c42702a0e"
+                }
+            ]
+        },
+        {
+            "name": "pycairo",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip2 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" pycairo"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/68/76/340ff847897296b2c8174dfa5a5ec3406e3ed783a2abac918cf326abad86/pycairo-1.17.1.tar.gz",
+                    "sha256": "0f0a35ec923d87bc495f6753b1e540fd046d95db56a35250c44089fbce03b698"
+                }
+            ]
+        },
+        {
+            "name": "PyGObject",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip2 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" PyGObject"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e0/e8/1e4f21800015a9ca153969e85fc29f7962f8f82fc5dbc1ecbdeb9dc54c75/PyGObject-3.28.3.tar.gz",
+                    "sha256": "250fb669b6ac64eba034cc4404fcbcc993717b1f77c29dff29f8c9202da20d55"
+                }
+            ]
+        },
+        {
+            "name": "telepathy-python",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://telepathy.freedesktop.org/releases/telepathy-python/telepathy-python-0.15.19.tar.gz",
+                    "sha256": "244c0e1bf4bbd78ae298ea659fe10bf3a73738db550156767cc2477aedf72376"
+                }
+            ]
+        },
+        {
+            "name": "turtleblocks",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python setup.py --no-sugar install --prefix=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/sugarlabs/turtleart-activity.git",
+                    "commit": "4a7df8af8d73884fc7b21c50682e37ec2e0af40a"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-setup-fixes.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-app-prefix.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-gsettings-schema.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-fix-desktop-file.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-more-info.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-generate-appdata.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-add-screenshots-appdata.patch"
+                }
+            ],
+            "post-install": [
+                "glib-compile-schemas /app/share/TurtleBlocks",
+                "install -D activity/turtleart.svg /app/share/icons/hicolor/scalable/apps/turtleart.svg",
+                "install -D activity/mimetypes.xml /app/share/mime/packages/org.laptop.TurtleArtActivity.xml"
+            ]
+        }
+    ]
+}

--- a/telepathy-python-fix-build.patch
+++ b/telepathy-python-fix-build.patch
@@ -1,0 +1,18 @@
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 135f2f0..ede1fc3 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -13,10 +13,12 @@ telepathy_PYTHON = \
+ spec_dir = $(top_srcdir)/spec
+ spec_files := $(patsubst $(spec_dir)%.xml,_generated%.py,$(wildcard $(spec_dir)/*.xml))
+ 
++# We leave _generated/errors.py out of here because there exists a
++# spec/errors.xml file, so that means there'll be a
++# _generated/errors.py in $(spec_files). See fd.o#32526
+ BUILT_SOURCES = \
+ 	_generated/interfaces.py \
+ 	_generated/constants.py \
+-	_generated/errors.py \
+ 	_generated/__init__.py \
+ 	$(spec_files)
+ 

--- a/turtleblock-add-oars.patch
+++ b/turtleblock-add-oars.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 68c0c29a..4e9b9009 100755
+--- a/setup.py
++++ b/setup.py
+@@ -39,6 +39,8 @@ def generate_appdata(prefix, bundle_id):
+         info.get('Activity', 'description')))
+     root.append(desc)
+ 
++    ET.SubElement(root, 'content_rating', type='oars-1.1')
++
+     copy_pairs = [('metadata_license', 'metadata_license'),
+                   ('license', 'project_license'),
+                   ('summary', 'summary'),

--- a/turtleblock-add-releases.patch
+++ b/turtleblock-add-releases.patch
@@ -1,0 +1,18 @@
+diff --git a/setup.py b/setup.py
+index 4e9b9009..36a889ea 100755
+--- a/setup.py
++++ b/setup.py
+@@ -41,6 +41,13 @@ def generate_appdata(prefix, bundle_id):
+ 
+     ET.SubElement(root, 'content_rating', type='oars-1.1')
+ 
++    release_pairs = [('218', '2018-05-22'),
++                     ('216', '2017-06-24'),
++                     ('215', '2017-04-19')]
++    releases_root = ET.SubElement(root, 'releases')
++    for version, date in release_pairs:
++        ET.SubElement(releases_root, 'release', date=date, version=version)
++
+     copy_pairs = [('metadata_license', 'metadata_license'),
+                   ('license', 'project_license'),
+                   ('summary', 'summary'),

--- a/turtleblock-add-screenshots-appdata.patch
+++ b/turtleblock-add-screenshots-appdata.patch
@@ -1,0 +1,10 @@
+diff --git a/activity/activity.info b/activity/activity.info
+index ae98c346..9052661c 100644
+--- a/activity/activity.info
++++ b/activity/activity.info
+@@ -13,4 +13,5 @@ categories = programming art
+ summary = A Logo-inspired turtle that draws colorful pictures with snap-together visual programming blocks
+ description = Turtle Art, also known as Turtle Blocks, is an activity with a Logo-inspired graphical "turtle" that draws colorful art based on snap-together visual programming elements. Its "low floor" provides an easy entry point for beginners. It also has "high ceiling" programming, graphics, mathematics, and Computer Science features which will challenge the more adventurous student.
+ repository = https://github.com/sugarlabs/turtleart-activity
++screenshots = https://raw.githubusercontent.com/sugarlabs/turtleart-activity/master/screenshots/1.png, https://raw.githubusercontent.com/sugarlabs/turtleart-activity/master/screenshots/2.png, https://raw.githubusercontent.com/sugarlabs/turtleart-activity/master/screenshots/3.png
+ 

--- a/turtleblock-app-prefix.patch
+++ b/turtleblock-app-prefix.patch
@@ -1,0 +1,26 @@
+diff --git a/setup.cfg b/setup.cfg
+index 891cdbd8..0eaae453 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -1,6 +1,6 @@
+ [install]
+-install_data=/usr/share/TurtleBlocks
+-install_scripts=/usr/bin
++install_data=/app/share/TurtleBlocks
++install_scripts=/app/bin
+ 
+ [pycodestyle]
+ # E402 module level import not at top of file
+diff --git a/setup.py b/setup.py
+index 042675d4..c1b67221 100755
+--- a/setup.py
++++ b/setup.py
+@@ -75,7 +75,7 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+         ('activity', get_files('activity/')),
+         ('icons', get_files('icons/')),
+         ('images', get_files('images/')),
+-        ('/usr/share/applications', ['turtleblocks.desktop']),
++        ('/app/share/applications', ['turtleblocks.desktop']),
+         ('org.laptop.TurtleArtActivity.gschema.xml')
+     ]
+ 

--- a/turtleblock-fix-desktop-file.patch
+++ b/turtleblock-fix-desktop-file.patch
@@ -1,0 +1,15 @@
+diff --git a/turtleblocks.desktop b/turtleblocks.desktop
+index f22df19b..2ac34640 100644
+--- a/turtleblocks.desktop
++++ b/turtleblocks.desktop
+@@ -5,8 +5,8 @@ Name[es]=TortugArte
+ GenericName=Sugar TurtleBlocks activity
+ GenericName[nb]=Sugar Skilpaddekunst-aktivitet
+ GenericName[es]=Actividad Sugar TortugArte
+-TryExec=/usr/share/sugar/activities/TurtleArt.activity/turtleblocks.py
+-Exec=/usr/share/sugar/activities/TurtleArt.activity/turtleblocks.py
++TryExec=turtleblocks
++Exec=turtleblocks
+ Icon=turtleart
+ Type=Application
+ Comment=A Logo programming environment

--- a/turtleblock-generate-appdata.patch
+++ b/turtleblock-generate-appdata.patch
@@ -1,0 +1,91 @@
+diff --git a/setup.py b/setup.py
+index 042675d4..344577d1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -1,6 +1,8 @@
+ #!/usr/bin/env python
+ 
+ import sys
++from ConfigParser import ConfigParser
++import xml.etree.cElementTree as ET
+ 
+ 
+ def get_files(path):
+@@ -10,6 +12,67 @@ def get_files(path):
+     return files
+ 
+ 
++def generate_appdata(prefix, bundle_id):
++    info = ConfigParser()
++    info.read(os.path.join('activity', 'activity.info'))
++
++    required_fields = ['metadata_license', 'license', 'name', 'icon',
++                       'description']
++    for name in required_fields:
++        if not info.has_option('Activity', name):
++            print('[WARNING] Activity needs more metadata for AppStream '
++                  'file')
++            print('  Without an AppStream file, the activity will NOT '
++                  'show in software stores!')
++            print('  Please `pydoc sugar3.activity.bundlebuilder` for'
++                  'more info')
++            return
++
++    # See https://www.freedesktop.org/software/appstream/docs/
++    root = ET.Element('component', type='desktop')
++    ET.SubElement(root, 'project_group').text = 'Sugar'
++    ET.SubElement(root, 'translation', type='gettext').text = \
++        bundle_id
++    ET.SubElement(root, 'id').text = \
++        bundle_id + '.desktop'
++    desc = ET.fromstring('<description>{}</description>'.format(
++        info.get('Activity', 'description')))
++    root.append(desc)
++
++    copy_pairs = [('metadata_license', 'metadata_license'),
++                  ('license', 'project_license'),
++                  ('summary', 'summary'),
++                  ('name', 'name')]
++    for key, ename in copy_pairs:
++        ET.SubElement(root, ename).text = info.get('Activity', key)
++
++    if info.has_option('Activity', 'screenshots'):
++        screenshots = info.get('Activity', 'screenshots').split()
++        ss_root = ET.SubElement(root, 'screenshots')
++        for i, screenshot in enumerate(screenshots):
++            e = ET.SubElement(ss_root, 'screenshot')
++            if i == 0:
++                e.set('type', 'default')
++            ET.SubElement(e, 'image').text = screenshot
++
++    if info.has_option('Activity', 'url'):
++        ET.SubElement(root, 'url', type='homepage').text = \
++            info.get('Activity', 'url')
++    if info.has_option('Activity', 'repository_url'):
++        ET.SubElement(root, 'url', type='bugtracker').text = \
++            info.get('Activity', 'repository_url')
++    elif info.has_option('Activity', 'repository'):
++        ET.SubElement(root, 'url', type='bugtracker').text = \
++            info.get('Activity', 'repository')
++
++    path = os.path.join(prefix, 'share', 'metainfo',
++                        bundle_id + '.appdata.xml')
++    if not os.path.isdir(os.path.dirname(path)):
++        os.makedirs(os.path.dirname(path))
++    tree = ET.ElementTree(root)
++    tree.write(path, encoding='UTF-8')
++
++
+ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+     # Remove the argument from the stack so we don't cause problems
+     # for distutils
+@@ -26,6 +89,9 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+             install.run(self)
+             print "Running post_install"
+ 
++            generate_appdata(self.prefix,
++                             'org.laptop.TurtleArtActivity')
++
+             # Create a simple module that allows the app where to discover
+             # its lib and share content.
+             dst = os.path.join(self.install_purelib, "TurtleArt")

--- a/turtleblock-gsettings-schema.patch
+++ b/turtleblock-gsettings-schema.patch
@@ -1,0 +1,47 @@
+diff --git a/TurtleArt/turtleblocks.py b/TurtleArt/turtleblocks.py
+index 14054ace..f15f1bae 100755
+--- a/TurtleArt/turtleblocks.py
++++ b/TurtleArt/turtleblocks.py
+@@ -139,22 +139,29 @@ class TurtleMain():
+     def _get_local_settings(self, activity_root):
+         """ return an activity-specific Gio.Settings
+         """
+-        # create schemas directory if missing
+-        path = os.path.join(get_path(None, 'data'), 'schemas')
+-        if not os.access(path, os.F_OK):
+-            os.makedirs(path)
+-
+-        # create compiled schema file if missing
+-        compiled = os.path.join(path, 'gschemas.compiled')
++        # create compiled schema file if missing from activity root
++        compiled = os.path.join(activity_root, 'gschemas.compiled')
+         if not os.access(compiled, os.R_OK):
+-            src = '%s.gschema.xml' % self._GIO_SETTINGS
+-            lines = open(os.path.join(activity_root, src), 'r').readlines()
+-            open(os.path.join(path, src), 'w').writelines(lines)
+-            os.system('glib-compile-schemas %s' % path)
+-            os.remove(os.path.join(path, src))
++            # create schemas directory if missing
++            path = os.path.join(get_path(None, 'data'), 'schemas')
++            if not os.access(path, os.F_OK):
++                os.makedirs(path)
++
++            # create compiled schema file if missing
++            compiled = os.path.join(path, 'gschemas.compiled')
++            if not os.access(compiled, os.R_OK):
++                src = '%s.gschema.xml' % self._GIO_SETTINGS
++                lines = open(os.path.join(activity_root, src), 'r').readlines()
++                open(os.path.join(path, src), 'w').writelines(lines)
++                os.system('glib-compile-schemas %s' % path)
++                os.remove(os.path.join(path, src))
++
++            schemas_path = path
++        else:
++            schemas_path = activity_root
+ 
+         # create a local Gio.Settings based on the compiled schema
+-        source = Gio.SettingsSchemaSource.new_from_directory(path, None, True)
++        source = Gio.SettingsSchemaSource.new_from_directory(schemas_path, None, True)
+         schema = source.lookup(self._GIO_SETTINGS, True)
+         _settings = Gio.Settings.new_full(schema, None, None)
+         return _settings

--- a/turtleblock-more-info.patch
+++ b/turtleblock-more-info.patch
@@ -1,0 +1,19 @@
+diff --git a/activity/activity.info b/activity/activity.info
+index 012c401e..ae98c346 100644
+--- a/activity/activity.info
++++ b/activity/activity.info
+@@ -2,6 +2,7 @@
+ name = TurtleBlocks
+ activity_version = 218
+ license = MIT
++metadata_license = CC0-1.0
+ bundle_id = org.laptop.TurtleArtActivity
+ exec = sugar-activity TurtleArtActivity.TurtleArtActivity
+ icon = activity-turtleart
+@@ -10,5 +11,6 @@ website = http://wiki.sugarlabs.org/go/Activities/Turtle_Art
+ mime_types = application/x-turtle-art;application/vnd.turtleblocks
+ categories = programming art
+ summary = A Logo-inspired turtle that draws colorful pictures with snap-together visual programming blocks
++description = Turtle Art, also known as Turtle Blocks, is an activity with a Logo-inspired graphical "turtle" that draws colorful art based on snap-together visual programming elements. Its "low floor" provides an easy entry point for beginners. It also has "high ceiling" programming, graphics, mathematics, and Computer Science features which will challenge the more adventurous student.
+ repository = https://github.com/sugarlabs/turtleart-activity
+ 

--- a/turtleblock-setup-fixes.patch
+++ b/turtleblock-setup-fixes.patch
@@ -1,0 +1,51 @@
+diff --git a/setup.py b/setup.py
+index b98e890e..042675d4 100755
+--- a/setup.py
++++ b/setup.py
+@@ -5,7 +5,7 @@ import sys
+ 
+ def get_files(path):
+     files = []
+-    for name in path:
++    for name in os.listdir(path):
+         files.append(os.path.join(path, name))
+     return files
+ 
+@@ -33,14 +33,16 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+             fd.write("INSTALL_PREFIX='%s'\n" % self.prefix)
+             fd.close()
+ 
++            root = self.root or ''
++
+             # distutils doesn't offer a nice way to do recursive install of
+             # a directory tree, so we install the remaining parts here.
+-            libdir = os.path.join(self.root + self.install_base, "lib",
++            libdir = os.path.join(root + self.install_base, "lib",
+                                   "TurtleBlocks")
+             if not os.path.isdir(libdir):
+                 os.makedirs(libdir)
+ 
+-            sharedir = os.path.join(self.root + self.install_base, "share",
++            sharedir = os.path.join(root + self.install_base, "share",
+                                     "TurtleBlocks")
+             if not os.path.isdir(sharedir):
+                 os.makedirs(sharedir)
+@@ -48,7 +50,7 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+             shutil.copytree("plugins", os.path.join(libdir, "plugins"))
+             shutil.copytree("samples", os.path.join(sharedir, "samples"))
+ 
+-            localedir = os.path.join(self.root + self.install_base, "share",
++            localedir = os.path.join(root + self.install_base, "share",
+                                      "locale")
+             for f in os.listdir('po'):
+                 if not f.endswith('.po') or f == 'pseudo.po':
+@@ -73,7 +75,8 @@ if len(sys.argv) > 1 and '--no-sugar' == sys.argv[1]:
+         ('activity', get_files('activity/')),
+         ('icons', get_files('icons/')),
+         ('images', get_files('images/')),
+-        ('/usr/share/applications', ['turtleblocks.desktop'])
++        ('/usr/share/applications', ['turtleblocks.desktop']),
++        ('org.laptop.TurtleArtActivity.gschema.xml')
+     ]
+ 
+     setup(name='Turtle Art',

--- a/turtleblocks-fix-expand.patch
+++ b/turtleblocks-fix-expand.patch
@@ -1,0 +1,12 @@
+diff --git a/TurtleArt/turtleblocks.py b/TurtleArt/turtleblocks.py
+index f15f1bae..75db765b 100755
+--- a/TurtleArt/turtleblocks.py
++++ b/TurtleArt/turtleblocks.py
+@@ -437,6 +437,7 @@ return %s(self)" % (p, P, P)
+         self.fixed.set_size_request(width, height)
+ 
+         self.vbox = Gtk.VBox(False, 0)
++        self.vbox.set_size_request(width, height)
+         self.vbox.show()
+ 
+         self.menu_bar = self._get_menu_bar()


### PR DESCRIPTION
A lot of custom patches are needed to build the flatpak at the moment, which I upstreamed in https://github.com/sugarlabs/turtleart-activity/pull/64.

Also, I used a git commit because the latest v218 release is not tagged in git upstream. (I asked for the next release to be tagged, if my fixes are accepted.)