### PR TITLE
Add org.gtk.Gtk3theme.Lounge-compact

### DIFF
--- a/org.gtk.Gtk3theme.Lounge-compact.appdata.xml
+++ b/org.gtk.Gtk3theme.Lounge-compact.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+    <id>org.gtk.Gtk3theme.Lounge-compact</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Lounge-compact gtk theme</name>
+    <summary>Lounge-compact gtk theme</summary>
+    <description>
+        <p>Simple and clean gtk theme</p>
+    </description>
+    <url type="homepage">https://github.com/monday15/lounge-gtk-theme</url>
+</component>

--- a/org.gtk.Gtk3theme.Lounge-compact.json
+++ b/org.gtk.Gtk3theme.Lounge-compact.json
@@ -1,0 +1,86 @@
+{
+  "id": "org.gtk.Gtk3theme.Lounge-compact",
+  "branch": "3.22",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "1.6",
+  "sdk": "org.freedesktop.Sdk",
+  "build-extension": true,
+  "appstream-compose": false,
+  "separate-locales": false,
+  "build-options": {
+    "prefix": "/usr/share/runtime/share/themes/Lounge-compact/gtk-3.0"
+  },
+  "modules": [
+    {
+      "name": "sassc",
+      "config-opts": ["--with-libsass=/usr/share/runtime/share/themes/Lounge-compact/gtk-3.0"],
+      "cleanup": ["*"],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/sass/sassc/archive/3.5.0.tar.gz",
+          "sha256": "26f54e31924b83dd706bc77df5f8f5553a84d51365f0e3c566df8de027918042"
+        },
+        {
+          "type": "script",
+          "dest-filename": "autogen.sh",
+          "commands": ["autoreconf -si"]
+        }
+      ],
+      "modules": [
+        {
+          "name": "libsass",
+          "cleanup": ["*"],
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://github.com/sass/libsass/archive/3.5.4.tar.gz",
+              "sha256": "5f61cbcddaf8e6ef7a725fcfa5d05297becd7843960f245197ebb655ff868770"
+            },
+            {
+              "type": "script",
+              "dest-filename": "autogen.sh",
+              "commands": ["autoreconf -si"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Lounge-compact",
+      "buildsystem": "meson",
+      "build-options": {
+        "prefix": "/usr/share/runtime",
+        "append-path": "/usr/share/runtime/share/themes/Lounge-compact/gtk-3.0/bin"
+      },
+      "config-opts": [
+        "-Dflatpak=true",
+        "-Dflatpak-size=compact",
+        "-Dflatpak-variant=light"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/monday15/lounge-gtk-theme.git",
+          "branch": "testing",
+          "commit": "76302725fec9ab3b297f03e8d826a442c0a642c4"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm644 org.gtk.Gtk3theme.Lounge-compact.appdata.xml ${FLATPAK_DEST}/share/appdata/org.gtk.Gtk3theme.Lounge-compact.appdata.xml",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Lounge-compact --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Lounge-compact"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Lounge-compact.appdata.xml"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
Hi!
This is compact variant of Lounge gtk theme, already published on flathub.

Note, I moved flatpak build instructions to the end of meson.build file, you can check it [here](https://github.com/monday15/lounge-gtk-theme/blob/testing/meson.build#L374).