### PR TITLE
Add 2 extra Adapta-gtk-theme variants to flathub

### DIFF
--- a/org.gtk.Gtk3theme.Adapta-Brila-Eta/org.gtk.Gtk3theme.Adapta-Brila-Eta.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Brila-Eta/org.gtk.Gtk3theme.Adapta-Brila-Eta.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta-Brila-Eta</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta-Brila-Eta Gtk+ theme</name>
+  <summary>Adapta-Brila-Eta Gtk+ theme</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta-Brila-Eta/org.gtk.Gtk3theme.Adapta-Brila-Eta.json
+++ b/org.gtk.Gtk3theme.Adapta-Brila-Eta/org.gtk.Gtk3theme.Adapta-Brila-Eta.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta-Brila-Eta",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.28",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta-Brila-Eta",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--enable-light",
+        "--enable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.95.0.1.tar.gz",
+          "sha256": "3d15f5fa445e0c0e4210df0a5d5fe1eb2688983346fdf1c572648ee78e549912"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta-Brila-Eta.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta-Brila-Eta --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta-Brila-Eta"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta-Brila-Eta.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.gtk.Gtk3theme.Adapta-Brila/org.gtk.Gtk3theme.Adapta-Brila.appdata.xml
+++ b/org.gtk.Gtk3theme.Adapta-Brila/org.gtk.Gtk3theme.Adapta-Brila.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.gtk.Gtk3theme.Adapta-Brila</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Adapta-Brila Gtk+ theme</name>
+  <summary>Adapta-Brila Gtk+ theme</summary>
+  <description>
+    <p>An adaptive Gtk+ theme based on Material Design</p>
+  </description>
+  <url type="homepage">https://github.com/adapta-project/adapta-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Adapta-Brila/org.gtk.Gtk3theme.Adapta-Brila.json
+++ b/org.gtk.Gtk3theme.Adapta-Brila/org.gtk.Gtk3theme.Adapta-Brila.json
@@ -1,0 +1,42 @@
+{
+  "id": "org.gtk.Gtk3theme.Adapta-Brila",
+  "branch": "3.22",
+  "runtime": "org.gnome.Sdk",
+  "build-extension": true,
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "3.28",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "Adapta-Brila",
+      "config-opts": [
+        "--prefix=/usr/share/runtime",
+        "--enable-light",
+        "--disable-compact"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/adapta-project/adapta-gtk-theme-flatpak/archive/3.95.0.1.tar.gz",
+          "sha256": "3d15f5fa445e0c0e4210df0a5d5fe1eb2688983346fdf1c572648ee78e549912"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p ${FLATPAK_DEST}/share/appdata",
+        "cp org.gtk.Gtk3theme.Adapta-Brila.appdata.xml ${FLATPAK_DEST}/share/appdata",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Adapta-Brila --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Adapta-Brila"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Adapta-Brila.appdata.xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Hi, I'm an author of Adapta-gtk-theme.

Then I've created 4 files for 2 our new theme variants (Released in our new 3.95.0 series).

* Adapta-Brila (complete light variant and standard widget size)
* Adapta-Brila-Eta (complete light variant and compact widget size)

Regards.