### PR TITLE
add com.toggl.TogglDesktop

### DIFF
--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -20,7 +20,7 @@
     "modules": [
         {
             "name": "TogglDesktop",
-            "buildsystem": "cmake",
+            "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DTOGGL_VERSION=7.4.356",
@@ -31,7 +31,7 @@
                 {
                     "type": "git",
                     "url": "http://github.com/toggl/toggldesktop",
-		    "tag": "v7.4.356"
+                    "tag": "v7.4.356"
                 }
             ]
         }

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -1,7 +1,7 @@
 {
     "id": "com.toggl.TogglDesktop",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.11",
+    "runtime-version": "5.12",
     "sdk": "org.kde.Sdk",
     "rename-desktop-file": "toggldesktop.desktop",
     "rename-appdata-file": "toggldesktop.appdata.xml",

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -1,0 +1,39 @@
+{
+    "id": "com.toggl.TogglDesktop",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.11",
+    "sdk": "org.kde.Sdk",
+    "rename-desktop-file": "toggldesktop.desktop",
+    "rename-appdata-file": "toggldesktop.appdata.xml",
+    "rename-icon": "toggldesktop",
+    "command": "TogglDesktop.sh",
+    "finish-args": [
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host",
+        "--share=network",
+        "--share=ipc",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "modules": [
+        {
+            "name": "TogglDesktop",
+            "buildsystem": "cmake",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DTOGGL_VERSION=7.4.356",
+                "-DTOGGL_PRODUCTION_BUILD=ON",
+                "-DTOGGL_ALLOW_UPDATE_CHECK=ON"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "http://github.com/toggl/toggldesktop",
+		    "tag": "v7.4.356"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi, I'm submitting a flatpak manifest for the Toggl Desktop application.
Toggl is a time tracking and productivity software and the desktop application is released under the BSD license.