### PR TITLE
Add com.szibele.e-juice-calc

### DIFF
--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -45,7 +45,7 @@
             ],
             "buildsystem": "simple",
             "cleanup": [],
-            "name": "ghc-8.2.2",
+            "name": "ghc-8.2.2-i386",
             "only-arches": [
                 "i386"
             ],
@@ -64,7 +64,7 @@
             ],
             "buildsystem": "simple",
             "cleanup": [],
-            "name": "ghc-8.2.2",
+            "name": "ghc-8.2.2-x86_64",
             "only-arches": [
                 "x86_64"
             ],
@@ -83,7 +83,7 @@
             ],
             "buildsystem": "simple",
             "cleanup": [],
-            "name": "ghc-8.2.2",
+            "name": "ghc-8.2.2-armv7",
             "only-arches": [
                 "arm"
             ],
@@ -102,7 +102,7 @@
             ],
             "buildsystem": "simple",
             "cleanup": [],
-            "name": "ghc-8.2.2",
+            "name": "ghc-8.2.2-aarch64",
             "only-arches": [
                 "aarch64"
             ],
@@ -134,7 +134,7 @@
                 {
                     "sha256": "e5464d0600821a116467d4b12fef12b15ff040c3599500e5f0274225e78c6faf",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/word8/0.1.3/word8.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/word8/0.1.3/word8.cabal"
                 }
             ]
         },
@@ -158,7 +158,7 @@
                 {
                     "sha256": "7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/random/1.1/random.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/random/1.1/random.cabal"
                 }
             ]
         },
@@ -182,7 +182,7 @@
                 {
                     "sha256": "3ebbb7022246f446fc625b77d0e1f509d66eedf1deb22bbd6df5c8450aaf923a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/dlist/0.8.0.4/dlist.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/dlist/0.8.0.4/dlist.cabal"
                 }
             ]
         },
@@ -206,7 +206,7 @@
                 {
                     "sha256": "a952817dcbe20af0346fb55a28c13e95e2ddbf3e99f9b4fffdc063f150f13b20",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/byteorder/1.0.4/byteorder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/byteorder/1.0.4/byteorder.cabal"
                 }
             ]
         },
@@ -230,7 +230,7 @@
                 {
                     "sha256": "aaf0d3d5050aa120b2eb98682bc7f8aeed947c1eb51a80375f32775af3d2ff68",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/semigroups/0.18.5/semigroups.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/semigroups/0.18.5/semigroups.cabal"
                 }
             ]
         },
@@ -254,7 +254,7 @@
                 {
                     "sha256": "69d44ecfcf243390f582a515905d614b0dc5c318ead621ca5641cfbd0aa56dff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
                 }
             ]
         },
@@ -278,7 +278,7 @@
                 {
                     "sha256": "0571ef33ec5530104503d32eaf24f2d7c221f350e5fc475a6dd8e84311bc0ca1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
                 }
             ]
         },
@@ -302,7 +302,7 @@
                 {
                     "sha256": "924bd2f574943848ba19189409b9acdc645612eda4d9130b40a62e9cb575bb47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
                 }
             ]
         },
@@ -326,7 +326,7 @@
                 {
                     "sha256": "db5a2ee91cce9afbe7e251c925c2d2b78725b515f6655eb5079aaeeb935c247b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/th-abstraction/0.2.8.0/th-abstraction.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/th-abstraction/0.2.8.0/th-abstraction.cabal"
                 }
             ]
         },
@@ -350,7 +350,7 @@
                 {
                     "sha256": "b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/tagged/0.8.6/tagged.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/tagged/0.8.6/tagged.cabal"
                 }
             ]
         },
@@ -374,7 +374,7 @@
                 {
                     "sha256": "5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/primitive/0.6.4.0/primitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/primitive/0.6.4.0/primitive.cabal"
                 }
             ]
         },
@@ -398,7 +398,7 @@
                 {
                     "sha256": "8a8a091e7113f9c07eb9ad4f58a67eb4a5ec58b2857c6ba80fa4d8d45015524c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/stm/2.4.5.0/stm.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/stm/2.4.5.0/stm.cabal"
                 }
             ]
         },
@@ -422,7 +422,7 @@
                 {
                     "sha256": "181580173130837a8274c8c192e042ef14dcddeb424972d57746d44a628ee217",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/appar/0.1.4/appar.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/appar/0.1.4/appar.cabal"
                 }
             ]
         },
@@ -446,7 +446,7 @@
                 {
                     "sha256": "66691ca16b7ceb8c38bd2bac6ffe8e0eee25f408020cb8150a0444f8824e7458",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/base-compat/0.9.3/base-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/base-compat/0.9.3/base-compat.cabal"
                 }
             ]
         },
@@ -470,7 +470,7 @@
                 {
                     "sha256": "3d644fff350ee3eee2896e4d00cb45e73956f2862f0b18ee502282702682b978",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/vector/0.12.0.1/vector.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/vector/0.12.0.1/vector.cabal"
                 }
             ]
         },
@@ -494,7 +494,7 @@
                 {
                     "sha256": "68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/utf8-string/1.0.1.1/utf8-string.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/utf8-string/1.0.1.1/utf8-string.cabal"
                 }
             ]
         },
@@ -518,7 +518,7 @@
                 {
                     "sha256": "15cbf4c77eb30d51b8b4b1db5ed3b19705ebf43792fe6e0d1aedf47569280b3d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
                 }
             ]
         },
@@ -542,7 +542,7 @@
                 {
                     "sha256": "9dc17a9736056785e11d8a6e3e1e3a88b2a16ed78bf6f27d34ff0827bad1ca21",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/text/1.2.3.0/text.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/text/1.2.3.0/text.cabal"
                 }
             ]
         },
@@ -566,7 +566,7 @@
                 {
                     "sha256": "fa992674ea28f6ea6569d93388d757aef928af1e2f0ce80a35c29fb782252a2d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/blaze-builder/0.4.1.0/blaze-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/blaze-builder/0.4.1.0/blaze-builder.cabal"
                 }
             ]
         },
@@ -590,7 +590,7 @@
                 {
                     "sha256": "9c4075e54aa6cabfe244e07e2a1de720f3e98a0a6980fc671ab9c0da30f0f259",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/string-conversions/0.4.0.1/string-conversions.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/string-conversions/0.4.0.1/string-conversions.cabal"
                 }
             ]
         },
@@ -614,7 +614,7 @@
                 {
                     "sha256": "d656c2627de5915fd4e45d9d01d9eed8ab37359f8f1376f87d537ff01bf12d7b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/unix-compat/0.5.0.1/unix-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/unix-compat/0.5.0.1/unix-compat.cabal"
                 }
             ]
         },
@@ -638,7 +638,7 @@
                 {
                     "sha256": "c11e24ac1df02ad71b861ba3f251b1ea8e64fa44632ba73944dd71767205bcad",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/zlib/0.6.2/zlib.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/zlib/0.6.2/zlib.cabal"
                 }
             ]
         },
@@ -662,7 +662,7 @@
                 {
                     "sha256": "eff944a412a26c7e3950c52128ea3b24ef6838f821f2db9854c62b320225f2ca",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/auto-update/0.1.4/auto-update.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/auto-update/0.1.4/auto-update.cabal"
                 }
             ]
         },
@@ -686,7 +686,7 @@
                 {
                     "sha256": "03b6836ca9cd3ad0e5a2f3cce989b001dd0e05f306a873db3196037adb30e0a4",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/hashable/1.2.7.0/hashable.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/hashable/1.2.7.0/hashable.cabal"
                 }
             ]
         },
@@ -710,7 +710,7 @@
                 {
                     "sha256": "ca2f237cba5db9c9c4238d41a7d8b583c5ca0ce8491de4027b26b17793fc3a87",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/case-insensitive/1.2.0.11/case-insensitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/case-insensitive/1.2.0.11/case-insensitive.cabal"
                 }
             ]
         },
@@ -734,7 +734,7 @@
                 {
                     "sha256": "12ce2fc081fde3cf219b630c2fb3815183a64eee236ba7aa735f666eab949610",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http-types/0.12.1/http-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http-types/0.12.1/http-types.cabal"
                 }
             ]
         },
@@ -758,7 +758,7 @@
                 {
                     "sha256": "124a5241860711a0e5c10e94d8aec8a127f0094df7a537cc1786e198d7571dfe",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/unordered-containers/0.2.9.0/unordered-containers.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/unordered-containers/0.2.9.0/unordered-containers.cabal"
                 }
             ]
         },
@@ -782,7 +782,7 @@
                 {
                     "sha256": "aa0869aa80026d0bfbbeee44a6381ccd2a2c960ce3ef7d484b14270e054ca79a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/vault/0.3.1.2/vault.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/vault/0.3.1.2/vault.cabal"
                 }
             ]
         },
@@ -806,7 +806,7 @@
                 {
                     "sha256": "01887ed945e74c3c361b00700bd9aeead37d1124d39c0d4f190f89fb0e909c47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/uuid-types/1.0.3/uuid-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/uuid-types/1.0.3/uuid-types.cabal"
                 }
             ]
         },
@@ -830,7 +830,7 @@
                 {
                     "sha256": "dd49abc76bd8e2b57e7a057dc2bb742a00527b4bf9350f9374be03b5934e55d8",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/scientific/0.3.6.2/scientific.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/scientific/0.3.6.2/scientific.cabal"
                 }
             ]
         },
@@ -854,7 +854,7 @@
                 {
                     "sha256": "189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/psqueues/0.2.7.0/psqueues.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/psqueues/0.2.7.0/psqueues.cabal"
                 }
             ]
         },
@@ -878,7 +878,7 @@
                 {
                     "sha256": "1ca79d81af02d7acd6032d5e6c9bde4618a8fdcfbe19bd42b49d420183975df0",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/network/2.6.3.6/network.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/network/2.6.3.6/network.cabal"
                 }
             ]
         },
@@ -902,7 +902,7 @@
                 {
                     "sha256": "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/wai/3.2.1.2/wai.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/wai/3.2.1.2/wai.cabal"
                 }
             ]
         },
@@ -926,7 +926,7 @@
                 {
                     "sha256": "0f64a907a08255d01b9ab58e6c9f72e3f42c22948303c2e914b1b53034a1fa2f",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/simple-sendfile/0.2.27/simple-sendfile.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/simple-sendfile/0.2.27/simple-sendfile.cabal"
                 }
             ]
         },
@@ -950,7 +950,7 @@
                 {
                     "sha256": "99a46f811058c0d7c5cd05b288a245f681d4bedcd7aa60d6bcc18d21a4558d65",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/iproute/1.7.5/iproute.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/iproute/1.7.5/iproute.cabal"
                 }
             ]
         },
@@ -974,7 +974,7 @@
                 {
                     "sha256": "2ce05388bbd8d78e17f130acfe60b2bd2b5a09b995c9f4eb7c2d1ae41a8b1652",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/async/2.1.1.1/async.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/async/2.1.1.1/async.cabal"
                 }
             ]
         },
@@ -998,7 +998,7 @@
                 {
                     "sha256": "3a02f84578f75eac1425dca877f8d697b68d379a21970c1dad96196620404803",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/streaming-commons/0.1.19/streaming-commons.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/streaming-commons/0.1.19/streaming-commons.cabal"
                 }
             ]
         },
@@ -1022,7 +1022,7 @@
                 {
                     "sha256": "69447dd3b077f7f89c2c25731e9c658a4f5a0121b77e41b6467a865143ff425b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/attoparsec/0.13.2.2/attoparsec.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/attoparsec/0.13.2.2/attoparsec.cabal"
                 }
             ]
         },
@@ -1046,7 +1046,7 @@
                 {
                     "sha256": "0551a9433d5ce29ad98f2839f025204c566b69aa1ab45d8488042fe8cde9ceff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http-date/0.0.8/http-date.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http-date/0.0.8/http-date.cabal"
                 }
             ]
         },
@@ -1070,7 +1070,7 @@
                 {
                     "sha256": "2ff56812644c3e272fef6b19aaff1ddab81c9984b1c1f8969521cb856bc22eab",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/aeson/1.2.4.0/aeson.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/aeson/1.2.4.0/aeson.cabal"
                 }
             ]
         },
@@ -1094,7 +1094,7 @@
                 {
                     "sha256": "c6ce9c4b4899a2177420d272b7e027aa4720cddb0ed465bebff4acb221165da1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http2/1.6.3/http2.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http2/1.6.3/http2.cabal"
                 }
             ]
         },
@@ -1118,7 +1118,7 @@
                 {
                     "sha256": "aa63f6fbcea0835c068c65bc9805fd0f3ec279c1b06744bfc357855d2c34f807",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/warp/3.2.23/warp.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/warp/3.2.23/warp.cabal"
                 }
             ]
         },
@@ -1160,7 +1160,7 @@
             "only-arches": [],
             "sources": [
                 {
-                    "sha256": "b423d32b7a1b5d7ba1ac2cd4becb44b69da9f844770213c71a32296390107478",
+                    "sha256": "4c4176d77d25e51df686bc1c30fa774e25132e45b787f3ce377ad92cd4562a2f",
                     "type": "archive",
                     "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.5/e-juice-calc-1.0.5.tar.gz"
                 }

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -135,7 +135,7 @@
                 {
                     "sha256": "e5464d0600821a116467d4b12fef12b15ff040c3599500e5f0274225e78c6faf",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/word8/0.1.3/word8.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/word8/0.1.3/word8.cabal"
                 }
             ]
         },
@@ -159,7 +159,7 @@
                 {
                     "sha256": "7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/random/1.1/random.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/random/1.1/random.cabal"
                 }
             ]
         },
@@ -183,7 +183,7 @@
                 {
                     "sha256": "3ebbb7022246f446fc625b77d0e1f509d66eedf1deb22bbd6df5c8450aaf923a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/dlist/0.8.0.4/dlist.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/dlist/0.8.0.4/dlist.cabal"
                 }
             ]
         },
@@ -207,7 +207,7 @@
                 {
                     "sha256": "a952817dcbe20af0346fb55a28c13e95e2ddbf3e99f9b4fffdc063f150f13b20",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/byteorder/1.0.4/byteorder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/byteorder/1.0.4/byteorder.cabal"
                 }
             ]
         },
@@ -231,7 +231,7 @@
                 {
                     "sha256": "aaf0d3d5050aa120b2eb98682bc7f8aeed947c1eb51a80375f32775af3d2ff68",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/semigroups/0.18.5/semigroups.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/semigroups/0.18.5/semigroups.cabal"
                 }
             ]
         },
@@ -255,7 +255,7 @@
                 {
                     "sha256": "69d44ecfcf243390f582a515905d614b0dc5c318ead621ca5641cfbd0aa56dff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
                 }
             ]
         },
@@ -279,7 +279,7 @@
                 {
                     "sha256": "0571ef33ec5530104503d32eaf24f2d7c221f350e5fc475a6dd8e84311bc0ca1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
                 }
             ]
         },
@@ -303,7 +303,7 @@
                 {
                     "sha256": "924bd2f574943848ba19189409b9acdc645612eda4d9130b40a62e9cb575bb47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
                 }
             ]
         },
@@ -327,7 +327,7 @@
                 {
                     "sha256": "db5a2ee91cce9afbe7e251c925c2d2b78725b515f6655eb5079aaeeb935c247b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/th-abstraction/0.2.8.0/th-abstraction.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/th-abstraction/0.2.8.0/th-abstraction.cabal"
                 }
             ]
         },
@@ -351,7 +351,7 @@
                 {
                     "sha256": "b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/tagged/0.8.6/tagged.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/tagged/0.8.6/tagged.cabal"
                 }
             ]
         },
@@ -375,7 +375,7 @@
                 {
                     "sha256": "5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/primitive/0.6.4.0/primitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/primitive/0.6.4.0/primitive.cabal"
                 }
             ]
         },
@@ -399,7 +399,7 @@
                 {
                     "sha256": "8a8a091e7113f9c07eb9ad4f58a67eb4a5ec58b2857c6ba80fa4d8d45015524c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/stm/2.4.5.0/stm.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/stm/2.4.5.0/stm.cabal"
                 }
             ]
         },
@@ -423,7 +423,7 @@
                 {
                     "sha256": "181580173130837a8274c8c192e042ef14dcddeb424972d57746d44a628ee217",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/appar/0.1.4/appar.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/appar/0.1.4/appar.cabal"
                 }
             ]
         },
@@ -447,7 +447,7 @@
                 {
                     "sha256": "66691ca16b7ceb8c38bd2bac6ffe8e0eee25f408020cb8150a0444f8824e7458",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/base-compat/0.9.3/base-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/base-compat/0.9.3/base-compat.cabal"
                 }
             ]
         },
@@ -471,7 +471,7 @@
                 {
                     "sha256": "3d644fff350ee3eee2896e4d00cb45e73956f2862f0b18ee502282702682b978",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/vector/0.12.0.1/vector.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/vector/0.12.0.1/vector.cabal"
                 }
             ]
         },
@@ -495,7 +495,7 @@
                 {
                     "sha256": "68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/utf8-string/1.0.1.1/utf8-string.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/utf8-string/1.0.1.1/utf8-string.cabal"
                 }
             ]
         },
@@ -519,7 +519,7 @@
                 {
                     "sha256": "15cbf4c77eb30d51b8b4b1db5ed3b19705ebf43792fe6e0d1aedf47569280b3d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
                 }
             ]
         },
@@ -543,7 +543,7 @@
                 {
                     "sha256": "9dc17a9736056785e11d8a6e3e1e3a88b2a16ed78bf6f27d34ff0827bad1ca21",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/text/1.2.3.0/text.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/text/1.2.3.0/text.cabal"
                 }
             ]
         },
@@ -567,7 +567,7 @@
                 {
                     "sha256": "fa992674ea28f6ea6569d93388d757aef928af1e2f0ce80a35c29fb782252a2d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/blaze-builder/0.4.1.0/blaze-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/blaze-builder/0.4.1.0/blaze-builder.cabal"
                 }
             ]
         },
@@ -591,7 +591,7 @@
                 {
                     "sha256": "9c4075e54aa6cabfe244e07e2a1de720f3e98a0a6980fc671ab9c0da30f0f259",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/string-conversions/0.4.0.1/string-conversions.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/string-conversions/0.4.0.1/string-conversions.cabal"
                 }
             ]
         },
@@ -615,7 +615,7 @@
                 {
                     "sha256": "d656c2627de5915fd4e45d9d01d9eed8ab37359f8f1376f87d537ff01bf12d7b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/unix-compat/0.5.0.1/unix-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/unix-compat/0.5.0.1/unix-compat.cabal"
                 }
             ]
         },
@@ -639,7 +639,7 @@
                 {
                     "sha256": "c11e24ac1df02ad71b861ba3f251b1ea8e64fa44632ba73944dd71767205bcad",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/zlib/0.6.2/zlib.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/zlib/0.6.2/zlib.cabal"
                 }
             ]
         },
@@ -663,7 +663,7 @@
                 {
                     "sha256": "eff944a412a26c7e3950c52128ea3b24ef6838f821f2db9854c62b320225f2ca",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/auto-update/0.1.4/auto-update.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/auto-update/0.1.4/auto-update.cabal"
                 }
             ]
         },
@@ -687,7 +687,7 @@
                 {
                     "sha256": "03b6836ca9cd3ad0e5a2f3cce989b001dd0e05f306a873db3196037adb30e0a4",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/hashable/1.2.7.0/hashable.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/hashable/1.2.7.0/hashable.cabal"
                 }
             ]
         },
@@ -711,7 +711,7 @@
                 {
                     "sha256": "ca2f237cba5db9c9c4238d41a7d8b583c5ca0ce8491de4027b26b17793fc3a87",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/case-insensitive/1.2.0.11/case-insensitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/case-insensitive/1.2.0.11/case-insensitive.cabal"
                 }
             ]
         },
@@ -735,7 +735,7 @@
                 {
                     "sha256": "12ce2fc081fde3cf219b630c2fb3815183a64eee236ba7aa735f666eab949610",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http-types/0.12.1/http-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/http-types/0.12.1/http-types.cabal"
                 }
             ]
         },
@@ -759,7 +759,7 @@
                 {
                     "sha256": "124a5241860711a0e5c10e94d8aec8a127f0094df7a537cc1786e198d7571dfe",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/unordered-containers/0.2.9.0/unordered-containers.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/unordered-containers/0.2.9.0/unordered-containers.cabal"
                 }
             ]
         },
@@ -783,7 +783,7 @@
                 {
                     "sha256": "aa0869aa80026d0bfbbeee44a6381ccd2a2c960ce3ef7d484b14270e054ca79a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/vault/0.3.1.2/vault.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/vault/0.3.1.2/vault.cabal"
                 }
             ]
         },
@@ -807,7 +807,7 @@
                 {
                     "sha256": "01887ed945e74c3c361b00700bd9aeead37d1124d39c0d4f190f89fb0e909c47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/uuid-types/1.0.3/uuid-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/uuid-types/1.0.3/uuid-types.cabal"
                 }
             ]
         },
@@ -831,7 +831,7 @@
                 {
                     "sha256": "dd49abc76bd8e2b57e7a057dc2bb742a00527b4bf9350f9374be03b5934e55d8",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/scientific/0.3.6.2/scientific.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/scientific/0.3.6.2/scientific.cabal"
                 }
             ]
         },
@@ -855,7 +855,7 @@
                 {
                     "sha256": "189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/psqueues/0.2.7.0/psqueues.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/psqueues/0.2.7.0/psqueues.cabal"
                 }
             ]
         },
@@ -879,7 +879,7 @@
                 {
                     "sha256": "1ca79d81af02d7acd6032d5e6c9bde4618a8fdcfbe19bd42b49d420183975df0",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/network/2.6.3.6/network.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/network/2.6.3.6/network.cabal"
                 }
             ]
         },
@@ -903,7 +903,7 @@
                 {
                     "sha256": "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/wai/3.2.1.2/wai.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/wai/3.2.1.2/wai.cabal"
                 }
             ]
         },
@@ -927,7 +927,7 @@
                 {
                     "sha256": "0f64a907a08255d01b9ab58e6c9f72e3f42c22948303c2e914b1b53034a1fa2f",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/simple-sendfile/0.2.27/simple-sendfile.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/simple-sendfile/0.2.27/simple-sendfile.cabal"
                 }
             ]
         },
@@ -951,7 +951,7 @@
                 {
                     "sha256": "99a46f811058c0d7c5cd05b288a245f681d4bedcd7aa60d6bcc18d21a4558d65",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/iproute/1.7.5/iproute.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/iproute/1.7.5/iproute.cabal"
                 }
             ]
         },
@@ -975,7 +975,7 @@
                 {
                     "sha256": "2ce05388bbd8d78e17f130acfe60b2bd2b5a09b995c9f4eb7c2d1ae41a8b1652",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/async/2.1.1.1/async.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/async/2.1.1.1/async.cabal"
                 }
             ]
         },
@@ -999,7 +999,7 @@
                 {
                     "sha256": "3a02f84578f75eac1425dca877f8d697b68d379a21970c1dad96196620404803",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/streaming-commons/0.1.19/streaming-commons.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/streaming-commons/0.1.19/streaming-commons.cabal"
                 }
             ]
         },
@@ -1023,7 +1023,7 @@
                 {
                     "sha256": "69447dd3b077f7f89c2c25731e9c658a4f5a0121b77e41b6467a865143ff425b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/attoparsec/0.13.2.2/attoparsec.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/attoparsec/0.13.2.2/attoparsec.cabal"
                 }
             ]
         },
@@ -1047,7 +1047,7 @@
                 {
                     "sha256": "0551a9433d5ce29ad98f2839f025204c566b69aa1ab45d8488042fe8cde9ceff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http-date/0.0.8/http-date.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/http-date/0.0.8/http-date.cabal"
                 }
             ]
         },
@@ -1071,7 +1071,7 @@
                 {
                     "sha256": "2ff56812644c3e272fef6b19aaff1ddab81c9984b1c1f8969521cb856bc22eab",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/aeson/1.2.4.0/aeson.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/aeson/1.2.4.0/aeson.cabal"
                 }
             ]
         },
@@ -1095,7 +1095,7 @@
                 {
                     "sha256": "c6ce9c4b4899a2177420d272b7e027aa4720cddb0ed465bebff4acb221165da1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/http2/1.6.3/http2.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/http2/1.6.3/http2.cabal"
                 }
             ]
         },
@@ -1119,7 +1119,7 @@
                 {
                     "sha256": "aa63f6fbcea0835c068c65bc9805fd0f3ec279c1b06744bfc357855d2c34f807",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/7f5a34fcc793af5def8e3a2aa3febabd689ac964/warp/3.2.23/warp.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/905e8cdb390944ff18d5e3d1bbe178e611799e58/warp/3.2.23/warp.cabal"
                 }
             ]
         },
@@ -1161,7 +1161,7 @@
             "only-arches": [],
             "sources": [
                 {
-                    "sha256": "4c4176d77d25e51df686bc1c30fa774e25132e45b787f3ce377ad92cd4562a2f",
+                    "sha256": "a678ddda81eded804313d7f6a4ffdea10019b72ecdde37844b385c8dcaecdb7d",
                     "type": "archive",
                     "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.5/e-juice-calc-1.0.5.tar.gz"
                 }

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -1,0 +1,1105 @@
+{
+    "app-id": "com.szibele.e-juice-calc",
+    "cleanup": [],
+    "cleanup-commands": [
+        "rm -rf /app/bin/ghc",
+        "rm -rf /app/bin/ghc-8.2.2",
+        "rm -rf /app/bin/ghc-pkg",
+        "rm -rf /app/bin/ghc-pkg-8.2.2",
+        "rm -rf /app/bin/ghci",
+        "rm -rf /app/bin/ghci-8.2.2",
+        "rm -rf /app/bin/haddock",
+        "rm -rf /app/bin/haddock-ghc-8.2.2",
+        "rm -rf /app/bin/hp2ps",
+        "rm -rf /app/bin/hpc",
+        "rm -rf /app/bin/hsc2hs",
+        "rm -rf /app/bin/runghc",
+        "rm -rf /app/bin/runghc-8.2.2",
+        "rm -rf /app/bin/runhaskell",
+        "rm -rf /app/lib/debug",
+        "rm -rf /app/lib/ghc-8.2.2",
+        "rm -rf /app/lib/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/share/doc/ghc-8.2.2",
+        "rm -rf /app/share/doc/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/share/man",
+        "rm -rf /app/share/x86_64-linux-ghc-8.2.2"
+    ],
+    "command": "e-juice-calc",
+    "finish-args": [
+        "--socket=x11"
+    ],
+    "modules": [
+        {
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "ghc-8.2.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a",
+                    "type": "archive",
+                    "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.2-release/ghc-8.2.2-x86_64-deb8-linux.tar.xz"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "word8-0.1.3",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "2630934c75728bfbf390c1f0206b225507b354f68d4047b06c018a36823b5d8a",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/word8-0.1.3.tar.gz"
+                },
+                {
+                    "sha256": "e5464d0600821a116467d4b12fef12b15ff040c3599500e5f0274225e78c6faf",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/word8/0.1.3/word8.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "random-1.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "b718a41057e25a3a71df693ab0fe2263d492e759679b3c2fea6ea33b171d3a5a",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/random-1.1.tar.gz"
+                },
+                {
+                    "sha256": "7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/random/1.1/random.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "dlist-0.8.0.4",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "acf1867b80cdd618b8d904e89eea33be60d3c4c3aeb80d61f29229a301cc397a",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/dlist-0.8.0.4.tar.gz"
+                },
+                {
+                    "sha256": "3ebbb7022246f446fc625b77d0e1f509d66eedf1deb22bbd6df5c8450aaf923a",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/dlist/0.8.0.4/dlist.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "byteorder-1.0.4",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "bd20bbb586947f99c38a4c93d9d0266f49f6fc581767b51ba568f6d5d52d2919",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/byteorder-1.0.4.tar.gz"
+                },
+                {
+                    "sha256": "a952817dcbe20af0346fb55a28c13e95e2ddbf3e99f9b4fffdc063f150f13b20",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/byteorder/1.0.4/byteorder.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "semigroups-0.18.5",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "ab2a96af6e81e31b909c37ba65f436f1493dbf387cfe0de10b6586270c4ce29d",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/semigroups-0.18.5.tar.gz"
+                },
+                {
+                    "sha256": "aaf0d3d5050aa120b2eb98682bc7f8aeed947c1eb51a80375f32775af3d2ff68",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/semigroups/0.18.5/semigroups.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "bytestring-builder-0.10.8.1.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "6d7404773621efb88b256ff88912a7dbcebc7fb86d27868ef58478249892dbc2",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/bytestring-builder-0.10.8.1.0.tar.gz"
+                },
+                {
+                    "sha256": "69d44ecfcf243390f582a515905d614b0dc5c318ead621ca5641cfbd0aa56dff",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "bsb-http-chunked-0.0.0.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "28cb750979763c815fbf69a6dc510f837b7ccbe262adf0a28ad270966737d5f4",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/bsb-http-chunked-0.0.0.2.tar.gz"
+                },
+                {
+                    "sha256": "0571ef33ec5530104503d32eaf24f2d7c221f350e5fc475a6dd8e84311bc0ca1",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "integer-logarithms-1.0.2.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "32ad4a482a60ec957d1af1268952e2a6b382b67438c14f74f6c2aef2e49b48f2",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/integer-logarithms-1.0.2.1.tar.gz"
+                },
+                {
+                    "sha256": "924bd2f574943848ba19189409b9acdc645612eda4d9130b40a62e9cb575bb47",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "th-abstraction-0.2.8.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "ca136bd3fa76230a288ba0a3a65c36a555f32c179369a258b4a04d2f30e12758",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/th-abstraction-0.2.8.0.tar.gz"
+                },
+                {
+                    "sha256": "db5a2ee91cce9afbe7e251c925c2d2b78725b515f6655eb5079aaeeb935c247b",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/th-abstraction/0.2.8.0/th-abstraction.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "tagged-0.8.6",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "ad16def0884cf6f05ae1ae8e90192cf9d8d9673fa264b249499bd9e4fac791dd",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/tagged-0.8.6.tar.gz"
+                },
+                {
+                    "sha256": "b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/tagged/0.8.6/tagged.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "primitive-0.6.4.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "4cbeaf7924dd79221f327ea101a29bf35c4976dc3319df157ff46ea68e6a0c64",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/primitive-0.6.4.0.tar.gz"
+                },
+                {
+                    "sha256": "5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/primitive/0.6.4.0/primitive.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "stm-2.4.5.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "31d7db183f13beed5c71409d12747a7f4cf3e145630553dc86336208540859a7",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/stm-2.4.5.0.tar.gz"
+                },
+                {
+                    "sha256": "8a8a091e7113f9c07eb9ad4f58a67eb4a5ec58b2857c6ba80fa4d8d45015524c",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/stm/2.4.5.0/stm.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "appar-0.1.4",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "58ea66abe4dd502d2fc01eecdb0828d5e214704a3c1b33b1f8b33974644c4b26",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/appar-0.1.4.tar.gz"
+                },
+                {
+                    "sha256": "181580173130837a8274c8c192e042ef14dcddeb424972d57746d44a628ee217",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/appar/0.1.4/appar.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "base-compat-0.9.3",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "7d602b0f0543fadbd598a090c738e9ce9b07a1896673dc27f1503ae3bea1a210",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/base-compat-0.9.3.tar.gz"
+                },
+                {
+                    "sha256": "66691ca16b7ceb8c38bd2bac6ffe8e0eee25f408020cb8150a0444f8824e7458",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/base-compat/0.9.3/base-compat.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "vector-0.12.0.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "b100ee79b9da2651276278cd3e0f08a3c152505cc52982beda507515af173d7b",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/vector-0.12.0.1.tar.gz"
+                },
+                {
+                    "sha256": "3d644fff350ee3eee2896e4d00cb45e73956f2862f0b18ee502282702682b978",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/vector/0.12.0.1/vector.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "utf8-string-1.0.1.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "fb0b9e3acbe0605bcd1c63e51f290a7bbbe6628dfa3294ff453e4235fbaef140",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/utf8-string-1.0.1.1.tar.gz"
+                },
+                {
+                    "sha256": "68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/utf8-string/1.0.1.1/utf8-string.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "time-locale-compat-0.1.1.4",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "f2d165557e2bbd014a4d6615b3e6c177adb034179a307a775e06836f91ebbe62",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/time-locale-compat-0.1.1.4.tar.gz"
+                },
+                {
+                    "sha256": "15cbf4c77eb30d51b8b4b1db5ed3b19705ebf43792fe6e0d1aedf47569280b3d",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "text-1.2.3.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "20e0b1627f613b32cc7f2d2e8dcc48a4a61938b24f3d14fb77cee694f0c9311a",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/text-1.2.3.0.tar.gz"
+                },
+                {
+                    "sha256": "9dc17a9736056785e11d8a6e3e1e3a88b2a16ed78bf6f27d34ff0827bad1ca21",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/text/1.2.3.0/text.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "blaze-builder-0.4.1.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "91fc8b966f3e9dc9461e1675c7566b881740f99abc906495491a3501630bc814",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/blaze-builder-0.4.1.0.tar.gz"
+                },
+                {
+                    "sha256": "fa992674ea28f6ea6569d93388d757aef928af1e2f0ce80a35c29fb782252a2d",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/blaze-builder/0.4.1.0/blaze-builder.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "string-conversions-0.4.0.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "46bcce6d9ce62c558b7658a75d9c6a62f7259d6b0473d011d8078234ad6a1994",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/string-conversions-0.4.0.1.tar.gz"
+                },
+                {
+                    "sha256": "9c4075e54aa6cabfe244e07e2a1de720f3e98a0a6980fc671ab9c0da30f0f259",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/string-conversions/0.4.0.1/string-conversions.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "unix-compat-0.5.0.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "c2f299e0439c15d93d5700911c922fd2b35543c19ba053779cd52f3b051caebd",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/unix-compat-0.5.0.1.tar.gz"
+                },
+                {
+                    "sha256": "d656c2627de5915fd4e45d9d01d9eed8ab37359f8f1376f87d537ff01bf12d7b",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/unix-compat/0.5.0.1/unix-compat.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "zlib-0.6.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "0dcc7d925769bdbeb323f83b66884101084167501f11d74d21eb9bc515707fed",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/zlib-0.6.2.tar.gz"
+                },
+                {
+                    "sha256": "c11e24ac1df02ad71b861ba3f251b1ea8e64fa44632ba73944dd71767205bcad",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/zlib/0.6.2/zlib.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "auto-update-0.1.4",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "5e96c151024e8bcaf4eaa932e16995872b2017f46124b967e155744d9580b425",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/auto-update-0.1.4.tar.gz"
+                },
+                {
+                    "sha256": "eff944a412a26c7e3950c52128ea3b24ef6838f821f2db9854c62b320225f2ca",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/auto-update/0.1.4/auto-update.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "hashable-1.2.7.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "ecb5efc0586023f5a0dc861100621c1dbb4cbb2f0516829a16ebac39f0432abf",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/hashable-1.2.7.0.tar.gz"
+                },
+                {
+                    "sha256": "03b6836ca9cd3ad0e5a2f3cce989b001dd0e05f306a873db3196037adb30e0a4",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/hashable/1.2.7.0/hashable.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "case-insensitive-1.2.0.11",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "a7ce6d17e50caaa0f19ad8e67361499022860554c521b1e57993759da3eb37e3",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/case-insensitive-1.2.0.11.tar.gz"
+                },
+                {
+                    "sha256": "ca2f237cba5db9c9c4238d41a7d8b583c5ca0ce8491de4027b26b17793fc3a87",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/case-insensitive/1.2.0.11/case-insensitive.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "http-types-0.12.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "3fa7715428f375b6aa4998ef17822871d7bfe1b55ebd9329efbacd4dad9969f3",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/http-types-0.12.1.tar.gz"
+                },
+                {
+                    "sha256": "12ce2fc081fde3cf219b630c2fb3815183a64eee236ba7aa735f666eab949610",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http-types/0.12.1/http-types.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "unordered-containers-0.2.9.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "6730cb5c4a3e953e2c199d6425be08fd088ff0089a3e140d63226c052e318250",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/unordered-containers-0.2.9.0.tar.gz"
+                },
+                {
+                    "sha256": "124a5241860711a0e5c10e94d8aec8a127f0094df7a537cc1786e198d7571dfe",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/unordered-containers/0.2.9.0/unordered-containers.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "vault-0.3.1.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "9e00e52ec0b054cfb9b1e44d8ce2eefb499cc1dcd4bcdd0d434b370d635e551c",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/vault-0.3.1.2.tar.gz"
+                },
+                {
+                    "sha256": "aa0869aa80026d0bfbbeee44a6381ccd2a2c960ce3ef7d484b14270e054ca79a",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/vault/0.3.1.2/vault.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "uuid-types-1.0.3",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "9276517ab24a9b06f39d6e3c33c6c2b4ace1fc2126dbc1cd9806866a6551b3fd",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/uuid-types-1.0.3.tar.gz"
+                },
+                {
+                    "sha256": "01887ed945e74c3c361b00700bd9aeead37d1124d39c0d4f190f89fb0e909c47",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/uuid-types/1.0.3/uuid-types.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "scientific-0.3.6.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "278d0afc87450254f8a76eab21b5583af63954efc9b74844a17a21a68013140f",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/scientific-0.3.6.2.tar.gz"
+                },
+                {
+                    "sha256": "dd49abc76bd8e2b57e7a057dc2bb742a00527b4bf9350f9374be03b5934e55d8",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/scientific/0.3.6.2/scientific.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "psqueues-0.2.7.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "4cf3628884015b091471e4425f5414207fd547cf71d9546e9b7318d857624fea",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/psqueues-0.2.7.0.tar.gz"
+                },
+                {
+                    "sha256": "189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/psqueues/0.2.7.0/psqueues.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "network-2.6.3.6",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "9bde0609ab39441daa7da376c09f501e2913305ef64be5d245c45ba84e5515a5",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/network-2.6.3.6.tar.gz"
+                },
+                {
+                    "sha256": "1ca79d81af02d7acd6032d5e6c9bde4618a8fdcfbe19bd42b49d420183975df0",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/network/2.6.3.6/network.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "wai-3.2.1.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "282351461f19fbac26aa0a7896d7ab583b4abef522fcd9aba944f1848e58234b",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/wai-3.2.1.2.tar.gz"
+                },
+                {
+                    "sha256": "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/wai/3.2.1.2/wai.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "simple-sendfile-0.2.27",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "f68572592099a2db3f7212ac7d133447ae5bbb2605285d3de1a29a52d9c79caf",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/simple-sendfile-0.2.27.tar.gz"
+                },
+                {
+                    "sha256": "0f64a907a08255d01b9ab58e6c9f72e3f42c22948303c2e914b1b53034a1fa2f",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/simple-sendfile/0.2.27/simple-sendfile.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "iproute-1.7.5",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "ed638e0b0a098ee4a0f5c5fe48b2a803939c0be4a3612b2d86e16fa447b581ef",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/iproute-1.7.5.tar.gz"
+                },
+                {
+                    "sha256": "99a46f811058c0d7c5cd05b288a245f681d4bedcd7aa60d6bcc18d21a4558d65",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/iproute/1.7.5/iproute.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "async-2.1.1.1",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "cd83e471466ea6885b2e8fb60f452db3ac3fdf3ea2d6370aa1e071ebc37544e2",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/async-2.1.1.1.tar.gz"
+                },
+                {
+                    "sha256": "2ce05388bbd8d78e17f130acfe60b2bd2b5a09b995c9f4eb7c2d1ae41a8b1652",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/async/2.1.1.1/async.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "streaming-commons-0.1.19",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "43fcae90df5548d9968b31371f13ec7271df86ac34a484c094616867ed4217a7",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/streaming-commons-0.1.19.tar.gz"
+                },
+                {
+                    "sha256": "3a02f84578f75eac1425dca877f8d697b68d379a21970c1dad96196620404803",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/streaming-commons/0.1.19/streaming-commons.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "attoparsec-0.13.2.2",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "dd93471eb969172cc4408222a3842d867adda3dd7fb39ad8a4df1b121a67d848",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/attoparsec-0.13.2.2.tar.gz"
+                },
+                {
+                    "sha256": "69447dd3b077f7f89c2c25731e9c658a4f5a0121b77e41b6467a865143ff425b",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/attoparsec/0.13.2.2/attoparsec.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "http-date-0.0.8",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "0f4c6348487abe4f9d58e43d3c23bdefc7fd1fd5672effd3c7d84aaff05f5427",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/http-date-0.0.8.tar.gz"
+                },
+                {
+                    "sha256": "0551a9433d5ce29ad98f2839f025204c566b69aa1ab45d8488042fe8cde9ceff",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http-date/0.0.8/http-date.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "aeson-1.2.4.0",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "3401dba4fddb92c8a971f6645b38e2f8a1b286ef7061cd392a1a567640bbfc9b",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/aeson-1.2.4.0.tar.gz"
+                },
+                {
+                    "sha256": "2ff56812644c3e272fef6b19aaff1ddab81c9984b1c1f8969521cb856bc22eab",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/aeson/1.2.4.0/aeson.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "http2-1.6.3",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "61620eca0f57875a6a9bd24f9cc04c301b5c3c668bf98f85e9989aad5d069c43",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/http2-1.6.3.tar.gz"
+                },
+                {
+                    "sha256": "c6ce9c4b4899a2177420d272b7e027aa4720cddb0ed465bebff4acb221165da1",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http2/1.6.3/http2.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "warp-3.2.23",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "a0aaff3afbda9675b61ec5725ced21fd48694257ba350fd2d2e07a4822c4698b",
+                    "type": "archive",
+                    "url": "https://s3.amazonaws.com/hackage.fpcomplete.com/package/warp-3.2.23.tar.gz"
+                },
+                {
+                    "sha256": "aa63f6fbcea0835c068c65bc9805fd0f3ec279c1b06744bfc357855d2c34f807",
+                    "type": "file",
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/warp/3.2.23/warp.cabal"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "cmake -DCMAKE_INSTALL_PREFIX=/app .",
+                "make install"
+            ],
+            "buildsystem": "cmake",
+            "cleanup": [],
+            "name": "qml-language-bridge",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "3b0288d5c534acb0c5b5f42ff0f878b26ad4cc233b36b43ec665d24a5af51937",
+                    "type": "archive",
+                    "url": "https://gitlab.com/rszibele/qml-language-bridge/-/archive/1.0.3/qml-language-bridge-1.0.3.tar.gz"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "ghc -threaded --make Setup",
+                "./Setup configure --prefix=/app",
+                "./Setup build",
+                "./Setup install",
+                "mkdir -p /app/share/e-juice-calc/res/",
+                "rm res/Screenshot*",
+                "cp -r res/* /app/share/e-juice-calc/res/",
+                "mkdir -p /app/share/metainfo /app/share/appdata /app/share/applications /app/share/icons/hicolor/scalable/apps",
+                "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/metainfo/",
+                "cp packaging/com.szibele.e-juice-calc.appdata.xml /app/share/appdata/",
+                "cp packaging/com.szibele.e-juice-calc.desktop /app/share/applications/",
+                "cp res/icon2.svg /app/share/icons/hicolor/scalable/apps/com.szibele.e-juice-calc.svg"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "e-juice-calc",
+            "only-arches": [],
+            "sources": [
+                {
+                    "sha256": "4d4a96ac0c063376a2ffa6701c5b5b727cd5ea4e2143b2c9d496d7a9c6234e23",
+                    "type": "archive",
+                    "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.4/e-juice-calc-1.0.4.tar.gz"
+                }
+            ]
+        }
+    ],
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.11",
+    "sdk": "org.kde.Sdk"
+}

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -18,11 +18,20 @@
         "rm -rf /app/bin/runhaskell",
         "rm -rf /app/lib/debug",
         "rm -rf /app/lib/ghc-8.2.2",
-        "rm -rf /app/lib/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/lib/i386-linux-ghc-8.2.2",
         "rm -rf /app/share/doc/ghc-8.2.2",
-        "rm -rf /app/share/doc/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/share/doc/i386-linux-ghc-8.2.2",
         "rm -rf /app/share/man",
-        "rm -rf /app/share/x86_64-linux-ghc-8.2.2"
+        "rm -rf /app/share/i386-linux-ghc-8.2.2",
+        "rm -rf /app/lib/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/share/doc/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/share/x86_64-linux-ghc-8.2.2",
+        "rm -rf /app/lib/armv7-linux-ghc-8.2.2",
+        "rm -rf /app/share/doc/armv7-linux-ghc-8.2.2",
+        "rm -rf /app/share/armv7-linux-ghc-8.2.2",
+        "rm -rf /app/lib/aarch64-linux-ghc-8.2.2",
+        "rm -rf /app/share/doc/aarch64-linux-ghc-8.2.2",
+        "rm -rf /app/share/aarch64-linux-ghc-8.2.2"
     ],
     "command": "e-juice-calc",
     "finish-args": [
@@ -37,12 +46,71 @@
             "buildsystem": "simple",
             "cleanup": [],
             "name": "ghc-8.2.2",
-            "only-arches": [],
+            "only-arches": [
+                "i386"
+            ],
+            "sources": [
+                {
+                    "sha256": "9e67d72d76482e0ba91c718e727b00386a1a12a32ed719714976dc56ca8c8223",
+                    "type": "archive",
+                    "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.2-release/ghc-8.2.2-i386-deb8-linux.tar.xz"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "ghc-8.2.2",
+            "only-arches": [
+                "x86_64"
+            ],
             "sources": [
                 {
                     "sha256": "48e205c62b9dc1ccf6739a4bc15a71e56dde2f891a9d786a1b115f0286111b2a",
                     "type": "archive",
                     "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.2-release/ghc-8.2.2-x86_64-deb8-linux.tar.xz"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "ghc-8.2.2",
+            "only-arches": [
+                "arm"
+            ],
+            "sources": [
+                {
+                    "sha256": "86e8d339c763575a9dba097fb1d8e17b9622156b7cede888187615682b46bbca",
+                    "type": "archive",
+                    "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.2-release/ghc-8.2.2-armv7-deb8-linux.tar.xz"
+                }
+            ]
+        },
+        {
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make install"
+            ],
+            "buildsystem": "simple",
+            "cleanup": [],
+            "name": "ghc-8.2.2",
+            "only-arches": [
+                "aarch64"
+            ],
+            "sources": [
+                {
+                    "sha256": "676698b0b3744af80a610d9e18e40735b9cf8ec337c072d8314d85cba8af4acc",
+                    "type": "archive",
+                    "url": "https://github.com/commercialhaskell/ghc/releases/download/ghc-8.2.2-release/ghc-8.2.2-aarch64-deb8-linux.tar.xz"
                 }
             ]
         },
@@ -66,7 +134,7 @@
                 {
                     "sha256": "e5464d0600821a116467d4b12fef12b15ff040c3599500e5f0274225e78c6faf",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/word8/0.1.3/word8.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/word8/0.1.3/word8.cabal"
                 }
             ]
         },
@@ -90,7 +158,7 @@
                 {
                     "sha256": "7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/random/1.1/random.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/random/1.1/random.cabal"
                 }
             ]
         },
@@ -114,7 +182,7 @@
                 {
                     "sha256": "3ebbb7022246f446fc625b77d0e1f509d66eedf1deb22bbd6df5c8450aaf923a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/dlist/0.8.0.4/dlist.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/dlist/0.8.0.4/dlist.cabal"
                 }
             ]
         },
@@ -138,7 +206,7 @@
                 {
                     "sha256": "a952817dcbe20af0346fb55a28c13e95e2ddbf3e99f9b4fffdc063f150f13b20",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/byteorder/1.0.4/byteorder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/byteorder/1.0.4/byteorder.cabal"
                 }
             ]
         },
@@ -162,7 +230,7 @@
                 {
                     "sha256": "aaf0d3d5050aa120b2eb98682bc7f8aeed947c1eb51a80375f32775af3d2ff68",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/semigroups/0.18.5/semigroups.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/semigroups/0.18.5/semigroups.cabal"
                 }
             ]
         },
@@ -186,7 +254,7 @@
                 {
                     "sha256": "69d44ecfcf243390f582a515905d614b0dc5c318ead621ca5641cfbd0aa56dff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
                 }
             ]
         },
@@ -210,7 +278,7 @@
                 {
                     "sha256": "0571ef33ec5530104503d32eaf24f2d7c221f350e5fc475a6dd8e84311bc0ca1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
                 }
             ]
         },
@@ -234,7 +302,7 @@
                 {
                     "sha256": "924bd2f574943848ba19189409b9acdc645612eda4d9130b40a62e9cb575bb47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
                 }
             ]
         },
@@ -258,7 +326,7 @@
                 {
                     "sha256": "db5a2ee91cce9afbe7e251c925c2d2b78725b515f6655eb5079aaeeb935c247b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/th-abstraction/0.2.8.0/th-abstraction.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/th-abstraction/0.2.8.0/th-abstraction.cabal"
                 }
             ]
         },
@@ -282,7 +350,7 @@
                 {
                     "sha256": "b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/tagged/0.8.6/tagged.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/tagged/0.8.6/tagged.cabal"
                 }
             ]
         },
@@ -306,7 +374,7 @@
                 {
                     "sha256": "5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/primitive/0.6.4.0/primitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/primitive/0.6.4.0/primitive.cabal"
                 }
             ]
         },
@@ -330,7 +398,7 @@
                 {
                     "sha256": "8a8a091e7113f9c07eb9ad4f58a67eb4a5ec58b2857c6ba80fa4d8d45015524c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/stm/2.4.5.0/stm.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/stm/2.4.5.0/stm.cabal"
                 }
             ]
         },
@@ -354,7 +422,7 @@
                 {
                     "sha256": "181580173130837a8274c8c192e042ef14dcddeb424972d57746d44a628ee217",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/appar/0.1.4/appar.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/appar/0.1.4/appar.cabal"
                 }
             ]
         },
@@ -378,7 +446,7 @@
                 {
                     "sha256": "66691ca16b7ceb8c38bd2bac6ffe8e0eee25f408020cb8150a0444f8824e7458",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/base-compat/0.9.3/base-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/base-compat/0.9.3/base-compat.cabal"
                 }
             ]
         },
@@ -402,7 +470,7 @@
                 {
                     "sha256": "3d644fff350ee3eee2896e4d00cb45e73956f2862f0b18ee502282702682b978",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/vector/0.12.0.1/vector.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/vector/0.12.0.1/vector.cabal"
                 }
             ]
         },
@@ -426,7 +494,7 @@
                 {
                     "sha256": "68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/utf8-string/1.0.1.1/utf8-string.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/utf8-string/1.0.1.1/utf8-string.cabal"
                 }
             ]
         },
@@ -450,7 +518,7 @@
                 {
                     "sha256": "15cbf4c77eb30d51b8b4b1db5ed3b19705ebf43792fe6e0d1aedf47569280b3d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
                 }
             ]
         },
@@ -474,7 +542,7 @@
                 {
                     "sha256": "9dc17a9736056785e11d8a6e3e1e3a88b2a16ed78bf6f27d34ff0827bad1ca21",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/text/1.2.3.0/text.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/text/1.2.3.0/text.cabal"
                 }
             ]
         },
@@ -498,7 +566,7 @@
                 {
                     "sha256": "fa992674ea28f6ea6569d93388d757aef928af1e2f0ce80a35c29fb782252a2d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/blaze-builder/0.4.1.0/blaze-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/blaze-builder/0.4.1.0/blaze-builder.cabal"
                 }
             ]
         },
@@ -522,7 +590,7 @@
                 {
                     "sha256": "9c4075e54aa6cabfe244e07e2a1de720f3e98a0a6980fc671ab9c0da30f0f259",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/string-conversions/0.4.0.1/string-conversions.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/string-conversions/0.4.0.1/string-conversions.cabal"
                 }
             ]
         },
@@ -546,7 +614,7 @@
                 {
                     "sha256": "d656c2627de5915fd4e45d9d01d9eed8ab37359f8f1376f87d537ff01bf12d7b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/unix-compat/0.5.0.1/unix-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/unix-compat/0.5.0.1/unix-compat.cabal"
                 }
             ]
         },
@@ -570,7 +638,7 @@
                 {
                     "sha256": "c11e24ac1df02ad71b861ba3f251b1ea8e64fa44632ba73944dd71767205bcad",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/zlib/0.6.2/zlib.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/zlib/0.6.2/zlib.cabal"
                 }
             ]
         },
@@ -594,7 +662,7 @@
                 {
                     "sha256": "eff944a412a26c7e3950c52128ea3b24ef6838f821f2db9854c62b320225f2ca",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/auto-update/0.1.4/auto-update.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/auto-update/0.1.4/auto-update.cabal"
                 }
             ]
         },
@@ -618,7 +686,7 @@
                 {
                     "sha256": "03b6836ca9cd3ad0e5a2f3cce989b001dd0e05f306a873db3196037adb30e0a4",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/hashable/1.2.7.0/hashable.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/hashable/1.2.7.0/hashable.cabal"
                 }
             ]
         },
@@ -642,7 +710,7 @@
                 {
                     "sha256": "ca2f237cba5db9c9c4238d41a7d8b583c5ca0ce8491de4027b26b17793fc3a87",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/case-insensitive/1.2.0.11/case-insensitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/case-insensitive/1.2.0.11/case-insensitive.cabal"
                 }
             ]
         },
@@ -666,7 +734,7 @@
                 {
                     "sha256": "12ce2fc081fde3cf219b630c2fb3815183a64eee236ba7aa735f666eab949610",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http-types/0.12.1/http-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http-types/0.12.1/http-types.cabal"
                 }
             ]
         },
@@ -690,7 +758,7 @@
                 {
                     "sha256": "124a5241860711a0e5c10e94d8aec8a127f0094df7a537cc1786e198d7571dfe",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/unordered-containers/0.2.9.0/unordered-containers.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/unordered-containers/0.2.9.0/unordered-containers.cabal"
                 }
             ]
         },
@@ -714,7 +782,7 @@
                 {
                     "sha256": "aa0869aa80026d0bfbbeee44a6381ccd2a2c960ce3ef7d484b14270e054ca79a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/vault/0.3.1.2/vault.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/vault/0.3.1.2/vault.cabal"
                 }
             ]
         },
@@ -738,7 +806,7 @@
                 {
                     "sha256": "01887ed945e74c3c361b00700bd9aeead37d1124d39c0d4f190f89fb0e909c47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/uuid-types/1.0.3/uuid-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/uuid-types/1.0.3/uuid-types.cabal"
                 }
             ]
         },
@@ -762,7 +830,7 @@
                 {
                     "sha256": "dd49abc76bd8e2b57e7a057dc2bb742a00527b4bf9350f9374be03b5934e55d8",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/scientific/0.3.6.2/scientific.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/scientific/0.3.6.2/scientific.cabal"
                 }
             ]
         },
@@ -786,7 +854,7 @@
                 {
                     "sha256": "189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/psqueues/0.2.7.0/psqueues.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/psqueues/0.2.7.0/psqueues.cabal"
                 }
             ]
         },
@@ -810,7 +878,7 @@
                 {
                     "sha256": "1ca79d81af02d7acd6032d5e6c9bde4618a8fdcfbe19bd42b49d420183975df0",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/network/2.6.3.6/network.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/network/2.6.3.6/network.cabal"
                 }
             ]
         },
@@ -834,7 +902,7 @@
                 {
                     "sha256": "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/wai/3.2.1.2/wai.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/wai/3.2.1.2/wai.cabal"
                 }
             ]
         },
@@ -858,7 +926,7 @@
                 {
                     "sha256": "0f64a907a08255d01b9ab58e6c9f72e3f42c22948303c2e914b1b53034a1fa2f",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/simple-sendfile/0.2.27/simple-sendfile.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/simple-sendfile/0.2.27/simple-sendfile.cabal"
                 }
             ]
         },
@@ -882,7 +950,7 @@
                 {
                     "sha256": "99a46f811058c0d7c5cd05b288a245f681d4bedcd7aa60d6bcc18d21a4558d65",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/iproute/1.7.5/iproute.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/iproute/1.7.5/iproute.cabal"
                 }
             ]
         },
@@ -906,7 +974,7 @@
                 {
                     "sha256": "2ce05388bbd8d78e17f130acfe60b2bd2b5a09b995c9f4eb7c2d1ae41a8b1652",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/async/2.1.1.1/async.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/async/2.1.1.1/async.cabal"
                 }
             ]
         },
@@ -930,7 +998,7 @@
                 {
                     "sha256": "3a02f84578f75eac1425dca877f8d697b68d379a21970c1dad96196620404803",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/streaming-commons/0.1.19/streaming-commons.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/streaming-commons/0.1.19/streaming-commons.cabal"
                 }
             ]
         },
@@ -954,7 +1022,7 @@
                 {
                     "sha256": "69447dd3b077f7f89c2c25731e9c658a4f5a0121b77e41b6467a865143ff425b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/attoparsec/0.13.2.2/attoparsec.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/attoparsec/0.13.2.2/attoparsec.cabal"
                 }
             ]
         },
@@ -978,7 +1046,7 @@
                 {
                     "sha256": "0551a9433d5ce29ad98f2839f025204c566b69aa1ab45d8488042fe8cde9ceff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http-date/0.0.8/http-date.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http-date/0.0.8/http-date.cabal"
                 }
             ]
         },
@@ -1002,7 +1070,7 @@
                 {
                     "sha256": "2ff56812644c3e272fef6b19aaff1ddab81c9984b1c1f8969521cb856bc22eab",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/aeson/1.2.4.0/aeson.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/aeson/1.2.4.0/aeson.cabal"
                 }
             ]
         },
@@ -1026,7 +1094,7 @@
                 {
                     "sha256": "c6ce9c4b4899a2177420d272b7e027aa4720cddb0ed465bebff4acb221165da1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http2/1.6.3/http2.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/http2/1.6.3/http2.cabal"
                 }
             ]
         },
@@ -1050,7 +1118,7 @@
                 {
                     "sha256": "aa63f6fbcea0835c068c65bc9805fd0f3ec279c1b06744bfc357855d2c34f807",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/warp/3.2.23/warp.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/4a44a2399248d6e971566761c8534e0615665991/warp/3.2.23/warp.cabal"
                 }
             ]
         },
@@ -1092,9 +1160,9 @@
             "only-arches": [],
             "sources": [
                 {
-                    "sha256": "5cdc684d3ea29cf65f7a197431272092fd5bd367943c151eaaced75e34848662",
+                    "sha256": "b423d32b7a1b5d7ba1ac2cd4becb44b69da9f844770213c71a32296390107478",
                     "type": "archive",
-                    "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.4/e-juice-calc-1.0.4.tar.gz"
+                    "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.5/e-juice-calc-1.0.5.tar.gz"
                 }
             ]
         }

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -66,7 +66,7 @@
                 {
                     "sha256": "e5464d0600821a116467d4b12fef12b15ff040c3599500e5f0274225e78c6faf",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/word8/0.1.3/word8.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/word8/0.1.3/word8.cabal"
                 }
             ]
         },
@@ -90,7 +90,7 @@
                 {
                     "sha256": "7b67624fd76ddf97c206de0801dc7e888097e9d572974be9b9ea6551d76965df",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/random/1.1/random.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/random/1.1/random.cabal"
                 }
             ]
         },
@@ -114,7 +114,7 @@
                 {
                     "sha256": "3ebbb7022246f446fc625b77d0e1f509d66eedf1deb22bbd6df5c8450aaf923a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/dlist/0.8.0.4/dlist.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/dlist/0.8.0.4/dlist.cabal"
                 }
             ]
         },
@@ -138,7 +138,7 @@
                 {
                     "sha256": "a952817dcbe20af0346fb55a28c13e95e2ddbf3e99f9b4fffdc063f150f13b20",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/byteorder/1.0.4/byteorder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/byteorder/1.0.4/byteorder.cabal"
                 }
             ]
         },
@@ -162,7 +162,7 @@
                 {
                     "sha256": "aaf0d3d5050aa120b2eb98682bc7f8aeed947c1eb51a80375f32775af3d2ff68",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/semigroups/0.18.5/semigroups.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/semigroups/0.18.5/semigroups.cabal"
                 }
             ]
         },
@@ -186,7 +186,7 @@
                 {
                     "sha256": "69d44ecfcf243390f582a515905d614b0dc5c318ead621ca5641cfbd0aa56dff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/bytestring-builder/0.10.8.1.0/bytestring-builder.cabal"
                 }
             ]
         },
@@ -210,7 +210,7 @@
                 {
                     "sha256": "0571ef33ec5530104503d32eaf24f2d7c221f350e5fc475a6dd8e84311bc0ca1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/bsb-http-chunked/0.0.0.2/bsb-http-chunked.cabal"
                 }
             ]
         },
@@ -234,7 +234,7 @@
                 {
                     "sha256": "924bd2f574943848ba19189409b9acdc645612eda4d9130b40a62e9cb575bb47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/integer-logarithms/1.0.2.1/integer-logarithms.cabal"
                 }
             ]
         },
@@ -258,7 +258,7 @@
                 {
                     "sha256": "db5a2ee91cce9afbe7e251c925c2d2b78725b515f6655eb5079aaeeb935c247b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/th-abstraction/0.2.8.0/th-abstraction.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/th-abstraction/0.2.8.0/th-abstraction.cabal"
                 }
             ]
         },
@@ -282,7 +282,7 @@
                 {
                     "sha256": "b5e1de3b14ff198b548928f686e5e8783301dc231413f751c23f4ee10cd47a7c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/tagged/0.8.6/tagged.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/tagged/0.8.6/tagged.cabal"
                 }
             ]
         },
@@ -306,7 +306,7 @@
                 {
                     "sha256": "5b6a2c3cc70a35aabd4565fcb9bb1dd78fe2814a36e62428a9a1aae8c32441a1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/primitive/0.6.4.0/primitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/primitive/0.6.4.0/primitive.cabal"
                 }
             ]
         },
@@ -330,7 +330,7 @@
                 {
                     "sha256": "8a8a091e7113f9c07eb9ad4f58a67eb4a5ec58b2857c6ba80fa4d8d45015524c",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/stm/2.4.5.0/stm.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/stm/2.4.5.0/stm.cabal"
                 }
             ]
         },
@@ -354,7 +354,7 @@
                 {
                     "sha256": "181580173130837a8274c8c192e042ef14dcddeb424972d57746d44a628ee217",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/appar/0.1.4/appar.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/appar/0.1.4/appar.cabal"
                 }
             ]
         },
@@ -378,7 +378,7 @@
                 {
                     "sha256": "66691ca16b7ceb8c38bd2bac6ffe8e0eee25f408020cb8150a0444f8824e7458",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/base-compat/0.9.3/base-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/base-compat/0.9.3/base-compat.cabal"
                 }
             ]
         },
@@ -402,7 +402,7 @@
                 {
                     "sha256": "3d644fff350ee3eee2896e4d00cb45e73956f2862f0b18ee502282702682b978",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/vector/0.12.0.1/vector.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/vector/0.12.0.1/vector.cabal"
                 }
             ]
         },
@@ -426,7 +426,7 @@
                 {
                     "sha256": "68cc6cf665e7212334a51b63d6936daeaca023b2cfe8637d130acfe95f91700b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/utf8-string/1.0.1.1/utf8-string.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/utf8-string/1.0.1.1/utf8-string.cabal"
                 }
             ]
         },
@@ -450,7 +450,7 @@
                 {
                     "sha256": "15cbf4c77eb30d51b8b4b1db5ed3b19705ebf43792fe6e0d1aedf47569280b3d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/time-locale-compat/0.1.1.4/time-locale-compat.cabal"
                 }
             ]
         },
@@ -474,7 +474,7 @@
                 {
                     "sha256": "9dc17a9736056785e11d8a6e3e1e3a88b2a16ed78bf6f27d34ff0827bad1ca21",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/text/1.2.3.0/text.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/text/1.2.3.0/text.cabal"
                 }
             ]
         },
@@ -498,7 +498,7 @@
                 {
                     "sha256": "fa992674ea28f6ea6569d93388d757aef928af1e2f0ce80a35c29fb782252a2d",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/blaze-builder/0.4.1.0/blaze-builder.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/blaze-builder/0.4.1.0/blaze-builder.cabal"
                 }
             ]
         },
@@ -522,7 +522,7 @@
                 {
                     "sha256": "9c4075e54aa6cabfe244e07e2a1de720f3e98a0a6980fc671ab9c0da30f0f259",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/string-conversions/0.4.0.1/string-conversions.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/string-conversions/0.4.0.1/string-conversions.cabal"
                 }
             ]
         },
@@ -546,7 +546,7 @@
                 {
                     "sha256": "d656c2627de5915fd4e45d9d01d9eed8ab37359f8f1376f87d537ff01bf12d7b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/unix-compat/0.5.0.1/unix-compat.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/unix-compat/0.5.0.1/unix-compat.cabal"
                 }
             ]
         },
@@ -570,7 +570,7 @@
                 {
                     "sha256": "c11e24ac1df02ad71b861ba3f251b1ea8e64fa44632ba73944dd71767205bcad",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/zlib/0.6.2/zlib.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/zlib/0.6.2/zlib.cabal"
                 }
             ]
         },
@@ -594,7 +594,7 @@
                 {
                     "sha256": "eff944a412a26c7e3950c52128ea3b24ef6838f821f2db9854c62b320225f2ca",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/auto-update/0.1.4/auto-update.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/auto-update/0.1.4/auto-update.cabal"
                 }
             ]
         },
@@ -618,7 +618,7 @@
                 {
                     "sha256": "03b6836ca9cd3ad0e5a2f3cce989b001dd0e05f306a873db3196037adb30e0a4",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/hashable/1.2.7.0/hashable.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/hashable/1.2.7.0/hashable.cabal"
                 }
             ]
         },
@@ -642,7 +642,7 @@
                 {
                     "sha256": "ca2f237cba5db9c9c4238d41a7d8b583c5ca0ce8491de4027b26b17793fc3a87",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/case-insensitive/1.2.0.11/case-insensitive.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/case-insensitive/1.2.0.11/case-insensitive.cabal"
                 }
             ]
         },
@@ -666,7 +666,7 @@
                 {
                     "sha256": "12ce2fc081fde3cf219b630c2fb3815183a64eee236ba7aa735f666eab949610",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http-types/0.12.1/http-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http-types/0.12.1/http-types.cabal"
                 }
             ]
         },
@@ -690,7 +690,7 @@
                 {
                     "sha256": "124a5241860711a0e5c10e94d8aec8a127f0094df7a537cc1786e198d7571dfe",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/unordered-containers/0.2.9.0/unordered-containers.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/unordered-containers/0.2.9.0/unordered-containers.cabal"
                 }
             ]
         },
@@ -714,7 +714,7 @@
                 {
                     "sha256": "aa0869aa80026d0bfbbeee44a6381ccd2a2c960ce3ef7d484b14270e054ca79a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/vault/0.3.1.2/vault.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/vault/0.3.1.2/vault.cabal"
                 }
             ]
         },
@@ -738,7 +738,7 @@
                 {
                     "sha256": "01887ed945e74c3c361b00700bd9aeead37d1124d39c0d4f190f89fb0e909c47",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/uuid-types/1.0.3/uuid-types.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/uuid-types/1.0.3/uuid-types.cabal"
                 }
             ]
         },
@@ -762,7 +762,7 @@
                 {
                     "sha256": "dd49abc76bd8e2b57e7a057dc2bb742a00527b4bf9350f9374be03b5934e55d8",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/scientific/0.3.6.2/scientific.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/scientific/0.3.6.2/scientific.cabal"
                 }
             ]
         },
@@ -786,7 +786,7 @@
                 {
                     "sha256": "189970837d0aae01f48cd2a8aac6ce314191939e118cc0488aee1fb12da1956a",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/psqueues/0.2.7.0/psqueues.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/psqueues/0.2.7.0/psqueues.cabal"
                 }
             ]
         },
@@ -810,7 +810,7 @@
                 {
                     "sha256": "1ca79d81af02d7acd6032d5e6c9bde4618a8fdcfbe19bd42b49d420183975df0",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/network/2.6.3.6/network.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/network/2.6.3.6/network.cabal"
                 }
             ]
         },
@@ -834,7 +834,7 @@
                 {
                     "sha256": "eea52c4967d8609c2f79213d6dffe6d6601034f1471776208404781de7051410",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/wai/3.2.1.2/wai.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/wai/3.2.1.2/wai.cabal"
                 }
             ]
         },
@@ -858,7 +858,7 @@
                 {
                     "sha256": "0f64a907a08255d01b9ab58e6c9f72e3f42c22948303c2e914b1b53034a1fa2f",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/simple-sendfile/0.2.27/simple-sendfile.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/simple-sendfile/0.2.27/simple-sendfile.cabal"
                 }
             ]
         },
@@ -882,7 +882,7 @@
                 {
                     "sha256": "99a46f811058c0d7c5cd05b288a245f681d4bedcd7aa60d6bcc18d21a4558d65",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/iproute/1.7.5/iproute.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/iproute/1.7.5/iproute.cabal"
                 }
             ]
         },
@@ -906,7 +906,7 @@
                 {
                     "sha256": "2ce05388bbd8d78e17f130acfe60b2bd2b5a09b995c9f4eb7c2d1ae41a8b1652",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/async/2.1.1.1/async.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/async/2.1.1.1/async.cabal"
                 }
             ]
         },
@@ -930,7 +930,7 @@
                 {
                     "sha256": "3a02f84578f75eac1425dca877f8d697b68d379a21970c1dad96196620404803",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/streaming-commons/0.1.19/streaming-commons.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/streaming-commons/0.1.19/streaming-commons.cabal"
                 }
             ]
         },
@@ -954,7 +954,7 @@
                 {
                     "sha256": "69447dd3b077f7f89c2c25731e9c658a4f5a0121b77e41b6467a865143ff425b",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/attoparsec/0.13.2.2/attoparsec.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/attoparsec/0.13.2.2/attoparsec.cabal"
                 }
             ]
         },
@@ -978,7 +978,7 @@
                 {
                     "sha256": "0551a9433d5ce29ad98f2839f025204c566b69aa1ab45d8488042fe8cde9ceff",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http-date/0.0.8/http-date.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http-date/0.0.8/http-date.cabal"
                 }
             ]
         },
@@ -1002,7 +1002,7 @@
                 {
                     "sha256": "2ff56812644c3e272fef6b19aaff1ddab81c9984b1c1f8969521cb856bc22eab",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/aeson/1.2.4.0/aeson.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/aeson/1.2.4.0/aeson.cabal"
                 }
             ]
         },
@@ -1026,7 +1026,7 @@
                 {
                     "sha256": "c6ce9c4b4899a2177420d272b7e027aa4720cddb0ed465bebff4acb221165da1",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/http2/1.6.3/http2.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/http2/1.6.3/http2.cabal"
                 }
             ]
         },
@@ -1050,7 +1050,7 @@
                 {
                     "sha256": "aa63f6fbcea0835c068c65bc9805fd0f3ec279c1b06744bfc357855d2c34f807",
                     "type": "file",
-                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/cd8d95753b12cb39576e9e376c7b855ce976b34a/warp/3.2.23/warp.cabal"
+                    "url": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-files/1086d62149f9a5a9515f169441e95e4624fca2f5/warp/3.2.23/warp.cabal"
                 }
             ]
         },
@@ -1092,7 +1092,7 @@
             "only-arches": [],
             "sources": [
                 {
-                    "sha256": "4d4a96ac0c063376a2ffa6701c5b5b727cd5ea4e2143b2c9d496d7a9c6234e23",
+                    "sha256": "5cdc684d3ea29cf65f7a197431272092fd5bd367943c151eaaced75e34848662",
                     "type": "archive",
                     "url": "https://gitlab.com/rszibele/e-juice-calc/-/archive/1.0.4/e-juice-calc-1.0.4.tar.gz"
                 }

--- a/com.szibele.e-juice-calc.json
+++ b/com.szibele.e-juice-calc.json
@@ -35,7 +35,8 @@
     ],
     "command": "e-juice-calc",
     "finish-args": [
-        "--socket=x11"
+        "--socket=x11",
+        "--share=ipc"
     ],
     "modules": [
         {


### PR DESCRIPTION
Hi,

This adds e-juice-calc which is available under the GPLv2 to Flathub: https://gitlab.com/rszibele/e-juice-calc

The Haskell dependencies within the manifest have been auto-generated by https://gitlab.com/rszibele/stackpak .

Thanks!