### PR TITLE
Add org.linux_hardware.hw-probe

### DIFF
--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -145,8 +145,8 @@ modules:
       - make install DESTDIR=$FLATPAK_DEST
     sources:
       - type: archive
-        url: http://ftp.riken.jp/Linux/kernel.org/linux/utils/kernel/kmod/kmod-12.tar.gz
-        sha256: 028f24139fd2ba235126cea45b09900a793a8b9480b3b6b25485eedf8ca4a95a
+        url: https://cdn.kernel.org/pub/linux/utils/kernel/kmod/kmod-12.tar.xz
+        sha256: c6189dd8c5a1e8d9224e8506bd188c0cd5dfa119fd6b7e5869b3640cbe8bf92f
   - name: libusb-1
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -89,7 +89,7 @@ modules:
       - ./configure --prefix=/
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - install -D ./ip/ip $FLATPAK_DEST/sbin/
+      - install -D ./ip/ip $FLATPAK_DEST/sbin/ip
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.18.0.tar.xz
@@ -190,7 +190,7 @@ modules:
       - sed -i -e 's/ -g / -s /' Makefile
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - install -D ./dmesg $FLATPAK_DEST/usr/bin/
+      - install -D ./dmesg $FLATPAK_DEST/usr/bin/dmesg
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.gz
@@ -358,16 +358,15 @@ modules:
     buildsystem: simple
     build-commands:
       - make install DESTDIR=$FLATPAK_DEST
-      - install -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
-      - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/
-      - chmod a+x $FLATPAK_DEST/bin/hw-probe-flatpak
+      - install -m 777 -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
+      - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/PERL5_BASE
       - install -D OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
       - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hw-probe.png
       - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hw-probe.png
       - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hw-probe.png
       - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
-      - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/
-      - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/
+      - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/usb.ids
+      - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/pci.ids
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
@@ -378,7 +377,7 @@ modules:
       - sh Configure -de -Dprefix=/usr
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - install -D ./perl $FLATPAK_DEST/usr/bin/
+      - install -D ./perl $FLATPAK_DEST/usr/bin/perl
       - cd lib && cat $FLATPAK_DEST/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done
     sources:
       - type: archive

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,4 +1,4 @@
-app-id: org.linux_hardware.hwprobe
+app-id: org.linux_hardware.hw-probe
 runtime: org.freedesktop.Platform
 runtime-version: 1.6
 sdk: org.freedesktop.Sdk
@@ -359,17 +359,17 @@ modules:
       - make install DESTDIR=$FLATPAK_DEST
       - install -m 777 -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
       - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/PERL5_BASE
-      - install -D flatpak/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hwprobe.appdata.xml
-      - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hwprobe.png
-      - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hwprobe.png
-      - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hwprobe.png
-      - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hwprobe.desktop
+      - install -D flatpak/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
+      - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
       - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/usb.ids
       - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/pci.ids
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: c3dcb0151339d5fea0d667599c94bbfe1ba8f68d488e5be5ab88ef93dd38ec89
+        sha256: 37a77f65a186049f99d977de771bc84dbc73694827a811001a367b70582590e1
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,6 +1,6 @@
 app-id: org.linux_hardware.hw-probe
 runtime: org.freedesktop.Platform
-runtime-version: 1.6
+runtime-version: 18.08
 sdk: org.freedesktop.Sdk
 command: hw-probe-flatpak
 finish-args:
@@ -13,6 +13,10 @@ finish-args:
   - --env=PERL5LIB=/app/usr/share/perl5:/app/usr/lib/x86_64-linux-gnu/perl-base:/app/usr/lib/i386-linux-gnu/perl-base
   - --env=LD_LIBRARY_PATH=/app/lib/x86_64-linux-gnu/:/app/lib/i386-linux-gnu/:/app/usr/lib64:/app/usr/lib:/app/usr/lib/x86_64-linux-gnu:/app/usr/lib/i386-linux-gnu
   - --env=LC_ALL=C
+build-options:
+      env:
+        - PERL5LIB=/app/share/automake-1.10/
+        - ACLOCAL_PATH=/app/share/aclocal
 cleanup:
   - /usr/include
   - /usr/man
@@ -62,6 +66,26 @@ cleanup:
   - /bin/lex
   - /var/lib
 modules:
+  - name: automake
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=$FLATPAK_DEST
+      - make -j $FLATPAK_BUILDER_N_JOBS
+      - make install
+    sources:
+      - type: archive
+        url: http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+        sha256: 7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
+  - name: libtool
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=$FLATPAK_DEST
+      - make -j $FLATPAK_BUILDER_N_JOBS
+      - make install
+    sources:
+      - type: archive
+        url: ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
+        sha256: e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
   - name: edid-decode
     buildsystem: simple
     build-commands:
@@ -173,7 +197,7 @@ modules:
   - name: smartmontools
     buildsystem: simple
     build-commands:
-      - sh autogen.sh
+      - NOCONFIGURE=1 sh autogen.sh
       - ./configure --with-nvme-devicescan --prefix=/
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
@@ -211,13 +235,14 @@ modules:
   - name: lex
     buildsystem: simple
     build-commands:
+      - NOCONFIGURE=1 sh autogen.sh
       - ./configure
       - make -j $FLATPAK_BUILDER_N_JOBS
       - install -D src/flex $FLATPAK_DEST/bin/lex
     sources:
       - type: archive
-        url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
-        sha256: e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+        url: https://github.com/linuxhw/build-stuff/releases/download/1.4/flex-20181004.tar.gz
+        sha256: bd7d248de7792dd2de2089a16b7ea60f94b2056e721e1f0f1b28083f4792e902
   - name: hwinfo
     buildsystem: simple
     build-commands:
@@ -348,7 +373,7 @@ modules:
       - chmod 777 -R ./INST
       - find ./INST -type f | perl -lne 'print if -B and -x' | xargs strip
       - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/usr/lib/perl/*/* $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/usr/lib/perl5/*/* $FLATPAK_DEST/usr/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/S/SM/SMUELLER/Data-Dumper-2.161.tar.gz

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -3,7 +3,6 @@ runtime: org.freedesktop.Platform
 runtime-version: 1.6
 sdk: org.freedesktop.Sdk
 command: hw-probe-flatpak
-rename-icon: hw-probe
 finish-args:
   - --share=network
   - --device=all
@@ -22,7 +21,6 @@ cleanup:
   - /usr/share/hwinfo
   - /usr/share/pkgconfig
   - /usr/share/usb.ids.gz
-  - /usr/share/PERL5_BASE
   - /usr/sbin/check_hd
   - /usr/sbin/convert_hd
   - /usr/sbin/fancontrol
@@ -52,6 +50,7 @@ cleanup:
   - /share/doc
   - /share/man
   - /share/smartmontools
+  - /share/PERL5_BASE
   - /sbin/smartd
   - /sbin/update-smart-drivedb
   - /lib/debug
@@ -90,8 +89,7 @@ modules:
       - ./configure --prefix=/
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - mkdir -p $FLATPAK_DEST/sbin/
-      - mv ip/ip $FLATPAK_DEST/sbin/
+      - install -D ./ip/ip $FLATPAK_DEST/sbin/
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.18.0.tar.xz
@@ -192,8 +190,7 @@ modules:
       - sed -i -e 's/ -g / -s /' Makefile
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - mkdir -p $FLATPAK_DEST/usr/bin/
-      - cp -f ./dmesg $FLATPAK_DEST/usr/bin/
+      - install -D ./dmesg $FLATPAK_DEST/usr/bin/
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.gz
@@ -216,8 +213,7 @@ modules:
     build-commands:
       - ./configure
       - make
-      - mkdir -p $FLATPAK_DEST/bin
-      - mv src/flex $FLATPAK_DEST/bin/lex
+      - install -D src/flex $FLATPAK_DEST/bin/lex
     sources:
       - type: archive
         url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
@@ -362,30 +358,28 @@ modules:
     buildsystem: simple
     build-commands:
       - make install DESTDIR=$FLATPAK_DEST
-      - mkdir -p $FLATPAK_DEST/bin
-      - mv flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
-      - mv flatpak/PERL5_BASE $FLATPAK_DEST/usr/share/
+      - install -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
+      - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/
       - chmod a+x $FLATPAK_DEST/bin/hw-probe-flatpak
-      - mkdir -p $FLATPAK_DEST/share/icons/hicolor/256x256/apps $FLATPAK_DEST/share/icons/hicolor/128x128/apps $FLATPAK_DEST/share/icons/hicolor/64x64/apps $FLATPAK_DEST/share/applications $FLATPAK_DEST/share/metainfo $FLATPAK_DEST/usr/share/
-      - mv OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
-      - mv flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/hw-probe.png
-      - mv flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/hw-probe.png
-      - mv flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/hw-probe.png
-      - mv flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
-      - mv flatpak/usb.ids flatpak/pci.ids $FLATPAK_DEST/usr/share/
+      - install -D OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
+      - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hw-probe.png
+      - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
+      - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/
+      - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: eb9c21fc0c9bec163a655076f3bde976b4a6c56409b25f753f73e9b68d9f25d7
+        sha256: 319e77d43eb8f75de858776d52953ac13f5b8afe44351e64596c24bf3c2d05ac
   - name: perl-base
     buildsystem: simple
     build-commands:
       - sh Configure -de -Dprefix=/usr
       - make
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - mv perl $FLATPAK_DEST/usr/bin/
-      - cd lib && cat $FLATPAK_DEST/usr/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done
+      - install -D ./perl $FLATPAK_DEST/usr/bin/
+      - cd lib && cat $FLATPAK_DEST/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done
     sources:
       - type: archive
         url: https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -2,7 +2,7 @@ app-id: org.linux_hardware.hw-probe
 runtime: org.freedesktop.Platform
 runtime-version: 18.08
 sdk: org.freedesktop.Sdk
-command: hw-probe-flatpak
+command: hw-probe
 finish-args:
   - --share=network
   - --device=all
@@ -381,8 +381,9 @@ modules:
   - name: hw-probe
     buildsystem: simple
     build-commands:
-      - make install DESTDIR=$FLATPAK_DEST
-      - install -m 777 -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
+      - make install DESTDIR=$FLATPAK_DEST prefix=/
+      - mv $FLATPAK_DEST/bin/hw-probe $FLATPAK_DEST/bin/hw-probe-flatpak
+      - install -m 777 -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe
       - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/PERL5_BASE
       - install -D flatpak/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
       - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hw-probe.png
@@ -394,7 +395,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: 37a77f65a186049f99d977de771bc84dbc73694827a811001a367b70582590e1
+        sha256: 77a4b119687cd745e29f7febe8cb1bcf05440730ba274ebc254bc07821692e3a
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -80,8 +80,8 @@ modules:
       - make install
     sources:
       - type: archive
-        url: http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
-        sha256: 7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924
+        url: https://ftp.gnu.org/gnu/automake/automake-1.15.tar.xz
+        sha256: 9908c75aabd49d13661d6dcb1bc382252d22cc77bf733a2d55e87f2aa2db8636
   - name: libtool
     buildsystem: simple
     build-commands:
@@ -90,8 +90,8 @@ modules:
       - make install
     sources:
       - type: archive
-        url: ftp://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
-        sha256: e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3
+        url: https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.xz
+        sha256: 7c87a8c2c8c0fc9cd5019e402bed4292462d00a718a7cd5f11218153bf28b26f
   - name: edid-decode
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -421,7 +421,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: 5688943f7c6f2b1a6a2e6fe82f08a535cbee58c5c299b801be1c5220ed428b2c
+        sha256: b43ea6dfeda2df961887abd133feb0cc57dda8975ea87a9d067e59887a6d586d
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,6 +1,6 @@
 app-id: org.linux_hardware.hw-probe
 runtime: org.freedesktop.Platform
-runtime-version: 18.08
+runtime-version: "18.08"
 sdk: org.freedesktop.Sdk
 command: hw-probe
 finish-args:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -231,7 +231,6 @@ modules:
     build-commands:
       - echo '2.1' > VERSION
       - rm -f git2log
-      - sed -i -e 's/defined(__i386__)/defined(__i386__) || defined(__arm__)/' mem.c
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
@@ -253,12 +252,29 @@ modules:
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/flex-20181004.tar.gz
         sha256: bd7d248de7792dd2de2089a16b7ea60f94b2056e721e1f0f1b28083f4792e902
   - name: hwinfo
+    skip-arches:
+      - aarch64
     buildsystem: simple
     build-commands:
       - echo '21.57' > VERSION
       - rm -f git2log
       - sed -i -e 's/ -g / -s /' Makefile.common
       - CFLAGS='-I'$FLATPAK_DEST'/include' LDFLAGS='-L'$FLATPAK_DEST'/lib64 -L'$FLATPAK_DEST'/lib -lx86emu' LD_LIBRARY_PATH=$FLATPAK_DEST'/lib64:'$FLATPAK_DEST'/lib' make
+      - make install DESTDIR=`pwd`/INST
+      - cp -fr INST/usr/* $FLATPAK_DEST/
+    sources:
+      - type: archive
+        url: https://github.com/openSUSE/hwinfo/archive/21.57.tar.gz
+        sha256: ef7c716447490a594fee09ffb6fc7827e418073af6cbf48bacfc64b2428b5703
+  - name: hwinfo
+    only-arches:
+      - aarch64
+    buildsystem: simple
+    build-commands:
+      - echo '21.57' > VERSION
+      - rm -f git2log
+      - sed -i -e 's/ -g / -s /' Makefile.common
+      - make
       - make install DESTDIR=`pwd`/INST
       - cp -fr INST/usr/* $FLATPAK_DEST/
     sources:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -231,6 +231,7 @@ modules:
     build-commands:
       - echo '2.1' > VERSION
       - rm -f git2log
+      - sed -i -e 's/defined(__i386__)/defined(__i386__) || defined(__arm__)/' mem.c
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,0 +1,393 @@
+app-id: org.linux_hardware.hw-probe
+branch: stable
+runtime: org.freedesktop.Platform
+runtime-version: 1.6
+sdk: org.freedesktop.Sdk
+command: /app/usr/bin/hw-probe-flatpak
+rename-icon: hw-probe
+finish-args:
+  - --share=network
+  - --device=all
+  - --filesystem=host:ro
+  - --filesystem=/var/log:ro
+  - --filesystem=/sys:ro
+  - --env=PATH=/usr/bin:/bin:/usr/sbin:/sbin:/app/sbin:/app/usr/sbin:/app/usr/bin:/app/bin
+  - --env=PERL5LIB=/app/usr/share/perl5:/app/usr/lib/x86_64-linux-gnu/perl-base:/app/usr/lib/i386-linux-gnu/perl-base
+  - --env=LD_LIBRARY_PATH=/app/lib/x86_64-linux-gnu/:/app/lib/i386-linux-gnu/:/app/usr/lib64:/app/usr/lib:/app/usr/lib/x86_64-linux-gnu:/app/usr/lib/i386-linux-gnu
+  - --env=LC_ALL=C
+cleanup:
+  - /usr/include
+  - /usr/man
+  - /usr/share/doc
+  - /usr/share/man
+  - /usr/share/hwinfo
+  - /usr/share/pkgconfig
+  - /usr/share/usb.ids.gz
+  - /usr/share/PERL5_BASE
+  - /usr/sbin/check_hd
+  - /usr/sbin/convert_hd
+  - /usr/sbin/fancontrol
+  - /usr/sbin/getsysinfo
+  - /usr/sbin/isadump
+  - /usr/sbin/isaset
+  - /usr/sbin/mk_isdnhwdb
+  - /usr/sbin/ownership
+  - /usr/sbin/pwmconfig
+  - /usr/sbin/sensors-detect
+  - /usr/sbin/setpci
+  - /usr/sbin/update-pciids
+  - /usr/sbin/update-usbids.sh
+  - /usr/sbin/vpddecode
+  - /usr/lib64/pkgconfig
+  - /usr/lib/pkgconfig
+  - /usr/bin/acpibin
+  - /usr/bin/acpiexamples
+  - /usr/bin/acpiexec
+  - /usr/bin/acpihelp
+  - /usr/bin/acpinames
+  - /usr/bin/acpisrc
+  - /usr/bin/kmod
+  - /usr/bin/lsusb.py
+  - /usr/bin/sensors-conf-convert
+  - /usr/bin/usbhid-dump
+  - /share/doc
+  - /share/man
+  - /share/smartmontools
+  - /sbin/smartd
+  - /sbin/update-smart-drivedb
+  - /lib/debug
+  - /etc/init.d
+  - /etc/smartd_warning.d
+  - /etc/sensors.d
+  - /etc/smartd.conf
+  - /etc/smartd_warning.sh
+  - /bin/lex
+  - /var/lib
+modules:
+  - name: edid-decode
+    buildsystem: simple
+    build-commands:
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make -j $FLATPAK_BUILDER_N_JOBS
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/linuxhw/build-stuff/releases/download/1.4/edid-decode-20180622.tar.gz
+        sha256: ab44c58a3712beca8ffa0ac937dc24d337cb0ecd18e703b4ddf3a10b0df35e1e
+  - name: dmidecode
+    buildsystem: simple
+    build-commands:
+      - sed -i -e 's/ -O2/ -s -O2/' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install prefix=/usr DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-3.1.tar.xz
+        sha256: d766ce9b25548c59b1e7e930505b4cad9a7bb0b904a1a391fbb604d529781ac0
+  - name: iproute2
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=/
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - mkdir -p $FLATPAK_DEST/sbin/
+      - mv ip/ip $FLATPAK_DEST/sbin/
+    sources:
+      - type: archive
+        url: https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2/iproute2-4.18.0.tar.xz
+        sha256: a9e6c70c95f513871c5e1f4e452c04fcb3c4d8a05be651bd794cd994a52daa45
+  - name: lm-sensors
+    buildsystem: simple
+    build-commands:
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install BUILD_STATIC_LIB=0 DEBUG=0 PREFIX=/usr DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://ftp.gwdg.de/pub/linux/misc/lm-sensors/lm_sensors-3.4.0.tar.bz2
+        sha256: e0579016081a262dd23eafe1d22b41ebde78921e73a1dcef71e05e424340061f
+  - name: libkmod
+    buildsystem: simple
+    build-commands:
+      - ./configure --disable-debug --disable-python --disable-logging --disable-test-modules --disable-manpages --prefix=/usr
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: http://ftp.riken.jp/Linux/kernel.org/linux/utils/kernel/kmod/kmod-12.tar.gz
+        sha256: 028f24139fd2ba235126cea45b09900a793a8b9480b3b6b25485eedf8ca4a95a
+  - name: libusb-1
+    buildsystem: simple
+    build-commands:
+      - NOCONFIGURE=1 sh autogen.sh
+      - ./configure --disable-static --disable-udev --prefix=/usr
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/libusb/libusb/archive/v1.0.22.tar.gz
+        sha256: 3500f7b182750cd9ccf9be8b1df998f83df56a39ab264976bdb3307773e16f48
+  - name: usbutils
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=/usr LIBUSB_CFLAGS='-I'$FLATPAK_DEST'/usr/include/libusb-1.0' LIBUSB_LIBS='-L'$FLATPAK_DEST'/usr/lib64 -L'$FLATPAK_DEST'/usr/lib -lusb-1.0'
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install DESTDIR=$FLATPAK_DEST
+      - sed -i -e 's|/usr/share/usb.ids|/var/tmp/PROBE_USB|' $FLATPAK_DEST/usr/bin/lsusb
+    sources:
+      - type: archive
+        url: https://mirrors.edge.kernel.org/pub/linux/utils/usb/usbutils/usbutils-007.tar.xz
+        sha256: 7593a01724bbc0fd9fe48e62bc721ceb61c76654f1d7b231b3c65f6dfbbaefa4
+  - name: pciutils
+    buildsystem: simple
+    build-commands:
+      - make install PREFIX=/usr DESTDIR=$FLATPAK_DEST SHARED=no LIBKMOD=no HWDB=no ZLIB=no DNS=no
+      - sed -i -e 's|/usr/share/pci.ids|/var/tmp/PROBE_PCI|' $FLATPAK_DEST/usr/sbin/lspci
+    sources:
+      - type: archive
+        url: https://github.com/pciutils/pciutils/archive/v3.6.2.tar.gz
+        sha256: d84d7096a71890f0ddddc50e88ac5a3bc7412bf48d8100fc15857a411564687d
+  - name: acpica-unix
+    buildsystem: simple
+    build-commands:
+      - make
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://acpica.org/sites/acpica/files/acpica-unix-20180629.tar.gz
+        sha256: 70d11f3f2adbdc64a5b33753e1889918af811ec8050722fbee0fdfc3bfd29a4f
+  - name: hdparm
+    buildsystem: simple
+    build-commands:
+      - make
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hdparm-9.56.tar.gz
+        sha256: 6ff9ed695f1017396eec4101f990f114b7b0e0a04c5aa6369c0394053d16e4da
+  - name: smartmontools
+    buildsystem: simple
+    build-commands:
+      - sh autogen.sh
+      - ./configure --with-nvme-devicescan --prefix=/
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/linuxhw/build-stuff/releases/download/1.4/smartmontools-6.6.tar.gz
+        sha256: 51f43d0fb064fccaf823bbe68cf0d317d0895ff895aa353b3339a3b316a53054
+  - name: util-linux
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=/usr
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - mkdir -p $FLATPAK_DEST/usr/bin/
+      - cp -f ./dmesg $FLATPAK_DEST/usr/bin/
+    sources:
+      - type: archive
+        url: https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.gz
+        sha256: 3bbf9f3d4a33d6653cf0f7e4fc422091b6a38c3b1195c0ee716c67148a1a7122
+  - name: libx86emu
+    buildsystem: simple
+    build-commands:
+      - echo '2.1' > VERSION
+      - rm -f git2log
+      - sed -i -e 's/ -g / -s /' Makefile
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/wfeldt/libx86emu/archive/2.1.tar.gz
+        sha256: 89fd46760a02e2337506e77e152469baae4ff1d59413277b0954b3fe0f39cbfb
+  - name: lex
+    buildsystem: simple
+    build-commands:
+      - ./configure
+      - make
+      - mkdir -p $FLATPAK_DEST/bin
+      - mv src/flex $FLATPAK_DEST/bin/lex
+    sources:
+      - type: archive
+        url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
+        sha256: e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+
+  - name: hwinfo
+    buildsystem: simple
+    build-commands:
+      - echo '21.57' > VERSION
+      - rm -f git2log
+      - sed -i -e 's/ -g / -s /' Makefile.common
+      - CFLAGS='-I'$FLATPAK_DEST'/usr/include' LDFLAGS='-L'$FLATPAK_DEST'/usr/lib64 -L'$FLATPAK_DEST'/usr/lib -lx86emu' LD_LIBRARY_PATH=$FLATPAK_DEST'/usr/lib64:'$FLATPAK_DEST'/usr/lib' make
+      - make install DESTDIR=$FLATPAK_DEST
+    sources:
+      - type: archive
+        url: https://github.com/openSUSE/hwinfo/archive/21.57.tar.gz
+        sha256: ef7c716447490a594fee09ffb6fc7827e418073af6cbf48bacfc64b2428b5703
+  - name: perl-uri
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-1.74.tar.gz
+        sha256: a9c254f45f89cb1dd946b689dfe433095404532a4543bdaab0b71ce0fdcdd53d
+  - name: perl-http-message
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.18.tar.gz
+        sha256: d060d170d388b694c58c14f4d13ed908a2807f0e581146cef45726641d809112
+  - name: perl-net-http
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.18.tar.gz
+        sha256: 7e42df2db7adce3e0eb4f78b88c450f453f5380f120fd5411232e03374ba951c
+  - name: perl-try-tiny
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz
+        sha256: da5bd0d5c903519bbf10bb9ba0cb7bcac0563882bcfe4503aee3fb143eddef6b
+  - name: perl-lwp-mediatypes
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz
+        sha256: 18790b0cc5f0a51468495c3847b16738f785a2d460403595001e0b932e5db676
+  - name: perl-http-date
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTTP-Date-6.02.tar.gz
+        sha256: e8b9941da0f9f0c9c01068401a5e81341f0e3707d1c754f8e11f42a7e629e333
+  - name: perl-timedate
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/G/GB/GBARR/TimeDate-2.30.tar.gz
+        sha256: 75bd254871cb5853a6aa0403ac0be270cdd75c9d1b6639f18ecba63c15298e86
+  - name: libwww-perl
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/libwww-perl-6.35.tar.gz
+        sha256: dda2578d7b32152c4afce834761a61d117de286c705a9f7972c7ac6032ca5953
+  - name: perl-parent
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/C/CO/CORION/parent-0.237.tar.gz
+        sha256: 1089d9648565c1d1e655fa4cb603272d3126747b7b5f836ffee685e27e53caae
+  - name: perl-time-local
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Time-Local-1.28.tar.gz
+        sha256: 9278b9e5cc99dcbb0fd27a43e914828b59685601edae082889b5ee7266afe10e
+  - name: perl-data-dumper
+    buildsystem: simple
+    build-commands:
+      - perl Makefile.PL
+      - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
+      - chmod 777 -R ./INST
+      - find ./INST -type f | perl -lne 'print if -B and -x' | xargs strip
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - cp -fr ./INST/usr/lib/perl/*/* $FLATPAK_DEST/usr/share/perl5/
+    sources:
+      - type: archive
+        url: https://cpan.metacpan.org/authors/id/S/SM/SMUELLER/Data-Dumper-2.161.tar.gz
+        sha256: 3aa4ac1b042b3880438165fb2b2139d377564a8e9928ffe689ede5304ee90558
+  - name: hw-probe
+    buildsystem: simple
+    build-commands:
+      - make install DESTDIR=$FLATPAK_DEST
+      - mv flatpak/hw-probe.sh $FLATPAK_DEST/usr/bin/hw-probe-flatpak
+      - mv flatpak/PERL5_BASE $FLATPAK_DEST/usr/share/
+      - chmod a+x $FLATPAK_DEST/usr/bin/hw-probe-flatpak
+      - mkdir -p $FLATPAK_DEST/share/icons/hicolor/256x256/apps $FLATPAK_DEST/share/icons/hicolor/128x128/apps $FLATPAK_DEST/share/icons/hicolor/64x64/apps $FLATPAK_DEST/share/applications $FLATPAK_DEST/share/metainfo $FLATPAK_DEST/usr/share/
+      - mv OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
+      - mv flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/hw-probe.png
+      - mv flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/hw-probe.png
+      - mv flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/hw-probe.png
+      - mv flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
+      - mv flatpak/usb.ids flatpak/pci.ids $FLATPAK_DEST/usr/share/
+    sources:
+      - type: archive
+        url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
+        sha256: b50c3461ebb8aa65f6ac7e2c95839c033d2ae6ff7446f5d96e0d93dd6099c8fa
+  - name: perl-base
+    buildsystem: simple
+    build-commands:
+      - sh Configure -de -Dprefix=/usr
+      - make
+      - find . -type f | perl -lne 'print if -B and -x' | xargs strip
+      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
+      - mv perl $FLATPAK_DEST/usr/bin/
+      - cd lib && cat $FLATPAK_DEST/usr/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done
+    sources:
+      - type: archive
+        url: https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz
+        sha256: 7e929f64d4cb0e9d1159d4a59fc89394e27fa1f7004d0836ca0d514685406ea8
+

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -421,7 +421,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: b43ea6dfeda2df961887abd133feb0cc57dda8975ea87a9d067e59887a6d586d
+        sha256: 50dff85abd6f647ae5916bae672db7db14e195cc62fb4dc9b3d126cd44ba7b37
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -2,9 +2,8 @@ app-id: org.linux_hardware.hw-probe
 runtime: org.freedesktop.Platform
 runtime-version: 1.6
 sdk: org.freedesktop.Sdk
-command: /app/usr/bin/hw-probe-flatpak
+command: hw-probe-flatpak
 rename-icon: hw-probe
-rename-appdata-file: org.linux_hardware.hw-probe.appdata.xml
 finish-args:
   - --share=network
   - --device=all
@@ -363,9 +362,10 @@ modules:
     buildsystem: simple
     build-commands:
       - make install DESTDIR=$FLATPAK_DEST
-      - mv flatpak/hw-probe.sh $FLATPAK_DEST/usr/bin/hw-probe-flatpak
+      - mkdir -p $FLATPAK_DEST/bin
+      - mv flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
       - mv flatpak/PERL5_BASE $FLATPAK_DEST/usr/share/
-      - chmod a+x $FLATPAK_DEST/usr/bin/hw-probe-flatpak
+      - chmod a+x $FLATPAK_DEST/bin/hw-probe-flatpak
       - mkdir -p $FLATPAK_DEST/share/icons/hicolor/256x256/apps $FLATPAK_DEST/share/icons/hicolor/128x128/apps $FLATPAK_DEST/share/icons/hicolor/64x64/apps $FLATPAK_DEST/share/applications $FLATPAK_DEST/share/metainfo $FLATPAK_DEST/usr/share/
       - mv OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
       - mv flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/hw-probe.png
@@ -376,7 +376,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: 79fc9c53cbe11aff9935b18f8e6f9b828537f2835e7727196be28689826ab5e4
+        sha256: eb9c21fc0c9bec163a655076f3bde976b4a6c56409b25f753f73e9b68d9f25d7
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -1,10 +1,10 @@
 app-id: org.linux_hardware.hw-probe
-branch: stable
 runtime: org.freedesktop.Platform
 runtime-version: 1.6
 sdk: org.freedesktop.Sdk
 command: /app/usr/bin/hw-probe-flatpak
 rename-icon: hw-probe
+rename-appdata-file: org.linux_hardware.hw-probe.appdata.xml
 finish-args:
   - --share=network
   - --device=all
@@ -376,7 +376,7 @@ modules:
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: b50c3461ebb8aa65f6ac7e2c95839c033d2ae6ff7446f5d96e0d93dd6099c8fa
+        sha256: 79fc9c53cbe11aff9935b18f8e6f9b828537f2835e7727196be28689826ab5e4
   - name: perl-base
     buildsystem: simple
     build-commands:

--- a/org.linux_hardware.hw-probe.yaml
+++ b/org.linux_hardware.hw-probe.yaml
@@ -9,61 +9,67 @@ finish-args:
   - --filesystem=host:ro
   - --filesystem=/var/log:ro
   - --filesystem=/sys:ro
-  - --env=PATH=/usr/bin:/bin:/usr/sbin:/sbin:/app/sbin:/app/usr/sbin:/app/usr/bin:/app/bin
-  - --env=PERL5LIB=/app/usr/share/perl5:/app/usr/lib/x86_64-linux-gnu/perl-base:/app/usr/lib/i386-linux-gnu/perl-base
-  - --env=LD_LIBRARY_PATH=/app/lib/x86_64-linux-gnu/:/app/lib/i386-linux-gnu/:/app/usr/lib64:/app/usr/lib:/app/usr/lib/x86_64-linux-gnu:/app/usr/lib/i386-linux-gnu
+  - --env=PATH=/usr/bin:/bin:/usr/sbin:/sbin:/app/bin:/app/sbin
+  - --env=PERL5LIB=/app/share/perl5:/app/lib/x86_64-linux-gnu/perl-base:/app/lib/i386-linux-gnu/perl-base
+  - --env=LD_LIBRARY_PATH=/app/lib/x86_64-linux-gnu/:/app/lib/i386-linux-gnu/:/app/lib64:/app/lib
   - --env=LC_ALL=C
 build-options:
       env:
         - PERL5LIB=/app/share/automake-1.10/
         - ACLOCAL_PATH=/app/share/aclocal
 cleanup:
-  - /usr/include
-  - /usr/man
-  - /usr/share/doc
-  - /usr/share/man
-  - /usr/share/hwinfo
-  - /usr/share/pkgconfig
-  - /usr/share/usb.ids.gz
-  - /usr/sbin/check_hd
-  - /usr/sbin/convert_hd
-  - /usr/sbin/fancontrol
-  - /usr/sbin/getsysinfo
-  - /usr/sbin/isadump
-  - /usr/sbin/isaset
-  - /usr/sbin/mk_isdnhwdb
-  - /usr/sbin/ownership
-  - /usr/sbin/pwmconfig
-  - /usr/sbin/sensors-detect
-  - /usr/sbin/setpci
-  - /usr/sbin/update-pciids
-  - /usr/sbin/update-usbids.sh
-  - /usr/sbin/vpddecode
-  - /usr/lib64/pkgconfig
-  - /usr/lib/pkgconfig
-  - /usr/bin/acpibin
-  - /usr/bin/acpiexamples
-  - /usr/bin/acpiexec
-  - /usr/bin/acpihelp
-  - /usr/bin/acpinames
-  - /usr/bin/acpisrc
-  - /usr/bin/kmod
-  - /usr/bin/lsusb.py
-  - /usr/bin/sensors-conf-convert
-  - /usr/bin/usbhid-dump
+  - /include
+  - /man
   - /share/doc
   - /share/man
+  - /share/hwinfo
+  - /share/pkgconfig
+  - /share/usb.ids.gz
   - /share/smartmontools
   - /share/PERL5_BASE
+  - /share/automake*
+  - /share/info
+  - /share/aclocal*
+  - /share/libtool
+  - /sbin/check_hd
+  - /sbin/convert_hd
+  - /sbin/fancontrol
+  - /sbin/getsysinfo
+  - /sbin/isadump
+  - /sbin/isaset
+  - /sbin/mk_isdnhwdb
+  - /sbin/ownership
+  - /sbin/pwmconfig
+  - /sbin/sensors-detect
+  - /sbin/setpci
+  - /sbin/update-pciids
+  - /sbin/update-usbids.sh
+  - /sbin/vpddecode
   - /sbin/smartd
   - /sbin/update-smart-drivedb
+  - /lib64/pkgconfig
+  - /lib/pkgconfig
   - /lib/debug
+  - /lib/libltdl*
+  - /bin/acpibin
+  - /bin/acpiexamples
+  - /bin/acpiexec
+  - /bin/acpihelp
+  - /bin/acpinames
+  - /bin/acpisrc
+  - /bin/kmod
+  - /bin/lsusb.py
+  - /bin/sensors-conf-convert
+  - /bin/usbhid-dump
+  - /bin/lex
+  - /bin/automake*
+  - /bin/aclocal*
+  - /bin/libtool*
   - /etc/init.d
   - /etc/smartd_warning.d
   - /etc/sensors.d
   - /etc/smartd.conf
   - /etc/smartd_warning.sh
-  - /bin/lex
   - /var/lib
 modules:
   - name: automake
@@ -91,7 +97,7 @@ modules:
     build-commands:
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install DESTDIR=$FLATPAK_DEST
+      - make install DESTDIR=$FLATPAK_DEST bindir=/bin mandir=/share/man
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/edid-decode-20180622.tar.gz
@@ -102,7 +108,7 @@ modules:
       - sed -i -e 's/ -O2/ -s -O2/' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - make install prefix=/usr DESTDIR=$FLATPAK_DEST
+      - make install prefix=/ DESTDIR=$FLATPAK_DEST
     sources:
       - type: archive
         url: https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-3.1.tar.xz
@@ -124,7 +130,7 @@ modules:
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - make install BUILD_STATIC_LIB=0 DEBUG=0 PREFIX=/usr DESTDIR=$FLATPAK_DEST
+      - make install BUILD_STATIC_LIB=0 DEBUG=0 PREFIX=/ DESTDIR=$FLATPAK_DEST
     sources:
       - type: archive
         url: https://ftp.gwdg.de/pub/linux/misc/lm-sensors/lm_sensors-3.4.0.tar.bz2
@@ -132,7 +138,7 @@ modules:
   - name: libkmod
     buildsystem: simple
     build-commands:
-      - ./configure --disable-debug --disable-python --disable-logging --disable-test-modules --disable-manpages --prefix=/usr
+      - ./configure --disable-debug --disable-python --disable-logging --disable-test-modules --disable-manpages --prefix=/
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
@@ -145,7 +151,7 @@ modules:
     buildsystem: simple
     build-commands:
       - NOCONFIGURE=1 sh autogen.sh
-      - ./configure --disable-static --disable-udev --prefix=/usr
+      - ./configure --disable-static --disable-udev --prefix=/
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
@@ -157,12 +163,12 @@ modules:
   - name: usbutils
     buildsystem: simple
     build-commands:
-      - ./configure --prefix=/usr LIBUSB_CFLAGS='-I'$FLATPAK_DEST'/usr/include/libusb-1.0' LIBUSB_LIBS='-L'$FLATPAK_DEST'/usr/lib64 -L'$FLATPAK_DEST'/usr/lib -lusb-1.0'
+      - ./configure --prefix=/ LIBUSB_CFLAGS='-I'$FLATPAK_DEST'/include/libusb-1.0' LIBUSB_LIBS='-L'$FLATPAK_DEST'/lib64 -L'$FLATPAK_DEST'/lib -lusb-1.0'
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
-      - sed -i -e 's|/usr/share/usb.ids|/var/tmp/PROBE_USB|' $FLATPAK_DEST/usr/bin/lsusb
+      - sed -i -e 's|/share/usb.ids|/var/tmp/P_USB|' $FLATPAK_DEST/bin/lsusb
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/usb/usbutils/usbutils-007.tar.xz
@@ -170,8 +176,8 @@ modules:
   - name: pciutils
     buildsystem: simple
     build-commands:
-      - make install PREFIX=/usr DESTDIR=$FLATPAK_DEST SHARED=no LIBKMOD=no HWDB=no ZLIB=no DNS=no
-      - sed -i -e 's|/usr/share/pci.ids|/var/tmp/PROBE_PCI|' $FLATPAK_DEST/usr/sbin/lspci
+      - make install PREFIX=/ DESTDIR=$FLATPAK_DEST SHARED=no LIBKMOD=no HWDB=no ZLIB=no DNS=no
+      - sed -i -e 's|/share/pci.ids|/var/tmp/P_PCI|' $FLATPAK_DEST/sbin/lspci
     sources:
       - type: archive
         url: https://github.com/pciutils/pciutils/archive/v3.6.2.tar.gz
@@ -180,7 +186,7 @@ modules:
     buildsystem: simple
     build-commands:
       - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install DESTDIR=$FLATPAK_DEST
+      - make install DESTDIR=$FLATPAK_DEST PREFIX=/
     sources:
       - type: archive
         url: https://acpica.org/sites/acpica/files/acpica-unix-20180629.tar.gz
@@ -189,7 +195,8 @@ modules:
     buildsystem: simple
     build-commands:
       - make -j $FLATPAK_BUILDER_N_JOBS
-      - make install DESTDIR=$FLATPAK_DEST
+      - make install DESTDIR=`pwd`/INST
+      - install -D INST/sbin/hdparm $FLATPAK_DEST/sbin/hdparm
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hdparm-9.56.tar.gz
@@ -210,11 +217,11 @@ modules:
   - name: util-linux
     buildsystem: simple
     build-commands:
-      - ./configure --prefix=/usr
+      - ./configure --prefix=/
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - install -D ./dmesg $FLATPAK_DEST/usr/bin/dmesg
+      - install -D ./dmesg $FLATPAK_DEST/bin/dmesg
     sources:
       - type: archive
         url: https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.gz
@@ -227,7 +234,8 @@ modules:
       - sed -i -e 's/ -g / -s /' Makefile
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - make install DESTDIR=$FLATPAK_DEST
+      - make install DESTDIR=`pwd`/INST
+      - cp -fr INST/usr/* $FLATPAK_DEST/
     sources:
       - type: archive
         url: https://github.com/wfeldt/libx86emu/archive/2.1.tar.gz
@@ -249,8 +257,9 @@ modules:
       - echo '21.57' > VERSION
       - rm -f git2log
       - sed -i -e 's/ -g / -s /' Makefile.common
-      - CFLAGS='-I'$FLATPAK_DEST'/usr/include' LDFLAGS='-L'$FLATPAK_DEST'/usr/lib64 -L'$FLATPAK_DEST'/usr/lib -lx86emu' LD_LIBRARY_PATH=$FLATPAK_DEST'/usr/lib64:'$FLATPAK_DEST'/usr/lib' make
-      - make install DESTDIR=$FLATPAK_DEST
+      - CFLAGS='-I'$FLATPAK_DEST'/include' LDFLAGS='-L'$FLATPAK_DEST'/lib64 -L'$FLATPAK_DEST'/lib -lx86emu' LD_LIBRARY_PATH=$FLATPAK_DEST'/lib64:'$FLATPAK_DEST'/lib' make
+      - make install DESTDIR=`pwd`/INST
+      - cp -fr INST/usr/* $FLATPAK_DEST/
     sources:
       - type: archive
         url: https://github.com/openSUSE/hwinfo/archive/21.57.tar.gz
@@ -260,8 +269,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/URI-1.74.tar.gz
@@ -271,8 +280,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.18.tar.gz
@@ -282,8 +291,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.18.tar.gz
@@ -293,8 +302,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.30.tar.gz
@@ -304,8 +313,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz
@@ -315,8 +324,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTTP-Date-6.02.tar.gz
@@ -326,8 +335,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/G/GB/GBARR/TimeDate-2.30.tar.gz
@@ -337,8 +346,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/libwww-perl-6.35.tar.gz
@@ -348,8 +357,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/C/CO/CORION/parent-0.237.tar.gz
@@ -359,8 +368,8 @@ modules:
     build-commands:
       - perl Makefile.PL
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/SITELIB/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/D/DR/DROLSKY/Time-Local-1.28.tar.gz
@@ -372,8 +381,8 @@ modules:
       - make install DESTDIR=`pwd`/INST INSTALLSITELIB=/SITELIB
       - chmod 777 -R ./INST
       - find ./INST -type f | perl -lne 'print if -B and -x' | xargs strip
-      - mkdir -p $FLATPAK_DEST/usr/share/perl5/
-      - cp -fr ./INST/usr/lib/perl5/*/* $FLATPAK_DEST/usr/share/perl5/
+      - mkdir -p $FLATPAK_DEST/share/perl5/
+      - cp -fr ./INST/usr/lib/perl5/*/* $FLATPAK_DEST/share/perl5/
     sources:
       - type: archive
         url: https://cpan.metacpan.org/authors/id/S/SM/SMUELLER/Data-Dumper-2.161.tar.gz
@@ -390,22 +399,21 @@ modules:
       - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hw-probe.png
       - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hw-probe.png
       - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
-      - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/usb.ids
-      - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/pci.ids
+      - install -D flatpak/usb.ids $FLATPAK_DEST/share/usb.ids
+      - install -D flatpak/pci.ids $FLATPAK_DEST/share/pci.ids
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: 77a4b119687cd745e29f7febe8cb1bcf05440730ba274ebc254bc07821692e3a
+        sha256: 5688943f7c6f2b1a6a2e6fe82f08a535cbee58c5c299b801be1c5220ed428b2c
   - name: perl-base
     buildsystem: simple
     build-commands:
-      - sh Configure -de -Dprefix=/usr
+      - sh Configure -de -Dprefix=/
       - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
-      - install -D ./perl $FLATPAK_DEST/usr/bin/perl
-      - cd lib && cat $FLATPAK_DEST/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done
+      - install -D ./perl $FLATPAK_DEST/bin/perl
+      - cd lib && cat $FLATPAK_DEST/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/share/perl5/$i; done
     sources:
       - type: archive
         url: https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz
         sha256: 7e929f64d4cb0e9d1159d4a59fc89394e27fa1f7004d0836ca0d514685406ea8
-

--- a/org.linux_hardware.hwprobe.yaml
+++ b/org.linux_hardware.hwprobe.yaml
@@ -1,4 +1,4 @@
-app-id: org.linux_hardware.hw-probe
+app-id: org.linux_hardware.hwprobe
 runtime: org.freedesktop.Platform
 runtime-version: 1.6
 sdk: org.freedesktop.Sdk
@@ -76,7 +76,7 @@ modules:
     buildsystem: simple
     build-commands:
       - sed -i -e 's/ -O2/ -s -O2/' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install prefix=/usr DESTDIR=$FLATPAK_DEST
     sources:
@@ -87,7 +87,7 @@ modules:
     buildsystem: simple
     build-commands:
       - ./configure --prefix=/
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - install -D ./ip/ip $FLATPAK_DEST/sbin/ip
     sources:
@@ -98,7 +98,7 @@ modules:
     buildsystem: simple
     build-commands:
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install BUILD_STATIC_LIB=0 DEBUG=0 PREFIX=/usr DESTDIR=$FLATPAK_DEST
     sources:
@@ -110,7 +110,7 @@ modules:
     build-commands:
       - ./configure --disable-debug --disable-python --disable-logging --disable-test-modules --disable-manpages --prefix=/usr
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
     sources:
@@ -123,7 +123,7 @@ modules:
       - NOCONFIGURE=1 sh autogen.sh
       - ./configure --disable-static --disable-udev --prefix=/usr
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
     sources:
@@ -135,7 +135,7 @@ modules:
     build-commands:
       - ./configure --prefix=/usr LIBUSB_CFLAGS='-I'$FLATPAK_DEST'/usr/include/libusb-1.0' LIBUSB_LIBS='-L'$FLATPAK_DEST'/usr/lib64 -L'$FLATPAK_DEST'/usr/lib -lusb-1.0'
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
       - sed -i -e 's|/usr/share/usb.ids|/var/tmp/PROBE_USB|' $FLATPAK_DEST/usr/bin/lsusb
@@ -155,7 +155,7 @@ modules:
   - name: acpica-unix
     buildsystem: simple
     build-commands:
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - make install DESTDIR=$FLATPAK_DEST
     sources:
       - type: archive
@@ -164,7 +164,7 @@ modules:
   - name: hdparm
     buildsystem: simple
     build-commands:
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - make install DESTDIR=$FLATPAK_DEST
     sources:
       - type: archive
@@ -176,7 +176,7 @@ modules:
       - sh autogen.sh
       - ./configure --with-nvme-devicescan --prefix=/
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
     sources:
@@ -188,7 +188,7 @@ modules:
     build-commands:
       - ./configure --prefix=/usr
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - install -D ./dmesg $FLATPAK_DEST/usr/bin/dmesg
     sources:
@@ -201,7 +201,7 @@ modules:
       - echo '2.1' > VERSION
       - rm -f git2log
       - sed -i -e 's/ -g / -s /' Makefile
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - make install DESTDIR=$FLATPAK_DEST
     sources:
@@ -212,13 +212,12 @@ modules:
     buildsystem: simple
     build-commands:
       - ./configure
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - install -D src/flex $FLATPAK_DEST/bin/lex
     sources:
       - type: archive
         url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
         sha256: e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
-
   - name: hwinfo
     buildsystem: simple
     build-commands:
@@ -360,22 +359,22 @@ modules:
       - make install DESTDIR=$FLATPAK_DEST
       - install -m 777 -D flatpak/hw-probe.sh $FLATPAK_DEST/bin/hw-probe-flatpak
       - install -D flatpak/PERL5_BASE $FLATPAK_DEST/share/PERL5_BASE
-      - install -D OBS/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hw-probe.appdata.xml
-      - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hw-probe.png
-      - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hw-probe.png
-      - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hw-probe.png
-      - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hw-probe.desktop
+      - install -D flatpak/hw-probe.appdata.xml $FLATPAK_DEST/share/metainfo/org.linux_hardware.hwprobe.appdata.xml
+      - install -D flatpak/icon-256x256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/org.linux_hardware.hwprobe.png
+      - install -D flatpak/icon-128x128.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps/org.linux_hardware.hwprobe.png
+      - install -D flatpak/icon-64x64.png $FLATPAK_DEST/share/icons/hicolor/64x64/apps/org.linux_hardware.hwprobe.png
+      - install -D flatpak/hw-probe.desktop $FLATPAK_DEST/share/applications/org.linux_hardware.hwprobe.desktop
       - install -D flatpak/usb.ids $FLATPAK_DEST/usr/share/usb.ids
       - install -D flatpak/pci.ids $FLATPAK_DEST/usr/share/pci.ids
     sources:
       - type: archive
         url: https://github.com/linuxhw/build-stuff/releases/download/1.4/hw-probe-1.4-AI.tar.gz
-        sha256: 319e77d43eb8f75de858776d52953ac13f5b8afe44351e64596c24bf3c2d05ac
+        sha256: c3dcb0151339d5fea0d667599c94bbfe1ba8f68d488e5be5ab88ef93dd38ec89
   - name: perl-base
     buildsystem: simple
     build-commands:
       - sh Configure -de -Dprefix=/usr
-      - make
+      - make -j $FLATPAK_BUILDER_N_JOBS
       - find . -type f | perl -lne 'print if -B and -x' | xargs strip
       - install -D ./perl $FLATPAK_DEST/usr/bin/perl
       - cd lib && cat $FLATPAK_DEST/share/PERL5_BASE | while read i; do mkdir -p $FLATPAK_DEST/usr/share/perl5/`dirname $i`; cp -fr $i $FLATPAK_DEST/usr/share/perl5/$i; done


### PR DESCRIPTION
Hi!

Please add `hw-probe` — a tool to check operability of computer hardware.

`sudo flatpak run org.linux_hardware.hw-probe -all -upload` works well, but I have no idea yet how to test the desktop file (the app doesn't appear in `Applications` after installation). Tested on Ubuntu 18.04.

More info: https://github.com/linuxhw/hw-probe

Thank you.