### PR TITLE
Add org.bluej.BlueJ

### DIFF
--- a/bluej
+++ b/bluej
@@ -1,0 +1,7 @@
+#!/bin/sh
+APPBASE="/app/bluej"
+JAVAPATH="/app/jre"
+JAVAFX_LIB="/app/javafx/lib"
+CP="$APPBASE/lib/bluej.jar"
+JAVAFX_CP="$JAVAFX_LIB/javafx.base.jar:$JAVAFX_LIB/javafx.controls.jar:$JAVAFX_LIB/javafx.fxml.jar:$JAVAFX_LIB/javafx.graphics.jar:$JAVAFX_LIB/javafx.media.jar:$JAVAFX_LIB/javafx.properties.jar:$JAVAFX_LIB/javafx.swing.jar:$JAVAFX_LIB/javafx.web.jar"
+"$JAVAPATH/bin/java" -Djavafx.embed.singleThread=true -Dawt.useSystemAAFontSettings=on -cp "$CP:$JAVAFX_CP" bluej.Boot  "$@"

--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -4,7 +4,7 @@
   <name>BlueJ</name>
   <developer_name>King's College London</developer_name>
   <summary>Java IDE for beginners</summary>
-  <metadata_license>CC0-1.0</metadata_license>
+  <metadata_license>GPL-2.0-with-classpath-exception</metadata_license>
   <project_license>GPL-2.0-with-classpath-exception</project_license>
   <url type="homepage">https://bluej.org</url>
   <description><p>BlueJ is a development environment that allows you to develop Java programs quickly and easily. Its main features are that it is simple, designed for teaching, interactive, portable, mature and innovative.</p></description>
@@ -36,4 +36,5 @@
     <release date="2019-02-07" version="4.2.0"/>
   </releases>
   <update_contact>florian.schallenberg@googlemail.com</update_contact>
+  <content_rating type="oars-1.1"></content_rating>
 </component>

--- a/org.bluej.BlueJ.appdata.xml
+++ b/org.bluej.BlueJ.appdata.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.bluej.BlueJ</id>
+  <name>BlueJ</name>
+  <developer_name>King's College London</developer_name>
+  <summary>Java IDE for beginners</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-with-classpath-exception</project_license>
+  <url type="homepage">https://bluej.org</url>
+  <description><p>BlueJ is a development environment that allows you to develop Java programs quickly and easily. Its main features are that it is simple, designed for teaching, interactive, portable, mature and innovative.</p></description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Scope Highlighting</caption>
+      <image>https://www.bluej.org/scope-highlighting.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Object Inspection</caption>
+      <image>https://www.bluej.org/object-inspection.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Method Invocation</caption>
+      <image>https://www.bluej.org/method-invocation.png</image>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Development</category>
+    <category>Education</category>
+  </categories>
+  <icon type="remote" height="256" width="256">https://www.bluej.org/bluej-icons/bluej-256.jpg</icon>
+  <icon type="remote" height="128" width="128">https://www.bluej.org/bluej-icons/bluej-128.jpg</icon>
+  <icon type="remote" height="64" width="64">https://www.bluej.org/bluej-icons/bluej-64.jpg</icon>
+  <kudos>
+    <kudo>HiDpiIcon</kudo>
+  </kudos>
+  <releases>
+    <release date="2019-02-07" version="4.2.0"/>
+  </releases>
+  <update_contact>florian.schallenberg@googlemail.com</update_contact>
+</component>

--- a/org.bluej.BlueJ.desktop
+++ b/org.bluej.BlueJ.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=BlueJ
+Exec=org.bluej.BlueJ
+Type=Application
+Icon=org.bluej.BlueJ
+Categories=Development;Education;

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -1,11 +1,23 @@
 {
   "app-id" : "org.bluej.BlueJ",
-  "branch" : "4.2.0",
+  "branch" : "stable",
   "runtime" : "org.gnome.Platform",
   "runtime-version" : "3.30",
   "sdk" : "org.gnome.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk11" ],
   "command": "org.bluej.BlueJ",
+  "finish-args" : [
+    "--env=PATH=/app/jre/bin:/usr/bin:/app/bin",
+    "--share=network",
+    "--socket=x11",
+    "--share=ipc",
+    "--socket=wayland",
+    "--device=dri",
+    "--socket=pulseaudio",
+    "--filesystem=host",
+    "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+    "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+  ],
   "modules" : [
     {
       "name" : "openjdk",
@@ -57,17 +69,5 @@
         "path": "org.bluej.BlueJ.appdata.xml"
       }]
     }
-  ],
-  "finish-args" : [
-    "--env=PATH=/app/jre/bin:/usr/bin:/app/bin",
-    "--share=network",
-    "--socket=x11",
-    "--share=ipc",
-    "--socket=wayland",
-    "--device=dri",
-    "--socket=pulseaudio",
-    "--filesystem=host",
-    "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
-    "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   ]
 }

--- a/org.bluej.BlueJ.json
+++ b/org.bluej.BlueJ.json
@@ -1,0 +1,73 @@
+{
+  "app-id" : "org.bluej.BlueJ",
+  "branch" : "4.2.0",
+  "runtime" : "org.gnome.Platform",
+  "runtime-version" : "3.30",
+  "sdk" : "org.gnome.Sdk",
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk11" ],
+  "command": "org.bluej.BlueJ",
+  "modules" : [
+    {
+      "name" : "openjdk",
+      "buildsystem" : "simple",
+      "build-commands" : [ "/usr/lib/sdk/openjdk11/install.sh" ]
+    },
+    {
+      "name" : "javafx",
+      "buildsystem" : "simple",
+      "build-commands": ["mkdir -p /app/javafx", "cp -r ./ /app/javafx"],
+      "sources": [{
+        "type": "archive",
+        "url": "https://download2.gluonhq.com/openjfx/11.0.2/openjfx-11.0.2_linux-x64_bin-sdk.zip",
+        "sha256": "40ef06cd50ea535d45403d9c44e9cb405b631c547734b5b50a6cb7b222293f97"
+      }]
+    },
+    {
+      "name": "bluej",
+      "buildsystem": "simple",
+      "build-commands": [
+        "unzip bluej-dist.jar -d dist",
+        "mkdir -p /app/bluej",
+        "cp -r dist/* /app/bluej",
+        "for size in 32 48 256; do install -Dm644 /app/bluej/lib/images/bluej-icon-${size}.png /app/share/icons/hicolor/${size}x${size}/apps/org.bluej.BlueJ.png; done"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "http://www.bluej.org/download/files/BlueJ-generic-420.jar",
+        "dest-filename": "BlueJ-generic-420.zip",
+        "sha256": "3d10306340f74e22885f2a5f939cb1b19cbc2e048c9e6e22418627ae5833c56f"
+      }]
+    },
+    {
+      "name": "bluej-startup",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm755 bluej /app/bin/org.bluej.BlueJ",
+        "install -Dm644 org.bluej.BlueJ.desktop /app/share/applications/org.bluej.BlueJ.desktop",
+        "install -Dm644 org.bluej.BlueJ.appdata.xml /app/share/metainfo/org.bluej.BlueJ.appdata.xml"
+      ],
+      "sources": [{
+        "type": "file",
+        "path": "bluej"
+      },{
+        "type": "file",
+        "path": "org.bluej.BlueJ.desktop"
+      },{
+        "type": "file",
+        "path": "org.bluej.BlueJ.appdata.xml"
+      }]
+    }
+  ],
+  "finish-args" : [
+    "--env=PATH=/app/jre/bin:/usr/bin:/app/bin",
+    "--share=network",
+    "--socket=x11",
+    "--share=ipc",
+    "--socket=wayland",
+    "--device=dri",
+    "--socket=pulseaudio",
+    "--filesystem=host",
+    "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+    "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+  ]
+}


### PR DESCRIPTION
I'd like to add BlueJ, an educational Java IDE that is frequently used in schools, to Flathub.

The pull request contains (in addition to the manifest and appdata):
- bluej: launcher script that would otherwise be generated by the official installer
- desktop file, which is not provided by the official installer.