### PR TITLE
Added initial swell-foop manifest with 3.30 release

### DIFF
--- a/org.gnome.SwellFoop.json
+++ b/org.gnome.SwellFoop.json
@@ -22,12 +22,6 @@
         "cxxflags": "-O2 -g"
     },
     "cleanup": [
-        "/include", "/lib/pkgconfig",
-        "/share/pkgconfig", "/share/aclocal",
-        "/man", "/share/man", "/share/gtk-doc",
-        "*.la", "*.a",
-        "/lib/girepository-1.0",
-        "/share/dbus-1", "/share/doc", "/share/gir-1.0"
     ],
     "modules" : [
         {

--- a/org.gnome.SwellFoop.json
+++ b/org.gnome.SwellFoop.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.SwellFoop",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.28",
+    "runtime-version" : "3.30",
     "sdk" : "org.gnome.Sdk",
     "command" : "swell-foop",
     "rename-icon" : "swell-foop",

--- a/org.gnome.SwellFoop.json
+++ b/org.gnome.SwellFoop.json
@@ -1,0 +1,45 @@
+{
+    "app-id" : "org.gnome.SwellFoop",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.28",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "swell-foop",
+    "rename-icon" : "swell-foop",
+    "rename-desktop-file" : "swell-foop.desktop",
+    "desktop-file-name-prefix" : "(Nightly) ",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options" : {
+        "cflags" : "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "cleanup": [
+        "/include", "/lib/pkgconfig",
+        "/share/pkgconfig", "/share/aclocal",
+        "/man", "/share/man", "/share/gtk-doc",
+        "*.la", "*.a",
+        "/lib/girepository-1.0",
+        "/share/dbus-1", "/share/doc", "/share/gir-1.0"
+    ],
+    "modules" : [
+        {
+            "name" : "swell-foop",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/swell-foop/3.30/swell-foop-3.30.0.tar.xz",
+                    "sha256" : "5d0185de6b4699b7e023def722c5d77b002c36d5d475f67480ec7b4659490702"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.SwellFoop.json
+++ b/org.gnome.SwellFoop.json
@@ -6,7 +6,7 @@
     "command" : "swell-foop",
     "rename-icon" : "swell-foop",
     "rename-desktop-file" : "swell-foop.desktop",
-    "desktop-file-name-prefix" : "(Nightly) ",
+    "rename-appdata-file" : "swell-foop.appdata.xml",
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",


### PR DESCRIPTION
Added a manifest based on the nightly build manifest kept upstream, for publishing the game Swell Foop developed under the GNOME project.