### PR TITLE
Add org.kde.WaylandDecoration.QGnomePlatform-decoration

### DIFF
--- a/org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml
+++ b/org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.kde.WaylandDecoration.QGnomePlatform</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>QGnomePlatform-decoration</name>
+  <summary>Qt Platform Theme aimed to accommodate GNOME settings</summary>
+  <description>
+    <p>QGnomePlatform is a Qt Platform Theme aimed at making Qt applications fit into a GNOME environment by reusing as many GNOME settings as it can, without changing any of them.</p>
+  </description>
+  <url type="homepage">https://github.com/FedoraQt/QGnomePlatform</url>
+</component>

--- a/org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml
+++ b/org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="runtime">
-  <id>org.kde.WaylandDecoration.QGnomePlatform</id>
+  <id>org.kde.WaylandDecoration.QGnomePlatform-decoration</id>
   <metadata_license>CC0-1.0</metadata_license>
   <name>QGnomePlatform-decoration</name>
   <summary>Qt Platform Theme aimed to accommodate GNOME settings</summary>

--- a/org.kde.WaylandDecoration.QGnomePlatform-decoration.json
+++ b/org.kde.WaylandDecoration.QGnomePlatform-decoration.json
@@ -1,0 +1,45 @@
+{
+    "id": "org.kde.WaylandDecoration.QGnomePlatform-decoration",
+    "branch": "5.12",
+    "runtime": "org.kde.Platform",
+    "build-extension": true,
+    "sdk": "org.kde.Sdk",
+    "runtime-version": "5.12",
+    "appstream-compose": false,
+    "separate-locales": false,
+    "modules": [
+        {
+            "name": "qgnomeplatform-decoration",
+            "buildsystem": "qmake",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/FedoraQt/QGnomePlatform.git",
+                    "branch": "727eeb0487a8d73f2ea4639b3c08eb08a492eced"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's@\$\$\\[QT_INSTALL_PLUGINS\\]@/usr/share/runtime/lib/plugins/QGnomePlatform-decoration@' decoration/decoration.pro",
+                        "sed -i 's@SUBDIRS += common decoration theme@SUBDIRS += common decoration@' qgnomeplatform.pro"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.kde.WaylandDecoration.QGnomePlatform-decoration --prefix=${FLATPAK_DEST} --origin=flatpak org.kde.WaylandDecoration.QGnomePlatform-decoration"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.kde.WaylandDecoration.QGnomePlatform-decoration.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
We recently added a new extension to the KDE runtime, which allows to install additional client-side decoration plugins. I have been working on decorations for Gnome as part of QGnomePlatform, however I have to push them separately as we cannot ship two different kind of plugins on one flatpak.

Note: Similar to org.kde.PlatformTheme.QGnomePlatform or org.kde.KStyle.Adwaita, this will need same Qt version matching, which means we will now need "branch/5.12" for the current KDE runtime with Qt 5.12 and later on "branch/5.13" and so on.