### PR TITLE
Add dk.tangramgames.mrrescue to flathub

### DIFF
--- a/dk.tangramgames.mrrescue.appdata.xml
+++ b/dk.tangramgames.mrrescue.appdata.xml
@@ -47,4 +47,7 @@
   <content_rating type="oars-1.0">
     <content_attribute id="violence-fantasy">mild</content_attribute>
   </content_rating>
+  <releases>
+    <release date="2016-03-10" version="1.02e"/>
+  </releases>
 </component>

--- a/dk.tangramgames.mrrescue.appdata.xml
+++ b/dk.tangramgames.mrrescue.appdata.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 Carles Pastor <cpbadosa@gmail.com> -->
+<component type="desktop">
+  <id>dk.tangramgames.mrrescue</id>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>Zlib</project_license>
+  <name>Mr Rescue</name>
+  <summary>Arcade-style fire fighting game</summary>
+  <description>
+    <p>Mr. Rescue is an arcade styled 2d action game centered around evacuating
+    civilians from burning buildings.
+
+    The game features fast paced fire extinguishing action, intense boss
+    battles, a catchy soundtrack and lots of throwing people around in
+    pseudo-randomly generated buildings.
+
+    As of version 1.02 we have added XBox 360 controller support and
+    fullscreen modes.</p>
+  </description>
+  <screenshots>
+    <screenshot>
+      <caption>Dousing enemy</caption>
+      <image>http://tangramgames.dk/games/mrrescue/images/2.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Mid-level text</caption>
+      <image>http://tangramgames.dk/games/mrrescue/images/3.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Rescuing person</caption>
+      <image>http://tangramgames.dk/games/mrrescue/images/4.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Level selection</caption>
+      <image>http://tangramgames.dk/games/mrrescue/images/5.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Burning building</caption>
+      <image>http://tangramgames.dk/games/mrrescue/images/6.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">http://tangramgames.dk/games/mrrescue/</url>
+  <launchable type="desktop-id">dk.tangramgames.mrrescue.desktop</launchable>
+  <provides>
+    <binary>mrrescue</binary>
+  </provides>
+  <content_rating type="oars-1.0">
+    <content_attribute id="violence-fantasy">mild</content_attribute>
+  </content_rating>
+</component>

--- a/dk.tangramgames.mrrescue.desktop
+++ b/dk.tangramgames.mrrescue.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Mr. Rescue
+Comment=Arcade-style fire fighting game
+Exec=mrrescue
+Type=Application
+Categories=Game;ArcadeGame;
+Terminal=false
+Icon=dk.tangramgames.mrrescue

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -7,8 +7,7 @@
   "finish-args": [
     "--device=all",
     "--socket=pulseaudio",
-    "--socket=x11",
-    "--socket=wayland"
+    "--socket=x11"
   ],
   "modules": [
     {

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -13,6 +13,12 @@
     {
       "name": "PhysicsFS",
       "buildsystem": "cmake-ninja",
+      "cleanup": [
+        "/lib/*.a",
+        "/include",
+        "/lib/pkgconfig",
+        "/bin"
+      ],
       "sources": [
         {
           "type": "archive",
@@ -23,6 +29,11 @@
     },
     {
       "name": "libmodplug",
+      "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.la"
+      ],
       "sources": [
         {
           "type": "archive",
@@ -37,6 +48,12 @@
       "make-install-args": [
         "PREFIX=/app"
       ],
+      "cleanup": [
+        "/share/man",
+        "/lib/*.a",
+        "/include",
+        "/lib/pkgconfig"
+      ],
       "sources": [
         {
           "type": "archive",
@@ -47,6 +64,12 @@
     },
     {
       "name": "love",
+      "cleanup": [
+        "/share/man",
+        "/share/applications",
+        "/share/mime/packages",
+        "/lib/*.la"
+      ],
       "sources": [
         {
           "type": "archive",

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -12,7 +12,7 @@
   "modules": [
     {
       "name": "PhysicsFS",
-      "buildsystem": "cmake",
+      "buildsystem": "cmake-ninja",
       "sources": [
         {
           "type": "archive",

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -58,8 +58,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://luajit.org/download/LuaJIT-2.0.5.tar.gz",
-          "sha256": "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
+          "url": "http://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz",
+          "sha256": "1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3"
         }
       ]
     },

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -52,7 +52,8 @@
         "/share/man",
         "/lib/*.a",
         "/include",
-        "/lib/pkgconfig"
+        "/lib/pkgconfig",
+        "/bin"
       ],
       "sources": [
         {

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -33,10 +33,9 @@
     },
     {
       "name": "luajit",
-      "buildsystem": "simple",
-      "build-commands": [
-        "make",
-        "make install PREFIX=/app"
+      "no-autogen": true,
+      "make-install-args": [
+        "PREFIX=/app"
       ],
       "sources": [
         {

--- a/dk.tangramgames.mrrescue.json
+++ b/dk.tangramgames.mrrescue.json
@@ -1,0 +1,94 @@
+{
+  "app-id": "dk.tangramgames.mrrescue",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "18.08",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "mrrescue",
+  "finish-args": [
+    "--device=all",
+    "--socket=pulseaudio",
+    "--socket=x11",
+    "--socket=wayland"
+  ],
+  "modules": [
+    {
+      "name": "PhysicsFS",
+      "buildsystem": "cmake",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://icculus.org/physfs/downloads/physfs-3.0.1.tar.bz2",
+          "sha256": "b77b9f853168d9636a44f75fca372b363106f52d789d18a2f776397bf117f2f1"
+        }
+      ]
+    },
+    {
+      "name": "libmodplug",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://sourceforge.net/projects/modplug-xmms/files/libmodplug/0.8.9.0/libmodplug-0.8.9.0.tar.gz",
+          "md5": "5ba16981e6515975e9a68a58d5ba69d1"
+        }
+      ]
+    },
+    {
+      "name": "luajit",
+      "buildsystem": "simple",
+      "build-commands": [
+        "make",
+        "make install PREFIX=/app"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://luajit.org/download/LuaJIT-2.0.5.tar.gz",
+          "sha256": "874b1f8297c697821f561f9b73b57ffd419ed8f4278c82e05b48806d30c1e979"
+        }
+      ]
+    },
+    {
+      "name": "love",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://bitbucket.org/rude/love/downloads/love-11.1-linux-src.tar.gz",
+          "sha256": "bc5e9a70021de830f1032d6afe900f0b81902e2b6c610e26cf1d6859bf8e7cde"
+        }
+      ]
+    },
+    {
+      "name": "mrrescue",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mv mrrescue /app/bin/mrrescue",
+        "install -Dm644 dk.tangramgames.mrrescue.desktop /app/share/applications/dk.tangramgames.mrrescue.desktop",
+        "install -Dm644 dk.tangramgames.mrrescue.appdata.xml /app/share/metainfo/dk.tangramgames.mrrescue.appdata.xml",
+        "install -Dm644 data/splash.png /app/share/icons/hicolor/256x256/apps/dk.tangramgames.mrrescue.png",
+        "zip -r /app/bin/mrrescue.love *"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/SimonLarsen/mrrescue.git",
+          "commit": "a5be73c60acb8d1be506f7b5e48e784492ba96ce"
+        },
+        {
+          "type": "script",
+          "commands":[
+            "love /app/bin/mrrescue.love"
+          ],
+          "dest-filename":"mrrescue"
+        },
+        {
+          "type": "file",
+          "path": "dk.tangramgames.mrrescue.desktop"
+        },
+        {
+          "type": "file",
+          "path": "dk.tangramgames.mrrescue.appdata.xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- It uses `--device=all`, I haven't found a better way for the gamepad support to work.
- It bundles its own desktop file, a pull request exists to add one upstream but it hasn't been merged yet.
- It bundles its own appdata file, a pull request exists to add one upstream but it hasn't been merged yet.

I have attempted to contact the author to see if they would be interested in maintaining the flathub build, but I have yet to receive an answer. In any case, I'm happy to do it myself.