### PR TITLE
Add Epiphany 3.32

### DIFF
--- a/org.gnome.Epiphany.yaml
+++ b/org.gnome.Epiphany.yaml
@@ -1,0 +1,56 @@
+app-id: org.gnome.Epiphany
+runtime: org.gnome.Platform
+runtime-version: '3.32'
+branch: stable
+sdk: org.gnome.Sdk
+command: epiphany
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=network
+  - --socket=pulseaudio
+  - --system-talk-name=org.freedesktop.GeoClue2
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Notifications
+  - --filesystem=xdg-download
+build-options:
+  config-opts:
+    - '--buildtype=debugoptimized'
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/pkgconfig
+  - /share/aclocal
+  - /man
+  - /share/man
+  - /share/gtk-doc
+  - '*.la'
+  - '*.a'
+modules:
+  - name: libdazzle
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libdazzle/3.32/libdazzle-3.32.3.tar.xz
+        sha256: 6c8d9b1514b5f6422107596f4145b89b8f2a99abef6383e086dfcd28c28667e8
+
+  - name: libhandy
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://source.puri.sm/Librem5/libhandy/-/archive/v0.0.11/libhandy-v0.0.11.tar.gz
+        sha256: c7e7b51203d9221c50b1a38ba81e0aefb5ab906c55e85b6ca2d0501e907e077d
+
+  - name: epiphany
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/epiphany/3.32/epiphany-3.32.5.tar.xz
+        sha256: be9697eeb4d15f0b37bc8771ec0fab1b1cc0fa1b3c627602340972378af744c2


### PR DESCRIPTION
Epiphany was marked end-of-life previously because GnuTLS was outdated but the GnuTLS on GNOME platform has been updated since then. The latest version of GnuTLS is 3.6.9 and GNOME 3.32 runtime has 3.6.6. GNOME 3.34 will have 3.6.9 when it is released.
The commit that marks Epiphany also says
> This is not an isolated problem, and fixing only GnuTLS is not a
> solution. Epiphany cannot return to Flathub until proper security
> support is provided by the entire runtime.

but I don’t know if other issues are solved or not. Maybe @mcatanzaro's input can help decide.