### PR TITLE
Add Nheko-Reborn

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 3.1)
+
+project(olm VERSION 2.2.2 LANGUAGES CXX C)
+
+add_definitions(-DOLMLIB_VERSION_MAJOR=${PROJECT_VERSION_MAJOR})
+add_definitions(-DOLMLIB_VERSION_MINOR=${PROJECT_VERSION_MINOR})
+add_definitions(-DOLMLIB_VERSION_PATCH=${PROJECT_VERSION_PATCH})
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+add_library(olm
+    src/account.cpp
+    src/base64.cpp
+    src/cipher.cpp
+    src/crypto.cpp
+    src/memory.cpp
+    src/message.cpp
+    src/pickle.cpp
+    src/ratchet.cpp
+    src/session.cpp
+    src/utility.cpp
+
+    src/ed25519.c
+    src/error.c
+    src/inbound_group_session.c
+    src/megolm.c
+    src/olm.cpp
+    src/outbound_group_session.c
+    src/pickle_encoding.c
+
+    lib/crypto-algorithms/aes.c
+    lib/crypto-algorithms/sha256.c
+    lib/curve25519-donna/curve25519-donna.c)
+add_library(Olm::Olm ALIAS olm)
+
+target_include_directories(olm
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+
+set_target_properties(olm PROPERTIES
+   SOVERSION ${PROJECT_VERSION_MAJOR}
+   VERSION ${PROJECT_VERSION})
+
+set_target_properties(olm PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+
+#
+# Installation
+#
+include(GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/Olm)
+install(TARGETS olm
+    EXPORT olm-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+# The exported target will be named Olm.
+set_target_properties(olm PROPERTIES EXPORT_NAME Olm)
+install(FILES
+    ${CMAKE_SOURCE_DIR}/include/olm/olm.h
+    ${CMAKE_SOURCE_DIR}/include/olm/outbound_group_session.h
+    ${CMAKE_SOURCE_DIR}/include/olm/inbound_group_session.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/olm)
+
+# Export the targets to a script.
+install(EXPORT olm-targets
+  FILE OlmTargets.cmake
+  NAMESPACE Olm::
+  DESTINATION ${INSTALL_CONFIGDIR})
+
+# Create a ConfigVersion.cmake file.
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/OlmConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/OlmConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/OlmConfig.cmake
+    INSTALL_DESTINATION ${INSTALL_CONFIGDIR})
+
+#Install the config & configversion.
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/OlmConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/OlmConfigVersion.cmake
+    DESTINATION ${INSTALL_CONFIGDIR})
+
+# Register package in user's package registry
+export(EXPORT olm-targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/OlmTargets.cmake
+    NAMESPACE Olm::)
+export(PACKAGE Olm)

--- a/cmake/OlmConfig.cmake.in
+++ b/cmake/OlmConfig.cmake.in
@@ -1,0 +1,11 @@
+get_filename_component(Olm_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${Olm_CMAKE_DIR})
+list(REMOVE_AT CMAKE_MODULE_PATH -1)
+
+if(NOT TARGET Olm::Olm)
+  include("${Olm_CMAKE_DIR}/OlmTargets.cmake")
+endif()
+
+set(Olm_LIBRARIES Olm::Olm)

--- a/io.github.Nheko-Reborn.Nheko.json
+++ b/io.github.Nheko-Reborn.Nheko.json
@@ -5,20 +5,9 @@
   "runtime": "org.kde.Platform",
   "runtime-version": "5.12",
   "sdk": "org.kde.Sdk",
-  "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.gcc8"
-  ],
   "rename-icon": "nheko",
   "rename-desktop-file": "nheko.desktop",
   "rename-appdata-file": "nheko.appdata.xml",
-  "build-options": {
-    "env": {
-      "CC": "/usr/lib/sdk/gcc8/bin/gcc",
-      "CXX": "/usr/lib/sdk/gcc8/bin/g++",
-      "LD_LIBRARY_PATH": "/usr/lib/sdk/gcc8/lib",
-      "V": "1"
-    }
-  },
   "finish-args": [
     "--device=dri",
     "--filesystem=home",
@@ -148,7 +137,7 @@
         {
           "sha256": "e7638d4a8233c0c763d48111fd13e8ad1dcd5f34e3e641b46eaf1bb920b73482",
           "type": "archive",
-          "url": "https://github.com/nheko-reborn/mtxclient/archive/v0.2.0.tar.gz"
+          "url": "https://github.com/Nheko-Reborn/mtxclient/archive/v0.2.0.tar.gz"
         },
         {
           "dest": "include",
@@ -183,9 +172,9 @@
       "name": "nheko",
       "sources": [
         {
-          "sha256": "869dea68ad53258cbff4e41bb3e2894742ef90568779787d8eb5391112eb3d48",
+          "sha256": "e88678d10195f5e2618e0d1a44cc9c152122ff3ab03b347d00f16b39abe2ac3e",
           "type": "archive",
-          "url": "https://github.com/mujx/nheko/archive/v0.6.2.tar.gz"
+          "url": "https://github.com/Nheko-Reborn/nheko/archive/v0.6.3.tar.gz"
         },
         {
           "dest": ".deps/lmdbxx",

--- a/io.github.Nheko-Reborn.Nheko.json
+++ b/io.github.Nheko-Reborn.Nheko.json
@@ -3,7 +3,7 @@
   "command": "nheko",
   "branch": "stable",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.11",
+  "runtime-version": "5.12",
   "sdk": "org.kde.Sdk",
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.gcc8"

--- a/io.github.Nheko-Reborn.Nheko.json
+++ b/io.github.Nheko-Reborn.Nheko.json
@@ -1,0 +1,199 @@
+{
+  "id": "io.github.Nheko-Reborn.Nheko",
+  "command": "nheko",
+  "branch": "stable",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.11",
+  "sdk": "org.kde.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.gcc8"
+  ],
+  "rename-icon": "nheko",
+  "rename-desktop-file": "nheko.desktop",
+  "rename-appdata-file": "nheko.appdata.xml",
+  "build-options": {
+    "env": {
+      "CC": "/usr/lib/sdk/gcc8/bin/gcc",
+      "CXX": "/usr/lib/sdk/gcc8/bin/g++",
+      "LD_LIBRARY_PATH": "/usr/lib/sdk/gcc8/lib",
+      "V": "1"
+    }
+  },
+  "finish-args": [
+    "--device=dri",
+    "--filesystem=home",
+    "--share=ipc",
+    "--share=network",
+    "--socket=pulseaudio",
+    "--socket=wayland",
+    "--socket=x11",
+    "--talk-name=org.freedesktop.Notifications",
+    "--talk-name=org.kde.StatusNotifierWatcher"
+  ],
+  "cleanup": [
+    "/include",
+    "/bin/mdb*",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "lmdb",
+      "sources": [
+        {
+          "sha256": "f3927859882eb608868c8c31586bb7eb84562a40a6bf5cc3e13b6b564641ea28",
+          "type": "archive",
+          "url": "https://github.com/LMDB/lmdb/archive/LMDB_0.9.22.tar.gz"
+        }
+      ],
+      "make-install-args": [
+        "prefix=/app"
+      ],
+      "no-autogen": true,
+      "subdir": "libraries/liblmdb"
+    },
+    {
+      "name": "cmark",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+	"-DCMARK_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "sha256": "acc98685d3c1b515ff787ac7c994188dadaf28a2d700c10c1221da4199bae1fc",
+          "type": "archive",
+          "url": "https://github.com/commonmark/cmark/archive/0.28.3.tar.gz"
+        }
+      ]
+    },
+    {
+      "name": "spdlog",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DSPDLOG_BUILD_EXAMPLES=0",
+        "-DSPDLOG_BUILD_BENCH=0",
+        "-DSPDLOG_BUILD_TESTING=0"
+      ],
+      "sources": [
+        {
+          "sha256": "3dbcbfd8c07e25f5e0d662b194d3a7772ef214358c49ada23c044c4747ce8b19",
+          "type": "archive",
+          "url": "https://github.com/gabime/spdlog/archive/v1.1.0.tar.gz"
+        }
+      ]
+    },
+    {
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+      ],
+      "buildsystem": "cmake-ninja",
+      "name": "olm",
+      "sources": [
+        {
+          "commit": "730e5e719c6c6ace4e1862ceacf0bb4f7c626251",
+          "disable-shallow-clone": true,
+          "tag": "2.2.2",
+          "type": "git",
+          "url": "https://gitlab.matrix.org/matrix-org/olm"
+        },
+        {
+          "dest": ".",
+          "path": "cmake/CMakeLists.txt",
+          "type": "file"
+        },
+        {
+          "dest": "cmake",
+          "path": "cmake/OlmConfig.cmake.in",
+          "type": "file"
+        }
+      ]
+    },
+    {
+      "name": "sodium",
+      "sources": [
+        {
+          "sha256": "eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533",
+          "type": "archive",
+          "url": "https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.16.tar.gz"
+        }
+      ]
+    },
+    {
+      "build-commands": [
+        "./bootstrap.sh --with-libraries=random,thread,system,iostreams,atomic,chrono,date_time,regex --prefix=/app",
+        "./b2 -d0 variant=release link=shared threading=multi --layout=system",
+        "./b2 -d0 install"
+      ],
+      "buildsystem": "simple",
+      "name": "boost",
+      "sources": [
+        {
+          "sha256": "7f6130bc3cf65f56a618888ce9d5ea704fa10b462be126ad053e80e553d6d8b7",
+          "type": "archive",
+          "url": "https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2"
+        }
+      ]
+    },
+    {
+      "config-opts": [
+        "-DBUILD_LIB_TESTS=OFF",
+        "-DBUILD_LIB_EXAMPLES=OFF",
+        "-DCMAKE_BUILD_TYPE=Release"
+      ],
+      "buildsystem": "cmake",
+      "name": "mtxclient",
+      "sources": [
+        {
+          "sha256": "e7638d4a8233c0c763d48111fd13e8ad1dcd5f34e3e641b46eaf1bb920b73482",
+          "type": "archive",
+          "url": "https://github.com/nheko-reborn/mtxclient/archive/v0.2.0.tar.gz"
+        },
+        {
+          "dest": "include",
+          "sha256": "ce6b5610a051ec6795fa11c33854abebb086f0fd67c311f5921c3c07f9531b44",
+          "type": "file",
+          "url": "https://github.com/nlohmann/json/releases/download/v3.2.0/json.hpp"
+        }
+      ]
+    },
+    {
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DTWEENY_BUILD_DOCUMENTATION=OFF",
+        "-DTWEENY_BUILD_EXAMPLES=OFF"
+      ],
+      "buildsystem": "cmake-ninja",
+      "name": "tweeny",
+      "sources": [
+        {
+          "sha256": "482857256a7235646004682912badb6521d361ed6987c8ebdae7986bf64ce694",
+          "type": "archive",
+          "url": "https://github.com/mobius3/tweeny/archive/43f4130f7e4a67c19d870b60864bc2862c19b81f.tar.gz"
+        }
+      ]
+    },
+    {
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLMDBXX_INCLUDE_DIR=.deps/lmdbxx"
+      ],
+      "buildsystem": "cmake",
+      "name": "nheko",
+      "sources": [
+        {
+          "sha256": "869dea68ad53258cbff4e41bb3e2894742ef90568779787d8eb5391112eb3d48",
+          "type": "archive",
+          "url": "https://github.com/mujx/nheko/archive/v0.6.2.tar.gz"
+        },
+        {
+          "dest": ".deps/lmdbxx",
+          "sha256": "93721132bbf5045d38ad62de2997655e9984c48ea5c9886746d42128f4b26fbd",
+          "type": "archive",
+          "url": "https://github.com/bendiken/lmdbxx/archive/0b43ca87d8cfabba392dfe884eb1edb83874de02.tar.gz"
+        }
+      ]
+    }
+  ]
+}

--- a/io.github.Nheko-Reborn.Nheko.json
+++ b/io.github.Nheko-Reborn.Nheko.json
@@ -96,7 +96,7 @@
           "disable-shallow-clone": true,
           "tag": "2.2.2",
           "type": "git",
-          "url": "https://gitlab.matrix.org/matrix-org/olm"
+          "url": "https://gitlab.matrix.org/matrix-org/olm.git"
         },
         {
           "dest": ".",

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -100,6 +100,20 @@
       ]
     },
     {
+      "config-opts":[
+        "-DJSON_BuildTests=OFF"
+      ],
+      "buildsystem":"cmake",
+      "name": "nlohmann",
+      "sources":[
+        {
+          "sha256": "2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1",
+          "type": "archive",
+          "url": "https://github.com/nlohmann/json/archive/v3.2.0.tar.gz"
+        }
+      ]
+    },
+    {
       "name": "sodium",
       "sources": [
         {
@@ -129,8 +143,7 @@
       "config-opts": [
         "-DBUILD_LIB_TESTS=OFF",
         "-DBUILD_LIB_EXAMPLES=OFF",
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DJson_INCLUDE_DIR=.deps/nlohmann/include"
+        "-DCMAKE_BUILD_TYPE=Release"
       ],
       "buildsystem": "cmake",
       "name": "mtxclient",
@@ -139,12 +152,6 @@
           "sha256": "c56b0cfbe15157b96d429dd56dd88b7f6e33a06f670815336c6dd2aade8d54fc",
           "type": "archive",
           "url": "https://github.com/Nheko-Reborn/mtxclient/archive/d5cc703848b44c1a9c543dc01355b7881f66ea81.tar.gz"
-        },
-        {
-          "dest": ".deps/nlohmann",
-          "sha256": "2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1",
-          "type": "archive",
-          "url": "https://github.com/nlohmann/json/archive/v3.2.0.tar.gz"
         }
       ]
     },

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -1,5 +1,5 @@
 {
-  "id": "io.github.Nheko-Reborn.Nheko",
+  "id": "io.github.NhekoReborn.Nheko",
   "command": "nheko",
   "branch": "stable",
   "runtime": "org.kde.Platform",

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -140,10 +140,9 @@
           "url": "https://github.com/Nheko-Reborn/mtxclient/archive/d5cc703848b44c1a9c543dc01355b7881f66ea81.tar.gz"
         },
         {
-          "dest": "include",
-          "sha256": "ce6b5610a051ec6795fa11c33854abebb086f0fd67c311f5921c3c07f9531b44",
-          "type": "file",
-          "url": "https://github.com/nlohmann/json/releases/download/v3.2.0/json.hpp"
+          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "type": "archive",
+          "url": "https://github.com/nlohmann/json/archive/v3.2.0.tar.gz"
         }
       ]
     },

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -140,7 +140,7 @@
           "url": "https://github.com/Nheko-Reborn/mtxclient/archive/d5cc703848b44c1a9c543dc01355b7881f66ea81.tar.gz"
         },
         {
-          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "sha256": "2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1",
           "type": "archive",
           "url": "https://github.com/nlohmann/json/archive/v3.2.0.tar.gz"
         }

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -135,9 +135,9 @@
       "name": "mtxclient",
       "sources": [
         {
-          "sha256": "e7638d4a8233c0c763d48111fd13e8ad1dcd5f34e3e641b46eaf1bb920b73482",
+          "sha256": "c56b0cfbe15157b96d429dd56dd88b7f6e33a06f670815336c6dd2aade8d54fc",
           "type": "archive",
-          "url": "https://github.com/Nheko-Reborn/mtxclient/archive/v0.2.0.tar.gz"
+          "url": "https://github.com/Nheko-Reborn/mtxclient/archive/d5cc703848b44c1a9c543dc01355b7881f66ea81.tar.gz"
         },
         {
           "dest": "include",
@@ -172,9 +172,9 @@
       "name": "nheko",
       "sources": [
         {
-          "sha256": "e88678d10195f5e2618e0d1a44cc9c152122ff3ab03b347d00f16b39abe2ac3e",
+          "sha256": "d596a57328fbcded784d7158b811df58ef8daedbf6dc9c80c456df1b6ed1fc25",
           "type": "archive",
-          "url": "https://github.com/Nheko-Reborn/nheko/archive/v0.6.3.tar.gz"
+          "url": "https://github.com/Nheko-Reborn/nheko/archive/7819fea9ff4c48aaab255d67e4172691ee25ca60.tar.gz"
         },
         {
           "dest": ".deps/lmdbxx",

--- a/io.github.NhekoReborn.Nheko.json
+++ b/io.github.NhekoReborn.Nheko.json
@@ -129,7 +129,8 @@
       "config-opts": [
         "-DBUILD_LIB_TESTS=OFF",
         "-DBUILD_LIB_EXAMPLES=OFF",
-        "-DCMAKE_BUILD_TYPE=Release"
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DJson_INCLUDE_DIR=.deps/nlohmann/include"
       ],
       "buildsystem": "cmake",
       "name": "mtxclient",
@@ -140,6 +141,7 @@
           "url": "https://github.com/Nheko-Reborn/mtxclient/archive/d5cc703848b44c1a9c543dc01355b7881f66ea81.tar.gz"
         },
         {
+          "dest": ".deps/nlohmann",
           "sha256": "2de558ff3b3b32eebfb51cf2ceb835a0fa5170e6b8712b02be9c2c07fcfe52a1",
           "type": "archive",
           "url": "https://github.com/nlohmann/json/archive/v3.2.0.tar.gz"


### PR DESCRIPTION
I'm opening a PR for an updated version of nheko.  @mujx has retired his nheko repository, so it is now being updated under Nheko-Reborn/nheko.  Several users have requested FlatHub / FlatPak packages of nheko.  I largely copied the manifest from https://github.com/flathub/io.github.mujx.Nheko, but updated it where appropriate to reference the new GitHub organization (and also update the path for olm, since it has moved).

Let me know what else I need to do.