### PR TITLE
Add de.lucaswerkmeister.corebird

### DIFF
--- a/de.lucaswerkmeister.corebird.json
+++ b/de.lucaswerkmeister.corebird.json
@@ -12,7 +12,9 @@
     "--socket=x11",
     "--socket=wayland",
     "--socket=pulseaudio",
-    "--filesystem=host",
+    "--filesystem=home:ro",
+    "--filesystem=~/.corebird/:rw",
+    "--filesystem=~/.config/corebird/:create",
     "--talk-name=ca.desrt.dconf",
     "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   ],

--- a/de.lucaswerkmeister.corebird.json
+++ b/de.lucaswerkmeister.corebird.json
@@ -1,0 +1,65 @@
+{
+  "app-id": "de.lucaswerkmeister.corebird",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.30",
+  "sdk" : "org.gnome.Sdk",
+  "command" : "corebird",
+  "rename-icon" : "corebird",
+  "copy-icon" : true,
+  "finish-args" : [
+    "--share=ipc",
+    "--share=network",
+    "--socket=x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--filesystem=host",
+    "--talk-name=ca.desrt.dconf",
+    "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+  ],
+  "build-options" : {
+    "cflags" : "-O2 -g"
+  },
+  "cleanup" : [
+    "/include", "/share/gir-1.0",
+    "/lib/pkgconfig", "/lib/girepository-1.0",
+    "/share/vala-0.34", "/bin/vala*", "/bin/vapi*",
+    "/share/devhelp", "/share/aclocal", "/lib/*.la",
+    "/lib/libvala*", "/lib/vala-0.34",
+    "/share/gtk-doc", "/share/man", "/share/vala"
+  ],
+  "modules" : [
+    {
+      "name" : "gst-libav",
+      "cleanup" : ["*.la"],
+      "sources" : [
+        {
+            "type" : "archive",
+            "url" : "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.14.4.tar.xz",
+            "sha256" : "dfd78591901df7853eab7e56a86c34a1b03635da0d3d56b89aa577f1897865da"
+        }
+      ]
+    },
+    {
+      "name" : "gspell",
+      "config-opts" : ["--enable-vala=yes"],
+      "sources" : [
+        {
+            "type" : "archive",
+            "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.1.tar.xz",
+            "sha256" : "819a1d23c7603000e73f5e738bdd284342e0cd345fb0c7650999c31ec741bbe5"
+        }
+      ]
+    },
+    {
+      "name" : "corebird",
+      "sources" : [
+        {
+          "type" : "git",
+          "url" : "https://github.com/lucaswerkmeister/corebird/",
+          "tag" : "1.7.4.2",
+          "commit" : "4a30d0c469b079222a0896379bd412b686dfe5c1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is a “life support” fork of the Corebird Twitter client, which was archived by its original author after Twitter removed support for streaming services. See the [README][1] for more information.

The manifest is based on the original [org.baedert.corebird manifest][2], with the sources section updated to point to the fork. The Flatpak Builder documentation I found indicates that autogen builds are supported, so we build directly from source instead of from a tarball containing the generated configure script.

[1]: https://github.com/lucaswerkmeister/corebird/blob/life-support/README.md
[2]: https://github.com/flathub/org.baedert.corebird