### PR TITLE
Bluray plugin for VLC

### DIFF
--- a/bluray-env.sh
+++ b/bluray-env.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -z "$LIBAACS_PATH" ]; then
+  export LIBAACS_PATH=/app/share/vlc/extra/bluray/lib/libaacs
+fi
+if [ -z "$LIBBDPLUS_PATH" ]; then
+  export LIBBDPLUS_PATH=/app/share/vlc/extra/bluray/lib/libbdplus
+fi
+
+export PATH=/app/share/vlc/extra/bluray/jre/bin:$PATH
+export JAVA_HOME=/app/share/vlc/extra/bluray/jre
+export LIBBLURAY_CP=/app/share/vlc/extra/bluray/share/java/

--- a/org.videolan.VLC.Plugin.bluray.appdata.xml
+++ b/org.videolan.VLC.Plugin.bluray.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.videolan.VLC.Plugin.bluray</id>
+  <extends>org.videolan.VLC</extends>
+  <name>Bluray plugin for VLC</name>
+  <summary>Provides Blu-ray playback in VLC.</summary>
+  <description>Provides support for Bluray discs on VLC. You need a recent KEYDB.cfg in ~/.var/app/org.videolan.VLC/config/aacs to support commercial Blurays.</description>
+  <url type="homepage">https://www.videolan.org/developers/libbluray.html</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+</component>

--- a/org.videolan.VLC.Plugin.bluray.json
+++ b/org.videolan.VLC.Plugin.bluray.json
@@ -1,0 +1,144 @@
+{
+  "id": "org.videolan.VLC.Plugin.bluray",
+  "build-extension": true,
+  "runtime": "org.videolan.VLC",
+  "runtime-version": "stable",
+  "branch": "3-18.08",
+  "sdk": "org.freedesktop.Sdk//18.08",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk8"],
+  "separate-locales": false,
+  "build-options": {
+    "env": {
+      "V": "1",
+      "JAVA_HOME": "/usr/lib/sdk/openjdk8"
+    },
+    "append-path": "/usr/lib/sdk/openjdk8/bin"
+  },
+  "modules": [
+    {
+      "name": "openjdk",
+        "buildsystem": "simple",
+        "build-commands": [
+          "mkdir -p /app/share/vlc/extra/bluray/jre",
+          "cp -r /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/* /app/share/vlc/extra/bluray/jre",
+          "rm -rf /app/share/vlc/extra/bluray/jre/src.zip /app/share/vlc/extra/bluray/jre/include /app/share/vlc/extra/bluray/jre/demo /app/share/vlc/extra/bluray/jre/sample"
+        ]
+    },
+    {
+      "name": "ant",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p /app/share/vlc/extra/bluray/ant",
+        "tar xf apache-ant-bin.tar.bz2 --strip-components=1 --directory=/app/share/vlc/extra/bluray/ant"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "http://apache.mirrors.ovh.net/ftp.apache.org/dist//ant/binaries/apache-ant-1.10.5-bin.tar.bz2",
+          "dest-filename": "apache-ant-bin.tar.bz2",
+          "sha512": "a7f1e0cec9d5ed1b3ab6cddbb9364f127305a997bbc88ecd734f9ef142ec0332375e01ace3592759bb5c3307cd9c1ac0a78a30053f304c7030ea459498e4ce4e"
+        }
+      ]
+    },
+    {
+      "name": "libbluray",
+      "config-opts": ["--enable-shared", "--disable-static", "--prefix=/app/share/vlc/extra/bluray"],
+      "build-options": {
+        "append-path": "/app/share/vlc/extra/bluray/ant/bin"
+      },
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://ftp.videolan.org/videolan/libbluray/1.0.2/libbluray-1.0.2.tar.bz2",
+          "sha256": "6d9e7c4e416f664c330d9fa5a05ad79a3fb39b95adfc3fd6910cbed503b7aeff"
+        }
+      ]
+    },
+    {
+      "name": "libgpg-error",
+      "config-opts": [
+        "--with-pic",
+        "--enable-shared",
+        "--disable-static",
+        "--prefix=/app/share/vlc/extra/bluray"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.32.tar.bz2",
+          "sha256": "c345c5e73cc2332f8d50db84a2280abfb1d8f6d4f1858b9daa30404db44540ca"
+        }
+      ]
+    },
+    {
+      "name": "libgcrypt",
+      "config-opts": [
+        "--with-pic",
+        "--enable-shared",
+        "--disable-static",
+        "--prefix=/app/share/vlc/extra/bluray",
+        "--with-libgpg-error-prefix=/app/share/vlc/extra/bluray"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.4.tar.bz2",
+          "sha256": "f638143a0672628fde0cad745e9b14deb85dffb175709cacc1f4fe24b93f2227"
+        }
+      ]
+    },
+    {
+      "name": "libaacs",
+      "config-opts": [
+        "--with-pic",
+        "--enable-shared",
+        "--disable-static",
+        "--prefix=/app/share/vlc/extra/bluray",
+        "--with-libgpg-error-prefix=/app/share/vlc/extra/bluray",
+        "--with-libgcrypt-prefix=/app/share/vlc/extra/bluray"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://ftp.videolan.org/videolan/libaacs/0.9.0/libaacs-0.9.0.tar.bz2",
+          "sha256": "47e0bdc9c9f0f6146ed7b4cc78ed1527a04a537012cf540cf5211e06a248bace"
+        }
+      ]
+    },
+    {
+      "name": "libbdplus",
+      "config-opts": [
+        "--with-pic",
+        "--enable-shared",
+        "--disable-static",
+        "--prefix=/app/share/vlc/extra/bluray",
+        "--with-gpg-error-prefix=/app/share/vlc/extra/bluray",
+        "--with-libgcrypt-prefix=/app/share/vlc/extra/bluray"
+      ],
+      "build-options": {
+        "append-path": "/app/share/vlc/extra/bluray/ant/bin"
+      },
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://ftp.videolan.org/videolan/libbdplus/0.1.2/libbdplus-0.1.2.tar.bz2",
+          "sha256": "a631cae3cd34bf054db040b64edbfc8430936e762eb433b1789358ac3d3dc80a"
+        }
+      ]
+    },
+    {
+      "name": "envvars",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mv bluray-env.sh /app/share/vlc/extra/bluray",
+        "rm -rf /app/share/vlc/extra/bluray/ant"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "bluray-env.sh"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Provides Bluray disc support for playback in VLC.
Done as an extension because it needs a JVM to support some menus.