### PR TITLE
Initial manifest for CRUSH (2.50-1).

### DIFF
--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -19,8 +19,11 @@
 		"build-commands": [
 			"/usr/lib/sdk/openjdk/install.sh",
 			"mkdir -p /app/share/crush",
+            "mkdir -p Install/posix/share/metainfo",
+			"mv com.sigmyne.crush.appdata.xml Install/posix/share/metainfo/",
 			"cp -a Install/posix/share /app/",
 			"cp -a Install/posix/man /app/share/",
+			"mkdir -p /app/share/doc/crush",
 			"cp -a Documentation/* /app/share/doc/crush/",
 			"cp -a copyright /app/share/doc/crush/",
 			"cp -a license.txt /app/share/doc/crush/",
@@ -42,6 +45,11 @@
 			"type": "archive",
 			"url": "https://github.com/attipaci/crush/releases/download/2.50-1/crush-2.50-1.tar.gz",
 			"sha256": "e5c95d0dd2fa99a865ae04d6fe8260070cd8507f1cdcce6ad14aef35fba7963f"
+		},
+		{
+			"type": "file",
+			"url": "https://www.sigmyne.com/crush/com.sigmyne.crush.appdata.xml",
+			"sha256": "9c154ec65c3c4587fe9e9afc14c287d6581bea4a9e61dd93baed9128afa2a58a"
 		}
 		]
 	}

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -1,0 +1,49 @@
+{
+    "app-id": "com.sigmyne.crush",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "18.08",
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
+    "command": "crush",
+    "finish-args": [
+   	"--share=network",
+       	"--socket=wayland",
+	"--socket=fallback-x11",
+	"--filesystem=host",
+	"--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
+    ],
+    "modules": [
+        {
+            "name": "crush",
+            "buildsystem": "simple",
+            "build-commands": [
+		"/usr/lib/sdk/openjdk/install.sh",
+    		"mkdir -p /app/share/crush",
+		"install -d Install/posix/share /app/",
+		"install -d Install/posix/man /app/share/",
+		"install -D -t /app/share/doc/crush Documentation/*",
+		"install -D -t /app/share/doc/crush copyright",
+		"install -D -t /app/share/doc/crush license.txt",
+		"rm -rf Install",
+		"rm -rf Documentation",
+		"cp -a * /app/share/crush/",
+		"mkdir -p /app/bin",
+		"ln -sfr /app/share/crush/crush /app/bin",
+		"ln -sfr /app/share/crush/coadd /app/bin",
+		"ln -sfr /app/share/crush/detect /app/bin",
+		"ln -sfr /app/share/crush/difference /app/bin",
+		"ln -sfr /app/share/crush/esorename /app/bin",
+		"ln -sfr /app/share/crush/histogram /app/bin",
+		"ln -sfr /app/share/crush/imagetool /app/bin",
+		"ln -sfr /app/share/crush/show /app/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/attipaci/crush/releases/download/2.50-1/crush-2.50-1.tar.gz",
+		    "sha256": "e5c95d0dd2fa99a865ae04d6fe8260070cd8507f1cdcce6ad14aef35fba7963f"
+                }
+            ]
+        }
+    ]
+}

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -18,7 +18,7 @@
             "buildsystem": "simple",
             "build-commands": [
 		"/usr/lib/sdk/openjdk/install.sh",
-    		"mkdir -p /app/share/crush",
+		"mkdir -p /app/share/crush",
 		"install -d Install/posix/share /app/",
 		"install -d Install/posix/man /app/share/",
 		"install -D -t /app/share/doc/crush Documentation/*",

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -1,49 +1,49 @@
 {
-    "app-id": "com.sigmyne.crush",
-    "runtime": "org.freedesktop.Platform",
-    "runtime-version": "18.08",
-    "sdk": "org.freedesktop.Sdk",
-    "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
-    "command": "crush",
-    "finish-args": [
-   	"--share=network",
-       	"--socket=wayland",
-	"--socket=fallback-x11",
-	"--filesystem=host",
-	"--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
-    ],
-    "modules": [
-        {
-            "name": "crush",
-            "buildsystem": "simple",
-            "build-commands": [
-		"/usr/lib/sdk/openjdk/install.sh",
-		"mkdir -p /app/share/crush",
-		"install -d Install/posix/share /app/",
-		"install -d Install/posix/man /app/share/",
-		"install -D -t /app/share/doc/crush Documentation/*",
-		"install -D -t /app/share/doc/crush copyright",
-		"install -D -t /app/share/doc/crush license.txt",
-		"rm -rf Install",
-		"rm -rf Documentation",
-		"cp -a * /app/share/crush/",
-		"mkdir -p /app/bin",
-		"ln -sfr /app/share/crush/crush /app/bin",
-		"ln -sfr /app/share/crush/coadd /app/bin",
-		"ln -sfr /app/share/crush/detect /app/bin",
-		"ln -sfr /app/share/crush/difference /app/bin",
-		"ln -sfr /app/share/crush/esorename /app/bin",
-		"ln -sfr /app/share/crush/histogram /app/bin",
-		"ln -sfr /app/share/crush/imagetool /app/bin",
-		"ln -sfr /app/share/crush/show /app/bin"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/attipaci/crush/releases/download/2.50-1/crush-2.50-1.tar.gz",
-		    "sha256": "e5c95d0dd2fa99a865ae04d6fe8260070cd8507f1cdcce6ad14aef35fba7963f"
-                }
-            ]
-        }
-    ]
+	"app-id": "com.sigmyne.crush",
+	"runtime": "org.freedesktop.Platform",
+	"runtime-version": "18.08",
+	"sdk": "org.freedesktop.Sdk",
+	"sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
+	"command": "crush",
+	"finish-args": [
+		"--share=network",
+		"--socket=wayland",
+		"--socket=fallback-x11",
+		"--filesystem=host",
+		"--env=PATH=/app/jre/bin:/app/bin:/usr/bin"
+	],
+	"modules": [
+	{
+		"name": "crush",
+		"buildsystem": "simple",
+		"build-commands": [
+			"/usr/lib/sdk/openjdk/install.sh",
+			"mkdir -p /app/share/crush",
+			"cp -a Install/posix/share /app/",
+			"cp -a Install/posix/man /app/share/",
+			"cp -a Documentation/* /app/share/doc/crush/",
+			"cp -a copyright /app/share/doc/crush/",
+			"cp -a license.txt /app/share/doc/crush/",
+			"rm -rf Install",
+			"rm -rf Documentation",
+			"cp -a * /app/share/crush/",
+			"mkdir -p /app/bin",
+			"ln -sfr /app/share/crush/crush /app/bin",
+			"ln -sfr /app/share/crush/coadd /app/bin",
+			"ln -sfr /app/share/crush/detect /app/bin",
+			"ln -sfr /app/share/crush/difference /app/bin",
+			"ln -sfr /app/share/crush/esorename /app/bin",
+			"ln -sfr /app/share/crush/histogram /app/bin",
+			"ln -sfr /app/share/crush/imagetool /app/bin",
+			"ln -sfr /app/share/crush/show /app/bin"
+		],
+		"sources": [
+		{
+			"type": "archive",
+			"url": "https://github.com/attipaci/crush/releases/download/2.50-1/crush-2.50-1.tar.gz",
+			"sha256": "e5c95d0dd2fa99a865ae04d6fe8260070cd8507f1cdcce6ad14aef35fba7963f"
+		}
+		]
+	}
+	]
 }

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -49,7 +49,7 @@
 		{
 			"type": "file",
 			"url": "https://www.sigmyne.com/crush/com.sigmyne.crush.appdata.xml",
-			"sha256": "9c154ec65c3c4587fe9e9afc14c287d6581bea4a9e61dd93baed9128afa2a58a"
+			"sha256": "9f1539049535f2531d7c6a82f58e6ac5b5b80e27dcf321a3459877181d8147f9"
 		}
 		]
 	}

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -49,7 +49,7 @@
 		{
 			"type": "file",
 			"url": "https://www.sigmyne.com/crush/com.sigmyne.crush.appdata.xml",
-			"sha256": "9f1539049535f2531d7c6a82f58e6ac5b5b80e27dcf321a3459877181d8147f9"
+			"sha256": "276c30e55650b9c4f63ab58d96612d905d9185e4ee88b3c27204dfc43211a682"
 		}
 		]
 	}

--- a/com.sigmyne.crush.json
+++ b/com.sigmyne.crush.json
@@ -19,7 +19,7 @@
 		"build-commands": [
 			"/usr/lib/sdk/openjdk/install.sh",
 			"mkdir -p /app/share/crush",
-            "mkdir -p Install/posix/share/metainfo",
+			"mkdir -p Install/posix/share/metainfo",
 			"mv com.sigmyne.crush.appdata.xml Install/posix/share/metainfo/",
 			"cp -a Install/posix/share /app/",
 			"cp -a Install/posix/man /app/share/",


### PR DESCRIPTION
CRUSH is an astronomical data reduction and imaging pipeline (see [sigmyne.com/crush](https://www.sigmyne.com/crush)).

It runs on Java (>= 8).

I thought I might as well provide a flatpak release as well. This is the initial manifest for it for the current release (2.50-1).