### PR TITLE
Added org.gnome.Notes

### DIFF
--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -1,0 +1,147 @@
+{
+    "app-id" : "org.gnome.Notes",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.32",
+    "branch" : "stable",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "bijiben",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--share=network",
+        "--talk-name=org.gtk.vfs",
+        "--talk-name=org.gtk.vfs.*",
+        "--filesystem=host",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--talk-name=org.gnome.OnlineAccounts",
+        "--talk-name=org.gnome.evolution.dataserver.AddressBook9",
+        "--talk-name=org.gnome.evolution.dataserver.Calendar7",
+        "--talk-name=org.gnome.evolution.dataserver.Sources5",
+        "--talk-name=org.gnome.evolution.dataserver.Subprocess.Backend.*"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "gnome-online-accounts",
+            "config-opts" : [
+                "--disable-Werror",
+                "--disable-documentation",
+                "--disable-backend"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gnome-online-accounts/3.32/gnome-online-accounts-3.32.0.tar.xz",
+                    "sha256" : "1c19e65771c8d16fa0016ab70d9a1ee2b75a84aeeedd24527a4e41b132e8d4aa"
+                }
+            ]
+        },
+        {
+            "name" : "libical",
+            "cleanup" : [
+                "/lib/cmake"
+            ],
+            "buildsystem" : "cmake",
+            "config-opts" : [
+                "-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib",
+                "-DBUILD_SHARED_LIBS:BOOL=ON"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/libical/libical/releases/download/v3.0.3/libical-3.0.3.tar.gz",
+                    "sha256" : "5b91eb8ad2d2dcada39d2f81d5e3ac15895823611dc7df91df39a35586f39241"
+                }
+            ]
+        },
+        {
+            "name" : "evolution-data-server",
+            "cleanup" : [
+                "/lib/cmake",
+                "/lib/evolution-data-server/*-backends",
+                "/libexec",
+                "/share/dbus-1/services"
+            ],
+            "buildsystem" : "cmake",
+            "config-opts" : [
+                "-DENABLE_GTK=ON",
+                "-DENABLE_GOOGLE_AUTH=OFF",
+                "-DENABLE_UOA=OFF",
+                "-DENABLE_GOOGLE=OFF",
+                "-DENABLE_VALA_BINDINGS=OFF",
+                "-DENABLE_WEATHER=OFF",
+                "-DWITH_OPENLDAP=OFF",
+                "-DWITH_LIBDB=OFF",
+                "-DENABLE_INTROSPECTION=OFF",
+                "-DENABLE_INSTALLED_TESTS=OFF",
+                "-DENABLE_GTK_DOC=OFF",
+                "-DENABLE_EXAMPLES=OFF"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/evolution-data-server/3.32/evolution-data-server-3.32.0.tar.xz",
+                    "sha256" : "8e10b84974e483322e07a97c57dff56ffb208aa0c33e39a13208d6c52470ddde"
+                }
+            ]
+        },
+        {
+            "name" : "tracker",
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "/bin",
+                "/etc",
+                "/lib/systemd",
+                "/libexec",
+                "/share/dbus-1/services"
+            ],
+            "config-opts" : [
+                "--default-library=shared",
+                "-Ddocs=false",
+                "-Dfts=false",
+                "-Dfunctional_tests=false",
+                "-Djournal=false",
+                "-Dbash-completion=no",
+                "-Dsystemd_user_services=no"
+            ],
+            "sources" : [
+                {
+                   "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/tracker/2.2/tracker-2.2.1.tar.xz",
+                    "sha256" : "0ccef9e67440859119fa6cae230355c1b1b3485ac08122017c9499ad2dada2ff"
+                }
+            ]
+        },
+        {
+            "name" : "bijiben",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "config-opts" : [
+                "-Dprivate_store=true"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/bijiben/3.32/bijiben-3.32.0.tar.xz",
+                    "sha256" : "6337d3c4866302bac8b833fb48936b7c41b3cb55e108cb8f205cbafcb6478926"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -2,7 +2,6 @@
     "app-id" : "org.gnome.Notes",
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "3.32",
-    "branch" : "stable",
     "sdk" : "org.gnome.Sdk",
     "command" : "bijiben",
     "finish-args" : [

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -12,7 +12,7 @@
         "--share=network",
         "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*",
-        "--filesystem=host",
+        "--filesystem=host:ro",
         "--filesystem=xdg-run/dconf",
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",

--- a/org.gnome.Notes.json
+++ b/org.gnome.Notes.json
@@ -131,7 +131,6 @@
         {
             "name" : "bijiben",
             "buildsystem" : "meson",
-            "builddir" : true,
             "config-opts" : [
                 "-Dprivate_store=true"
             ],


### PR DESCRIPTION
This is a request to add org.gnome.Notes which is replacing org.gnome.bijiben application.
In GNOME 3.32 cycle, application id, application data and many other components were changed to org.gnome.Notes.