### PR TITLE
README.md: send people looking for website repo to linux-store-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Contributing to Flathub
 -----------------------
 
 For information on creating packages or reporting issues please see the [contributing page](/CONTRIBUTING.md).
+
+***Note:*** *this repository is not for reporting issues related to the flathub.org website itself or contributing to its development. For that, go to https://github.com/flathub/linux-store-frontend*


### PR DESCRIPTION
I almost opened an issue here due to misunderstanding what this repo is for, figured a small clarification in README.md would save everyone some hassle if something similar would happen in the future.

(Would it make sense to also do this in the description of the repo?)

See also: https://github.com/flathub/linux-store-frontend/issues/167