### PR TITLE
Add GNOME LightsOff

### DIFF
--- a/org.gnome.LightsOff.json
+++ b/org.gnome.LightsOff.json
@@ -1,0 +1,29 @@
+{
+    "app-id": "org.gnome.LightsOff",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.32",
+    "sdk": "org.gnome.Sdk",
+    "command": "lightsoff",
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11",
+        /* Wayland access */
+        "--socket=wayland",
+        "--device=dri",
+        /* dconf */
+        "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [
+        {
+            "name": "lightsoff",
+            "buildsystem": "meson",
+            "sources": [{
+                "type": "git",
+                "path": "https://gitlab.gnome.org/GNOME/lightsoff.git",
+                "tag": "3.32.0",
+                "commit": "6f05d33a890c3026e2e13720f107daae54f6e505"
+            }]
+        }
+    ]
+}

--- a/org.gnome.LightsOff.json
+++ b/org.gnome.LightsOff.json
@@ -20,7 +20,7 @@
             "buildsystem": "meson",
             "sources": [{
                 "type": "git",
-                "path": "https://gitlab.gnome.org/GNOME/lightsoff.git",
+                "url": "https://gitlab.gnome.org/GNOME/lightsoff.git",
                 "tag": "3.32.0",
                 "commit": "6f05d33a890c3026e2e13720f107daae54f6e505"
             }]


### PR DESCRIPTION
LightsOff does now have a flatpak manifest since https://gitlab.gnome.org/GNOME/lightsoff/merge_requests/6
The app also have been updated the app-id on 3.32 so it should be safe to have it here on Flathub to promote more those games
