### PR TITLE
Added Biblereader

### DIFF
--- a/org.homelinuxserver.vance.biblereader.json
+++ b/org.homelinuxserver.vance.biblereader.json
@@ -11,13 +11,6 @@
         "--share=network",
         "--persist=.sword"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
-        "env" : {
-            "V" : "1"
-        }
-    },
     "cleanup" : [
         "/bin/mm-common-prepare",
         "/share/mm-common",

--- a/org.homelinuxserver.vance.biblereader.json
+++ b/org.homelinuxserver.vance.biblereader.json
@@ -1,0 +1,157 @@
+{
+    "app-id" : "org.homelinuxserver.vance.biblereader",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "18.08",
+    "sdk" : "org.freedesktop.Sdk",
+    "command" : "biblereader",
+    "finish-args" : [
+        "--socket=x11",
+        "--socket=wayland",
+        "--share=ipc",
+        "--share=network",
+        "--persist=.sword"
+    ],
+    "build-options" : {
+        "cflags" : "-O2 -g",
+        "cxxflags" : "-O2 -g",
+        "env" : {
+            "V" : "1"
+        }
+    },
+    "cleanup" : [
+        "/bin/mm-common-prepare",
+        "/share/mm-common",
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "mm-common",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/mm-common/0.9/mm-common-0.9.12.tar.xz",
+                    "sha256" : "ceffdcce1e5b52742884c233ec604bf6fded12eea9da077ce7a62c02c87e7c0b"
+                }
+            ]
+        },
+        {
+            "name" : "sigc++",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/libsigc++/2.10/libsigc++-2.10.1.tar.xz",
+                    "sha256" : "c9a25f26178c6cbb147f9904d8c533b5a5c5111a41ac2eb781eb734eea446003"
+                }
+            ]
+        },
+        {
+            "name" : "glibmm",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/glibmm/2.58/glibmm-2.58.1.tar.xz",
+                    "sha256" : "6e5fe03bdf1e220eeffd543e017fd2fb15bcec9235f0ffd50674aff9362a85f0"
+                }
+            ]
+        },
+        {
+            "name" : "cairomm",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "build-options" : {
+                "cxxflags" : "-std=c++17"
+            },
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://www.cairographics.org/releases/cairomm-1.12.2.tar.gz",               
+                    "sha256" : "45c47fd4d0aa77464a75cdca011143fea3ef795c4753f6e860057da5fb8bd599"
+                }
+            ]
+        },
+        {
+            "name" : "pangomm",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/pangomm/2.42/pangomm-2.42.0.tar.xz",
+                    "sha256" : "ca6da067ff93a6445780c0b4b226eb84f484ab104b8391fb744a45cbc7edbf56"
+                }
+            ]
+        },
+        {
+            "name" : "atkmm",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/atkmm/2.28/atkmm-2.28.0.tar.xz",
+                    "sha256" : "4c4cfc917fd42d3879ce997b463428d6982affa0fb660cafcc0bc2d9afcedd3a"
+                }
+            ]
+        },
+        {
+            "name" : "gtkmm",
+            "config-opts" : [
+                "--disable-documentation"
+            ],
+            "build-options" : {
+                "cxxflags" : "-O2 -g -std=c++17"
+            },
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gtkmm/3.24/gtkmm-3.24.1.tar.xz",
+                    "sha256" : "ddfe42ed2458a20a34de252854bcf4b52d3f0c671c045f56b42aa27c7542d2fd"
+                }
+            ]
+        },
+        {
+            "name" : "sword",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://crosswire.org/ftpmirror/pub/sword/source/v1.8/sword-1.8.1.tar.gz",
+                    "sha256" : "ce9aa8f721a737f406115d35ff438bd07c829fce1605f0d6dcdabc4318bc5e93"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "sword.patch"
+                }
+            ]
+        },
+        {
+            "name" : "biblereader",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.com/natervance/biblereader.git",
+                    "tag" : "1.0.2",
+                    "commit" : "2158c7291fdce8682ee11f9df3788489ab12b89f"
+                }
+            ]
+        }
+    ]
+}
+

--- a/sword.patch
+++ b/sword.patch
@@ -1,0 +1,80 @@
+diff -ruN sword-1.8.1/include/utf8transliterator.h sword-1.8.1-patched/include/utf8transliterator.h
+--- sword-1.8.1/include/utf8transliterator.h	2013-07-17 18:34:43.000000000 -0400
++++ sword-1.8.1-patched/include/utf8transliterator.h	2019-04-02 17:00:26.509842604 -0400
+@@ -47,6 +47,8 @@
+ 
+ SWORD_NAMESPACE_START
+ 
++using namespace icu;
++
+ class SWModule;
+ 
+ struct SWTransData {
+diff -ruN sword-1.8.1/src/modules/filters/scsuutf8.cpp sword-1.8.1-patched/src/modules/filters/scsuutf8.cpp
+--- sword-1.8.1/src/modules/filters/scsuutf8.cpp	2017-05-22 00:19:02.000000000 -0400
++++ sword-1.8.1-patched/src/modules/filters/scsuutf8.cpp	2019-04-02 17:00:26.528842699 -0400
+@@ -39,6 +39,7 @@
+ 
+ SWORD_NAMESPACE_START
+ 
++using namespace icu;
+ 
+ SCSUUTF8::SCSUUTF8() {
+ #ifdef _ICU_
+diff -ruN sword-1.8.1/src/modules/filters/utf8nfc.cpp sword-1.8.1-patched/src/modules/filters/utf8nfc.cpp
+--- sword-1.8.1/src/modules/filters/utf8nfc.cpp	2014-03-05 14:52:08.000000000 -0500
++++ sword-1.8.1-patched/src/modules/filters/utf8nfc.cpp	2019-04-02 17:00:26.530842708 -0400
+@@ -32,6 +32,8 @@
+ 
+ SWORD_NAMESPACE_START
+ 
++using namespace icu;
++
+ UTF8NFC::UTF8NFC() {
+         conv = ucnv_open("UTF-8", &err);
+ }
+diff -ruN sword-1.8.1/src/modules/filters/utf8scsu.cpp sword-1.8.1-patched/src/modules/filters/utf8scsu.cpp
+--- sword-1.8.1/src/modules/filters/utf8scsu.cpp	2014-03-12 00:34:32.000000000 -0400
++++ sword-1.8.1-patched/src/modules/filters/utf8scsu.cpp	2019-04-02 17:00:26.530842708 -0400
+@@ -27,6 +27,7 @@
+ 
+ SWORD_NAMESPACE_START
+ 
++using namespace icu;
+ 
+ UTF8SCSU::UTF8SCSU() {
+ 	// initialize SCSU converter
+diff -ruN sword-1.8.1/src/modules/swmodule.cpp sword-1.8.1-patched/src/modules/swmodule.cpp
+--- sword-1.8.1/src/modules/swmodule.cpp	2017-11-01 07:38:09.000000000 -0400
++++ sword-1.8.1-patched/src/modules/swmodule.cpp	2019-04-02 17:00:26.531842713 -0400
+@@ -46,6 +46,7 @@
+ #endif
+ #elif defined(USEICUREGEX)
+ #include <unicode/regex.h>
++using namespace icu;
+ #ifndef REG_ICASE
+ #define REG_ICASE UREGEX_CASE_INSENSITIVE
+ #endif
+diff -ruN sword-1.8.1/tests/tlitmgrtest.cpp sword-1.8.1-patched/tests/tlitmgrtest.cpp
+--- sword-1.8.1/tests/tlitmgrtest.cpp	2013-06-29 02:40:28.000000000 -0400
++++ sword-1.8.1-patched/tests/tlitmgrtest.cpp	2019-04-02 17:00:26.543842773 -0400
+@@ -247,6 +247,8 @@
+ #include "unicode/ustream.h"
+ #include <iostream>
+ 
++using namespace icu;
++
+ class SWCharString {
+  public:
+     inline SWCharString(const UnicodeString& str);
+diff -ruN sword-1.8.1/tests/translittest.cpp sword-1.8.1-patched/tests/translittest.cpp
+--- sword-1.8.1/tests/translittest.cpp	2013-06-29 02:40:28.000000000 -0400
++++ sword-1.8.1-patched/tests/translittest.cpp	2019-04-02 17:00:26.543842773 -0400
+@@ -34,6 +34,7 @@
+ #include "utf8transliterator.h"
+ 
+ using namespace std;
++using namespace icu;
+ 
+ // Print the given string to stdout
+ void uprintf(const UnicodeString &str) {


### PR DESCRIPTION
The sword.patch file is necessary for the current version of SWORD to compile against modern ICU (the patch has been submitted upstream but I have yet to hear a response).

Also, first time using the flathub system, so apologies if I missed something in the requirements.