### PR TITLE
Add com.github.debauchee.barrier

### DIFF
--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -1,0 +1,101 @@
+<!-- https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html -->
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.github.debauchee.barrier</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Barrier</name>
+  <!-- From the Github repo -->
+  <summary>Open-source KVM software</summary>
+  <description>
+  What is it?
+
+  Barrier is KVM software forked from Symless's synergy 1.9 codebase. Synergy was a commercialized reimplementation of the original CosmoSynergy written by Chris Schoeneman.
+
+  What's different?
+
+  Whereas synergy has moved beyond its goals from the 1.x era, Barrier aims to maintain that simplicity. Barrier will let you use your keyboard and mouse from machine A to control machine B (or more). It's that simple.
+
+  Project goals
+
+  Hassle-free reliability. We are users, too. Barrier was created so that we could solve the issues we had with synergy and then share these fixes with other users.
+
+  Compatibility. We use more than one operating system and you probably do, too. Windows, OSX, Linux, FreeBSD... Barrier should "just work". We will also have our eye on Wayland when the time comes.
+
+  Communication. Everything we do is in the open. Our issue tracker will let you see if others are having the same problem you're having and will allow you to add additional information. You will also be able to see when progress is made and how the issue gets resolved.
+
+  Contact & support
+
+  Please be aware that the only way to draw our attention to a bug is to create a new PR in the issue tracker. Write a clear, concise, detailed report and you will get a clear, concise, detailed response. Priority is always given to issues that affect a wider range of users.
+
+  For short and simple questions or to just say hello find us on the Freenode IRC network in the #barrier channel.
+
+  Contributions
+
+  At this time we are looking for developers to help fix the issues found in the issue tracker. Submit pull requests once you've polished up your patch and we'll review and possibly merge it.
+  </description>
+  <!-- https://specifications.freedesktop.org/menu-spec/latest/apa.html -->
+  <!-- https://specifications.freedesktop.org/menu-spec/latest/apas02.html -->
+  <categories>
+    <category>Network</category>
+  </categories>
+  <url type="homepage">https://github.com/debauchee/barrier/</url>
+  <url type="bugtracker">https://github.com/debauchee/barrier/issues/</url>
+  <launchable type="desktop-id">com.github.debauchee.barrier.desktop</launchable>
+ 
+  <releases>
+    <release date="2019-01-11" version="2.1.2" urgency="medium" />
+    <release date="2018-07-02" version="2.1.1" urgency="medium" />
+  </releases>
+ 
+  <project_group>Debauchee</project_group>
+  <project_license>GPL-2.0</project_license>
+  <developer_name>Siix</developer_name>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main application window</caption>
+      <image type="source">https://i.imgur.com/hTlK5Sp.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The Server Configuration window</caption>
+      <image type="source">https://i.imgur.com/JmzUSbh.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The Settings menu</caption>
+      <image type="source">https://i.imgur.com/YueKkh4.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <update_contact>adrianlucrececeleste@airmail.cc</update_contact>
+ 
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+ 
+</component>

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -35,9 +35,6 @@
   </description>
   <!-- https://specifications.freedesktop.org/menu-spec/latest/apa.html -->
   <!-- https://specifications.freedesktop.org/menu-spec/latest/apas02.html -->
-  <categories>
-    <category>Network</category>
-  </categories>
   <url type="homepage">https://github.com/debauchee/barrier/</url>
   <url type="bugtracker">https://github.com/debauchee/barrier/issues/</url>
   <launchable type="desktop-id">com.github.debauchee.barrier.desktop</launchable>
@@ -71,34 +68,5 @@
   
   <update_contact>adrianlucrececeleste@airmail.cc</update_contact>
  
-  <content_rating type="oars-1.1">
-    <content_attribute id="violence-cartoon">none</content_attribute>
-    <content_attribute id="violence-fantasy">none</content_attribute>
-    <content_attribute id="violence-realistic">none</content_attribute>
-    <content_attribute id="violence-bloodshed">none</content_attribute>
-    <content_attribute id="violence-sexual">none</content_attribute>
-    <content_attribute id="violence-desecration">none</content_attribute>
-    <content_attribute id="violence-slavery">none</content_attribute>
-    <content_attribute id="violence-worship">none</content_attribute>
-    <content_attribute id="drugs-alcohol">none</content_attribute>
-    <content_attribute id="drugs-narcotics">none</content_attribute>
-    <content_attribute id="drugs-tobacco">none</content_attribute>
-    <content_attribute id="sex-nudity">none</content_attribute>
-    <content_attribute id="sex-themes">none</content_attribute>
-    <content_attribute id="sex-homosexuality">none</content_attribute>
-    <content_attribute id="sex-prostitution">none</content_attribute>
-    <content_attribute id="sex-adultery">none</content_attribute>
-    <content_attribute id="sex-appearance">none</content_attribute>
-    <content_attribute id="language-profanity">none</content_attribute>
-    <content_attribute id="language-humor">none</content_attribute>
-    <content_attribute id="language-discrimination">none</content_attribute>
-    <content_attribute id="social-chat">none</content_attribute>
-    <content_attribute id="social-info">none</content_attribute>
-    <content_attribute id="social-audio">none</content_attribute>
-    <content_attribute id="social-location">none</content_attribute>
-    <content_attribute id="social-contacts">none</content_attribute>
-    <content_attribute id="money-purchasing">none</content_attribute>
-    <content_attribute id="money-gambling">none</content_attribute>
-  </content_rating>
- 
+  <content_rating type="oars-1.1" />
 </component>

--- a/com.github.debauchee.barrier.appdata.xml
+++ b/com.github.debauchee.barrier.appdata.xml
@@ -23,7 +23,7 @@
 
   Communication. Everything we do is in the open. Our issue tracker will let you see if others are having the same problem you're having and will allow you to add additional information. You will also be able to see when progress is made and how the issue gets resolved.
 
-  Contact & support
+  Contact &amp; support
 
   Please be aware that the only way to draw our attention to a bug is to create a new PR in the issue tracker. Write a clear, concise, detailed report and you will get a clear, concise, detailed response. Priority is always given to issues that affect a wider range of users.
 
@@ -50,6 +50,9 @@
   <project_group>Debauchee</project_group>
   <project_license>GPL-2.0</project_license>
   <developer_name>Siix</developer_name>
+
+  <translation type="gettext">avahi</translation>
+  <launchable type="desktop-id">barrier.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -14,11 +14,6 @@
         "--system-talk-name=org.freedesktop.Avahi",
         "--device=dri"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g"
-
-    },
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -63,7 +63,14 @@
                     "url" : "https://github.com/debauchee/barrier.git",
                     "tag" : "v2.1.2",
                     "commit" : "53ebc47ace7486d0b7ba975e58506c4a9f28acd6"
+                },
+                {
+                    "type" : "file",
+                    "path" : "com.github.debauchee.barrier.appdata.xml"
                 }
+            ],
+            "post-install": [
+                "install -Dm644 com.github.debauchee.barrier.appdata.xml /app/share/metainfo/com.github.debauchee.barrier.appdata.xml"
             ]
         }
     ]

--- a/com.github.debauchee.barrier.json
+++ b/com.github.debauchee.barrier.json
@@ -1,0 +1,75 @@
+{
+    "app-id" : "com.github.debauchee.barrier",
+    "runtime" : "org.kde.Platform",
+    "runtime-version" : "5.12",
+    "sdk" : "org.kde.Sdk",
+    "command" : "barrier",
+    "rename-icon" : "barrier",
+    "rename-desktop-file" : "barrier.desktop",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--share=network",
+        "--talk-name=org.a11y.*",
+        "--system-talk-name=org.freedesktop.Avahi",
+        "--device=dri"
+    ],
+    "build-options" : {
+        "cflags" : "-O2 -g",
+        "cxxflags" : "-O2 -g"
+
+    },
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "avahi",
+            "config-opts" : [
+                "--disable-libdaemon",
+                "--enable-compat-libdns_sd",
+                "--disable-python",
+                "--disable-doxygen-doc",
+                "--with-distro=none",
+                "--disable-glib",
+                "--disable-gobject",
+                "--disable-introspection",
+                "--disable-gtk",
+                "--disable-gtk3",
+                "--disable-qt3",
+                "--disable-qt4",
+                "--disable-mono",
+                "--disable-monodoc",
+                "--disable-manpages",
+                "--disable-xmltoman",
+                "--disable-utils"
+            ],
+            "cleanup" : [
+                "/bin"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/lathiat/avahi/releases/download/v0.7/avahi-0.7.tar.gz",
+                    "sha256" : "57a99b5dfe7fdae794e3d1ee7a62973a368e91e414bd0dfa5d84434de5b14804"
+                }
+            ]
+        },
+        {
+            "name" : "barrier",
+            "buildsystem" : "cmake-ninja",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/debauchee/barrier.git",
+                    "tag" : "v2.1.2",
+                    "commit" : "53ebc47ace7486d0b7ba975e58506c4a9f28acd6"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Trying to put this up on flathub, should make it more maintainable in the long run (rather than having it in our own repo).

Does:
- Build (on every architecture, last time I tested)
- Pass `appstream-util validate-relax`
- Run

Doesn't:
- Currently run on wayland

Having trouble with:
- I've noticed an issue where apparently an application entry isn't installed into the launcher.