### PR TITLE
add gnome-screenshot

### DIFF
--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -1,0 +1,53 @@
+{
+  "app-id": "org.gnome.Screenshot",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.28",
+  "sdk": "org.gnome.Sdk",
+  "command": "gnome-screenshot",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--talk-name=org.gnome.Shell.Screenshot",
+    "--filesystem=xdg-run/dconf",
+    "--filesystem=~/.config/dconf:ro",
+    "--talk-name=ca.desrt.dconf",
+    "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+    "--filesystem=home"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/share/pkgconfig",
+    "/share/aclocal",
+    "/man",
+    "/share/man",
+    "/share/gtk-doc",
+    "/share/vala",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "libcanberra-gtk3",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+          "sha256": "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+        }
+      ]
+    },
+    {
+      "name": "gnome-screenshot",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.gnome.org/GNOME/gnome-screenshot/-/archive/3.26.0/gnome-screenshot-3.26.0.tar.gz",
+          "sha256": "7bb1462b4b14db574e270d5dddbcd4ec8bf2f5f45681c729b66ecdabae4abad4"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The latest release is 3.30. The one before is 3.26, used that until the 3.30 runtime is ready!