### PR TITLE
Add space.fips.Fips

### DIFF
--- a/space.fips.Fips.appdata.xml
+++ b/space.fips.Fips.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 Matwey V. Kornilov <matwey.kornilov@gmail.com> -->
+<component type="desktop-application">
+<content_rating type="oars-1.0" />
+<id>space.fips.Fips</id>
+<metadata_license>CC0-1.0</metadata_license>
+<project_license>LGPL-3.0+</project_license>
+<name>FIPS</name>
+<summary>OpenGL-based FITS image viewer</summary>
+<description>
+	<p>
+FIPS is a cross-platform FITS viewer with responsive user interface. Unlike
+other FITS viewers FIPS uses GPU hardware via OpenGL to provide usual
+functionality such as zooming, panning and level adjustments. OpenGL 2.1 and
+later is supported.
+	</p>
+	<p>
+FIPS supports all 2D image formats (excluding floating point for OpenGL 2.1).
+FITS image extension has basic limited support.
+	</p>
+</description>
+<screenshots>
+	<screenshot type="default">https://fips.space/.screenshot/1.png</screenshot>
+</screenshots>
+<update_contact>matwey.kornilov_AT_gmail.com</update_contact>
+<launchable type="desktop-id">space.fips.Fips.desktop</launchable>
+<url type="homepage">https://fips.space</url>
+<url type="bugtracker">https://github.com/matwey/fips3/issues</url>
+<releases>
+	<release version="3.3.0" timestamp="2018-08-10" />
+</releases>
+</component>

--- a/space.fips.Fips.json
+++ b/space.fips.Fips.json
@@ -1,0 +1,38 @@
+{
+	"app-id": "space.fips.Fips",
+	"runtime": "org.kde.Platform",
+	"runtime-version": "5.9",
+	"sdk": "org.kde.Sdk",
+	"command": "fips",
+	"finish-args": [
+		"--share=ipc",
+		"--share=network",
+		"--socket=x11",
+		"--socket=wayland",
+		"--filesystem=host:ro",
+		"--device=dri"
+	],
+	"modules": [
+		{
+			"name": "fips",
+			"buildsystem": "cmake",
+			"config-opts": [
+				"-DCMAKE_BUILD_TYPE=RelWithDebugInfo"
+			],
+			"sources": [
+				{
+					"type": "git",
+					"url": "https://github.com/matwey/fips3",
+					"branch": "3.3.0"
+				},
+				{
+					"type": "file",
+					"path": "space.fips.Fips.appdata.xml"
+				}
+			],
+			"post-install": [
+				"install -D -m 644 space.fips.Fips.appdata.xml /app/share/appdata/space.fips.Fips.appdata.xml"
+			]
+		}
+	]
+}


### PR DESCRIPTION
Hi,

I would like to add Fips (https://github.com/matwey/fips3)
It is my image viewer for astronomers, it can read most common FITS astronomical data format. Currently, we have brew cask packages for Mac OS users.