### PR TITLE
Add org.freedesktop.Tuhi

### DIFF
--- a/org.freedesktop.Tuhi.json
+++ b/org.freedesktop.Tuhi.json
@@ -1,0 +1,69 @@
+{
+    "app-id": "org.freedesktop.Tuhi",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.32",
+    "sdk": "org.gnome.Sdk",
+    "command": "tuhi",
+      "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.tuhi1",
+        "--own-name=org.freedesktop.tuhi1",
+        "--system-talk-name=org.bluez"
+      ],
+    "modules": [
+        {
+            "name": "pyxdg",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://anongit.freedesktop.org/xdg/pyxdg"
+                }
+            ],
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} ."
+            ]
+        },
+        {
+            "name": "python-pyparsing",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/pyparsing/pyparsing/releases/download/pyparsing_2.4.2/pyparsing-2.4.2.tar.gz",
+                    "sha512": "27e5959eb1cf0c4d899746d2d32f5f000c3753278bdbbb670d24a077053e5c08caf8429f684186c502f6d9bf358702e0a8b3fea40cd2b50807cf02ea38c750dd"
+                }
+            ],
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} ."
+            ]
+        },
+        {
+            "name": "python-svgwrite",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mozman/svgwrite.git"
+                }
+            ],
+            "build-commands": [
+                "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} ."
+            ]
+        },
+        {
+            "name": "tuhi",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/tuhiproject/tuhi",
+                    "tag": "0.2",
+                    "commit": "c71076ca1d23f939a101cdffd062a4db8ce65ada"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.Tuhi.json
+++ b/org.freedesktop.Tuhi.json
@@ -4,14 +4,14 @@
     "runtime-version": "3.32",
     "sdk": "org.gnome.Sdk",
     "command": "tuhi",
-      "finish-args": [
+    "finish-args": [
         "--share=ipc",
         "--socket=x11",
         "--socket=wayland",
         "--talk-name=org.freedesktop.tuhi1",
         "--own-name=org.freedesktop.tuhi1",
         "--system-talk-name=org.bluez"
-      ],
+    ],
     "modules": [
         {
             "name": "pyxdg",
@@ -19,7 +19,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "git://anongit.freedesktop.org/xdg/pyxdg"
+                    "url": "https://gitlab.freedesktop.org/xdg/pyxdg",
+                    "tag": "rel-0.26",
+                    "commit": "7db14dcf4c4305c3859a2d9fcf9f5da2db328330"
                 }
             ],
             "build-commands": [
@@ -46,7 +48,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/mozman/svgwrite.git"
+                    "url": "https://github.com/mozman/svgwrite.git",
+                    "tag": "v1.3.1",
+                    "commit": "13633ad13d7a4b3253d1304d31db8fc2c8d1dd9e"
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
Tuhi is GTK application to download and show drawings from Wacom Smartpad devices.

Internally it has two components, a dbus server to talk to the device and the GUI as separate process. this is for historical reasons but that's why we need the dbus bits.