### PR TITLE
Add org.gtk.Gtk3theme.Sierra-Negra theme

### DIFF
--- a/org.gtk.Gtk3theme.Sierra-Negra.appdata.xml
+++ b/org.gtk.Gtk3theme.Sierra-Negra.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+    <id>org.gtk.Gtk3theme.Sierra-Negra</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Sierra Negra GTK Theme</name>
+    <summary>Sierra Negra theme for GTK 3 by thepante.</summary>
+    <description>
+        <p>Sierra Negra theme for GTK 3 by thepante and is based on Sierra solid.</p>
+    </description>
+    <url type="homepage">https://github.com/thepante/setup/releases</url>
+</component>

--- a/org.gtk.Gtk3theme.Sierra-Negra.json
+++ b/org.gtk.Gtk3theme.Sierra-Negra.json
@@ -1,0 +1,43 @@
+{
+   "id":"org.gtk.Gtk3theme.Sierra-Negra",
+   "branch":"3.22",
+   "runtime":"org.gnome.Sdk",
+   "build-extension":true,
+   "sdk":"org.gnome.Sdk",
+   "runtime-version":"3.26",
+   "appstream-compose":false,
+   "separate-locales":false,
+   "modules":[
+      {
+         "name":"Sierra-Negra",
+         "buildsystem":"simple",
+         "build-commands":[
+            "install -dm755 /usr/share/runtime/share/themes/Sierra-Negra/gtk-3.0",
+            "cp -aL gtk-3.0/* /usr/share/runtime/share/themes/Sierra-Negra/gtk-3.0",
+            "cp -a index.theme /usr/share/runtime/share/themes/Sierra-Negra"
+         ],
+         "sources":[
+            {
+               "type":"archive",
+               "url":"https://github.com/thepante/setup/releases/download/0.5.1/Sierranegra-0.5.1.zip",
+               "sha256":"676b589cd02a563e02a6baf7884a6014391c68bb171a7f28dcddba09852c9aa0"
+            }
+         ]
+      },
+      {
+         "name":"appdata",
+         "buildsystem":"simple",
+         "build-commands":[
+            "mkdir -p ${FLATPAK_DEST}/share/appdata",
+            "cp org.gtk.Gtk3theme.Sierra-Negra.appdata.xml ${FLATPAK_DEST}/share/appdata",
+            "appstream-compose --basename=org.gtk.Gtk3theme.Sierra-Negra --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Sierra-Negra"
+         ],
+         "sources":[
+            {
+               "type":"file",
+               "path":"org.gtk.Gtk3theme.Sierra-Negra.appdata.xml"
+            }
+         ]
+      }
+   ]
+}

--- a/org.gtk.Gtk3theme.Sierra-Negra.json
+++ b/org.gtk.Gtk3theme.Sierra-Negra.json
@@ -1,41 +1,41 @@
 {
-   "id":"org.gtk.Gtk3theme.Sierra-Negra",
-   "branch":"3.22",
-   "runtime":"org.gnome.Sdk",
-   "build-extension":true,
-   "sdk":"org.gnome.Sdk",
-   "runtime-version":"3.26",
-   "appstream-compose":false,
-   "separate-locales":false,
-   "modules":[
+   "id" : "org.gtk.Gtk3theme.Sierra-Negra",
+   "branch" : "3.22",
+   "runtime" : "org.gnome.Sdk",
+   "build-extension" : true,
+   "sdk" : "org.gnome.Sdk",
+   "runtime-version" : "3.26",
+   "appstream-compose" : false,
+   "separate-locales" : false,
+   "modules" : [
       {
-         "name":"Sierra-Negra",
-         "buildsystem":"simple",
-         "build-commands":[
+         "name" : "Sierra-Negra",
+         "buildsystem" : "simple",
+         "build-commands" : [
             "install -dm755 /usr/share/runtime/share/themes/Sierra-Negra/gtk-3.0",
             "cp -aL gtk-3.0/* /usr/share/runtime/share/themes/Sierra-Negra/gtk-3.0",
             "cp -a index.theme /usr/share/runtime/share/themes/Sierra-Negra"
          ],
-         "sources":[
+         "sources" : [
             {
-               "type":"archive",
-               "url":"https://github.com/thepante/setup/releases/download/0.5.1/Sierranegra-0.5.1.zip",
-               "sha256":"676b589cd02a563e02a6baf7884a6014391c68bb171a7f28dcddba09852c9aa0"
+               "type" : "archive",
+               "url" : "https://github.com/thepante/setup/releases/download/0.5.1/Sierranegra-0.5.1.zip",
+               "sha256" : "676b589cd02a563e02a6baf7884a6014391c68bb171a7f28dcddba09852c9aa0"
             }
          ]
       },
       {
-         "name":"appdata",
-         "buildsystem":"simple",
-         "build-commands":[
+         "name" : "appdata",
+         "buildsystem" : "simple",
+         "build-commands" : [
             "mkdir -p ${FLATPAK_DEST}/share/appdata",
             "cp org.gtk.Gtk3theme.Sierra-Negra.appdata.xml ${FLATPAK_DEST}/share/appdata",
             "appstream-compose --basename=org.gtk.Gtk3theme.Sierra-Negra --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Sierra-Negra"
          ],
-         "sources":[
+         "sources" : [
             {
-               "type":"file",
-               "path":"org.gtk.Gtk3theme.Sierra-Negra.appdata.xml"
+               "type" : "file",
+               "path" : "org.gtk.Gtk3theme.Sierra-Negra.appdata.xml"
             }
          ]
       }


### PR DESCRIPTION
This theme was adapted by thepante (repo: https://github.com/thepante/setup/tree/master/.themes/Sierra%20Negra) from the Sierra Solid Dark theme by vinceliuice (repo: https://github.com/vinceliuice/Sierra-gtk-theme). It has been tested on my system and works here. The applications it was tested as working with were Gnome Builder and GnuCash. It did not appear to affect the appear of Gnome MPV but other flatpak themes seemed to have the same problem.

Edit: spelling fixes