### PR TITLE
WIP: Diffoscope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/app
+/.flatpak-builder

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+Diffoscope
+==========
+
+In-depth comparison of files, archives, and directories.
+
+* [Upstream Website](https://diffoscope.org/)
+
+Flatpak Maintenance
+-------------------
+
+Update `python3-diffoscope.json` with:
+
+```bash
+flatpak-pip-generator diffoscope
+```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,17 @@ In-depth comparison of files, archives, and directories.
 Flatpak Maintenance
 -------------------
 
-Update `python3-diffoscope.json` with:
+In theory, update `python3-diffoscope.json` with:
 
 ```bash
-flatpak-pip-generator diffoscope
+flatpak-pip-generator --output python3-diffoscope.json \
+  'diffoscope[distro_detection,cmdline,comparators]'
+```
+
+But unfortunately some of the optional packages pulled in by `diffoscope[comparators]` are not on PyPI (namely `guestfs`, `rpm-python` and `tlsh`). So, expand that list manually, removing those problematic ones:
+
+```bash
+flatpak-pip-generator --output python3-diffoscope.json \
+  'diffoscope[distro_detection,cmdline]' \
+  binwalk defusedxml jsondiff python-debian pypdf2 pyxattr
 ```

--- a/org.diffoscope.Diffoscope.appdata.xml
+++ b/org.diffoscope.Diffoscope.appdata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2018 Will Thompson <will@willthompson.co.uk> -->
+<component type="console-application">
+  <id>org.diffoscope.Diffoscope</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Diffoscope</name>
+  <summary>In-depth comparison of files, archives, and directories</summary>
+  <description>
+    <p>Diffoscope will try to get to the bottom of what makes files or directories different. It will recursively unpack archives of many kinds and transform various binary formats into more human readable form to compare them. It can compare two tarballs, ISO images, or PDF just as easily.</p>
+  </description>
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+  <url type="homepage">https://diffoscope.org/</url>
+  <url type="bugtracker">https://bugs.debian.org/src:diffoscope</url>
+  <url type="donation">https://reproducible-builds.org/donate/</url>
+  <url type="help">https://salsa.debian.org/reproducible-builds/diffoscope/blob/master/README.rst</url>
+  <provides>
+    <binary>diffoscope</binary>
+  </provides>
+  <!-- Nothing suitable for faq, translate -->
+  <project_license>GPL-3.0</project_license>
+  <developer_name>Reproducible builds</developer_name>
+  <!-- TODO: screenshots -->
+  <update_contact>will_AT_willthompson.co.uk</update_contact>
+  <!-- Diffoscope has no content beyond what you feed to it, so has no interesting age rating properties -->
+  <content_rating type="oars-1.1" />
+</component>

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -1,6 +1,6 @@
 app-id: org.diffoscope.Diffoscope
 runtime: org.freedesktop.Sdk
-runtime-version: 18.08
+runtime-version: '18.08'
 sdk: org.freedesktop.Sdk
 command: diffoscope
 finish-args:

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -19,6 +19,7 @@ modules:
       - type: archive
         url: https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz
         sha256: 3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
+
   - name: poppler-data
     no-autogen: true
     make-install-args:
@@ -29,6 +30,7 @@ modules:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz
         sha256: 1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012
+
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
@@ -58,6 +60,7 @@ modules:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-0.70.1.tar.xz
         sha256: 66972047d9ef8162cc8c389d7e7698291dfc9f2b3e4ea9a9f08ae604107451bd
+
   - name: xxd
     sources:
       - type: git
@@ -69,4 +72,5 @@ modules:
     build-commands:
       - "make"
       - "install -D -m755 xxd /app/bin/xxd"
+
   - python3-diffoscope.json

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -12,9 +12,9 @@ modules:
       - -DBUILD_CODEC=OFF
     cleanup: /lib/openjpeg-2.3
     sources:
-      - type: git
-        url: https://github.com/uclouvain/openjpeg.git
-        commit: d2205ba2ee78faeea659263383446c4472b1f9df
+      - type: archive
+        url: https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz
+        sha256: 3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a
   - name: poppler-data
     no-autogen: true
     make-install-args:

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -73,4 +73,35 @@ modules:
       - "make"
       - "install -D -m755 xxd /app/bin/xxd"
 
+  - name: imagemagick
+    config-opts:
+      - --enable-shared=no
+      - --disable-docs
+    cleanup:
+      - /bin/animate
+      - /bin/composite
+      - /bin/conjure
+      - /bin/display
+      - /bin/import
+      - /bin/Magick++-config
+      - /bin/MagickCore-config
+      - /bin/magick-script
+      - /bin/MagickWand-config
+      - /bin/mogrify
+      - /bin/montage
+      - /bin/stream
+      - /lib
+      - /share/man
+      - /include
+    sources:
+      # You might hope you could use a tarball release like
+      # https://www.imagemagick.org/download/releases/ImageMagick-7.0.8-14.tar.xz
+      # but for each version w.x.y-z only the most recent -z is actually
+      # available, so using a tarball guarantees that the manifest will stop
+      # working after the next patch release.
+      - type: git
+        url: https://github.com/ImageMagick/ImageMagick
+        tag: 7.0.8-14
+        commit: 66c3d774ccfcbf4b6f82ee69598f1b08d970c825
+
   - python3-diffoscope.json

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -10,7 +10,11 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DBUILD_CODEC=OFF
-    cleanup: /lib/openjpeg-2.3
+    cleanup:
+      - /include
+      - /lib/*.a
+      - /lib/openjpeg-2.3
+      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz
@@ -19,6 +23,8 @@ modules:
     no-autogen: true
     make-install-args:
       - prefix=/app
+    cleanup:
+      - /share/pkgconfig
     sources:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz
@@ -29,7 +35,25 @@ modules:
       - -DCMAKE_INSTALL_LIBDIR=/app/lib
       - -DCMAKE_INSTALL_INCLUDEDIR=/app/include
     cleanup:
+      # We only want pdftotext
+      - /bin/pdfdetach
+      - /bin/pdffonts
+      - /bin/pdfimages
+      - /bin/pdfinfo
+      - /bin/pdfseparate
+      - /bin/pdfsig
+      - /bin/pdftocairo
+      - /bin/pdftohtml
+      - /bin/pdftoppm
+      - /bin/pdftops
+      - /bin/pdfunite
       - /include
+      - /lib/girepository-1.0
+      - /lib/libpoppler-cpp.so*
+      - /lib/libpoppler-glib.so*
+      - /lib/pkgconfig
+      - /share/gir-1.0
+      - /share/man
     sources:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-0.70.1.tar.xz

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -111,3 +111,11 @@ modules:
       - "ln -s /usr/bin/unzip /app/bin/zipinfo"
 
   - python3-diffoscope.json
+
+  - name: diffoscope-appdata
+    sources:
+      - type: file
+        path: org.diffoscope.Diffoscope.appdata.xml
+    buildsystem: simple
+    build-commands:
+      - "install -D -t /app/share/metainfo/ org.diffoscope.Diffoscope.appdata.xml"

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -58,4 +58,15 @@ modules:
       - type: archive
         url: https://poppler.freedesktop.org/poppler-0.70.1.tar.xz
         sha256: 66972047d9ef8162cc8c389d7e7698291dfc9f2b3e4ea9a9f08ae604107451bd
+  - name: xxd
+    sources:
+      - type: git
+        url: https://github.com/vim/vim
+        tag: v8.1.0500
+        commit: 833e5dab143034b7e43bc0be49b2eb3687ff9ab7
+    subdir: src/xxd
+    buildsystem: simple
+    build-commands:
+      - "make"
+      - "install -D -m755 xxd /app/bin/xxd"
   - python3-diffoscope.json

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -1,0 +1,37 @@
+app-id: org.diffoscope.Diffoscope
+runtime: org.freedesktop.Sdk
+runtime-version: 18.08
+sdk: org.freedesktop.Sdk
+command: diffoscope
+finish-args:
+  - --filesystem=host
+modules:
+  - name: openjpeg
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_CODEC=OFF
+    cleanup: /lib/openjpeg-2.3
+    sources:
+      - type: git
+        url: https://github.com/uclouvain/openjpeg.git
+        commit: d2205ba2ee78faeea659263383446c4472b1f9df
+  - name: poppler-data
+    no-autogen: true
+    make-install-args:
+      - prefix=/app
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-data-0.4.9.tar.gz
+        sha256: 1f9c7e7de9ecd0db6ab287349e31bf815ca108a5a175cf906a90163bdbe32012
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=/app/lib
+      - -DCMAKE_INSTALL_INCLUDEDIR=/app/include
+    cleanup:
+      - /include
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-0.70.1.tar.xz
+        sha256: 66972047d9ef8162cc8c389d7e7698291dfc9f2b3e4ea9a9f08ae604107451bd
+  - python3-diffoscope.json

--- a/org.diffoscope.Diffoscope.yaml
+++ b/org.diffoscope.Diffoscope.yaml
@@ -104,4 +104,10 @@ modules:
         tag: 7.0.8-14
         commit: 66c3d774ccfcbf4b6f82ee69598f1b08d970c825
 
+  # https://gitlab.com/freedesktop-sdk/freedesktop-sdk/issues/465
+  - name: zipinfo
+    buildsystem: simple
+    build-commands:
+      - "ln -s /usr/bin/unzip /app/bin/zipinfo"
+
   - python3-diffoscope.json

--- a/python3-diffoscope.json
+++ b/python3-diffoscope.json
@@ -1,10 +1,35 @@
 {
-    "name": "python3-diffoscope",
+    "name": "python3-diffoscope[distro_detection,cmdline]",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} diffoscope"
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} 'diffoscope[distro_detection,cmdline]' binwalk defusedxml jsondiff python-debian pypdf2 pyxattr"
     ],
     "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz",
+            "sha256": "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz",
+            "sha256": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/d2/42/3b059929a920cd9d4e91e7a5e35f0d2ed75211f8f4e877be9d1bde9fdf46/distro-1.3.0.tar.gz",
+            "sha256": "224041cef9600e72d19ae41ba006e71c05c4dc802516da715d7fda55ba3d8742"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a3/a6/b8e451f6cff1c99b4747a2f7235aa904d2d49e8e1464e0b798272aa84358/progressbar-2.5.tar.gz",
+            "sha256": "5d81cb529da2e223b53962afd6c8ca0f05c6670e40309a7219eacc36af9b6c63"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/3c/21/9741e5e5e63245a8cdafb32ffc738bff6e7ef6253b65953e77933e56ce88/argcomplete-1.9.4.tar.gz",
+            "sha256": "06c8a54ffaa6bfc9006314498742ec8843601206a3b94212f82657673662ecf1"
+        },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/b9/2c/c975b3410e148dab00d14471784a743268614e21121e50e4e00b13f38370/libarchive-c-2.8.tar.gz",
@@ -17,8 +42,38 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e2/70/b2b40203fc1eb3ae66c7a45a8db77e4e6c3dc086f3b557f42ef4f234afff/diffoscope-105.tar.gz",
-            "sha256": "036fc036a284f1e09ac23502b169e11f0b167b9961e371a2c3cb6fbaf3e6132f"
+            "url": "https://files.pythonhosted.org/packages/36/1d/1a5f3165f330e1a0427636f2bd995dbcc02d0f7660e89458d64806a2ed1e/pyxattr-0.6.1.tar.gz",
+            "sha256": "b525843f6b51036198b3b87c4773a5093d6dec57d60c18a1f269dd7059aa16e3"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b4/01/68fcc0d43daf4c6bdbc6b33cc3f77bda531c86b174cac56ef0ffdb96faab/PyPDF2-1.26.0.tar.gz",
+            "sha256": "e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b9/02/81d72ec3885b1f87547f1723d2cd045032776cef218f8e7897894e135106/python-debian-0.1.33.tar.gz",
+            "sha256": "06e91d45019fe5f2e111ba827ea77730d6ce2fea698ada4e5b0b70b5fdbc18c5"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/33/0c/ddb17571e061c655871ccbf76cdada55a31569327d21517de779d4887241/jsondiff-1.1.2.tar.gz",
+            "sha256": "7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/74/ba/4ba4e89e21b5a2e267d80736ea674609a0a33cc4435a6d748ef04f1f9374/defusedxml-0.5.0.tar.gz",
+            "sha256": "24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/6e/a8/b52eb5fb66f4b582aa21f3b236bcd479bb2d2f602b639d5632a1b080e747/binwalk-2.1.0.tar.gz",
+            "sha256": "218c8045c6cb3ed6e21814fb89cdb913808b02dfe5a6cc30f85f4a59e8129f6b"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/97/10/4e01fd43272742e348885b11f50f4c7eb1104fb078eb36c7f7328bec14a0/diffoscope-106.tar.gz",
+            "sha256": "aa1931e3b8a646ab4c05c8b1851981558528713e8ead5860d2c20a05edb92e63"
         }
     ]
 }

--- a/python3-diffoscope.json
+++ b/python3-diffoscope.json
@@ -1,0 +1,24 @@
+{
+    "name": "python3-diffoscope",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} diffoscope"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b9/2c/c975b3410e148dab00d14471784a743268614e21121e50e4e00b13f38370/libarchive-c-2.8.tar.gz",
+            "sha256": "06d44d5b9520bdac93048c72b7ed66d11a6626da16d2086f9aad079674d8e061"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/84/30/80932401906eaf787f2e9bd86dc458f1d2e75b064b4c187341f29516945c/python-magic-0.4.15.tar.gz",
+            "sha256": "f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fc/b2/3bb5d8e35dc8139e7ad3106d74c2b06fd38494ed96473630d09437348182/diffoscope-104.tar.gz",
+            "sha256": "0def4a971733b6fedc1db5976b0ede728b295153bc520175808fb78db785ce6e"
+        }
+    ]
+}

--- a/python3-diffoscope.json
+++ b/python3-diffoscope.json
@@ -17,8 +17,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/fc/b2/3bb5d8e35dc8139e7ad3106d74c2b06fd38494ed96473630d09437348182/diffoscope-104.tar.gz",
-            "sha256": "0def4a971733b6fedc1db5976b0ede728b295153bc520175808fb78db785ce6e"
+            "url": "https://files.pythonhosted.org/packages/e2/70/b2b40203fc1eb3ae66c7a45a8db77e4e6c3dc086f3b557f42ef4f234afff/diffoscope-105.tar.gz",
+            "sha256": "036fc036a284f1e09ac23502b169e11f0b167b9961e371a2c3cb6fbaf3e6132f"
         }
     ]
 }


### PR DESCRIPTION
Includes diffoscope itself, and poppler in order to get pdftotext. Many other tools come from using the SDK as the runtime, but there are still many gaps.

TODO:

* [x] Add some more missing tools
  * I opened [an upstream MR](https://salsa.debian.org/reproducible-builds/diffoscope/merge_requests/14) to add a `--list-missing-tools` flag, and have a local, external equivalent
* [ ] Clean up stray tools, headers, libraries, ...
* [x] Add Appdata
* [ ] Get a clear pronouncement on whether CLI-only tools, with no `.desktop` file, are generally accepted on the Flat Hub