### PR TITLE
add org.kde.ksudoku

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.kde.ksudoku.json
+++ b/org.kde.ksudoku.json
@@ -1,0 +1,53 @@
+{
+    "id": "org.kde.ksudoku",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.11",
+    "sdk": "org.kde.Sdk",
+    "command": "ksudoku",
+    "rename-icon": "ksudoku",
+    "finish-args": [
+        "--share=ipc", 
+        "--socket=x11", 
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--talk-name=org.kde.kuiserver",
+        "--talk-name=org.kde.JobViewServer"
+    ],
+    "modules": [
+        "shared-modules/glu/glu-9.0.0.json",
+        {
+            "name": "libkdegames",
+            "buildsystem": "cmake-ninja",
+            "sources": [ 
+                { 
+                    "type": "archive", 
+                    "url": "https://download.kde.org/stable/applications/18.08.0/src/libkdegames-18.08.0.tar.xz",
+                    "sha256": "e0bca02674c5e961db17e8225affc689c437ab78eabcd620a1e38ee7b1d583ca"
+                } 
+            ]
+        },
+        {
+            "name": "openal",
+            "buildsystem": "cmake-ninja",
+            "sources": [ 
+                    { 
+                        "type": "archive", 
+                        "url": "https://github.com/kcat/openal-soft/archive/openal-soft-1.18.2.tar.gz", 
+                        "sha256": "a598241d1af2e90c25a1b91da4c9ddc0e7cb6a4b5f1477fc680d139c57cd38cc" 
+                    } 
+                ]
+        },
+        {
+            "name": "ksudoku",
+            "buildsystem": "cmake-ninja",
+            "sources": [ 
+                { 
+                    "type": "archive", 
+                    "url": "https://download.kde.org/stable/applications/18.08.0/src/ksudoku-18.08.0.tar.xz",
+                    "sha256": "2da6dd1cca5e647762e0929faa68373075473d2c76917ebd0d452da097698739"
+                } 
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
@aleixpol I'm not sure about the dbus talk name stuff. I added it because the app was calling those address' in testing but I know a lot less about the architecture of a KDE desktop than you people.