### PR TITLE
add net.danigm.timetrack

### DIFF
--- a/net.danigm.timetrack.json
+++ b/net.danigm.timetrack.json
@@ -1,9 +1,9 @@
 {
-    "app-id": "org.gnome.timetrack",
+    "app-id": "net.danigm.timetrack",
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "3.30",
     "sdk" : "org.gnome.Sdk",
-    "command" : "gnome-timetrack",
+    "command" : "timetrack",
     "finish-args" : [
         "--share=ipc",
         "--socket=x11",
@@ -23,8 +23,8 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/danigm/timetrack.git",
-                    "tag" : "3.30.0",
-                    "commit" : "b1754604c722a81e456c231deb11d8f024f6a535"
+                    "tag" : "1.0.0",
+                    "commit" : "0e0556a6e98c4376a1dae0ff83d2f5739dd75598"
                 }
             ]
         }

--- a/org.gnome.timetrack.json
+++ b/org.gnome.timetrack.json
@@ -21,7 +21,6 @@
         {
             "name" : "timetrack",
             "buildsystem" : "meson",
-            "builddir" : true,
             "sources" : [
                 {
                     "type" : "git",

--- a/org.gnome.timetrack.json
+++ b/org.gnome.timetrack.json
@@ -13,8 +13,6 @@
         "--filesystem=xdg-run/gvfs",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--talk-name=ca.desrt.dconf",
-        "--talk-name=org.gtk.vfs",
-        "--talk-name=org.gtk.vfs.*",
         "--talk-name=org.freedesktop.Notifications"
     ],
     "modules" : [

--- a/org.gnome.timetrack.json
+++ b/org.gnome.timetrack.json
@@ -1,0 +1,35 @@
+{
+    "app-id": "org.gnome.timetrack",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.30",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "gnome-timetrack",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--filesystem=xdg-run/gvfs",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=ca.desrt.dconf",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "modules" : [
+        {
+            "name" : "timetrack",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/danigm/timetrack.git",
+                    "tag" : "3.30.0",
+                    "commit" : "b1754604c722a81e456c231deb11d8f024f6a535"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is a small app to do timetrack for GNOME. This app tracks the working time and stores in a sqlite database in your system so you can view daily, weekly or monthly reports.