### PR TITLE
added confclerk conference schedules offline viewer

### DIFF
--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -35,4 +35,7 @@
     <release date="2017-10-01" version="0.6.3"/>
     <release date="2017-01-24" version="0.6.2"/>
   </releases>
+  <provides>
+    <id>confclerk</id>
+  </provides>
 </component>

--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -4,9 +4,12 @@
   <id>at.priv.toastfreeware.ConfClerk</id>
   <translation type="qt">ConfClerk</translation>
   <name>ConfClerk</name>
-  <summary>ConfClerk is an application written in ​Qt, which makes conference schedules available offline. It displays the conference schedule from various views, supports searches on various items (speaker, speech topic, location, etc.) and enables you to select favorite events and create your own schedule</summary>
+  <summary>ConfClerk is an application which makes conference schedules available offline</summary>
   <developer_name>confclerk developers</developer_name>
   <description>
+   <p>
+    It displays the conference schedule from various views, supports searches on various items (speaker, speech topic, location, etc.) and enables you to select favorite events and create your own schedule
+   </p>
    <p>
     At the moment ConfClerk is able to import schedules in XML format created by the ​PentaBarf conference management system (or ​frab) used by ​FOSDEM, ​DebConf, ​Grazer Linuxtage, the ​CCC congresses, ​FrOSCon, and ​many others.
    </p>

--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -27,7 +27,7 @@
       <image>http://www.toastfreeware.priv.at/confclerk/raw-attachment/wiki/WikiStart/2013-01-28-175815_517x502_scrot.png</image>
     </screenshot>
   </screenshots>
-  <launchable type="desktop-id">@app-id@.desktop</launchable>
+  <launchable type="desktop-id">at.priv.toastfreeware.ConfClerk.desktop</launchable>
   <update_contact>tobiasmue@gnome.org</update_contact>
   <content_rating type="oars-1.0"/>
   <releases>

--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2019 Tobias Mueller <tobiasmue@gnome.org>-->
 <component type="desktop">
-  <id>cat.priv.toastfreeware.ConfClerk</id>
+  <id>at.priv.toastfreeware.ConfClerk</id>
   <translation type="qt">ConfClerk</translation>
   <name>ConfClerk</name>
   <summary>ConfClerk is an application written in ​Qt, which makes conference schedules available offline. It displays the conference schedule from various views, supports searches on various items (speaker, speech topic, location, etc.) and enables you to select favorite events and create your own schedule</summary>

--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2019 Tobias Mueller <tobiasmue@gnome.org>-->
 <component type="desktop">
-  <id>cat.priv.toastfreeware.ConfClerk.desktop</id>
+  <id>cat.priv.toastfreeware.ConfClerk</id>
   <translation type="qt">ConfClerk</translation>
   <name>ConfClerk</name>
   <summary>ConfClerk is an application written in ​Qt, which makes conference schedules available offline. It displays the conference schedule from various views, supports searches on various items (speaker, speech topic, location, etc.) and enables you to select favorite events and create your own schedule</summary>

--- a/at.priv.toastfreeware.ConfClerk.appdata.xml
+++ b/at.priv.toastfreeware.ConfClerk.appdata.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Tobias Mueller <tobiasmue@gnome.org>-->
+<component type="desktop">
+  <id>cat.priv.toastfreeware.ConfClerk.desktop</id>
+  <translation type="qt">ConfClerk</translation>
+  <name>ConfClerk</name>
+  <summary>ConfClerk is an application written in ​Qt, which makes conference schedules available offline. It displays the conference schedule from various views, supports searches on various items (speaker, speech topic, location, etc.) and enables you to select favorite events and create your own schedule</summary>
+  <developer_name>confclerk developers</developer_name>
+  <description>
+   <p>
+    At the moment ConfClerk is able to import schedules in XML format created by the ​PentaBarf conference management system (or ​frab) used by ​FOSDEM, ​DebConf, ​Grazer Linuxtage, the ​CCC congresses, ​FrOSCon, and ​many others.
+   </p>
+   <p>
+    ConfClerk is targetted at mobile devices like the Nokia N810 and N900 but works on any system running ​Qt.
+   </p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <url type="bugtracker">http://www.toastfreeware.priv.at/confclerk/report</url>
+  <url type="help">http://www.toastfreeware.priv.at/confclerk/browser/README</url>
+  <url type="homepage">http://www.toastfreeware.priv.at/confclerk/browser/</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>http://www.toastfreeware.priv.at/confclerk/raw-attachment/wiki/WikiStart/Screenshot-20130128-180409.png</image>
+    </screenshot>
+    <screenshot>
+      <image>http://www.toastfreeware.priv.at/confclerk/raw-attachment/wiki/WikiStart/2013-01-28-175815_517x502_scrot.png</image>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">@app-id@.desktop</launchable>
+  <update_contact>tobiasmue@gnome.org</update_contact>
+  <content_rating type="oars-1.0"/>
+  <releases>
+    <release date="2017-12-08" version="0.6.4"/>
+    <release date="2017-10-01" version="0.6.3"/>
+    <release date="2017-01-24" version="0.6.2"/>
+  </releases>
+</component>

--- a/at.priv.toastfreeware.ConfClerk.yaml
+++ b/at.priv.toastfreeware.ConfClerk.yaml
@@ -4,6 +4,7 @@ runtime-version: '5.12'
 sdk: org.kde.Sdk
 command: confclerk
 rename-icon: confclerk
+copy-icon: true
 rename-desktop-file: confclerk.desktop
 finish-args:
   # X11 + XShm access

--- a/at.priv.toastfreeware.ConfClerk.yaml
+++ b/at.priv.toastfreeware.ConfClerk.yaml
@@ -1,0 +1,44 @@
+app-id: at.priv.toastfreeware.ConfClerk
+runtime: org.kde.Platform
+runtime-version: '5.12'
+sdk: org.kde.Sdk
+command: confclerk
+rename-icon: confclerk
+rename-desktop-file: confclerk.desktop
+finish-args:
+  # X11 + XShm access
+  - "--share=ipc"
+  - "--socket=x11"
+  # Wayland access
+  - "--socket=wayland"
+  # The app gets the schedules from the Internet
+  - "--share=network"
+
+cleanup:
+  - "/include"
+  - "/lib/pkgconfig"
+  - "/man"
+  - "/share/doc"
+  - "/share/gtk-doc"
+  - "/share/man"
+  - "/share/pkgconfig"
+  - "*.la"
+  - "*.a"
+
+modules:
+  - name: confclerk
+    buildsystem: qmake
+    post-install:
+        - install -D -m a+r data/confclerk.desktop /app/share/applications/confclerk.desktop
+        #- install -D -m a+r data/confclerk.svg /app/share/icons/hicolor/scalable/apps/confclerk.svg
+        - rsvg-convert -w 128 -h 128 -f png -o data/confclerk.png data/confclerk.svg
+        - install -D -m a+r data/confclerk.png /app/share/icons/hicolor/128x128/apps/confclerk.png
+        - install -D -m u+rwx,a+rx ./src/bin/confclerk /app/bin/confclerk
+
+    sources:
+      - type: archive
+        url: http://www.toastfreeware.priv.at/tarballs/confclerk/confclerk-0.6.4.tar.gz
+        sha256: 6389fc74fd6827d59aa26f6792919583e8266e65818c3bda5cdb927e09793083
+
+      - type: file
+        path: at.priv.toastfreeware.ConfClerk.appdata.xml

--- a/at.priv.toastfreeware.ConfClerk.yaml
+++ b/at.priv.toastfreeware.ConfClerk.yaml
@@ -34,6 +34,7 @@ modules:
         #- install -D -m a+r data/confclerk.svg /app/share/icons/hicolor/scalable/apps/confclerk.svg
         - rsvg-convert -w 128 -h 128 -f png -o data/confclerk.png data/confclerk.svg
         - install -D -m a+r data/confclerk.png /app/share/icons/hicolor/128x128/apps/confclerk.png
+        - install -D -m a+r at.priv.toastfreeware.ConfClerk.appdata.xml  /app/share/metainfo/at.priv.toastfreeware.ConfClerk.appdata.xml
         - install -D -m u+rwx,a+rx ./src/bin/confclerk /app/bin/confclerk
 
     sources:


### PR DESCRIPTION
http://www.toastfreeware.priv.at/confclerk

It works well enough for me, locally.

Somehow the build system does not respect the prefix, so I had to manually install the executable.