### PR TITLE
added xournalpp

### DIFF
--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -1,7 +1,7 @@
 app-id: com.github.xournalpp.xournalpp
-runtime: org.gnome.Platform
-runtime-version: '3.32'
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: '18.08'
+sdk: org.freedesktop.Sdk
 command: xournalpp
 rename-icon: xournalpp
 rename-desktop-file: xournalpp.desktop

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -91,7 +91,7 @@ modules:
     buildsystem: cmake-ninja
     post-install:
       - sed -i s,xournalpp.desktop,com.github.xournalpp.desktop,g  xournalpp.appdata.xml
-      - install -Dma+r xournalpp.appdata.xml /app/share/metainfo/com.github.xournalpp.appdata.xml
+      - install -Dma+r xournalpp.appdata.xml /app/share/metainfo/com.github.xournalpp.xournalpp.appdata.xml
       - install -Dma+r /app/share/mime/packages/xournalpp.xml  /app/share/mime/packages/com.github.xournalpp.xournalpp.xml
 
     sources:

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -92,7 +92,7 @@ modules:
     post-install:
       - sed -i s,xournalpp.desktop,com.github.xournalpp.desktop,g  xournalpp.appdata.xml
       - install -Dma+r xournalpp.appdata.xml /app/share/metainfo/com.github.xournalpp.appdata.xml
-      - install -Dma+r /app/share/mime/packages/xournalpp.xml  /app/share/mime/packages/com.github.xournalpp.xml
+      - install -Dma+r /app/share/mime/packages/xournalpp.xml  /app/share/mime/packages/com.github.xournalpp.xournalpp.xml
 
     sources:
       - type: git

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -5,7 +5,6 @@ sdk: org.gnome.Sdk
 command: xournalpp
 rename-icon: xournalpp
 rename-desktop-file: xournalpp.desktop
-rename-appdata-file: xournalpp.xml
 finish-args:
   # X11 + XShm access
   - "--share=ipc"

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -1,0 +1,104 @@
+app-id: com.github.xournalpp.xournalpp
+runtime: org.gnome.Platform
+runtime-version: '3.32'
+sdk: org.gnome.Sdk
+command: xournalpp
+rename-icon: xournalpp
+rename-desktop-file: xournalpp.desktop
+rename-appdata-file: xournalpp.xml
+finish-args:
+  # X11 + XShm access
+  - "--share=ipc"
+  - "--socket=x11"
+  # Wayland access
+  - "--socket=wayland"
+  # Needs to save files locally
+  # Why are portals not used? Does the app re-implement the open dialogue?
+  - "--filesystem=xdg-documents"
+  - "--socket=pulseaudio"
+  # Allow dconf
+  - "--filesystem=xdg-run/dconf"
+  - "--filesystem=~/.config/dconf:ro"
+  - "--talk-name=ca.desrt.dconf"
+  - "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+  - "--persist=.xournalpp"
+
+cleanup:
+  - "/include"
+  - "/lib/pkgconfig"
+  - "/man"
+  - "/share/doc"
+  - "/share/gtk-doc"
+  - "/share/man"
+  - "/share/pkgconfig"
+  - "*.la"
+  - "*.a"
+modules:
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+      - "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+      - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
+      - "-DENABLE_LIBOPENJPEG=none"
+    cleanup:
+      - "/bin"
+    sources:
+      - type: archive
+        url: https://poppler.freedesktop.org/poppler-0.69.0.tar.xz
+        sha256: 637ff943f805f304ff1da77ba2e7f1cbd675f474941fd8ae1e0fc01a5b45a3f9
+  - name: libzip
+    buildsystem: cmake-ninja
+    config-opts:
+      - "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+      - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
+    cleanup:
+      - "/bin"
+    sources:
+      - type: archive
+        url: https://libzip.org/download/libzip-1.5.2.tar.xz
+        sha256: b3de4d4bd49a01e0cab3507fc163f88e1651695b6b9cb25ad174dbe319d4a3b4
+
+  - name: libportaudiocpp
+    buildsystem: autotools
+    config-opts:
+      - "--enable-cxx" # compile with c++ headers!!!
+    make-args:
+        # seem parallel build is broken. At least it breaks for me, locally
+        - -j1
+    sources:
+      - type: git
+        url: https://git.assembla.com/portaudio.git
+        commit: 396fe4b6699ae929d3a685b3ef8a7e97396139a4
+    cleanup:
+      - "/include"
+      - "/lib/*.a"
+      - "/lib/*.la"
+      - "/lib/pkgconfig"
+      - "/man"
+      - "/share/aclocal"
+      - "/share/doc"
+      - "/share/gtk-doc"
+      - "/share/man"
+      - "/share/pkgconfig"
+
+  - name: libsndfile
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: http://www.mega-nerd.com/libsndfile/files/libsndfile-1.0.27.tar.gz
+        sha256: a391952f27f4a92ceb2b4c06493ac107896ed6c76be9a613a4731f076d30fac0
+
+  - name: xournallpp
+    buildsystem: cmake-ninja
+    post-install:
+      - sed -i s,xournalpp.desktop,com.github.xournalpp.desktop,g  xournalpp.appdata.xml
+      - install -Dma+r xournalpp.appdata.xml /app/share/metainfo/com.github.xournalpp.appdata.xml
+      - install -Dma+r /app/share/mime/packages/xournalpp.xml  /app/share/mime/packages/com.github.xournalpp.xml
+
+    sources:
+      - type: git
+        url: https://github.com/xournalpp/xournalpp
+        commit: 14e9012b94e005112387dbb7d2ed59274d542885
+        tag: 1.0.10
+      - type: file
+        path: xournalpp.appdata.xml

--- a/com.github.xournalpp.xournalpp.yaml
+++ b/com.github.xournalpp.xournalpp.yaml
@@ -90,7 +90,7 @@ modules:
   - name: xournallpp
     buildsystem: cmake-ninja
     post-install:
-      - sed -i s,xournalpp.desktop,com.github.xournalpp.desktop,g  xournalpp.appdata.xml
+      - sed -i s,xournalpp.desktop,com.github.xournalpp.xournalpp.desktop,g  xournalpp.appdata.xml
       - install -Dma+r xournalpp.appdata.xml /app/share/metainfo/com.github.xournalpp.xournalpp.appdata.xml
       - install -Dma+r /app/share/mime/packages/xournalpp.xml  /app/share/mime/packages/com.github.xournalpp.xournalpp.xml
 

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -65,4 +65,14 @@
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <update_contact>webmaster_AT_huberulrich.de</update_contact>
   <content_rating type="oars-1.0"/>
+  <releases>
+    <!-- Could be automated more:
+	 `git tag --list | grep "^[0-9]*\.[0-9]*\.[0-9]*$`"
+    -->
+    <release date="2019-05-26" version="1.0.12"/>
+    <release date="2019-04-01" version="1.0.10"/>
+    <release date="2019-02-16" version="1.0.8"/>
+    <release date="2019-01-19" version="1.0.7"/>
+    <release date="2018-12-30" version="1.0.5"/>
+  </releases>
 </component>

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -66,6 +66,6 @@
       <image>https://i.imgur.com/3uxu40d.png</image>
     </screenshot>
   </screenshots>
-  <launchable type="desktop-id">xournalpp.desktop</launchable>
+  <launchable type="desktop-id">@app-id@.desktop</launchable>
   <update_contact>webmaster_AT_huberulrich.de</update_contact>
 </component>

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -64,4 +64,5 @@
   </screenshots>
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <update_contact>webmaster_AT_huberulrich.de</update_contact>
+  <content_rating type="oars-1.0"/>
 </component>

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>xournalpp.desktop</id>
+  <translation type="gettext">xournalpp</translation>
+  <name>Xournal++</name>
+  <summary>Take handwritten notes</summary>
+  <summary xml:lang="ca">Preneu notes a mà</summary>
+  <summary xml:lang="cs">Dělejte si rukou psané poznámky</summary>
+  <summary xml:lang="de">Handnotizen erstellen</summary>
+  <summary xml:lang="fr">Prise de notes manuscrites</summary>
+  <summary xml:lang="pl">Notatki odręczne</summary>
+  <developer_name>Xournalpp Developers</developer_name>
+  <description>
+   <p>
+    Xournal++ is a hand note taking software written in C++ with the target of
+    flexibility, functionality and speed. Stroke recognizer and other parts are
+    based on Xournal Code, which you can find at sourceforge. It supports Linux
+    (e.g. Ubuntu, Debian, Arch, Suse), macOS and Windows 10. Supports pen input
+    from devices such as Wacom Tablets. 
+   </p>
+   <p>Xournal++ features:</p>
+   <ul>
+     <li>Support for Pen preassure, e.g. Wacom Tablet</li>
+     <li>Support for annotating PDFs</li>
+     <li>Fill shape functionality</li>
+     <li>PDF Export (with and without paper style)</li>
+     <li>PNG Export (with and without transparent background)</li>
+     <li>Allow to map different tools / colors etc. to stylus buttons / mouse buttons</li>
+     <li>Sidebar with Page Previews with advanced page sorting, PDF Bookmarks and Layers</li>
+     <li>Enhanced support for image insertion</li>
+     <li>Eraser with multiple configurations</li>
+     <li>Significantly reduced memory usage and code to detect memory leaks compared to Xournal</li>
+     <li>LaTeX support (requires a working LaTeX install)</li>
+     <li>Bug reporting, autosave, and auto backup tools</li>
+     <li>Customizeable toolbar, with multiple configurations, e.g. to optimize toolbar for portrait/landscape</li>
+     <li>Page Template definitions</li>
+     <li>Shape drawing (line, arrow, circle, rect)</li>
+     <li>Shape resizing and rotation</li>
+     <li>Rotation snapping every 45 degrees</li>
+     <li>Rect snapping to grid</li>
+     <li>Audio recording and playback alongside with handwritten notes</li>
+     <li>Multi Language Support, Like English, German (Deutsch), Italian (Italiano)...</li>
+     <li>Plugins using LUA Scripting</li>
+   </ul>
+  </description>
+  <categories>
+    <category>Utility</category>
+    <category>TextEditor</category>
+  </categories>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <url type="bugtracker">https://github.com/xournalpp/xournalpp/issues</url>
+  <url type="help">https://github.com/xournalpp/xournalpp/wiki/User-Manual</url>
+  <url type="homepage">https://github.com/xournalpp/xournalpp</url>
+  <project_group>GNOME</project_group>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://i.imgur.com/Muc4nmw.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/xournalpp/xournalpp/master/readme/background.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://i.imgur.com/awHSGG9.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://i.imgur.com/3uxu40d.png</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">xournalpp.desktop</launchable>
+  <update_contact>webmaster_AT_huberulrich.de</update_contact>
+</component>

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -43,10 +43,6 @@
      <li>Plugins using LUA Scripting</li>
    </ul>
   </description>
-  <categories>
-    <category>Utility</category>
-    <category>TextEditor</category>
-  </categories>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <url type="bugtracker">https://github.com/xournalpp/xournalpp/issues</url>

--- a/xournalpp.appdata.xml
+++ b/xournalpp.appdata.xml
@@ -52,7 +52,6 @@
   <url type="bugtracker">https://github.com/xournalpp/xournalpp/issues</url>
   <url type="help">https://github.com/xournalpp/xournalpp/wiki/User-Manual</url>
   <url type="homepage">https://github.com/xournalpp/xournalpp</url>
-  <project_group>GNOME</project_group>
   <screenshots>
     <screenshot type="default">
       <image>https://i.imgur.com/Muc4nmw.png</image>


### PR DESCRIPTION
https://github.com/xournalpp/xournalpp/

The manifest has been taken from the upstream repository.
It has been tweaked a little bit: The parallel build of libportaudiocpp has been disabled, because it failed for me.
And the empty build-options (and configure) array has been removed as well as an appdata file is installed.
The appdata file has been taken from https://github.com/xournalpp/xournalpp/issues/1298 and has been proposed as a PR upstream.