### PR TITLE
Add Fontforge font editor

### DIFF
--- a/io.github.Fontforge.appdata.xml
+++ b/io.github.Fontforge.appdata.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Joe Da Silva <digital@joescat.com> -->
+<application>
+ <id type="desktop">fontforge.desktop</id>
+ <licence>CC0</licence>
+ <description>
+  <p xml:lang="C">
+  FontForge is a font editor for outline and bitmap fonts that lets you create,
+  edit, or convert, a range of fonts, including PostScript, TrueType, OpenType,
+  cid-keyed, multi-master, cff, SVG and BitMap (bdf, FON, NFNT) fonts.</p>
+  <p xml:lang="C">
+  FontForge is free Open Source Software written to run on various computer operating
+  systems. You can use FontForge Graphically or as a command-line tool.</p>
+  <p xml:lang="C">
+  Learning to use FontForge is easy, and there are various tutorials available beginning
+  with the basics up to more advanced features such as making and using scripts.</p>
+  <p xml:lang="es">
+  FontForge es un editor tipográfico que permite crear, editar y convertir una gran
+  gama de fuentes en formatos vectoriales y basados en mapas de bits, entre los cuales están
+  PostScript, TrueType, OpenType, CID, «multi-master», CFF, SVG, BDF, FON y NFNT.</p>
+  <p xml:lang="es">
+  FontForge es software libre y de código abierto, compatible con varios sistemas operativos.
+  Es posible usar FontForge mediante su interfaz gráfica o en la consola de texto.</p>
+  <p xml:lang="es">
+  Es fácil aprender a utilizar FontForge, y existen diversos tutoriales que cubren desde los
+  conceptos básicos hasta las funcionalidades avanzadas, como la creación y uso de «scripts».</p>
+  <p xml:lang="fr">
+  FontForge est un éditeur de polices de caractères numériques qui vous permet de créer, éditer,
+  ou convertir une large gamme de polices incluant PostScript, TrueType, OpenType, cid-keyed, 
+  multi-master, cff, SVG et BitMap (bdf, FON, NFNT).</p>
+  <p xml:lang="fr">
+  FontForge est un logiciel libre, gratuit et disponible pour divers systèmes d’exploitation.
+  Vous pouvez utiliser l'interface graphique de FontForge ou comme un outil à la ligne de commande.</p>
+  <p xml:lang="fr">
+  Apprendre à utiliser FontForge est facile, et il y a plusieurs tutoriels disponibles en commençant
+  par les bases jusqu'à des fonctionnalités plus avancées telles que la fabrication et l'utilisation de scripts.</p>
+  <p xml:lang="uk">
+  FontForge — редактор контурних та растрових шрифтів, за допомогою якого ви можете
+  створювати, редагувати та перетворювати шрифти у форматах PostScript, TrueType, OpenType,
+  cid-keyed, multi-master, cff, SVG та растрових (bdf, FON, NFNT).</p>
+  <p xml:lang="pt">
+  FontForge — um editor de fontes para fontes outline e de bitmap que lhe permite criar,
+  editar ou converter, uma série de fontes, incluindo PostScript, TrueType, OpenType,
+  cid-keyed, multi-master, cff, SVG e de bitmap (bdf, FON, NFNT) fontes.</p>
+  <p xml:lang="pt">
+  Aprender a usar FontForge é fácil, e existem vários tutoriais disponíveis que começam
+  com o básico até mais recursos avançados, como fazer e usar scripts.</p>
+  <p xml:lang="zh_CN">
+  FontForge是一个矢量字体和位图字体的编辑器。你可以用它来创造，编辑或者转换一些字体。支持的字体格式包括PostScript，TrueType，OpenType，CID-keyed，multi-master，CFF，SVG和位图（bdf，PON，NFNT）。</p>
+  <p xml:lang="zh_CN">
+  FontForge是一个自由开源软件，可以运行在多种计算机操作系统上。你可以使用FontForge的图形界面，也可以将其作为一个命令行工具来使用。</p>
+  <p xml:lang="zh_CN">
+  学习使用FontForge并不难，有各种各样的教程涵盖了基础知识到更高级的特性，比如制作和使用脚本。</p>
+  <p xml:lang="ko">
+  폰트포지는 외곽선 및 비트맵 글꼴 편집기입니다. 포스트스크립트, 트루타입, 오픈타입, CID 폰트,
+  멀티마스터, CFF, SVG 그리고 비트맵(bdf, FON, NFNT) 글꼴을 제작, 편집, 변환할 수 있습니다.</p>
+  <p xml:lang="ko">
+  폰트포지는 여러 컴퓨터 운영체제에서 작동하도록 쓰여진 오픈소스 소프트웨어입니다.
+  명령어 인터페이스 또는 GUI로 사용할 수 있습니다.</p>
+  <p xml:lang="ko">
+  폰트포지는 배우기 쉽습니다. 기본적인 것부터 시작해서, 스크립트를 짜서 쓰는 고급 기능까지
+  다양한 튜토리얼들이 준비되어 있습니다.</p>
+ <p xml:lang="ca">
+  El FontForge és un editor de tipus de lletra, tant vectorials com de mapa de bits,
+  que permet crear, editar o convertir tipus de diferents formats, com ara PostScript,
+  TrueType, OpenType, CID, MM, CFF, SVG i BitMap (BDF, FON, NFNT).</p>
+ <p xml:lang="ca">
+  El FontForge és programari lliure dissenyat per poder ser utilitzat en diversos
+  sistemes operatius, tant des de la interfície gràfica com des de la línia d'ordres.</p>
+ <p xml:lang="ca">
+  Aprendre a utilitzar el FontForge és senzill; podeu consultar els tutorials
+  existents que van de les funcions més bàsiques del programa fins a les més complicades,
+  com ara escriure i usar scripts.</p>
+  <p xml:lang="it">
+  FontForge è un editor di font per i caratteri di testo outline e bitmap che ti permette di creare,
+  modificare o convertire diversi tipi di font, inclusi PostScript, TrueType, OpenType,
+  CID, multi-master, cff, SVG e BitMap (bdf, FON, NFNT).</p>
+  <p xml:lang="it">
+  FontForge è un Software Open Source gratuito, scritto per funzionare su vari sistemi
+  operativi. Puoi usare FontForge con interfaccia grafica o tramite riga di comando.</p>
+  <p xml:lang="it">
+  Imparare ad usare FontForge è facile, e sono disponibili vari tutorial che iniziano dalle basi
+  fino ad arrivare alle funzioni avanzate, come la creazione e l'uso di script.</p>
+ </description>
+ <screenshots>
+  <screenshot type="default" width="1200" height="675">https://github.com/fontforge/fontforge/raw/master/doc/html/ff-screenshot.png</screenshot>
+ </screenshots>
+  <url type="homepage">https://github.com/fontforge/fontforge</url>
+ <updatecontact>fontforge-devel@lists.sourceforge.net</updatecontact>
+</application>

--- a/io.github.Fontforge.appdata.xml
+++ b/io.github.Fontforge.appdata.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Joe Da Silva <digital@joescat.com> -->
 <application>
- <id type="desktop">fontforge.desktop</id>
+ <id type="desktop">io.github.Fontforge</id>
+ ​<launchable type="desktop-id">io.github.Fontforge.desktop</launchable>
  <licence>CC0</licence>
  <description>
   <p xml:lang="C">
@@ -87,4 +88,11 @@
  </screenshots>
   <url type="homepage">https://github.com/fontforge/fontforge</url>
  <updatecontact>fontforge-devel@lists.sourceforge.net</updatecontact>
+
+ <content_rating type="oars-1.1" />
+
+ <releases>
+    <release version="20170731" date="2017-07-31" />
+    <release version="20161005" date="2016-10-05" />
+ </releases>
 </application>

--- a/io.github.Fontforge.yaml
+++ b/io.github.Fontforge.yaml
@@ -2,7 +2,7 @@ app-id: io.github.Fontforge
 branch: stable
 
 runtime: org.freedesktop.Platform
-runtime-version: 1.6
+runtime-version: "18.08"
 sdk: org.freedesktop.Sdk
 
 command: fontforge
@@ -13,6 +13,12 @@ finish-args:
   - --filesystem=host
 
 modules:
+  - name: pango
+    sources:
+        - type: archive
+          url: http://ftp.gnome.org/pub/GNOME/sources/pango/1.42/pango-1.42.4.tar.xz
+          sha256: 1d2b74cd63e8bd41961f2f8d952355aa0f9be6002b52c8aa7699d9f5da597c9d
+
   - name: libspiro
     sources:
         - type: archive

--- a/io.github.Fontforge.yaml
+++ b/io.github.Fontforge.yaml
@@ -1,0 +1,31 @@
+app-id: io.github.Fontforge
+branch: stable
+
+runtime: org.freedesktop.Platform
+runtime-version: 1.6
+sdk: org.freedesktop.Sdk
+
+command: fontforge
+
+finish-args:
+  - --socket=x11
+
+modules:
+  - name: libspiro
+    sources:
+        - type: archive
+          url: https://github.com/fontforge/libspiro/releases/download/0.5.20150702/libspiro-dist-0.5.20150702.tar.gz
+          sha256: 514d215942b860c8ee77282b14e11129ecea1992f8dfcb9ea69c0f68249f6c94
+
+
+  - name: libuinameslist
+    sources:
+        - type: archive
+          url: https://github.com/fontforge/libuninameslist/releases/download/20180701/libuninameslist-dist-20180701.tar.gz
+          sha256: 8aed97d0bc872d893d8bf642a14e49958b0613136e1bfe2a415c69599c803c90
+
+  - name: fontforge
+    sources:
+        - type: archive
+          url: https://github.com/fontforge/fontforge/releases/download/20170731/fontforge-dist-20170731.tar.xz
+          sha256: 840adefbedd1717e6b70b33ad1e7f2b116678fa6a3d52d45316793b9fd808822

--- a/io.github.Fontforge.yaml
+++ b/io.github.Fontforge.yaml
@@ -9,6 +9,8 @@ command: fontforge
 
 finish-args:
   - --socket=x11
+  # The file picker does not use portals :(
+  - --filesystem=host
 
 modules:
   - name: libspiro


### PR DESCRIPTION
This manifest is for the Fontforge editor.  It works well for me, except that I had to disable the Python stuff due to some linkage weirdness at runtime, i.e. it seems to have linked against python2 which in turn seems to not be available in the runtime. Another issue is the installation of the appdata file which upstream currently does not do. So we have to install it ourselves. But both, Debian and Upstream have issues for it, so if all goes well it'll be fixed soon™.