### PR TITLE
Add org.gnome.Chess

### DIFF
--- a/org.gnome.Chess.json
+++ b/org.gnome.Chess.json
@@ -1,0 +1,40 @@
+{
+    "app-id": "org.gnome.Chess",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.32",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-chess",
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* Wayland access */
+        "--socket=wayland",
+        /* dconf */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "cleanup": ["/share/gnuchess", "/share/info", "/share/man", "/include"],
+    "modules": [
+        {
+            "name": "gnuchess",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ftpmirror.gnu.org/chess/gnuchess-6.2.5.tar.gz",
+                    "sha256": "9a99e963355706cab32099d140b698eda9de164ebce40a5420b1b9772dd04802"
+                }
+            ]
+        },
+        {
+            "name": "gnome-chess",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-chess/3.32/gnome-chess-3.32.0.tar.xz",
+                    "sha256": "6998a9bc6cee1d7b6b203f9ec744f33c6f1983adb0b0a7b477c1bbca8936eb43"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This repository is replacement for `org.gnome.chess`, which can't be updated to `gnome-chess 3.32`.

`org.gnome.chess` will be marked as end-of-life.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>