### PR TITLE
Bluray Java menus (BDJ) plugin for VLC

### DIFF
--- a/bdj-env.sh
+++ b/bdj-env.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export PATH=/app/share/vlc/extra/bdj/jre/bin:$PATH
+export JAVA_HOME=/app/share/vlc/extra/bdj/jre
+export LIBBLURAY_CP=/app/share/vlc/extra/bdj/share/java/

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-arches": ["arm"]
+}

--- a/org.videolan.VLC.Plugin.bdj.appdata.xml
+++ b/org.videolan.VLC.Plugin.bdj.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.videolan.VLC.Plugin.bdj</id>
+  <extends>org.videolan.VLC</extends>
+  <name>Bluray Java menus (BDJ) plugin for VLC</name>
+  <summary>Provides Bluray Java menus (BDJ) support in VLC.</summary>
+  <description>Provides support for Bluray Java menus (BDJ) in VLC. You need a recent KEYDB.cfg in ~/.var/app/org.videolan.VLC/config/aacs to support commercial Blurays.</description>
+  <url type="homepage">https://www.videolan.org/developers/libbluray.html</url>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+</component>

--- a/org.videolan.VLC.Plugin.bdj.json
+++ b/org.videolan.VLC.Plugin.bdj.json
@@ -1,0 +1,79 @@
+{
+  "id": "org.videolan.VLC.Plugin.bdj",
+  "build-extension": true,
+  "runtime": "org.videolan.VLC",
+  "runtime-version": "stable",
+  "branch": "3-18.08",
+  "sdk": "org.freedesktop.Sdk//18.08",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.openjdk8"],
+  "separate-locales": false,
+ "appstream-compose": false,
+  "build-options": {
+    "env": {
+      "V": "1",
+      "JAVA_HOME": "/usr/lib/sdk/openjdk8"
+    },
+    "append-path": "/usr/lib/sdk/openjdk8/bin"
+  },
+  "modules": [
+    {
+      "name": "openjdk",
+        "buildsystem": "simple",
+        "build-commands": [
+          "mkdir -p /app/share/vlc/extra/bdj/jre",
+          "cp -r /usr/lib/sdk/openjdk8/jvm/java-8-openjdk/* /app/share/vlc/extra/bdj/jre",
+          "rm -rf /app/share/vlc/extra/bdj/jre/src.zip /app/share/vlc/extra/bdj/jre/include /app/share/vlc/extra/bdj/jre/demo /app/share/vlc/extra/bdj/jre/sample"
+        ]
+    },
+    {
+      "name": "ant",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p /app/share/vlc/extra/bdj/ant",
+        "tar xf apache-ant-bin.tar.bz2 --strip-components=1 --directory=/app/share/vlc/extra/bdj/ant"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "http://apache.mirrors.ovh.net/ftp.apache.org/dist//ant/binaries/apache-ant-1.10.5-bin.tar.bz2",
+          "dest-filename": "apache-ant-bin.tar.bz2",
+          "sha512": "a7f1e0cec9d5ed1b3ab6cddbb9364f127305a997bbc88ecd734f9ef142ec0332375e01ace3592759bb5c3307cd9c1ac0a78a30053f304c7030ea459498e4ce4e"
+        }
+      ]
+    },
+    {
+      "name": "libbluray",
+      "config-opts": ["--enable-shared", "--disable-static", "--prefix=/app/share/vlc/extra/bdj"],
+      "build-options": {
+        "append-path": "/app/share/vlc/extra/bdj/ant/bin"
+      },
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://ftp.videolan.org/videolan/libbluray/1.0.2/libbluray-1.0.2.tar.bz2",
+          "sha256": "6d9e7c4e416f664c330d9fa5a05ad79a3fb39b95adfc3fd6910cbed503b7aeff"
+        }
+      ]
+    },
+    {
+      "name": "envvars",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mv bdj-env.sh /app/share/vlc/extra/bdj",
+        "rm -rf /app/share/vlc/extra/bdj/ant",
+        "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.videolan.VLC.Plugin.bdj.appdata.xml",
+        "appstream-compose --basename=org.videolan.VLC.Plugin.bdj --prefix=${FLATPAK_DEST} --origin=flatpak org.videolan.VLC.Plugin.bdj"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "bdj-env.sh"
+        },
+        {
+          "type": "file",
+          "path": "org.videolan.VLC.Plugin.bdj.appdata.xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Done as an extension because it needs a JVM.