### PR TITLE
Add Kvantum KDE style

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.kde.KStyle.Kvantum.appdata.xml
+++ b/org.kde.KStyle.Kvantum.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+    <id>org.kde.KStyle.Kvantum</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Kvantum theme engine</name>
+    <summary>SVG-based theme engine for Qt4/Qt5 and KDE</summary>
+    <description>
+        <p>A Linux SVG-based theme engine for Qt4/Qt5 and KDE.</p>
+    </description>
+    <url type="homepage">https://github.com/tsujan/Kvantum</url>
+</component>

--- a/org.kde.KStyle.Kvantum.appdata.xml
+++ b/org.kde.KStyle.Kvantum.appdata.xml
@@ -3,7 +3,7 @@
     <id>org.kde.KStyle.Kvantum</id>
     <metadata_license>CC0-1.0</metadata_license>
     <name>Kvantum theme engine</name>
-    <summary>SVG-based theme engine for Qt4/Qt5 and KDE</summary>
+    <summary>SVG-based theme engine for Qt5</summary>
     <description>
         <p>A Linux SVG-based theme engine for Qt4/Qt5 and KDE.</p>
     </description>

--- a/org.kde.KStyle.Kvantum.appdata.xml
+++ b/org.kde.KStyle.Kvantum.appdata.xml
@@ -8,4 +8,7 @@
         <p>A Linux SVG-based theme engine for Qt4/Qt5 and KDE.</p>
     </description>
     <url type="homepage">https://github.com/tsujan/Kvantum</url>
+  <releases>
+    <release version="0.19.0" date="2021-03-13"/>
+  </releases>
 </component>

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -25,8 +25,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/tsujan/Kvantum/archive/V0.10.8.tar.gz",
-                    "sha256": "a169a19a05985124a946ae638bee2729adad1544497693d911bb7d15160fd20c"
+                    "url": "https://github.com/tsujan/Kvantum/archive/V0.10.9.tar.gz",
+                    "sha256": "e588c2e7acbc00b2ccf197dc34e09a3bc4c1f5d4574f26b929ad372177183041"
                 }
             ]
         },

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -20,9 +20,9 @@
             "subdir": "Kvantum",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/tsujan/Kvantum.git",
-                    "tag": "V0.10.6"
+                    "type": "archive",
+                    "url": "https://github.com/tsujan/Kvantum/archive/V0.10.8.tar.gz",
+                    "sha256": "a169a19a05985124a946ae638bee2729adad1544497693d911bb7d15160fd20c"
                 }
             ]
         },

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -30,7 +30,8 @@
             "name": "appdata",
             "buildsystem": "simple",
             "build-commands": [
-                "install -Dm644 org.kde.KStyle.Kvantum.appdata.xml -t ${FLATPAK_DEST}/share/appdata/"
+                "install -Dm644 ${FLATPAK_ID}.appdata.xml -t ${FLATPAK_DEST}/share/appdata/",
+                "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}"
             ],
             "sources": [
                 {

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.kde.KStyle.Kvantum",
+    "branch": "master",
+    "runtime": "org.kde.Platform",
+    "build-extension": true,
+    "sdk": "org.kde.Sdk",
+    "runtime-version": "5.10",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "modules": [
+        {
+            "name": "kvantum",
+            "buildsystem": "qmake",
+            "config-opts": [
+                "PREFIX=${FLATPAK_DEST}"
+            ],
+            "build-commands": [
+                "install -Dm755 -t ${FLATPAK_DEST}/styles/ style/libkvantum.so"
+            ],
+            "subdir": "Kvantum",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/tsujan/Kvantum.git",
+                    "tag": "V0.10.6"
+                }
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 org.kde.KStyle.Kvantum.appdata.xml -t ${FLATPAK_DEST}/share/appdata/"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.kde.KStyle.Kvantum.appdata.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.KStyle.Kvantum",
-    "branch": "master",
+    "branch": "5.12",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "master",
+    "runtime-version": "5.12",
     "separate-locales": false,
     "appstream-compose": false,
     "finish-args": [

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -7,6 +7,10 @@
     "runtime-version": "master",
     "separate-locales": false,
     "appstream-compose": false,
+    "finish-args": [
+        "--filesystem=xdg-config/Kvantum:ro",
+        "--filesystem=xdg-config/KvantumManagerrc:ro"
+    ],
     "modules": [
         {
             "name": "kvantum",

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -4,7 +4,7 @@
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.10",
+    "runtime-version": "master",
     "separate-locales": false,
     "appstream-compose": false,
     "modules": [

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -25,8 +25,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/tsujan/Kvantum/archive/V0.10.9.tar.gz",
-                    "sha256": "e588c2e7acbc00b2ccf197dc34e09a3bc4c1f5d4574f26b929ad372177183041"
+                    "url": "https://github.com/tsujan/Kvantum/archive/V0.11.1.tar.gz",
+                    "sha256": "c91101157873803e3365607d83d31a02e17364390f074d7defd6860ae01bdd51"
                 }
             ]
         },

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -7,10 +7,6 @@
     "runtime-version": "5.12",
     "separate-locales": false,
     "appstream-compose": false,
-    "finish-args": [
-        "--filesystem=xdg-config/Kvantum:ro",
-        "--filesystem=xdg-config/KvantumManagerrc:ro"
-    ],
     "modules": [
         {
             "name": "kvantum",

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -7,13 +7,13 @@
     "runtime-version": "5.15",
     "separate-locales": false,
     "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/share/runtime/lib/plugins/Kvantum"
+    },
     "modules": [
         {
             "name": "kvantum",
-            "buildsystem": "qmake",
-            "config-opts": [
-                "PREFIX=${FLATPAK_DEST}"
-            ],
+            "buildsystem": "cmake-ninja",
             "build-commands": [
                 "install -Dm755 -t ${FLATPAK_DEST}/styles/ style/libkvantum.so"
             ],
@@ -23,6 +23,13 @@
                     "type": "archive",
                     "url": "https://github.com/tsujan/Kvantum/archive/V0.11.1.tar.gz",
                     "sha256": "c91101157873803e3365607d83d31a02e17364390f074d7defd6860ae01bdd51"
+                },
+                {
+                    "type": "shell",
+                    "dest": "Kvantum/style",
+                    "commands": [
+                        "sed \"s|\\${_Qt5_PLUGIN_INSTALL_DIR}|${FLATPAK_DEST}|g\" -i CMakeLists.txt"
+                    ]
                 }
             ]
         },

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -22,8 +22,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/tsujan/Kvantum.git",
-                    "tag": "V0.11.1",
-                    "commit": "48e0ed857d54a4d42d1091088ead56e80f00dd0e",
+                    "tag": "V0.19.0",
+                    "commit": "b9bd0ec1507ad1d1af0fa14c2133a344783228e0",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/tsujan/Kvantum/releases/latest",

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -1,10 +1,10 @@
 {
     "id": "org.kde.KStyle.Kvantum",
-    "branch": "5.12",
+    "branch": "5.15",
     "runtime": "org.kde.Platform",
     "build-extension": true,
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.12",
+    "runtime-version": "5.15",
     "separate-locales": false,
     "appstream-compose": false,
     "modules": [

--- a/org.kde.KStyle.Kvantum.json
+++ b/org.kde.KStyle.Kvantum.json
@@ -20,9 +20,16 @@
             "subdir": "Kvantum",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/tsujan/Kvantum/archive/V0.11.1.tar.gz",
-                    "sha256": "c91101157873803e3365607d83d31a02e17364390f074d7defd6860ae01bdd51"
+                    "type": "git",
+                    "url": "https://github.com/tsujan/Kvantum.git",
+                    "tag": "V0.11.1",
+                    "commit": "48e0ed857d54a4d42d1091088ead56e80f00dd0e",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/tsujan/Kvantum/releases/latest",
+                        "tag-query": ".tag_name",
+                        "version-query": "$tag | sub(\"^[vV]\"; \"\")"
+                    }
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
Kvantum is a theme engine for Qt.
This extension would require access to `xdg-config/Kvantum` directory to work seamlessly, but I'm not sure if it's possible to apply permissions via extension.
Also 3rd-party themes installed system-wide wouldn't work, but default (those comes with Kvantum itself) and installed per-user ones work fine.
I guess multiple branches of this (e.g. 5.9 and 5.11) have to be built.