### PR TITLE
Add Jami (new name / successor of cx.ring.Ring)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/io.qt.qt5-base.json
+++ b/io.qt.qt5-base.json
@@ -1,0 +1,87 @@
+{
+	"name": "qt5-qtbase-minimal",
+	"cleanup-platform": [
+		"/bin",
+		"/mkspecs"
+	],
+	"build-options" : {
+		"arch" : {
+			"x86_64" : {
+				"config-opts" : [
+					"-debug",
+					"-reduce-relocations"
+				]
+			},
+			"arm" : {
+				"config-opts" : [
+					"-no-reduce-relocations",
+					"-no-use-gold-linker",
+					"-optimize-size"
+				]
+			}
+		}
+	},
+	"@note": "When the dependency on Qt5Gui is removed by libringclient, add these flags: -no-gui -no-feature-network -no-freetype -no-fontconfig",
+	"config-opts": [
+		"-confirm-license",
+		"-opensource",
+		"-shared",
+		"-platform linux-g++",
+		"-optimized-qmake",
+		"-nomake examples",
+		"-nomake tests",
+		"-system-sqlite",
+		"-no-accessibility",
+		"-dbus-linked",
+		"-fontconfig",
+		"-glib",
+		"-icu",
+		"-openssl-linked",
+		"-gui",
+		"-sql-sqlite",
+		"-no-gtk",
+		"-no-opengl",
+		"-no-widgets",
+		"-no-pch",
+		"-no-rpath",
+		"-no-directfb",
+		"-no-evdev",
+		"-no-feature-concurrent",
+		"-no-feature-im",
+		"-no-feature-sessionmanager",
+		"-no-feature-testlib",
+		"-no-feature-vnc",
+		"-no-feature-xlib",
+		"-no-feature-xml",
+		"-no-gbm",
+		"-no-harfbuzz",
+		"-no-ico",
+		"-no-linuxfb",
+		"-no-kms",
+		"-no-mirclient",
+		"-no-xcb",
+		"-no-xkbcommon",
+		"-no-vulkan",
+		"-no-cups",
+		"-system-proxies"
+	],
+	"sources": [
+		{
+			"type": "archive",
+			"url": "https://download.qt.io/archive/qt/5.12/5.12.2/submodules/qtbase-everywhere-src-5.12.2.tar.xz",
+			"sha256": "562c095a59c95f393762ec53bc05c0d80fad1758fd5ff7a5231967d1a98d56c1"
+		},
+		{
+			"type": "shell",
+			"commands": [ "mv configure configure.qt" ]
+		},
+		{
+			"type": "script",
+			"commands": [
+				"processed=`sed -e 's/--/-/g ; s/=/ /g' <<< $@`",
+				"./configure.qt $processed"
+			],
+			"dest-filename": "configure"
+		}
+	]
+}

--- a/net.jami.Jami.json
+++ b/net.jami.Jami.json
@@ -1,0 +1,179 @@
+{
+	"app-id": "net.jami.Jami",
+	"runtime": "org.gnome.Platform",
+	"runtime-version": "3.28",
+	"sdk": "org.gnome.Sdk",
+	"command": "gnome-ring",
+	"finish-args": [
+		"--socket=x11",
+		"--socket=wayland",
+		"--socket=pulseaudio",
+		"--share=network",
+		"--device=all",
+		"--share=ipc",
+		"--talk-name=org.freedesktop.secrets",
+		"--talk-name=org.freedesktop.Notifications",
+		"--talk-name=org.gnome.SettingsDaemon.MediaKeys",
+		"--talk-name=org.mate.SettingsDaemon",
+		"--talk-name=org.gnome.ScreenSaver",
+		"--talk-name=org.cinnamon.ScreenSaver",
+		"--talk-name=org.freedesktop.ScreenSaver",
+		"--talk-name=com.canonical.Unity.Session",
+		"--talk-name=org.kde.StatusNotifierWatcher",
+		"--talk-name=com.canonical.indicator.application",
+		"--talk-name=org.gnome.evolution",
+		"--filesystem=~/.local/share/ring",
+		"--filesystem=~/.local/share/gnome-ring",
+		"--filesystem=xdg-config/ring",
+		"--filesystem=xdg-download",
+		"--filesystem=xdg-music",
+		"--filesystem=xdg-pictures",
+		"--filesystem=xdg-videos",
+		"--filesystem=xdg-documents",
+		"--talk-name=ca.desrt.dconf",
+		"--own-name=cx.ring.Ring",
+		"--own-name=cx.ring.RingGnome"
+	],
+	"build-options" : {
+		"cflags": "-Os -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+		"cxxflags": "-Os -g -fstack-protector-strong -D_FORTIFY_SOURCE=2",
+		"ldflags": "-fstack-protector-strong -Wl,-z,relro,-z,now -L/app/lib"
+	},
+	"cleanup": [
+		"*.a",
+		"*.la",
+		"*.prl",
+		"/doc",
+		"/include",
+		"/libexec",
+		"/mkspecs",
+		"/etc",
+		"/lib/pkgconfig",
+		"/lib/cmake",
+		"/lib/systemd",
+		"/lib/udev",
+		"/share/man",
+		"/share/pkgconfig",
+		"/share/vala"
+	],
+	"cleanup-commands": [
+		"mkdir /app/tmp",
+		"cp /app/bin/gnome-ring /app/tmp",
+		"rm -rf /app/bin/*",
+		"mv /app/tmp/* /app/bin",
+		"rm -rf /app/share/dbus-1/services/org.gnome.evolution.dataserver.*",
+		"rm -rf /app/tmp"
+	],
+	"rename-desktop-file": "gnome-ring.desktop",
+	"rename-appdata-file": "gnome-ring.appdata.xml",
+	"rename-icon": "jami",
+	"modules": [
+		{
+			"name": "ring-client-gnome",
+			"buildsystem": "simple",
+			"build-commands": [
+				"./make-ring.py --install --global-install --debug"
+			],
+			"sources": [
+				{
+					"type": "archive",
+					"url": "https://dl.ring.cx/ring-release/tarballs/ring_20190319.4.a16a99f.tar.gz",
+					"sha256": "94b731bc248577adce577ffd7c894cffa9bcbe246f8c57c41e884f7daa36d6b0"
+				},
+				{
+					"type": "patch",
+					"path": "ring-flatpak-patch/flatpak-ring.patch"
+				},
+				{
+					"type": "patch",
+					"path": "ring-flatpak-patch/dbus-cpp-config.patch"
+				},
+				{
+					"type": "patch",
+					"path": "ring-flatpak-patch/restbed-link-openssl-dynamic.patch"
+				},
+				{
+					"type": "patch",
+					"path": "ring-flatpak-patch/contrib-minimal-deps.patch"
+				},
+				{
+					"type": "file",
+					"url": "https://github.com/open-source-parsers/jsoncpp/archive/1.7.5.tar.gz",
+					"sha256": "4338c6cab8af8dee6cdfd54e6218bd0533785f552c6162bb083f8dd28bf8fbbe",
+					"dest": "daemon/contrib/tarballs",
+					"dest-filename": "jsoncpp-1.7.5.tar.gz"
+				},
+				{
+					"type": "patch",
+					"path": "ring-flatpak-patch/jsoncpp-version.patch"
+				}
+			],
+			"modules": [
+				"io.qt.qt5-base.json",
+				"shared-modules/udev/udev-175.json",
+				{
+					"name": "evolution-data-server",
+					"buildsystem": "cmake-ninja",
+					"config-opts": [
+						"-DCMAKE_INSTALL_PREFIX=/app",
+						"-DENABLE_UOA=OFF",
+						"-DENABLE_INSTALLED_TESTS=OFF",
+						"-DENABLE_CANBERRA=OFF",
+						"-DENABLE_DOT_LOCKING=OFF",
+						"-DENABLE_FILE_LOCKING=OFF",
+						"-DENABLE_GOA=OFF",
+						"-DENABLE_GOOGLE=OFF",
+						"-DENABLE_GOOGLE_AUTH=OFF",
+						"-DENABLE_GTK_DOC=OFF",
+						"-DENABLE_INTROSPECTION=OFF",
+						"-DWITH_KRB5=OFF",
+						"-DWITH_LIBDB=OFF",
+						"-DENABLE_OAUTH2=OFF",
+						"-DWITH_OPENLDAP=OFF",
+						"-DENABLE_SCHEMAS_COMPILE=OFF",
+						"-DENABLE_WEATHER=OFF",
+						"-DENABLE_VALA_BINDINGS=OFF",
+						"-DENABLE_EXAMPLES=OFF"
+					],
+					"sources": [
+						{
+							"type": "archive",
+							"url": "https://gitlab.gnome.org/GNOME/evolution-data-server/-/archive/3.28.2/evolution-data-server-3.28.2.tar.bz2",
+							"sha256": "7eac87a1c275524bfeb9c5623623b9ec9303f5a5519cec6a2d901bd6df25bec5"
+						}
+					],
+					"modules": [
+						{
+							"name": "libical",
+							"buildsystem": "cmake-ninja",
+							"config-opts": [
+								"-DCMAKE_BUILD_TYPE=Release",
+								"-DSHARED_ONLY=true",
+								"-DCMAKE_INSTALL_PREFIX=/app",
+								"-DCMAKE_INSTALL_LIBDIR=/app/lib"
+							],
+							"sources": [
+								{
+									"type": "archive",
+									"url": "https://github.com/libical/libical/archive/v2.0.0.tar.gz",
+									"sha256": "20f4a98475052e1200d2691ba50b27969e4bedc6e50bffd5e2fa81f4ac90de9a"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "qrencode",
+					"buildsystem": "cmake-ninja",
+					"sources": [
+						{
+							"type": "archive",
+							"url": "https://fukuchi.org/works/qrencode/qrencode-4.0.2.tar.bz2",
+							"sha512": "2429c7938e32eacbaf327c029c7745ba33259f879661a8b6470cc617c780daf5bd1d5689599151df62e84badd2568eccab6c12f157331e512ab24a3899e0f002"
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/ring-flatpak-patch/contrib-minimal-deps.patch
+++ b/ring-flatpak-patch/contrib-minimal-deps.patch
@@ -1,0 +1,32 @@
+--- ring-client-gnome/daemon/contrib/src/opendht/rules.mak.orig	2019-03-19 22:26:52.000000000 +0100
++++ ring-client-gnome/daemon/contrib/src/opendht/rules.mak	2019-04-04 19:20:01.626841937 +0200
+@@ -20,9 +20,6 @@
+ ifneq ($(call need_pkg,"jsoncpp"),)
+ DEPS_opendht += jsoncpp
+ endif
+-ifneq ($(call need_pkg,"gnutls >= 3.3.0"),)
+-DEPS_opendht += gnutls
+-endif
+ 
+ $(TARBALLS)/opendht-$(OPENDHT_VERSION).tar.gz:
+ 	$(call download,$(OPENDHT_URL))
+--- ring-client-gnome/daemon/contrib/src/pjproject/rules.mak.orig	2019-03-19 22:26:52.000000000 +0100
++++ ring-client-gnome/daemon/contrib/src/pjproject/rules.mak	2019-04-04 19:21:38.327316029 +0200
+@@ -37,7 +37,6 @@
+ PKGS_FOUND += pjproject
+ endif
+ 
+-DEPS_pjproject += gnutls
+ ifndef HAVE_WIN32
+ ifndef HAVE_MACOSX
+ DEPS_pjproject += uuid
+--- ring-client-gnome/daemon/contrib/src/secp256k1/rules.mak.orig	2019-03-19 22:26:52.000000000 +0100
++++ ring-client-gnome/daemon/contrib/src/secp256k1/rules.mak	2019-04-04 19:23:00.075712812 +0200
+@@ -7,7 +7,6 @@
+ ifeq ($(call need_pkg,"libsecp256k1"),)
+ PKGS_FOUND += secp256k1
+ endif
+-DEPS_secp256k1 = gmp
+ 
+ $(TARBALLS)/secp256k1-$(SECP256K1_VERSION).tar.gz:
+ 	$(call download,$(SECP256K1_URL))

--- a/ring-flatpak-patch/dbus-cpp-config.patch
+++ b/ring-flatpak-patch/dbus-cpp-config.patch
@@ -1,0 +1,14 @@
+diff -urN ring-project-orig/daemon/contrib/src/dbus-cpp/rules.mak ring-project/daemon/contrib/src/dbus-cpp/rules.mak
+--- ring-project-orig/daemon/contrib/src/dbus-cpp/rules.mak	2017-10-24 11:20:14.000000000 -0400
++++ ring-project/daemon/contrib/src/dbus-cpp/rules.mak	2017-11-20 19:31:28.194081738 -0500
+@@ -24,7 +24,9 @@
+ 	$(APPLY) $(SRC)/dbus-cpp/dbus-c++-threading.patch
+ 	$(APPLY) $(SRC)/dbus-cpp/dbus-c++-writechar.patch
+ 	$(APPLY) $(SRC)/dbus-cpp/dbus-c++-gcc4.7.patch
++	cp -p /usr/share/automake-*/config.{sub,guess} $(UNPACK_DIR)
+-	$(UPDATE_AUTOCONFIG)
++	#$(UPDATE_AUTOCONFIG)
++	#autoconf -f -B build/autoconf_prepend-include
+ 	$(MOVE)
+ 
+ .dbus-cpp: dbus-cpp

--- a/ring-flatpak-patch/flatpak-ring.patch
+++ b/ring-flatpak-patch/flatpak-ring.patch
@@ -1,0 +1,109 @@
+--- ring-client-gnome/make-ring.py.orig	2019-03-19 22:26:32.000000000 +0100
++++ ring-client-gnome/make-ring.py	2019-04-04 14:13:03.893668028 +0200
+@@ -240,6 +240,10 @@
+         print("The Android version does not need more dependencies.\nPlease continue with the --install instruction.")
+         sys.exit(1)
+ 
++    elif args.distribution == "org.gnome.Platform":
++        print("Flatpak dependancinies are handled in top level json.\nPlease continue with the --install instruction.")
++        sys.exit(1)
++
+     else:
+         print("Not yet implemented for current distribution (%s)" % args.distribution)
+         sys.exit(1)
+@@ -391,7 +395,7 @@
+     """Validate the args values, exit if error is found"""
+ 
+     # Check arg values
+-    supported_distros = [ANDROID_DISTRIBUTION_NAME, OSX_DISTRIBUTION_NAME, IOS_DISTRIBUTION_NAME] + APT_BASED_DISTROS + DNF_BASED_DISTROS + PACMAN_BASED_DISTROS + ZYPPER_BASED_DISTROS + ['mingw32','mingw64']
++    supported_distros = [ANDROID_DISTRIBUTION_NAME, OSX_DISTRIBUTION_NAME, IOS_DISTRIBUTION_NAME] + APT_BASED_DISTROS + DNF_BASED_DISTROS + PACMAN_BASED_DISTROS + ZYPPER_BASED_DISTROS + ['mingw32','mingw64','org.gnome.Platform']
+ 
+     if parsed_args.distribution not in supported_distros:
+         print('Distribution \''+parsed_args.distribution+'\' not supported.\nChoose one of: %s' \
+--- ring-client-gnome/scripts/install.sh.orig	2019-03-19 22:26:32.000000000 +0100
++++ ring-client-gnome/scripts/install.sh	2019-04-04 14:17:10.558745126 +0200
+@@ -37,14 +37,14 @@
+ done
+ 
+ make_install() {
+-  if $1; then
+-    sudo make install
+-    # Or else the next non-sudo install will fail, because this generates some
+-    # root owned files like install_manifest.txt under the build directory.
+-    sudo chown -R "$USER" .
+-  else
++#   if $1; then
++#     sudo make install
++#     # Or else the next non-sudo install will fail, because this generates some
++#     # root owned files like install_manifest.txt under the build directory.
++#     sudo chown -R "$USER" .
++#   else
+     make install
+-  fi
++#   fi
+ }
+ 
+ TOP="$(pwd)"
+@@ -56,6 +56,9 @@
+     BUILDDIR="build-local"
+ fi
+ 
++# Fix these values, since they can't be anything else in flatpak controled environment
++client="client-gnome"
++proc=`grep -m 1 'cpu cores' /proc/cpuinfo | awk '{split($0,a,": "); print(a[2]);}'`
+ cd "${TOP}/daemon"
+ DAEMON="$(pwd)"
+ cd contrib
+@@ -64,7 +67,7 @@
+ if [[ "$OSTYPE" == "darwin"* ]]; then
+     enableRestbed="--enable-restbed"
+ fi
+-../bootstrap $enableRestbed
++../bootstrap $enableRestbed --disable-downloads --disable-ffmpeg --disable-gcrypt --disable-gmp --disable-gnutls --disable-gpg-error --disable-nettle --disable-opus --disable-speex --disable-speexdsp --disable-vpx --disable-zlib --disable-libressl --enable-debug --prefix=/app
+ make
+ cd "${DAEMON}"
+ ./autogen.sh
+@@ -75,18 +78,18 @@
+ fi
+ 
+ if $global; then
+-  ./configure $sharedLib $CONFIGURE_FLAGS
++  ./configure $sharedLib $CONFIGURE_FLAGS --prefix="/app"
+ else
+   ./configure $sharedLib $CONFIGURE_FLAGS --prefix="${INSTALL}/daemon"
+ fi
+ make -j${proc}
+-make_install $global
++make_install
+ 
+ cd "${TOP}/lrc"
+ mkdir -p ${BUILDDIR}
+ cd ${BUILDDIR}
+ if $global; then
+-  cmake .. -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DCMAKE_BUILD_TYPE=Debug $static
++  cmake .. -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="/app" $static
+ else
+   cmake ..  -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
+             -DCMAKE_BUILD_TYPE=Debug \
+@@ -94,13 +97,13 @@
+             -DRING_BUILD_DIR="${DAEMON}/src" $static
+ fi
+ make -j${proc}
+-make_install $global
++make_install
+ 
+ cd "${TOP}/${client}"
+ mkdir -p ${BUILDDIR}
+ cd ${BUILDDIR}
+ if $global; then
+-  cmake .. -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH $static
++  cmake .. -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="/app" $static
+ else
+   cmake ..  -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
+             -DCMAKE_INSTALL_PREFIX="${INSTALL}/${client}" \
+@@ -108,4 +111,4 @@
+             -DLibRingClient_DIR="${INSTALL}/lrc/lib/cmake/LibRingClient" $static
+ fi
+ make -j${proc}
+-make_install $global
++make_install

--- a/ring-flatpak-patch/jsoncpp-version.patch
+++ b/ring-flatpak-patch/jsoncpp-version.patch
@@ -1,0 +1,16 @@
+diff -ruN ring-project/daemon/contrib/src/jsoncpp/rules.mak ring-project-fixed/daemon/contrib/src/jsoncpp/rules.mak
+--- ring-project/daemon/contrib/src/jsoncpp/rules.mak	2018-02-09 18:10:00.000000000 -0500
++++ ring-project-fixed/daemon/contrib/src/jsoncpp/rules.mak	2018-02-10 14:26:17.202660730 -0500
+@@ -1,5 +1,5 @@
+ # JSONCPP
+-JSONCPP_VERSION := 1.7.2
++JSONCPP_VERSION := 1.7.5
+ JSONCPP_URL := https://github.com/open-source-parsers/jsoncpp/archive/$(JSONCPP_VERSION).tar.gz
+ 
+ PKGS += jsoncpp
+diff -ruN ring-project/daemon/contrib/src/jsoncpp/SHA512SUMS ring-project-fixed/daemon/contrib/src/jsoncpp/SHA512SUMS
+--- ring-project/daemon/contrib/src/jsoncpp/SHA512SUMS	2018-02-09 18:10:00.000000000 -0500
++++ ring-project-fixed/daemon/contrib/src/jsoncpp/SHA512SUMS	2018-02-10 14:44:07.267122848 -0500
+@@ -1 +1,2 @@
+ 32702147229ea7a3679654325572c38f4188f258ab6ac21f9e04059d53ef2a7cd0542ec4ec3b0e7b9089acd2b7bce389f16b9ff24b2e63e0ba2a5bcd46bab766  jsoncpp-1.7.2.tar.gz
++c8217e390d4b15e046a6f14ad54257ac8ecc13b70073a15c502b451df25c6d8bbc645ee50bb12e67433bf2c9053e2a39544d465c19124c7b882b69dd80b70ab2  jsoncpp-1.7.5.tar.gz

--- a/ring-flatpak-patch/restbed-link-openssl-dynamic.patch
+++ b/ring-flatpak-patch/restbed-link-openssl-dynamic.patch
@@ -1,0 +1,24 @@
+--- /dev/null	2019-04-03 23:29:51.942446036 +0200
++++ ring-client-gnome/daemon/contrib/src/restbed/link-openssl-dynamic.patch	2019-04-04 15:26:46.878228661 +0200
+@@ -0,0 +1,11 @@
++--- restbed/CMakeLists.txt.orig	2019-04-04 15:24:06.789542379 +0200
+++++ restbed/CMakeLists.txt	2019-04-04 15:24:26.765628334 +0200
++@@ -63,7 +63,7 @@
++     set_property( TARGET ${STATIC_LIBRARY_NAME} PROPERTY CXX_STANDARD_REQUIRED ON )
++     set_target_properties( ${STATIC_LIBRARY_NAME} PROPERTIES OUTPUT_NAME ${PROJECT_NAME} )
++     if ( BUILD_SSL )
++-        target_link_libraries( ${STATIC_LIBRARY_NAME} LINK_PRIVATE ${ssl_LIBRARY_STATIC} ${crypto_LIBRARY_STATIC} )
+++        target_link_libraries( ${STATIC_LIBRARY_NAME} LINK_PRIVATE ${ssl_LIBRARY_SHARED} ${crypto_LIBRARY_SHARED} )
++     else ( )
++         target_link_libraries( ${STATIC_LIBRARY_NAME} )
++     endif ( )
+--- ring-client-gnome/daemon/contrib/src/restbed/rules.mak.orig	2019-04-04 15:29:42.042973191 +0200
++++ ring-client-gnome/daemon/contrib/src/restbed/rules.mak	2019-04-04 15:32:06.507582598 +0200
+@@ -43,6 +43,7 @@
+ 
+ restbed: restbed-$(RESTBED_VERSION).tar.gz .sum-restbed
+ 	$(UNPACK)
++	$(APPLY) $(SRC)/restbed/link-openssl-dynamic.patch
+ 	$(MOVE)
+ 
+ .restbed: restbed toolchain.cmake


### PR DESCRIPTION
As per the discussion on https://github.com/flathub/cx.ring.Ring/issues/10, I'm submitting this new version of Ring as a new application here. The contents of this branch are just a snapshot of the current Jami Flatpak version that may be found here: https://gitlab.com/ntninja/net.jami.Jami – I fully intend to force-push over whatever repository is created for me with that version to retain the previous commit history. Hopefully this is not a problem.
Legally, there should be no difference between this and cx.ring.Ring as I only updated and removed packages in the new image.