### PR TITLE
Add org.gnome.GScope.json

### DIFF
--- a/org.gnome.GScope.json
+++ b/org.gnome.GScope.json
@@ -1,0 +1,75 @@
+{
+    "app-id": "org.gnome.GScope",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.30",
+    "sdk": "org.gnome.Sdk",
+    "command": "gscope",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options": {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g",
+        "env": {
+            "V": "1"
+        }
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name" : "gtksourceview",
+            "config-opts" : [ "--disable-Werror" ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "branch" : "gnome-3-24",
+                    "url" : "https://gitlab.gnome.org/GNOME/gtksourceview.git"
+                }
+            ]
+        },
+        {
+            "name": "cscope",
+            "build-options": {
+                    "cflags": "-ltinfo",
+                    "cxxflags": "-ltinfo"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://sourceforge.net/projects/cscope/files/cscope/v15.9/cscope-15.9.tar.gz",
+                    "sha256": "c5505ae075a871a9cd8d9801859b0ff1c09782075df281c72c23e72115d9f159"
+                }
+            ]
+        },
+        {
+            "name": "gscope",
+            "buildsystem": "meson",
+            "config-opts": [ "--libdir=lib" ],
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "git",
+                    "tag": "v0.1",
+                    "url": "https://gitlab.gnome.org/carlo.caione/gscope.git"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
gScope is source browsing tool for large and complex projects written in C.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>