### PR TITLE
Add org.gnome.Mahjongg

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,18 @@
+--- a/data/org.gnome.Mahjongg.appdata.xml.in	2019-06-10 16:01:57.476292999 +0200
++++ b/data/org.gnome.Mahjongg.appdata.xml.in	2019-06-10 16:03:47.839849171 +0200
+@@ -21,6 +21,9 @@
+    time penalty.
+   </p>
+   </description>
++  <releases>
++    <release version="3.32.0" date="2019-03-11" />
++  </releases>
+   <screenshots>
+     <screenshot height="524" width="972" type="default">
+       <image>https://people.gnome.org/~mcatanzaro/gnome-mahjongg.png</image>
+@@ -40,4 +43,5 @@
+     <kudo>UserDocs</kudo>
+   </kudos>
+   <translation type="gettext">gnome-mahjongg</translation>
++  <content_rating type="oars-1.1" />
+ </component>

--- a/org.gnome.Mahjongg.yaml
+++ b/org.gnome.Mahjongg.yaml
@@ -1,0 +1,28 @@
+app-id: org.gnome.Mahjongg
+runtime: org.gnome.Platform
+sdk: org.gnome.Sdk
+runtime-version: '3.32'
+command: gnome-mahjongg
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+
+modules:
+  - name: gnome-mahjongg
+    buildsystem: meson
+    sources:
+        - type: git
+          url: https://gitlab.gnome.org/GNOME/gnome-mahjongg.git
+          tag: '3.32.0'
+          commit: 'ab72d2b3f50f4d96e092c3afcb93c3e7d76bd3b5'
+        - type: patch
+          path: appdata.patch
+cleanup:
+  - "/share/man"


### PR DESCRIPTION
I took over https://github.com/flathub/flathub/pull/755 and added a patch to fix the appdata file.
Of course, I sent that patch upstream: https://gitlab.gnome.org/GNOME/gnome-mahjongg/merge_requests/14