### PR TITLE
org.gnome.Tomboy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/dbus-sharp-glib-no-system.patch
+++ b/dbus-sharp-glib-no-system.patch
@@ -1,0 +1,10 @@
+--- https_github.com_hbons_dbus-sharp-glib/src/GLib.cs~	2017-10-16 10:19:42.163777219 +0100
++++ https_github.com_hbons_dbus-sharp-glib/src/GLib.cs	2017-10-18 18:47:16.886584156 +0100
+@@ -19,7 +19,6 @@
+ 			if (initialized)
+ 				return;
+ 
+-			Init (Bus.System);
+ 			Init (Bus.Session);
+ 			//TODO: consider starter bus?
+ 

--- a/mono-terminfo-integer-fix.patch
+++ b/mono-terminfo-integer-fix.patch
@@ -1,0 +1,52 @@
+commit 083dd95a0315c18b0f1c7b4e807f67b62a7a7e0f
+Author: Bernhard Urban <bernhard.urban@xamarin.com>
+Date:   Thu Jul 19 13:12:54 2018 +0200
+
+    [TermInfo] fix reading integer value for new file format (#9520)
+    
+    16bit vs. 32bit only applies for offsets, not for actual entries in the
+    file format.
+    
+    Fixes https://github.com/mono/mono/issues/8340
+
+diff --git a/mcs/class/corlib/System/TermInfoReader.cs b/mcs/class/corlib/System/TermInfoReader.cs
+index 2be4627e791..bb36aca5e4c 100644
+--- a/mcs/class/corlib/System/TermInfoReader.cs
++++ b/mcs/class/corlib/System/TermInfoReader.cs
+@@ -173,7 +173,7 @@ namespace System {
+ 				offset++;
+ 
+ 			offset += ((int) number) * intOffset;
+-			return GetInteger (buffer, offset);
++			return GetInt16 (buffer, offset);
+ 		}
+ 
+ 		public string Get (TermInfoStrings tstr)
+@@ -222,27 +222,6 @@ namespace System {
+ 			return (short) (uno + dos * 256);
+ 		}
+ 
+-		int GetInt32 (byte [] buffer, int offset)
+-		{
+-			int b1 = (int) buffer [offset];
+-			int b2 = (int) buffer [offset + 1];
+-			int b3 = (int) buffer [offset + 2];
+-			int b4 = (int) buffer [offset + 3];
+-			if (b1 == 255 && b2 == 255 && b3 == 255 && b4 == 255)
+-				return -1;
+-
+-			return b1 + b2 << 8 + b3 << 16 + b4 << 24;
+-		}
+-
+-		int GetInteger (byte [] buffer, int offset)
+-		{
+-			if (intOffset == 2)
+-				return GetInt16 (buffer, offset);
+-			else
+-				// intOffset == 4
+-				return GetInt32 (buffer, offset);
+-		}
+-
+ 		string GetString (byte [] buffer, int offset)
+ 		{
+ 			int length = 0;

--- a/mono-terminfo-ncurses6.patch
+++ b/mono-terminfo-ncurses6.patch
@@ -1,0 +1,149 @@
+commit 2c1f45f3791f274855e0f5fd2fb0af71c9a756f7
+Author: Bernhard Urban <bernhard.urban@xamarin.com>
+Date:   Wed Feb 14 05:35:11 2018 +0100
+
+    [TermInfo] support new file format terminfo2 introduced with ncurses6.1 (#6960)
+    
+    See also https://github.com/mirror/ncurses/commit/1501ae2a13db0ffd2db8404c24aa5010a88ea91b#diff-2c0786db969084ba9e087d82f8275e0b
+    
+    Fixes https://github.com/mono/mono/issues/6752
+
+diff --git a/mcs/class/corlib/System/TermInfoReader.cs b/mcs/class/corlib/System/TermInfoReader.cs
+index a171706add6..2be4627e791 100644
+--- a/mcs/class/corlib/System/TermInfoReader.cs
++++ b/mcs/class/corlib/System/TermInfoReader.cs
+@@ -32,7 +32,8 @@ using System.IO;
+ using System.Text;
+ namespace System {
+ 	// This class reads data from a byte array or file containing the terminfo capabilities
+-	// information for any given terminal. The maximum allowed size is 4096 bytes.
++	// information for any given terminal. The maximum allowed size is 4096 (or
++	// 32768 for terminfo2) bytes.
+ 	//
+ 	// Terminfo database files are divided in the following sections:
+ 	//
+@@ -45,7 +46,7 @@ namespace System {
+ 	//
+ 	// The header is as follows:
+ 	//
+-	//	Magic number (0x1 and 0x1A)
++	//	Magic number (0x11A/0432 or 0x21e/01036 for terminfo2)
+ 	//	Terminal names size
+ 	//	Boolean section size
+ 	//	Numeric section size
+@@ -58,8 +59,9 @@ namespace System {
+ 	// The boolean capabilities section has bytes that are set to 1 if the capability is supported
+ 	// and 0 otherwise. If the index of a capability is greater than the section size, 0 is assumed.
+ 	//
+-	// The numeric capabilities section holds 2-byte integers in little endian format. No negative
+-	// values are allowed and the absence of a capability is marked as two 0xFF.
++	// The numeric capabilities section holds 2-byte integers (4-byte integers for terminfo2) in
++	// little endian format. No negative values are allowed and the absence of a capability is marked
++	// as two 0xFF (four 0xFF for terminfo2).
+ 	//
+ 	// The string offsets section contains 2-byte integer offsets into the string capabilies section.
+ 	// If the capability is not supported, the index will be two 0xFF bytes.
+@@ -72,17 +74,17 @@ namespace System {
+ 	//
+ 
+ 	class TermInfoReader {
+-		//short nameSize;
+-		short boolSize;
+-		short numSize;
+-		short strOffsets;
+-		//short strSize;
++		int boolSize;
++		int numSize;
++		int strOffsets;
+ 
+ 		//string [] names; // Last one is the description
+ 		byte [] buffer;
+ 		int booleansOffset;
+ 		//string term;
+ 
++		int intOffset;
++
+ 		public TermInfoReader (string term, string filename)
+ 		{
+ 			using (FileStream st = File.OpenRead (filename)) {
+@@ -114,12 +116,21 @@ namespace System {
+ //			get { return term; }
+ //		}
+ 
++		void DetermineVersion (short magic)
++		{
++			if (magic == 0x11a)
++				intOffset = 2;
++			else if (magic == 0x21e)
++				intOffset = 4;
++			else
++				throw new Exception (String.Format ("Magic number is unexpected: {0}", magic));
++		}
++
+ 		void ReadHeader (byte [] buffer, ref int position)
+ 		{
+ 			short magic = GetInt16 (buffer, position);
+ 			position += 2;
+-			if (magic != 282)
+-				throw new Exception (String.Format ("Magic number is wrong: {0}", magic));
++			DetermineVersion (magic);
+ 			
+ 			/*nameSize =*/ GetInt16 (buffer, position);
+ 			position += 2;
+@@ -161,8 +172,8 @@ namespace System {
+ 			if ((offset % 2) == 1)
+ 				offset++;
+ 
+-			offset += ((int) number) * 2;
+-			return GetInt16 (buffer, offset);
++			offset += ((int) number) * intOffset;
++			return GetInteger (buffer, offset);
+ 		}
+ 
+ 		public string Get (TermInfoStrings tstr)
+@@ -175,7 +186,7 @@ namespace System {
+ 			if ((offset % 2) == 1)
+ 				offset++;
+ 
+-			offset += numSize * 2;
++			offset += numSize * intOffset;
+ 			int off2 = GetInt16 (buffer, offset + (int) tstr * 2);
+ 			if (off2 == -1)
+ 				return null;
+@@ -193,7 +204,7 @@ namespace System {
+ 			if ((offset % 2) == 1)
+ 				offset++;
+ 
+-			offset += numSize * 2;
++			offset += numSize * intOffset;
+ 			int off2 = GetInt16 (buffer, offset + (int) tstr * 2);
+ 			if (off2 == -1)
+ 				return null;
+@@ -211,6 +222,27 @@ namespace System {
+ 			return (short) (uno + dos * 256);
+ 		}
+ 
++		int GetInt32 (byte [] buffer, int offset)
++		{
++			int b1 = (int) buffer [offset];
++			int b2 = (int) buffer [offset + 1];
++			int b3 = (int) buffer [offset + 2];
++			int b4 = (int) buffer [offset + 3];
++			if (b1 == 255 && b2 == 255 && b3 == 255 && b4 == 255)
++				return -1;
++
++			return b1 + b2 << 8 + b3 << 16 + b4 << 24;
++		}
++
++		int GetInteger (byte [] buffer, int offset)
++		{
++			if (intOffset == 2)
++				return GetInt16 (buffer, offset);
++			else
++				// intOffset == 4
++				return GetInt32 (buffer, offset);
++		}
++
+ 		string GetString (byte [] buffer, int offset)
+ 		{
+ 			int length = 0;

--- a/org.gnome.Tomboy.appdata.xml
+++ b/org.gnome.Tomboy.appdata.xml
@@ -4,9 +4,10 @@
 BugReportURL: https://bugzilla.gnome.org/show_bug.cgi?id=736869
 SentUpstream: 2014-09-18
 -->
-<application>
-  <id type="desktop">org.gnome.Tomboy</id>
+<component type="desktop">
+  <id>org.gnome.Tomboy</id>
   <name>Tomboy</name>
+  <launchable type="desktop-id">org.gnome.Tomboy.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.1+</project_license>
   <description>
@@ -29,42 +30,25 @@ SentUpstream: 2014-09-18
       cluttered and run more smoothly.
     </p>
   </description>
+  <developer_name>Alex Graveley, Boyd Timothy, Sandy Armstrong, et al.</developer_name>
   <releases>
-    <release version="1.15.9" date="2018-11-06">
-      <description>Initial Flathub release of most recent available version.</description>
+    <release date="2017-07-16" version="1.15.9">
+      <description>
+        <ul>
+          <li>Fixed search and highlight problems for notes with multibyte characters (gh45)</li>
+          <li>Fixed Tomboy crash upon deleting a note after closing Search All window (gh52)</li>
+          <li>Main README updated &amp; converted to Markdown (thanks DamienDoumer for initial idea!)</li>
+        </ul>
+      </description>
     </release>
   </releases>
   <screenshots>
-    <screenshot type="default">https://raw.githubusercontent.com/hughsie/fedora-appstream/master/screenshots-extra/tomboy/a.png</screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/hughsie/fedora-appstream/master/screenshots-extra/tomboy/a.png</image>
+    </screenshot>
   </screenshots>
+  <content_rating type="oars-1.1" />
   <url type="homepage">https://projects.gnome.org/tomboy/</url>
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
-</application>
+  <url type="bugtracker">https://github.com/tomboy-notes/tomboy/issues</url>
+  <url type="help">http://lists.beatniksoftware.com/listinfo.cgi/tomboy-list-beatniksoftware.com</url>
+</component>

--- a/org.gnome.Tomboy.appdata.xml
+++ b/org.gnome.Tomboy.appdata.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Richard Hughes <richard@hughsie.com> -->
+<!--
+BugReportURL: https://bugzilla.gnome.org/show_bug.cgi?id=736869
+SentUpstream: 2014-09-18
+-->
+<application>
+  <id type="desktop">org.gnome.Tomboy</id>
+  <name>Tomboy</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1+</project_license>
+  <description>
+    <p>
+      Tomboy is a desktop note-taking application for GNU/Linux, Unix, Windows, and
+      Mac OS X.
+      Simple and easy to use, but with potential to help you organize the ideas and
+      information you deal with every day.
+    </p>
+    <p>
+      Have you ever felt the frustration at not being able to locate a website you
+      wanted to check out, or find an email you found interesting, or remember an idea
+      about the direction of the political landscape in post-industrial Australia?
+      Or are you one of those desperate souls with home-made, buggy, or not-quite-perfect
+      notes systems?
+      Time for Tomboy.
+    </p>
+    <p>
+      We bet you'll be surprised at how well a little application can make life less
+      cluttered and run more smoothly.
+    </p>
+  </description>
+  <releases>
+    <release version="1.15.9" date="2018-11-06">
+      <description>Initial Flathub release of most recent available version.</description>
+    </release>
+  </releases>
+  <screenshots>
+    <screenshot type="default">https://raw.githubusercontent.com/hughsie/fedora-appstream/master/screenshots-extra/tomboy/a.png</screenshot>
+  </screenshots>
+  <url type="homepage">https://projects.gnome.org/tomboy/</url>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+</application>

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -5,7 +5,6 @@
     "runtime-version": "18.08",
     "command": "tomboy",
     "finish-args": [
-        "--device=dri",
         "--filesystem=home",
         "--share=ipc",
         "--share=network",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -1,0 +1,117 @@
+{
+    "app-id": "org.gnome.Tomboy",
+    "sdk": "org.gnome.Sdk",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "command": "tomboy",
+    "finish-args": [
+        "--device=dri",
+        "--filesystem=home",
+        "--share=ipc",
+        "--share=network",
+        "--socket=x11",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*"
+    ],
+    "cleanup": [
+        "/lib/debug",
+        "/lib/monodoc"
+    ],
+    "rename-desktop-file": "tomboy.desktop",
+    "rename-icon": "tomboy",
+    "modules": [
+        {
+            "name": "mono",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://download.mono-project.com/sources/mono/mono-4.8.1.0.tar.bz2",
+                    "sha256": "18cb38a670e51609c36c687ed90ad42cfedabeffd0a2dc5f7f0c46249eb8dbef"
+                }
+            ]
+        },
+        {
+            "name": "dbus-sharp",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mono/dbus-sharp",
+                    "commit": "f7dbfc28f2395e65bf6cf5961ba57aa2713e8715"
+                }
+            ]
+        },
+        {
+            "name": "dbus-sharp-glib",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/hbons/dbus-sharp-glib",
+                    "commit": "9c003f566efa7cbcb413d6b374ccb15ec8abb330"
+                }
+            ]
+        },
+        {
+            "name": "libglade",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libglade/2.6/libglade-2.6.4.tar.bz2",
+                    "sha256": "64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec"
+                }
+            ]
+        },
+        {
+            "name": "gtk-sharp",
+            "config-opts": [ "--disable-gtk-doc",
+                             "--disable-man" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.mono-project.com/sources/gtk-sharp212/gtk-sharp-2.12.45.tar.gz",
+                    "sha256": "02680578e4535441064aac21d33315daa009d742cab8098ac8b2749d86fffb6a"
+                }
+            ]
+        },
+        {
+            "name": "mono-addins",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mono/mono-addins",
+                    "commit": "5b1979439bb1c13f2c347f18fc89dff6b1e1aa2c"
+                }
+            ]
+        },
+        {
+            "name": "gconf-sharp",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-sharp/2.24/gnome-sharp-2.24.2.tar.bz2",
+                    "sha256": "122b1e03966d63ec3389decf5440fb94285907d1b6be48352dcf6aca292cf7b0"
+                }
+            ]
+        },
+        {
+            "name": "tomboy",
+            "config-opts": [ "--disable-schemas-install" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ftp.gnome.org/pub/GNOME/sources/tomboy/1.15/tomboy-1.15.9.tar.xz",
+                    "sha256": "78d0a5f33db9b1077115773ad3291ecaf6e656f58545859b77a2ae7440abb248"
+                },
+                {
+                    "type": "patch",
+                    "path": "tomboy-fix-mkdir.patch"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf -vfi" ]
+                }
+            ]
+        }
+    ]
+}
+

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -1,8 +1,8 @@
 {
     "app-id": "org.gnome.Tomboy",
-    "sdk": "org.gnome.Sdk",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
+    "sdk": "org.freedesktop.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "18.08",
     "command": "tomboy",
     "finish-args": [
         "--device=dri",
@@ -43,9 +43,19 @@
                     /* the last Mono 4 version - Tomboy is not compatible with Mono 5 */
                     "url": "http://download.mono-project.com/sources/mono/mono-4.8.1.0.tar.bz2",
                     "sha256": "18cb38a670e51609c36c687ed90ad42cfedabeffd0a2dc5f7f0c46249eb8dbef"
+                },
+                /* Mono 4 TermInfo not compatible with ncurses6.1... */
+                {
+                    "type": "patch",
+                    "path": "mono-terminfo-ncurses6.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "mono-terminfo-integer-fix.patch"
                 }
             ]
         },
+        "shared-modules/gtk2/gtk2.json",
         {
             "name": "libglade",
             "config-opts": [
@@ -81,6 +91,21 @@
                     "url": "https://github.com/mono/mono-addins",
                     /* last upstream version before compatibility with Mono 4 seems to break */
                     "commit": "5b1979439bb1c13f2c347f18fc89dff6b1e1aa2c"
+                }
+            ]
+        },
+        {
+            "name": "dbus-glib",
+            "cleanup": [ "*.la", "/bin", "/etc", "/include", "/libexec", "/share/gtk-doc", "/share/man" ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-gtk-doc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
+                    "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
                 }
             ]
         },
@@ -135,6 +160,24 @@
                 {
                     "type": "patch",
                     "path": "dbus-sharp-glib-no-system.patch"
+                }
+            ]
+        },
+        {
+            "name": "enchant",
+            "config-opts": ["--disable-static", "--with-myspell-dir=/usr/share/hunspell"],
+            "cleanup": [
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                     "url": "https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz",
+                     "sha256": "bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf -vfi" ]
                 }
             ]
         },

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -128,11 +128,18 @@
         {
             "name": "tomboy",
             "config-opts": [ "--disable-schemas-install" ],
+            "post-install": [
+              "install -D -m644 org.gnome.Tomboy.appdata.xml /app/share/appdata/org.gnome.Tomboy.appdata.xml"
+            ],
             "sources": [
                 {
                     "type": "archive",
                     "url": "https://ftp.gnome.org/pub/GNOME/sources/tomboy/1.15/tomboy-1.15.9.tar.xz",
                     "sha256": "78d0a5f33db9b1077115773ad3291ecaf6e656f58545859b77a2ae7440abb248"
+                },
+                {
+                    "type": "file",
+                    "path": "org.gnome.Tomboy.appdata.xml"
                 },
                 {
                     "type": "patch",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -10,9 +10,7 @@
         "--share=ipc",
         "--share=network",
         "--socket=x11",
-        "--talk-name=org.freedesktop.Notifications",
-        "--talk-name=org.gtk.vfs",
-        "--talk-name=org.gtk.vfs.*"
+        "--talk-name=org.gnome.GConf"
     ],
     "cleanup": [
         "/lib/debug",
@@ -28,6 +26,68 @@
                     "type": "archive",
                     "url": "http://download.mono-project.com/sources/mono/mono-4.8.1.0.tar.bz2",
                     "sha256": "18cb38a670e51609c36c687ed90ad42cfedabeffd0a2dc5f7f0c46249eb8dbef"
+                }
+            ]
+        },
+        {
+            "name": "libglade",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libglade/2.6/libglade-2.6.4.tar.bz2",
+                    "sha256": "64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec"
+                }
+            ]
+        },
+        {
+            "name": "gtk-sharp",
+            "config-opts": [
+                "--disable-gtk-doc",
+                "--disable-man"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.mono-project.com/sources/gtk-sharp212/gtk-sharp-2.12.45.tar.gz",
+                    "sha256": "02680578e4535441064aac21d33315daa009d742cab8098ac8b2749d86fffb6a"
+                }
+            ]
+        },
+        {
+            "name": "mono-addins",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mono/mono-addins",
+                    "commit": "5b1979439bb1c13f2c347f18fc89dff6b1e1aa2c"
+                }
+            ]
+        },
+        {
+            "name": "gconf",
+            "config-opts": [
+                "--disable-introspection",
+                "--disable-gtk-doc",
+                "--disable-orbit",
+                "--disable-static",
+                "--without-openldap"
+            ],
+            "cleanup": [ "/bin", "/include", "/libexec", "/lib/pkgconfig", "/share", "/etc" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://ftp.gnome.org/pub/GNOME/sources/GConf/3.2/GConf-3.2.6.tar.xz",
+                    "sha256": "1912b91803ab09a5eed34d364bf09fe3a2a9c96751fde03a4e0cfa51a04d784c"
+                }
+            ]
+        },
+        {
+            "name": "gconf-sharp",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-sharp/2.24/gnome-sharp-2.24.2.tar.bz2",
+                    "sha256": "122b1e03966d63ec3389decf5440fb94285907d1b6be48352dcf6aca292cf7b0"
                 }
             ]
         },
@@ -48,48 +108,20 @@
                     "type": "git",
                     "url": "https://github.com/hbons/dbus-sharp-glib",
                     "commit": "9c003f566efa7cbcb413d6b374ccb15ec8abb330"
+                },
+                {
+                    "type": "patch",
+                    "path": "dbus-sharp-glib-no-system.patch"
                 }
             ]
         },
         {
-            "name": "libglade",
+            "name": "gtkspell",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libglade/2.6/libglade-2.6.4.tar.bz2",
-                    "sha256": "64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec"
-                }
-            ]
-        },
-        {
-            "name": "gtk-sharp",
-            "config-opts": [ "--disable-gtk-doc",
-                             "--disable-man" ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.mono-project.com/sources/gtk-sharp212/gtk-sharp-2.12.45.tar.gz",
-                    "sha256": "02680578e4535441064aac21d33315daa009d742cab8098ac8b2749d86fffb6a"
-                }
-            ]
-        },
-        {
-            "name": "mono-addins",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/mono/mono-addins",
-                    "commit": "5b1979439bb1c13f2c347f18fc89dff6b1e1aa2c"
-                }
-            ]
-        },
-        {
-            "name": "gconf-sharp",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/gnome-sharp/2.24/gnome-sharp-2.24.2.tar.bz2",
-                    "sha256": "122b1e03966d63ec3389decf5440fb94285907d1b6be48352dcf6aca292cf7b0"
+                    "url": "http://http.debian.net/debian/pool/main/g/gtkspell/gtkspell_2.0.16.orig.tar.gz",
+                    "sha256": "8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
                 }
             ]
         },

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -16,11 +16,26 @@
     ],
     "rename-desktop-file": "tomboy.desktop",
     "rename-icon": "tomboy",
+    "cleanup": [
+       "*.la",
+        "/include",
+        "/lib/gtk-sharp-2.0",
+        "/lib/mono-source-libs",
+        "/lib/pkgconfig",
+        "/share/gapi-2.0",
+        "/share/man",
+        "/share/mono-2.0",
+        "/share/xml"
+    ],
     "modules": [
         {
             "name": "mono",
             "config-opts": [
-                "--with-mcs-docs=no"
+                "--disable-boehm",
+                "--disable-libraries",
+                "--with-ikvm-native=no",
+                "--with-mcs-docs=no",
+                "--with-profile4=no"
             ],
             "sources": [
                 {
@@ -33,6 +48,9 @@
         },
         {
             "name": "libglade",
+            "config-opts": [
+                "--disable-gtk-doc"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -44,7 +62,7 @@
         {
             "name": "gtk-sharp",
             "config-opts": [
-                "--disable-gtk-doc",
+                "--disable-monodoc",
                 "--disable-man"
             ],
             "sources": [
@@ -122,6 +140,9 @@
         },
         {
             "name": "gtkspell",
+            "config-opts": [
+                "--disable-gtk-doc"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -191,6 +191,10 @@
                     "type": "archive",
                     "url": "http://http.debian.net/debian/pool/main/g/gtkspell/gtkspell_2.0.16.orig.tar.gz",
                     "sha256": "8fc7dc560167b2cb7193e76aca625a152dc19b0ebf49816b78539cbb90d80d02"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf -vfi" ]
                 }
             ]
         },

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -130,6 +130,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gnome-sharp/2.24/gnome-sharp-2.24.2.tar.bz2",
                     "sha256": "122b1e03966d63ec3389decf5440fb94285907d1b6be48352dcf6aca292cf7b0"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf -vfi" ]
                 }
             ]
         },

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -12,15 +12,14 @@
         "--socket=x11",
         "--talk-name=org.gnome.GConf"
     ],
-    "cleanup": [
-        "/lib/debug",
-        "/lib/monodoc"
-    ],
     "rename-desktop-file": "tomboy.desktop",
     "rename-icon": "tomboy",
     "modules": [
         {
             "name": "mono",
+            "config-opts": [
+                "--with-mcs-docs=no"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -29,6 +29,13 @@
     "modules": [
         {
             "name": "mono",
+            "build-options": {
+                "arch": {
+                    "arm": {
+                        "no-debuginfo": true
+                     }
+                 }
+            },
             "config-opts": [
                 "--disable-boehm",
                 "--disable-libraries",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -94,21 +94,7 @@
                 }
             ]
         },
-        {
-            "name": "dbus-glib",
-            "cleanup": [ "*.la", "/bin", "/etc", "/include", "/libexec", "/share/gtk-doc", "/share/man" ],
-            "config-opts": [
-                "--disable-static",
-                "--disable-gtk-doc"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
-                    "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
-                }
-            ]
-        },
+        "shared-modules/dbus-glib/dbus-glib-0.110.json",
         {
             "name": "gconf",
             "config-opts": [

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -10,7 +10,9 @@
         "--share=ipc",
         "--share=network",
         "--socket=x11",
-        "--talk-name=org.gnome.GConf"
+        "--talk-name=org.gnome.GConf",
+        /* workaround for dbus-sharp quirk, where it connects unconditionally to the system bus */
+        "--system-talk-name=org.freedesktop.DBus"
     ],
     "rename-desktop-file": "tomboy.desktop",
     "rename-icon": "tomboy",

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -65,6 +65,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/libglade/2.6/libglade-2.6.4.tar.bz2",
                     "sha256": "64361e7647839d36ed8336d992fd210d3e8139882269bed47dc4674980165dec"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "autoreconf -vfi" ]
                 }
             ]
         },

--- a/org.gnome.Tomboy.json
+++ b/org.gnome.Tomboy.json
@@ -25,6 +25,7 @@
             "sources": [
                 {
                     "type": "archive",
+                    /* the last Mono 4 version - Tomboy is not compatible with Mono 5 */
                     "url": "http://download.mono-project.com/sources/mono/mono-4.8.1.0.tar.bz2",
                     "sha256": "18cb38a670e51609c36c687ed90ad42cfedabeffd0a2dc5f7f0c46249eb8dbef"
                 }
@@ -60,6 +61,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mono/mono-addins",
+                    /* last upstream version before compatibility with Mono 4 seems to break */
                     "commit": "5b1979439bb1c13f2c347f18fc89dff6b1e1aa2c"
                 }
             ]
@@ -98,6 +100,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mono/dbus-sharp",
+                    /* the commit before unix FD passing, which is incompatible with Mono 4 */
                     "commit": "f7dbfc28f2395e65bf6cf5961ba57aa2713e8715"
                 }
             ]
@@ -107,6 +110,7 @@
             "sources": [
                 {
                     "type": "git",
+                    /* a branch from upstream to fix some build issues */
                     "url": "https://github.com/hbons/dbus-sharp-glib",
                     "commit": "9c003f566efa7cbcb413d6b374ccb15ec8abb330"
                 },

--- a/tomboy-fix-mkdir.patch
+++ b/tomboy-fix-mkdir.patch
@@ -1,0 +1,10 @@
+--- tomboy-2/Tomboy/Makefile.am~	2017-10-15 22:11:10.618409232 +0100
++++ tomboy-2/Tomboy/Makefile.am	2017-10-15 22:11:17.242463382 +0100
+@@ -209,6 +209,7 @@
+ 	chmod +x $(PANEL_WRAPPER)
+ 
+ $(TARGET).config: $(srcdir)/$(TARGET_NAME).config.in Makefile
++	mkdir -p `dirname $(TARGET)` && \
+ 	sed -e "s|\@pkglibdir\@|$(pkglibdir)|" \
+ 	    < $< > $@
+ 


### PR DESCRIPTION
Although based on Gtk2+ and C#/Mono frameworks from a more hopeful time when .NET would save GNOME from perils of manual memory management, the Tomboy notes client still works well on my GNOME 3 desktop.

No other desktop software supports the Tomboy note sync web protocol which I use together with https://apps.nextcloud.com/apps/grauphel (server) and https://play.google.com/store/apps/details?id=org.tomdroid (Android client).

There is user/upstream demand for this Flatpak: https://github.com/tomboy-notes/tomboy/issues/55