### PR TITLE
FDK-AAC encoder plugin for VLC

### DIFF
--- a/org.videolan.VLC.Plugin.fdkaac.appdata.xml
+++ b/org.videolan.VLC.Plugin.fdkaac.appdata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.videolan.VLC.Plugin.fdkaac</id>
+  <extends>org.videolan.VLC</extends>
+  <name>FDK-AAC Encoding Plugin for VLC</name>
+  <summary>Provides better AAC encoding and HE profiles support.</summary>
+  <url type="homepage">https://www.videolan.org/</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+</component>

--- a/org.videolan.VLC.Plugin.fdkaac.json
+++ b/org.videolan.VLC.Plugin.fdkaac.json
@@ -1,0 +1,73 @@
+{
+  "id": "org.videolan.VLC.Plugin.fdkaac",
+  "runtime": "org.videolan.VLC",
+  "runtime-version": "stable",
+  "branch": "3-1.6",
+  "sdk": "org.freedesktop.Sdk//1.6",
+  "build-extension": true,
+  "separate-locales": false,
+  "appstream-compose": false,
+  "build-options": {
+    "cflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+    "cxxflags": "-O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+    "ldflags": "-fstack-protector-strong -Wl,-z,relro,-z,now",
+    "env": {
+      "V": "1"
+    }
+  },
+  "modules": [
+    {
+      "name": "fdkaac",
+      "config-opts": [
+        "--with-pic",
+        "--disable-static",
+        "--enable-shared",
+        "--prefix=/app/share/vlc/extra/fdkaac"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/mstorsjo/fdk-aac/archive/v0.1.6.tar.gz",
+          "sha256": "adbcd793e406e1b88b3c1c41382d49f8c27371485b823c0fdab69c9124fd2ce3"
+        },
+        {
+          "type": "script",
+          "commands": [
+            "autoreconf -fiv"
+          ],
+          "dest-filename": "autogen.sh"
+        }
+      ]
+    },
+    {
+      "name": "vlc",
+      "rm-configure": true,
+      "config-opts": [
+        "BUILDCC=/usr/bin/gcc -std=gnu99",
+        "PKG_CONFIG_PATH=/app/share/vlc/extra/fdkaac/lib/pkgconfig",
+        "--disable-a52",
+        "--disable-lua",
+        "--enable-fdkaac",
+        "--prefix=/var/tmp/install"
+      ],
+      "post-install": [
+        "mkdir -p /app/share/vlc/extra/fdkaac/plugins",
+        "mv /var/tmp/install/lib/vlc/plugins/codec/libfdkaac_plugin.so /app/share/vlc/extra/fdkaac/plugins",
+        "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.videolan.VLC.Plugin.fdkaac.appdata.xml",
+        "appstream-compose --basename=org.videolan.VLC.Plugin.fdkaac --prefix=${FLATPAK_DEST} --origin=flatpak org.videolan.VLC.Plugin.fdkaac"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.videolan.org/pub/videolan/vlc/3.0.4/vlc-3.0.4.tar.xz",
+          "sha256": "01f3db3790714038c01f5e23c709e31ecd6f1c046ac93d19e1dde38b3fc05a9e"
+        },
+        {
+          "type": "file",
+          "path": "org.videolan.VLC.Plugin.fdkaac.appdata.xml",
+          "sha256": "ebf2a176be614f5d36cc56c41711f8c84aa7e6e49e17c3e60673077612298c07"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Packaged separately because the license is incompatible with GPL, but still free.

Allows better encoding quality and the use of HE profiles.