### PR TITLE
Add io.github.wereturtle.ghostwriter

### DIFF
--- a/io.github.wereturtle.ghostwriter.json
+++ b/io.github.wereturtle.ghostwriter.json
@@ -100,7 +100,15 @@
         },
         {
             "name": "ghostwriter",
-            "buildsystem": "simple",
+            "buildsystem": "qmake",
+            "builddir": "true",
+            "build-options":
+                {
+                    "env":
+                        {
+                            "QMAKEPATH": "/app/lib"
+                        }
+                },
             "sources": [
                 {
                     "type": "git",
@@ -108,12 +116,6 @@
                     "tag": "v1.7.3",
                     "commit": "f73578e26951a573aa1f246983a3222b66240555"
                 }
-            ],
-            "build-commands": [
-                "ln -s /app/include/QtWebKitWidgets/qwebframe.h /app/include/QtWebKitWidgets/QWebFrame.h",
-                "export QMAKEPATH=QMAKEPATH:/app/lib && qmake -makefile \"INCLUDEPATH+=/app/include/QtWebKitWidgets\" \"INCLUDEPATH+=/app/include/QtWebKit\" \"QMAKE_LIBDIR+=/app/lib\" PREFIX=/app",
-                "export QMAKEPATH=QMAKEPATH:/app/lib && make",
-                "make install"
             ]
         }
     ]

--- a/io.github.wereturtle.ghostwriter.json
+++ b/io.github.wereturtle.ghostwriter.json
@@ -1,0 +1,120 @@
+{
+    "app-id": "io.github.wereturtle.ghostwriter",
+    "base": "io.qt.qtwebkit.BaseApp",
+    "base-version": "stable",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.11",
+    "sdk": "org.kde.Sdk",
+    "command": "ghostwriter",
+    "rename-icon": "ghostwriter",
+    "rename-desktop-file": "ghostwriter.desktop",
+    "rename-appdata-file": "ghostwriter.appdata.xml",
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--share=ipc",
+        "--share=network",
+        "--filesystem=home",
+        "--device=dri"
+    ],
+    "modules": [
+        {
+            "name": "cmark",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/commonmark/cmark.git",
+                    "tag": "0.28.3"
+                }
+            ]
+        },
+        {
+            "name": "cmark-gfm",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/github/cmark.git",
+                    "tag": "0.28.3.gfm.12"
+                }
+            ]
+        },
+        {
+            "name": "MultiMarkdown",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/fletcher/MultiMarkdown-6.git",
+                    "tag": "6.3.2"
+                }
+            ]
+        },
+        {
+            "name": "discount",
+            "no-autogen": true,
+            "sources":[
+                {
+                    "type":"archive",
+                    "url": "https://github.com/Orc/discount/archive/v2.2.3a.tar.gz",
+                    "sha256": "40defe460dc005dbc78a4e6174fce29fca2ac3ccd5acd400c05eb713f824df97"
+                },
+                {
+                    "type": "shell",
+                    "commands": ["./configure.sh --prefix=/app"]
+                }
+            ]
+        },
+        {
+            "name": "Pandoc",
+            "only-arches": ["x86_64"],
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp bin/pandoc /app/bin/pandoc",
+                "cp bin/pandoc-citeproc /app/bin/pandoc-citeproc"
+            ],
+            "sources":[
+                {
+                    "type":"archive",
+                    "url": "https://github.com/jgm/pandoc/releases/download/2.2.1/pandoc-2.2.1-linux.tar.gz",
+                    "sha256": "3b1b573cdf957b4102c42ce6f5a641787267a55a5e88dcca942fd471c25793cb"
+                }
+            ]
+        },
+        {
+            "name": "ghostwriter",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/wereturtle/ghostwriter.git",
+                    "tag": "v1.7.3",
+                    "commit": "f73578e26951a573aa1f246983a3222b66240555"
+                }
+            ],
+            "build-commands": [
+                "ln -s /app/include/QtWebKitWidgets/qwebframe.h /app/include/QtWebKitWidgets/QWebFrame.h",
+                "export QMAKEPATH=QMAKEPATH:/app/lib && qmake -makefile \"INCLUDEPATH+=/app/include/QtWebKitWidgets\" \"INCLUDEPATH+=/app/include/QtWebKit\" \"QMAKE_LIBDIR+=/app/lib\" PREFIX=/app",
+                "export QMAKEPATH=QMAKEPATH:/app/lib && make",
+                "make install"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
ghostwriter is a Markdown editor available at http://wereturtle.github.io/ghostwriter.  The icons and appdata.xml file are in the `resources/linux/` directory in the app's [Github repository](http://github.com/wereturtle/ghostwriter) and are installed as part of running qmake and make.

Thanks!