### PR TITLE
Add GNOME Screenshot

### DIFF
--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -41,7 +41,7 @@
 		{
 		    "type": "archive",
 		    "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
-        "sha256": "cb7bad07790a27f97ba57909d3d09726d564bd3111c37ec3e728b8d5d521e630"
+                    "sha256": "cb7bad07790a27f97ba57909d3d09726d564bd3111c37ec3e728b8d5d521e630"
 		}
 	    ]
 	},
@@ -52,7 +52,7 @@
 		{
 		    "type": "archive",
 		    "url": "https://gitlab.gnome.org/GNOME/gnome-screenshot/-/archive/3.32.0/gnome-screenshot-3.32.0.tar.gz",
-        "sha256": "8041fb78516b9f5503fcb3c43f6c3701065d4b66"
+                    "sha256": "8041fb78516b9f5503fcb3c43f6c3701065d4b66"
 		}
 	    ]
 	}

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Screenshot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "master",
+    "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-screenshot",
     "finish-args": [

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -1,0 +1,60 @@
+{
+    "app-id": "org.gnome.Screenshot",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-screenshot",
+    "finish-args": [
+	"--share=ipc",
+	"--socket=x11",
+	"--socket=wayland",
+	"--talk-name=org.gnome.Shell.Screenshot",
+	"--filesystem=xdg-run/dconf",
+	"--filesystem=~/.config/dconf:ro",
+	"--filesystem=home",
+	"--talk-name=ca.desrt.dconf",
+	"--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "cleanup": [
+	"/include",
+	"/lib/pkgconfig",
+	"/share/pkgconfig",
+	"/share/aclocal",
+	"/man",
+	"/share/man",
+	"/share/gtk-doc",
+	"/share/vala",
+	"*.la",
+	"*.a"
+    ],
+    "modules": [
+	{
+	    "name": "libcanberra-gtk3",
+	    "cleanup": [
+		"/bin",
+		"/lib/gnome-settings-daemon-3.0",
+		"/share/doc",
+		"/share/gdm",
+		"/share/gnome"
+	    ],
+	    "sources": [
+		{
+		    "type": "archive",
+		    "url": "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+        "sha256": "cb7bad07790a27f97ba57909d3d09726d564bd3111c37ec3e728b8d5d521e630"
+		}
+	    ]
+	},
+	{
+	    "name": "gnome-screenshot",
+	    "buildsystem": "meson",
+	    "sources": [
+		{
+		    "type": "archive",
+		    "url": "https://gitlab.gnome.org/GNOME/gnome-screenshot/-/archive/3.32.0/gnome-screenshot-3.32.0.tar.gz",
+        "sha256": "8041fb78516b9f5503fcb3c43f6c3701065d4b66"
+		}
+	    ]
+	}
+    ]
+}


### PR DESCRIPTION
GNOME Screenshot is missing from Silverblue base
so it would be nice if we could get it from Flathub

the Flatpak manifest is identical to upstream
with the addition of the "home" permission,
see PR on Gitlab: https://gitlab.gnome.org/GNOME/gnome-screenshot/merge_requests/13

Also the issue on Gitlab: https://gitlab.gnome.org/GNOME/gnome-screenshot/issues/33