### PR TITLE
add torbrowser

### DIFF
--- a/org.torproject.torbrowser.appdata.xml
+++ b/org.torproject.torbrowser.appdata.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2014 Micah Lee <micah@micahflee.com> -->
+<component>
+ <id>org.torproject.torbrowser.desktop</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>MIT</project_license>
+ <name>Tor Browser</name>
+ <summary>Protect yourself against tracking, surveillance, and censorship. </summary>
+ <description>
+  <p>Get connected
+
+  If you are in a country where Tor is blocked, you can configure Tor to connect to a bridge during the setup process.
+
+  Select "Tor is censored in my country."
+
+  If Tor is not censored, one of the most common reasons Tor won't connect is an incorrect system clock. Please make sure it's set correctly.
+  </p>
+  <p>
+  Stay safe
+
+  Please do not torrent over Tor.
+  Tor Browser will block browser plugins such as Flash, RealPlayer, Quicktime, and others: they can be manipulated into revealing your IP address.
+
+  We do not recommend installing additional add-ons or plugins into Tor Browser
+
+  Plugins or addons may bypass Tor or compromise your privacy. Tor Browser already comes with HTTPS Everywhere, NoScript, and other patches to protect your privacy and security.  
+  </p>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image>https://raw.githubusercontent.com/micahflee/torbrowser-launcher/master/screenshot.png</image>
+   <caption>Window to change Tor Browser Launcher settings</caption>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">https://github.com/micahflee/torbrowser-launcher</url>
+ <update_contact>tobiasmue@gnome.org</update_contact>
+</component>
+

--- a/org.torproject.torbrowser.yml
+++ b/org.torproject.torbrowser.yml
@@ -46,5 +46,5 @@ modules:
           dest-filename: launch.sh
 
         - type: archive
-          url: https://www.torproject.org/dist/torbrowser/8.5.3/tor-browser-linux64-8.5.3_en-US.tar.xz
-          sha256: 4f2011f83f014abddc1a23ead058efd7b8ec75bfdd23040573b4c6c3be02b496
+          url: https://www.torproject.org/dist/torbrowser/8.5.4/tor-browser-linux64-8.5.4_en-US.tar.xz
+          sha256: df248f7751b8bff862c761dab3a1502557ab92864f4ac40e41cd523ba6f5df5a

--- a/org.torproject.torbrowser.yml
+++ b/org.torproject.torbrowser.yml
@@ -1,0 +1,50 @@
+app-id: org.torproject.torbrowser
+
+runtime: org.gnome.Platform
+runtime-version: "3.32"
+sdk: org.gnome.Sdk
+
+command: launch.sh
+
+finish-args:
+  - --socket=x11
+  # - --share=ipc
+  - --share=network
+
+modules:
+  - name: torbrowser
+    buildsystem: simple
+    build-commands:
+        - install -D Browser/browser/chrome/icons/default/default64.png   /app/share/icons/hicolor/64x64/apps/org.torproject.torbrowser.png
+        #- install -D Browser/start-tor-browser.desktop /app/share/applications/org.torproject.browser.desktop
+        - sed -i s,Icon=torbrowser,Icon=org.torproject.torbrowser,  torbrowser.desktop
+        - sed -i "s,Exec=torbrowser-launcher %u,Exec=/app/bin/launch.sh,"  torbrowser.desktop
+        - install -D torbrowser.appdata.xml  /app/share/metainfo/org.torproject.torbrowser.appdata.xml
+        - install -D torbrowser.desktop  /app/share/applications/org.torproject.torbrowser.desktop
+        - mv Browser /app
+        - install -D -m a=rx launch.sh   /app/bin/launch.sh
+    
+    cleanup:
+      - /Browser/TorBrowser/Docs/
+    sources:
+        - type: file
+          url: https://raw.githubusercontent.com/micahflee/torbrowser-launcher/develop/share/metainfo/torbrowser.appdata.xml
+          sha256: 4aa47248ce6ea3b54fe349bfa03169dc72cceb2f206d517cbf37eeab929d68d0
+
+        - type: file
+          url: https://raw.githubusercontent.com/micahflee/torbrowser-launcher/develop/share/applications/torbrowser.desktop
+          sha256: edc4a08adcfb78468a34bd46ef8f0de0ef5fdb141bd438709e755dc8b2a3eee6
+
+        - type: script
+          commands:
+            # Yes. This is dirty. The tarball contains a Firefox profile directory which Firefox expects to be able to write...
+            # The tmp directory is, at least when following this manifest and not overwriting the settings, a tmpfs, so we can (or have to) copy over everytime we launch.
+            - cp -ar --reflink=auto /app/Browser /tmp/
+            - cd /tmp/
+            - cd Browser
+            - ./start-tor-browser
+          dest-filename: launch.sh
+
+        - type: archive
+          url: https://www.torproject.org/dist/torbrowser/8.5.3/tor-browser-linux64-8.5.3_en-US.tar.xz
+          sha256: 4f2011f83f014abddc1a23ead058efd7b8ec75bfdd23040573b4c6c3be02b496


### PR DESCRIPTION
This is a flatpak for the Tor Browser: https://www.torproject.org/download/

It is a bit rough around the edges, i.e. it copies `/app/` to `/tmp/`, because `/app/` is a Firefox profile directory and Firefox wants to write to that.  `/tmp`  is a tmpfs so we have an ephemeral state, which is probably appreciated if updates are regularly trickling through to the flatpaked version.
Anyway, I appreciate that this is a bit unorthodox and may present a reason for not including the app on flathub. In that case, some other interested party might be interested in picking the work up from here and include the app in their "appstore".

Building from source doesn't even work for mere mortals on a normal machine, so I haven't even tried to build the torbrowser from source.

I've mentioned the manifest upstream in this ticket and asked for co-maintenance: https://trac.torproject.org/projects/tor/ticket/25578

