### PR TITLE
Add org.librepcb.LibrePCB

### DIFF
--- a/0001-Make-appdata-ready-for-Flatpak-release.patch
+++ b/0001-Make-appdata-ready-for-Flatpak-release.patch
@@ -1,0 +1,63 @@
+From 9a8cbc67466f452d7d6786743712ecb55f653fa0 Mon Sep 17 00:00:00 2001
+From: "U. Bruhin" <urbibruhin@bluewin.ch>
+Date: Tue, 27 Nov 2018 22:05:53 +0100
+Subject: [PATCH] Make appdata ready for Flatpak release
+
+---
+ share/metainfo/org.librepcb.LibrePCB.appdata.xml | 21 ++++++++-------------
+ 1 file changed, 8 insertions(+), 13 deletions(-)
+
+diff --git a/share/metainfo/org.librepcb.LibrePCB.appdata.xml b/share/metainfo/org.librepcb.LibrePCB.appdata.xml
+index fe75c93..406b6d6 100644
+--- a/share/metainfo/org.librepcb.LibrePCB.appdata.xml
++++ b/share/metainfo/org.librepcb.LibrePCB.appdata.xml
+@@ -5,9 +5,10 @@
+   <project_license>GPL-3.0</project_license>
+   <name>LibrePCB</name>
+   <summary>Design Schematics and PCBs</summary>
++  <developer_name>The LibrePCB Developers</developer_name>
+ 
+   <description>
+-    <p>LibrePCB is a free EDA software to develop printed circuit boards. It’s currently under heavy development to bring out first stable releases as soon as possible.</p>
++    <p>LibrePCB is a free EDA software to develop printed circuit boards.</p>
+     <p>Key Features:</p>
+     <ul>
+       <li>Cross-platform (Unix/Linux, Mac OS X, Windows)</li>
+@@ -17,16 +18,6 @@
+       <li>Human-readable file formats</li>
+       <li>Open Source (GNU GPLv3)</li>
+     </ul>
+-    <p>Control Panel:</p>
+-    <p>The control panel gives you fast access to all of your projects, especially to recently used and favorite projects. It also shows you the description of projects without opening them, if available. Just create a README.md inside your project’s directory!</p>
+-    <p>Schematic Editor:</p>
+-    <p>The schematic editor is very easy to use and still powerful. Thanks to the innovative library concept, you don’t have to worry about choosing footprints while drawing the schematic. In contrast to other EDA tools, you also don’t have to worry about manually assigning symbol pins to footprint pads later in the board editor.</p>
+-    <p>Board Editor:</p>
+-    <p>Ever struggled in the middle of layouting if you need to relocate some devices before continue routing the traces? LibrePCB’s board editor just lets you fork your half-done layout to continue with two different layouting strategies! Of course all of the existing boards are always in sync with the schematics.</p>
+-    <p>Library Browser:</p>
+-    <p>When adding components to the schematic, most EDA tools let you choose them from a simple list of the installed libraries (often named by manufacturer). LibrePCB thinks this is a stupid system and thus lets you choose your components from a tree of categories instead, no matter which library provides them.</p>
+-    <p>Library Manager:</p>
+-    <p>Managing libraries has never been easier than with LibrePCB’s library manager. It downloads, installs and updates libraries directly from the internet. No more need to do this manually.</p>
+   </description>
+ 
+   <screenshots>
+@@ -58,11 +49,15 @@
+   <url type="homepage">https://librepcb.org</url>
+   <url type="bugtracker">https://github.com/LibrePCB/LibrePCB/issues</url>
+   <url type="help">https://docs.librepcb.org/</url>
+-  
++
+   <provides>
+     <binary>librepcb</binary>
+     <binary>librepcb-cli</binary>
+   </provides>
+-  
++
++  <releases>
++    <release version="0.1.0" date="2018-11-25"/>
++  </releases>
++
+   <content_rating type="oars-1.1"/>
+ </component>
+-- 
+2.7.4
+

--- a/org.librepcb.LibrePCB.json
+++ b/org.librepcb.LibrePCB.json
@@ -1,0 +1,34 @@
+{
+    "app-id": "org.librepcb.LibrePCB",
+    "runtime": "org.kde.Sdk",
+    "runtime-version": "5.11",
+    "sdk": "org.kde.Sdk",
+    "command": "librepcb",
+    "finish-args": [
+        "--device=dri",
+        "--socket=x11",
+        "--socket=wayland",
+        "--share=ipc",
+        "--share=network", /* required for downloading libraries */
+        "--filesystem=home" /* required for storing workspace, libraries etc. */
+    ],
+    "modules": [
+        {
+            "name": "librepcb",
+            "buildsystem": "qmake",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/LibrePCB/LibrePCB",
+                    "tag": "0.1.0",
+                    "commit": "d7458d3b3e126499902e1a66a0ef889f516a7c97"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Make-appdata-ready-for-Flatpak-release.patch"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
A free EDA software to develop printed circuit boards.

Project repository: https://github.com/LibrePCB/LibrePCB
Website: https://librepcb.org/