### PR TITLE
Add org.kiwix.Client application to flathub.

### DIFF
--- a/org.kiwix.desktop.json
+++ b/org.kiwix.desktop.json
@@ -1,0 +1,142 @@
+{
+    "app-id": "org.kiwix.desktop",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.12",
+    "sdk": "org.kde.Sdk",
+    "command": "kiwix-desktop",
+    "rename-icon": "kiwix-desktop",
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--share=network",
+        "--share=ipc",
+        "--device=dri",
+        "--socket=pulseaudio"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/cmake",
+        "/lib/*.la",
+        "/bin/curl",
+        "/bin/copydatabase",
+        "/bin/kiwix-compile-resources",
+        "/bin/quest",
+        "/bin/simple*",
+        "/bin/xapian-*",
+        "/share/aclocal",
+        "/share/doc",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name": "pugixml",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "0f422dad86da0a2e56a37fb2a88376aae6e931f22cc8b956978460c9db06136b",
+                    "url": "http://download.kiwix.org/dev/pugixml-1.2.tar.gz",
+                    "dest": "src"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/pugixml_meson.patch"
+                }
+            ]
+        },
+        {
+            "name": "xapian-core",
+            "config-opts": [
+                "--disable-sse",
+                "--disable-backend-chert",
+                "--disable-backend-inmemory",
+                "--disable-documentation"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "13f08a0b649c7afa804fa0e85678d693fd6069dd394c9b9e7d41973d74a3b5d3",
+                    "url": "http://download.kiwix.org/dev/xapian-core-1.4.7.tar.xz"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/xapian_sys_types.patch"
+                }
+            ]
+        },
+        {
+            "name": "libzim",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/openzim/libzim.git",
+                    "tag": "4.0.4",
+                    "commit": "684c355a6c56208c3d9e0be7990c4923b7ed8c50"
+                }
+            ]
+        },
+        {
+            "name": "mustache",
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp mustache.hpp /app/include"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "0d17298a81c08f12ebc446cdee387268a395d34bb724050fe67d5ce8c4e98b7a",
+                    "url": "https://github.com/kainjow/Mustache/archive/v3.2.1.tar.gz"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/mustache_virtual_destructor.patch"
+                }
+            ]
+        },
+        {
+            "name": "kiwix-lib",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/kiwix/kiwix-lib.git",
+                    "tag": "4.0.0",
+                    "commit": "ab94ac0ee84631a0af11d4a33f50eecc8c3e329c"
+                }
+            ]
+        },
+        {
+            "name": "aria2",
+            "config-opts": [
+                "--disable-libaria2",
+                "--disable-websocket",
+                "--without-sqlite3"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "3a44a802631606e138a9e172a3e9f5bcbaac43ce2895c1d8e2b46f30487e77a3",
+                    "url": "https://github.com/aria2/aria2/releases/download/release-1.34.0/aria2-1.34.0.tar.xz"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/libaria2_android.patch"
+                }
+            ]
+        },
+        {
+            "name": "kiwix-desktop",
+            "buildsystem": "qmake",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/kiwix/kiwix-desktop.git",
+                    "tag": "2.0-beta3",
+                    "commit": "a6bcef230a0bfca3107be461cdc0de0b78adb38f"
+                }
+            ]
+        }
+    ]
+}

--- a/patches/libaria2_android.patch
+++ b/patches/libaria2_android.patch
@@ -1,0 +1,29 @@
+diff -ur libaria2-1.33.1/src/a2io.h libaria2-1.33.1.patched/src/a2io.h
+--- libaria2-1.33.1/src/a2io.h	2017-11-08 13:39:06.000000000 +0100
++++ libaria2-1.33.1.patched/src/a2io.h	2018-03-27 17:02:45.651414060 +0200
+@@ -147,7 +147,7 @@
+ // # define a2fseek(fp, offset, origin): No fseek64 and not used in aria2
+ #define a2fstat(fd, buf) fstat64(fd, buf)
+ // # define a2ftell(fd): No ftell64 and not used in aria2
+-#define a2_struct_stat struct stat
++#define a2_struct_stat struct stat64
+ #define a2stat(path, buf) stat64(path, buf)
+ #define a2mkdir(path, openMode) mkdir(path, openMode)
+ #define a2utimbuf utimbuf
+diff -ur libaria2-1.33.1/src/crypto_endian.h libaria2-1.33.1.patched/src/crypto_endian.h
+--- libaria2-1.33.1/src/crypto_endian.h	2017-11-08 13:39:06.000000000 +0100
++++ libaria2-1.33.1.patched/src/crypto_endian.h	2018-03-27 16:56:55.264371501 +0200
+@@ -33,9 +33,13 @@
+ #define BIG_ENDIAN 4321
+ #define BYTE_ORDER LITTLE_ENDIAN
+ #else // !  defined(_WIN32) || defined(__INTEL_COMPILER) || defined (_MSC_VER)
++#if defined(__ANDROID__)
++#include <endian.h>
++#else // defined(__ANDROID__)
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif // HAVE_SYS_PARAM_H
++#endif // defined(__ANDROID__)
+ #endif // !  defined(_WIN32) || defined(__INTEL_COMPILER) || defined (_MSC_VER)
+ 
+ #if !defined(LITTLE_ENDIAN) || !defined(BIG_ENDIAN) || !defined(BYTE_ORDER) || \

--- a/patches/mustache_virtual_destructor.patch
+++ b/patches/mustache_virtual_destructor.patch
@@ -1,0 +1,11 @@
+diff -u mustache/mustache.hpp mustache.patched/mustache.hpp
+--- mustache/mustache.hpp	2018-07-23 05:13:12.000000000 +0200
++++ mustache.patched/mustache.hpp	2019-01-07 18:08:24.601917507 +0100
+@@ -423,6 +423,7 @@
+ template <typename string_type>
+ class basic_context {
+ public:
++    virtual ~basic_context() = default;
+     virtual void push(const basic_data<string_type>* data) = 0;
+     virtual void pop() = 0;
+ 

--- a/patches/pugixml_meson.patch
+++ b/patches/pugixml_meson.patch
@@ -1,0 +1,22 @@
+Les sous-répertoires pugixml-1.2.orig/contrib et pugixml-1.2/contrib sont identiques
+Les sous-répertoires pugixml-1.2.orig/docs et pugixml-1.2/docs sont identiques
+diff -Nu pugixml-1.2.orig/meson.build pugixml-1.2/meson.build
+--- pugixml-1.2.orig/meson.build	1970-01-01 01:00:00.000000000 +0100
++++ pugixml-1.2/meson.build	2016-12-09 16:40:24.749898766 +0100
+@@ -0,0 +1,13 @@
++project('pugixml', 'cpp')
++
++install_headers(['src/pugixml.hpp', 'src/pugiconfig.hpp'])
++pugixml = library('pugixml',
++                  ['src/pugixml.cpp'],
++                  install:true)
++
++pkg_mod = import('pkgconfig')
++pkg_mod.generate(libraries : pugixml,
++                 version : '1.2',
++                 name : 'libpugixml',
++                 description : 'pugixml',
++                 filebase : 'pugixml')
+\ Pas de fin de ligne à la fin du fichier
+Les sous-répertoires pugixml-1.2.orig/scripts et pugixml-1.2/scripts sont identiques
+Les sous-répertoires pugixml-1.2.orig/src et pugixml-1.2/src sont identiques

--- a/patches/xapian_sys_types.patch
+++ b/patches/xapian_sys_types.patch
@@ -1,0 +1,12 @@
+diff -ur xapian-core-1.4.7/backends/glass/glass_dbcheck.h xapian-core-1.4.7.patched/backends/glass/glass_dbcheck.h
+--- xapian-core-1.4.7/backends/glass/glass_dbcheck.h	2017-10-16 04:32:24.000000000 +0200
++++ xapian-core-1.4.7.patched/backends/glass/glass_dbcheck.h	2018-06-13 14:55:58.574898188 +0200
+@@ -24,7 +24,7 @@
+ 
+ #include "xapian/types.h"
+ 
+-#include <cstring> // For size_t.
++#include <sys/types.h> // For size_t and off_t.
+ #include <iosfwd>
+ #include <string>
+ #include <vector>


### PR DESCRIPTION
The manifest (and the patches) are generated by kiwix-build
(github kiwix/kiwix-build).

Kiwix is a application to allow offline access to content archive (zim),
as Wikipedia, Stackoverflow, ...

The flatpak bundle of the application can already be found at
http://download.kiwix.org/release/kiwix-desktop/org.kiwix.Client.2.0-beta1.flatpak