### PR TITLE
add com.github.artemanufrij.regextester

### DIFF
--- a/com.github.artemanufrij.regextester.yml
+++ b/com.github.artemanufrij.regextester.yml
@@ -24,3 +24,5 @@ modules:
         sha256: 528b61e1df1436767133d082a1b473c460f18b4de09b869964b04f4cf18fa894
       - type: patch
         path: elementary-theme.patch
+    post-install:
+      - glib-compile-schemas /app/share/glib-2.0/schemas/

--- a/com.github.artemanufrij.regextester.yml
+++ b/com.github.artemanufrij.regextester.yml
@@ -1,0 +1,26 @@
+app-id: com.github.artemanufrij.regextester
+runtime: org.freedesktop.Platform
+sdk: org.freedesktop.Sdk
+runtime-version: '18.08'
+base: io.elementary.BaseApp
+base-version: juno
+command: com.github.artemanufrij.regextester
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+modules:
+  - name: regextester
+    buildsystem: meson
+    config-opts:
+      - --buildtype=release
+    sources:
+      - type: archive
+        url: https://github.com/artemanufrij/regextester/archive/1.0.1.tar.gz
+        sha256: 528b61e1df1436767133d082a1b473c460f18b4de09b869964b04f4cf18fa894
+      - type: patch
+        path: elementary-theme.patch

--- a/elementary-theme.patch
+++ b/elementary-theme.patch
@@ -1,0 +1,12 @@
+--- a/src/Application.vala	2018-10-25 22:38:30.000000000 +0200
++++ b/src/Application.vala	2018-10-31 13:59:00.027116997 +0100
+@@ -49,7 +49,8 @@
+                 mainwindow.present ();
+                 return;
+             }
+-
++            Gtk.Settings.get_default().set_property("gtk-theme-name", "elementary");
++            Gtk.Settings.get_default().set_property("gtk-icon-theme-name", "elementary");
+             mainwindow = new MainWindow ();
+             mainwindow.set_application(this);
+         }


### PR DESCRIPTION
Simple app by @artemanufrij
https://github.com/artemanufrij/regextester

It works as expected, uses the elmentary juno baseApp. I used the post-install until upstream merges this https://github.com/artemanufrij/regextester/pull/11 which adds a post install script to compile schemes & refresh the icon cache :) 