### PR TITLE
Add net.baseart.Glide

### DIFF
--- a/net.baseart.Glide.yaml
+++ b/net.baseart.Glide.yaml
@@ -1,0 +1,31 @@
+app-id: net.baseart.Glide
+runtime: org.gnome.Platform
+runtime-version: '3.28'
+sdk: org.gnome.Sdk
+sdk-extensions:
+- org.freedesktop.Sdk.Extension.rust-stable
+command: glide
+finish-args:
+- --device=dri
+- --share=network
+- --share=ipc
+- --device=dri
+- --socket=x11
+- --socket=wayland
+- --socket=pulseaudio
+- --filesystem=home
+- --talk-name=ca.desrt.dconf
+- --filesystem=xdg-run/dconf
+- --filesystem=~/.config/dconf:ro
+- --env=DCONF_USER_CONFIG_DIR=.config/dconf
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin
+  env:
+    CARGO_HOME: /run/build/glide/cargo
+modules:
+- name: glide
+  buildsystem: meson
+  sources:
+  - type: archive
+    url: https://github.com/philn/glide/releases/download/0.5.4/glide-0.5.4.tar.xz
+    sha256: 81272e6f2c0106c18c770e0d3d302e1a4e4778ff0fd3c34fe131a37d6f97e753


### PR DESCRIPTION
Glide is simplistic media player relying on GTK+ for the user interface and
GStreamer for the multimedia support.