### PR TITLE
Add jp.yvt.OpenSpades

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/disable-nonfree-download.patch
+++ b/disable-nonfree-download.patch
@@ -1,0 +1,34 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5cc2d18..e6f98cc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -226,13 +226,11 @@ if(UNIX AND NOT APPLE)
+ 	if(OPENSPADES_RESOURCES)
+ 		# install asset paks (including non-GPL one)
+ 		install(FILES
+-			${CMAKE_BINARY_DIR}/Resources/pak000-Nonfree.pak
+ 			${CMAKE_BINARY_DIR}/Resources/pak002-Base.pak
+ 			${CMAKE_BINARY_DIR}/Resources/pak005-Models.pak
+ 			${CMAKE_BINARY_DIR}/Resources/pak010-BaseSkin.pak
+ 			${CMAKE_BINARY_DIR}/Resources/pak050-Locales.pak
+ 			${CMAKE_BINARY_DIR}/Resources/pak999-References.pak
+-			${CMAKE_BINARY_DIR}/Resources/font-unifont.pak
+ 			DESTINATION ${OPENSPADES_INSTALL_RESOURCES})
+ 	endif(OPENSPADES_RESOURCES)
+ 
+diff --git a/Resources/CMakeLists.txt b/Resources/CMakeLists.txt
+index 1f9b514..34010fa 100644
+--- a/Resources/CMakeLists.txt
++++ b/Resources/CMakeLists.txt
+@@ -4,11 +4,6 @@ if(OPENSPADES_RESOURCES)
+ 	if (WIN32)
+ 		# No automatic downloading for Windows (for now)
+ 	elseif (UNIX)
+-		add_custom_target(OpenSpades_Resources_DevPaks ALL COMMENT "Downloading non-GPL assets")
+-		add_custom_command(
+-			TARGET OpenSpades_Resources_DevPaks
+-			COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/downloadpak.sh
+-			WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+ 	endif()
+ 
+# TODO: subgroups for script files

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-arches": ["arm"]
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "skip-arches": ["arm"]
+  "skip-arches": ["arm", "aarch64"]
 }

--- a/jp.yvt.OpenSpades.appdata.xml
+++ b/jp.yvt.OpenSpades.appdata.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>jp.yvt.OpenSpades.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <project_license>OpenSpades Non-GPL Pak License</project_license>
+  <name>OpenSpades</name>
+
+  <summary>Open Source voxel shooter</summary>
+
+  <description>
+    <p> OpenSpades is a clone of Ace of Spades 0.75, which is a free online
+    first-person shooter created by Ben Aksoy, featuring fully destructible
+    terrain and plenty of game modes (including the well-known Capture the
+    Flag) created by the community.</p>
+    <ul>
+      <li>Can connect to a vanilla/pyspades/pysnip server</li>
+      <li>Uses OpenGL/AL for better experience</li>
+      <li>Open source, and cross platform</li>
+    </ul>
+  </description>
+
+  <categories>
+    <category>Game</category>
+    <category>Shooter</category>
+  ​</categories>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
+
+  <launchable type="desktop-id">jp.yvt.OpenSpades.desktop</launchable>
+
+  <url type="homepage">http://openspades.yvt.jp/</url>
+  <url type="bugtracker">https://github.com/yvt/openspades/issues</url>
+  <url type="translate">https://crowdin.com/project/openspades</url>
+  
+  <screenshots>
+    <screenshot type="default">
+      <image>http://openspades.yvt.jp/media/images/ss4.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://openspades.yvt.jp/media/images/ss5.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://openspades.yvt.jp/media/images/ss6.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://openspades.yvt.jp/media/images/ss1.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://openspades.yvt.jp/media/images/ss2.jpg</image>
+    </screenshot>
+    <screenshot>
+      <image>http://openspades.yvt.jp/media/images/ss3.jpg</image>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.1.3" date="2019-01-04">
+      <description>
+        This release contains minor fixes since the previous version 0.1.2.
+      </description>
+    </release>
+    <release version="0.1.2" date="2018-01-01">
+      <description>
+        This release contains minor fixes since the previous version 0.1.1c.
+      </description>
+    </release>
+    <release version="0.1.1c" date="2017-03-04">
+      <description>
+        Contains minor or critical fixes since the previous version 0.1.1b.
+      </description>
+    </release>
+  </releases>
+</component>

--- a/jp.yvt.OpenSpades.appdata.xml
+++ b/jp.yvt.OpenSpades.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-  <id>jp.yvt.OpenSpades.desktop</id>
+  <id>jp.yvt.OpenSpades</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <project_license>OpenSpades Non-GPL Pak License</project_license>

--- a/jp.yvt.OpenSpades.json
+++ b/jp.yvt.OpenSpades.json
@@ -1,0 +1,114 @@
+{
+  "app-id": "jp.yvt.OpenSpades",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "18.08",
+  "sdk": "org.freedesktop.Sdk",
+  "command": "openspades",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=pulseaudio",
+    "--socket=wayland",
+    "--share=network",
+    "--device=dri",
+    "--extension=org.freedesktop.Platform.GL=directory=lib/GL",
+    "--persist=.local/share/openspades"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig"
+  ],
+  "modules": [
+    "shared-modules/glew/glew.json",
+    {
+      "name": "opus",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://archive.mozilla.org/pub/opus/opus-1.3.tar.gz",
+          "sha256": "4f3d69aefdf2dbaf9825408e452a8a414ffc60494c70633560700398820dc550"
+        }
+      ]
+    },
+    {
+      "name": "opusfile",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/xiph/opusfile/releases/download/v0.10/opusfile-0.10.tar.gz",
+          "sha256": "48e03526ba87ef9cf5f1c47b5ebe3aa195bd89b912a57060c36184a6cd19412f"
+        }
+      ]
+    },
+    {
+      "name": "imagemagick",
+      "cleanup": [
+        "/bin",
+        "/etc",
+        "/share",
+        "/lib"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://imagemagick.org/download/ImageMagick-6.9.10-35.tar.gz",
+          "sha256": "3b8bc2a6fae0e4955e2d2ef4d07052c610d21432f982e2102162a0b6c7e8dec3"
+        }
+      ]
+    },
+    {
+      "name": "openspades",
+      "buildsystem": "cmake",
+      "config-opts": [
+        "-DOPENSPADES_INSTALL_BINARY=bin",
+        "-DOPENSPADES_RESDIR=/app/extra/Resources/",
+        "-DCMAKE_CXX_FLAGS=-DGLEW_NO_GLU",
+        "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+      ],
+      "post-install": [
+        "mv /app/share/applications/openspades.desktop /app/share/applications/jp.yvt.OpenSpades.desktop",
+        "mkdir -p /app/share/appdata/",
+        "install -Dm0644 jp.yvt.OpenSpades.appdata.xml /app/share/appdata/jp.yvt.OpenSpades.appdata.xml",
+        "install -D apply_extra /app/bin/apply_extra"
+      ],
+      "sources": [
+        {
+          "type": "script",
+          "dest-filename": "apply_extra",
+          "commands": [
+            "unzip -q nonfree-paks.zip",
+            "rm nonfree-paks.zip",
+            "mkdir Resources",
+            "mv Nonfree/* ./Resources",
+            "mv OfficialMods/* ./Resources",
+            "rmdir Nonfree OfficialMods"
+          ]
+        },
+        {
+          "type": "archive",
+          "url": "https://github.com/yvt/openspades/archive/v0.1.3.tar.gz",
+          "sha256": "ecd7aaf568f80712d981ecdd7bf9e380221dc2c16e86d2e56a0ddda87432bea3"
+        },
+        {
+          "type": "patch",
+          "path": "use-xdg-icon-name.patch"
+        },
+        {
+          "type": "patch",
+          "path": "disable-nonfree-download.patch"
+        },
+        {
+          "type": "file",
+          "path": "jp.yvt.OpenSpades.appdata.xml"
+        },
+        {
+          "type": "extra-data",
+          "filename": "nonfree-paks.zip",
+          "url": "https://github.com/yvt/openspades-paks/releases/download/r33/OpenSpadesDevPackage-r33.zip",
+          "sha256": "0927dc323a0b3aba0ee8d1d68d6b544b00fe654740fead6d1faad37aac77a2ad",
+          "size": 4036321
+        }
+      ]
+    }
+  ]
+}

--- a/use-xdg-icon-name.patch
+++ b/use-xdg-icon-name.patch
@@ -1,0 +1,25 @@
+diff --git a/Resources/Icons/converticons.sh b/Resources/Icons/converticons.sh
+index 1e8dc9b..46d504f 100755
+--- a/Resources/Icons/converticons.sh
++++ b/Resources/Icons/converticons.sh
+@@ -21,7 +21,7 @@ rm tmp/40x40.png # nobody uses icons with such res
+ for fn in tmp/*.png; do
+ 	RES=$( basename $fn | sed 's/.png//' )
+ 	mkdir -p "$OUTPUT_DIR/$RES/apps"
+-	mv $fn "$OUTPUT_DIR/$RES/apps/openspades.png"
++	mv $fn "$OUTPUT_DIR/$RES/apps/jp.yvt.OpenSpades.png"
+ done
+ 
+ rm -rf tmp/
+diff --git a/Resources/Unix/Desktop/openspades.desktop b/Resources/Unix/Desktop/openspades.desktop
+index 985d474..2a7809c 100644
+--- a/Resources/Unix/Desktop/openspades.desktop
++++ b/Resources/Unix/Desktop/openspades.desktop
+@@ -7,6 +7,6 @@ Name=OpenSpades
+ GenericName=Sandbox building and FPS videogame
+ Comment=Open-source clone of Ace of Spades
+ Keywords=game;fps;sandbox;voxel;aos;
+-Icon=openspades
++Icon=jp.yvt.OpenSpades
+ Categories=Game;ActionGame;
+MimeType=x-scheme-handler/aos;


### PR DESCRIPTION
OpenSpades is an open-source clone of Ace of Spades

I am not the original developer of this project but because no one has added it to Flathub, I thought I would go ahead and do it. The flatpak manifest file(s) are in the openspades branch. If anything is missing, some other files are here.

Credit goes to @kdeleteme and @theunknownxy for creating the manifest file. I have made a few changes to fix compatibility with different versions of ImageMagick. (https://github.com/yvt/openspades/blob/master/flatpak/jp.yvt.OpenSpades.json)

(This is the main PR for OpenSpades)