### PR TITLE
Add a new OpenJDK 'latest' extension to follow the latest releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# SDK Extension for OpenJDK 12
+
+This extension contains the OpenJDK 12 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+
+OpenJDK 12 is the current latest (non-LTS) version.
+
+For the current long-term support (LTS) version, see the [OpenJDK 11](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11) extension.
+
+## Usage
+
+You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
+
+```
+{
+  "id" : "org.example.MyApp",
+  "branch" : "1.0",
+  "runtime" : "org.freedesktop.Platform",
+  "runtime-version" : "18.08",
+  "sdk" : "org.freedesktop.Sdk",
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
+  "modules" : [ {
+    "name" : "openjdk",
+    "buildsystem" : "simple",
+    "build-commands" : [ "/usr/lib/sdk/openjdk/install.sh" ]
+  }, {
+    "name" : "myapp",
+    "buildsystem" : "simple",
+    ....
+  } ]
+  ....
+  "finish-args" : [ "--env=PATH=/app/jre/bin:/usr/bin" ]
+}
+```

--- a/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk.appdata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.openjdk</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>0BSD AND Apache-1.1 AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FTL AND GPL-2.0 AND GPL-2.0-with-classpath-exception AND IJG AND ISC AND LGPL-2.1-or-later AND MIT AND MPL-2.0 AND RSA-MD AND SAX-PD AND W3C AND Zlib</project_license>
+  <name>OpenJDK SDK extension</name>
+  <summary>The latest version of the OpenJDK JRE and JDK</summary>
+  <description>
+    <p>
+      This SDK extension allows the building and running of Java-based applications.
+    </p>
+  </description>
+</component>

--- a/org.freedesktop.Sdk.Extension.openjdk.json
+++ b/org.freedesktop.Sdk.Extension.openjdk.json
@@ -1,0 +1,146 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.openjdk",
+    "branch": "18.08",
+    "runtime": "org.freedesktop.Sdk",
+    "runtime-version": "18.08",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.openjdk11"
+    ],
+    "separate-locales": false,
+    "appstream-compose": false,
+    "cleanup": [
+        "/share/info",
+        "/share/man"
+    ],
+    "build-options": {
+        "no-debuginfo": true,
+        "strip": true,
+        "prefix": "/usr/lib/sdk/openjdk",
+        "env": {
+            "V": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "java",
+            "buildsystem": "autotools",
+            "no-parallel-make": true,
+            "config-opts": [
+                "--with-boot-jdk=/usr/lib/sdk/openjdk11/jvm/openjdk-11",
+                "--with-jvm-variants=server",
+                "--with-version-build=32",
+                "--with-version-pre=",
+                "--with-version-opt=",
+                "--with-debug-level=release",
+                "--with-native-debug-symbols=internal",
+                "--enable-unlimited-crypto",
+                "--with-zlib=system",
+                "--with-libjpeg=system",
+                "--with-giflib=system",
+                "--with-libpng=system",
+                "--with-lcms=system",
+                "--with-stdc++lib=dynamic",
+                "--with-extra-cxxflags=-O2 -g -Wno-error -std=gnu++98 -fno-delete-null-pointer-checks -fno-lifetime-dse",
+                "--with-extra-cflags=-O2 -g -fstack-protector-strong -Wno-error -fno-delete-null-pointer-checks -fno-lifetime-dse -fpermissive",
+                "--with-extra-ldflags=-Wl,-z,relro -Wl,-z,now",
+                "--disable-javac-server",
+                "--disable-warnings-as-errors"
+            ],
+            "make-args": [
+                "JAVAC_FLAGS=-g",
+                "LOG=trace",
+                "WARNINGS_ARE_ERRORS=-Wno-error",
+                "CFLAGS_WARNINGS_ARE_ERRORS=-Wno-error",
+                "images"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://hg.openjdk.java.net/jdk/jdk12/archive/jdk-12+32.tar.gz",
+                    "sha512": "f95ee88ef1c2f3fe27aa07a808b9f52683918629a28f8451defd6bc4a194e69d85108fceefc2a61f914963f17489f8d4533f76ede73926600bb43123c9aa98fe"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "chmod a+x configure"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "maven",
+            "buildsystem": "simple",
+            "cleanup": [
+                "*.cmd"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "http://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz",
+                    "dest-filename": "apache-maven-bin.tar.gz",
+                    "sha512": "fae9c12b570c3ba18116a4e26ea524b29f7279c17cbaadc3326ca72927368924d9131d11b9e851b8dc9162228b6fdea955446be41207a5cfc61283dd8a561d2f"
+                }
+            ],
+            "build-commands": [
+                "mkdir -p $FLATPAK_DEST/maven",
+                "tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native --directory=$FLATPAK_DEST/maven",
+                "ln -s $FLATPAK_DEST/maven/bin/mvn $FLATPAK_DEST/maven/bin/mvnDebug $FLATPAK_DEST/bin"
+            ]
+        },
+        {
+            "name": "scripts",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/jre/bin",
+                        "cd /usr/lib/sdk/openjdk/jvm/openjdk-12",
+                        "cp -ra conf lib /app/jre/",
+                        "rm /app/jre/lib/src.zip /app/jre/lib/ct.sym",
+                        "cp -ra bin/{java,jjs,keytool,pack200,rmid,rmiregistry,unpack200} /app/jre/bin"
+                    ],
+                    "dest-filename": "install.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "mkdir -p /app/jdk/",
+                        "cd /usr/lib/sdk/openjdk/jvm/openjdk-12",
+                        "cp -ra bin conf include lib /app/jdk/"
+                    ],
+                    "dest-filename": "installjdk.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "export JAVA_HOME=/usr/lib/sdk/openjdk/jvm/openjdk-12",
+                        "export PATH=$PATH:/usr/lib/sdk/openjdk/bin"
+                    ],
+                    "dest-filename": "enable.sh"
+                }
+            ],
+            "build-commands": [
+                "(cd /usr/lib/sdk/openjdk/jvm && ln -s openjdk-12.0.0 openjdk-12)",
+                "cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk/"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.openjdk.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.openjdk"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.openjdk.appdata.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.Sdk.Extension.openjdk.json
+++ b/org.freedesktop.Sdk.Extension.openjdk.json
@@ -30,7 +30,7 @@
             "config-opts": [
                 "--with-boot-jdk=/usr/lib/sdk/openjdk11/jvm/openjdk-11",
                 "--with-jvm-variants=server",
-                "--with-version-build=32",
+                "--with-version-build=33",
                 "--with-version-pre=",
                 "--with-version-opt=",
                 "--with-debug-level=release",
@@ -58,8 +58,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://hg.openjdk.java.net/jdk/jdk12/archive/jdk-12+32.tar.gz",
-                    "sha512": "f95ee88ef1c2f3fe27aa07a808b9f52683918629a28f8451defd6bc4a194e69d85108fceefc2a61f914963f17489f8d4533f76ede73926600bb43123c9aa98fe"
+                    "url": "https://hg.openjdk.java.net/jdk/jdk12/archive/jdk-12+33.tar.gz",
+                    "sha512": "5d391bd616ca9579d65481d72cbb4b5af14ce62ef4282c6cb7a0f9d1d057b83652e1a7bc459241ec989c6c1576500cc8665b1e148cd31545093f814167acd316"
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
Going forward, OpenJDK releases will be frequent and short-lived, so
this extension is for tracking the short-lived latest releases.

This is as opposed LTS (long-term support) releases like the OpenJDK
11 extension, which will be kept separate.

Signed-off-by: Mat Booth <mat.booth@redhat.com>