### PR TITLE
Add org.gnome.GHex

### DIFF
--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -1,0 +1,26 @@
+{
+    "app-id": "org.gnome.GHex",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.34",
+    "sdk": "org.gnome.Sdk",
+    "command": "ghex",
+    "finish-args": [
+        /* X11 + XShm */
+        "--share=ipc", "--socket=x11",
+        /* Wayland */
+        "--socket=wayland",
+        /* Filesystem */
+        "--filesystem=host"
+    ],
+    "modules": [
+        {
+            "name": "ghex",
+            "sources": [{
+                "type": "git",
+                "url": "https://gitlab.gnome.org/GNOME/ghex.git",
+                "tag": "3.18.4",
+                "commit": "228094e8d203ab62e49c33df2734fc9628c74775"
+            }]
+        }
+    ]
+}

--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -15,6 +15,7 @@
     "modules": [
         {
             "name": "ghex",
+            "buildsystem": "meson",
             "sources": [{
                 "type": "git",
                 "url": "https://gitlab.gnome.org/GNOME/ghex.git",


### PR DESCRIPTION
Replaces https://github.com/flathub/org.gnome.ghex
EOL: https://github.com/flathub/org.gnome.ghex/commit/37ab898c1672dd8ef34b4f040b87c2b6685a1d46