### PR TITLE
Add org.kde.kxstitch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.flatpak-builder/
+appdir/
+repo/
+*.flatpak

--- a/org.kde.kxstitch.yaml
+++ b/org.kde.kxstitch.yaml
@@ -1,0 +1,55 @@
+id: org.kde.kxstitch
+
+runtime: org.kde.Platform
+runtime-version: '5.12'
+sdk: org.kde.Sdk
+
+command: kxstitch
+rename-icon: kxstitch
+
+finish-args:
+  # X11 + XShm access
+  - --socket=x11
+  - --share=ipc
+  # Wayland
+  - --socket=wayland
+  # OpenGL
+  - --device=dri
+  # Connectivity
+  - --share=network
+  # Audio
+  - --socket=pulseaudio
+
+modules:
+  - name: imagemagick
+    config-opts:
+      - --disable-static
+      - --disable-docs
+      - --without-utilities
+    sources:
+      - type: archive
+        url: https://github.com/ImageMagick/ImageMagick/archive/7.0.8-25.tar.gz
+        sha256: 2ccaa0f7616289c56ba7206db60e72d0680d69393b69db8ef4f43ae85431b1f1
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - '*.la'
+
+  - name: kxstitch
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: archive
+        url: https://download.kde.org/stable/kxstitch/2.1.1/kxstitch-2.1.1.tar.xz
+        sha256: a194f366223f8eee7d93b2ace9c464c8ed968d5e928175bc4f49fbba9b4d8e15
+      - type: patch
+        paths:
+          # Fix builds on newer Qt versions
+          - patch/fix-qt5.11-build.patch
+          # Fix color selector crash
+          - patch/floss-find.patch
+    cleanup:
+      - /share/icons/hicolor/icon-theme.cache
+

--- a/patch/fix-qt5.11-build.patch
+++ b/patch/fix-qt5.11-build.patch
@@ -1,0 +1,38 @@
+From ca0f451dceecadc696ba6777084f22ceb5d372f0 Mon Sep 17 00:00:00 2001
+From: Jonathan Riddell <jr@jriddell.org>
+Date: Wed, 27 Jun 2018 16:45:16 +0100
+Subject: fix build with Qt 5.11
+
+---
+ src/LibraryPatternPropertiesDlg.cpp | 2 ++
+ src/TextElementDlg.cpp              | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/src/LibraryPatternPropertiesDlg.cpp b/src/LibraryPatternPropertiesDlg.cpp
+index 8d2e24c..c10da3f 100644
+--- a/src/LibraryPatternPropertiesDlg.cpp
++++ b/src/LibraryPatternPropertiesDlg.cpp
+@@ -11,6 +11,8 @@
+ 
+ #include "LibraryPatternPropertiesDlg.h"
+ 
++#include <QIcon>
++
+ #include <KConfigGroup>
+ #include <KHelpClient>
+ #include <KLocalizedString>
+diff --git a/src/TextElementDlg.cpp b/src/TextElementDlg.cpp
+index 4d88b1e..fb545d1 100644
+--- a/src/TextElementDlg.cpp
++++ b/src/TextElementDlg.cpp
+@@ -16,6 +16,7 @@
+ #include "TextElementDlg.h"
+ 
+ #include <QColorDialog>
++#include <QButtonGroup>
+ 
+ #include <KHelpClient>
+ #include <KLocalizedString>
+-- 
+cgit v1.1
+

--- a/patch/floss-find.patch
+++ b/patch/floss-find.patch
@@ -1,0 +1,50 @@
+From 26f7fce0508a149aefb9e9256f682abe87211760 Mon Sep 17 00:00:00 2001
+From: Steve Allewell <steve.allewell@gmail.com>
+Date: Sat, 13 Oct 2018 20:11:46 +0100
+Subject: Fix for import image failing to find a floss color
+
+Searching for a near color sometimes fails due to the distance from the
+available colors to the target color.  This fix provided by Sean Enck
+will find the nearest color within a larger target area.
+---
+ src/FlossScheme.cpp | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/src/FlossScheme.cpp b/src/FlossScheme.cpp
+index e4cd117..2df85b0 100644
+--- a/src/FlossScheme.cpp
++++ b/src/FlossScheme.cpp
+@@ -65,21 +65,23 @@ Floss *FlossScheme::find(const QColor &color) const
+ {
+     QListIterator<Floss *> flossIterator(m_flosses);
+ 
++    Floss *matched = nullptr;
++    int closest = 100;
++
+     while (flossIterator.hasNext()) {
+         Floss *floss = flossIterator.next();
+         QColor c = floss->color();
+ 
+-        if (c == color) {
+-            return floss;
+-        }
+-
+         // the color mapping may not be perfect so search for a near match.
+-        if (abs(color.red()-c.red())<2 && abs(color.green()-c.green())<2 && abs(color.blue()-c.blue())<2) {
+-            return floss;
++        int distance = abs(color.red()-c.red()) + abs(color.green()-c.green()) + abs(color.blue()-c.blue());
++
++        if (distance < closest) {
++            matched = floss;
++            closest = distance;
+         }
+     }
+ 
+-    return nullptr;
++    return matched;
+ }
+ 
+ 
+-- 
+cgit v1.1
+


### PR DESCRIPTION
Seems to work fine, although I do get an error regarding Phonon and audio:
```
❯ flatpak run org.kde.kxstitch/x86_64/master 
Warning: Ignoring XDG_SESSION_TYPE=wayland on Gnome. Use QT_QPA_PLATFORM=wayland to run on Wayland anyway.

(kxstitch:2): Gdk-WARNING **: 11:22:50.214: Failed to read portal settings: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Rozhranie „org.freedesktop.portal.Settings“ nie je v objekte na ceste /org/freedesktop/portal/desktop
Qt: Session management error: None of the authentication protocols specified are supported
QLayout: Attempting to add QLayout "" to MainWindow "MainWindow#", which already has a layout
WARNING: bool Phonon::FactoryPrivate::createBackend() phonon backend plugin could not be loaded
WARNING: Disabling PulseAudio integration for lack of GLib event loop.
WARNING: bool Phonon::FactoryPrivate::createBackend() phonon backend plugin could not be loaded
WARNING: bool Phonon::FactoryPrivate::createBackend() phonon backend plugin could not be loaded
org.kde.knotifications: Audio notification requested, but sound file from notifyrc file was not found, aborting audio notification
```

I haven’t found any instance of this on Flathub, not sure what to do with it.