### PR TITLE
Add GNOME SoundRecorder

### DIFF
--- a/org.gnome.SoundRecorder.json
+++ b/org.gnome.SoundRecorder.json
@@ -24,7 +24,8 @@
                     "type" : "git",
                     "disable-shallow-clone" : true,
                     "url" : "https://gitlab.gnome.org/GNOME/gnome-sound-recorder.git",
-                    "branch" : "gnome-3-28"
+                    "branch" : "gnome-3-28",
+                    "commit" : "721080149bb6e58fcae6f277fc8c37ddd30e1c49"
                 }
             ]
         }

--- a/org.gnome.SoundRecorder.json
+++ b/org.gnome.SoundRecorder.json
@@ -1,0 +1,32 @@
+{
+    "app-id" : "org.gnome.SoundRecorder",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.28",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "gnome-sound-recorder",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--filesystem=~/Recordings:create"
+    ],
+    "modules" : [
+        {
+            "name" : "gnome-sound-recorder",
+            "buildsystem" : "autotools",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "disable-shallow-clone" : true,
+                    "url" : "https://gitlab.gnome.org/GNOME/gnome-sound-recorder.git",
+                    "branch" : "gnome-3-28"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.SoundRecorder.json
+++ b/org.gnome.SoundRecorder.json
@@ -18,7 +18,6 @@
     "modules" : [
         {
             "name" : "gnome-sound-recorder",
-            "buildsystem" : "autotools",
             "sources" : [
                 {
                     "type" : "git",


### PR DESCRIPTION
I use gnome-sound-recorder for some small voice recordings, and it would be nice to have it in Flathub.

It has a very simple manifest.