### PR TITLE
Add org.entangle_photo.Manager

### DIFF
--- a/entangle-2.8-appdata.patch
+++ b/entangle-2.8-appdata.patch
@@ -1,0 +1,41 @@
+diff -Naur entangle-2.0/src/entangle.appdata.xml.in entangle-2.0/src/entangle.appdata.xml.in
+index bbb8351..8695f82 100644
+--- entangle-2.0/src/entangle.appdata.xml.in
++++ entangle-2.0/src/entangle.appdata.xml.in
+@@ -38,5 +38,36 @@
+   <url type="homepage">http://entangle-photo.org/</url>
+   <developer_name>The Entangle Photo project</developer_name>
+   <updatecontact>https://groups.google.com/forum/#!forum/entangle-devel</updatecontact>
++  <content_rating type="oars-1.1" />
++  <releases>
++    <release version="2.0" date="2018-01-13">
++      <description>
++        <ul>
++          <li>Require gobject introspection >= 1.54</li>
++          <li>Require GTK3 >= 3.22</li>
++          <li>Fix dependency on libraw</li>
++          <li>Fix variable name in photobox plugin</li>
++          <li>Document some missing keyboard shortcuts</li>
++          <li>Fix upper bound in histogram to display clipped pixel</li>
++          <li>Refresh translations</li>
++          <li>Option to highlight over exposed pixels in red</li>
++          <li>Disable noisy compiler warning</li>
++          <li>Remove use of deprecated application menu concept</li>
++          <li>Fix image redraw when changing some settings</li>
++          <li>Update mailing list address in appdaat</li>
++          <li>Add more fields to appdata content</li>
++          <li>Fix reference counting during window close</li>
++          <li>Use correct API for destroying top level windows</li>
++          <li>Fix unmounting of cameras with newer gvfs URI naming scheme</li>
++          <li>Avoid out of bounds read of property values</li>
++          <li>Fix many memory leaks</li>
++          <li>Workaround for combo boxes not displaying on Wayland</li>
++          <li>Fix race condition in building enums</li>
++          <li>Fix setting of gschema directory during startup</li>
++          <li>Set env to ensure plugins can find introspection typelib</li>
++        </ul>
++      </description>
++    </release>
++  </releases>
+   <translation type="gettext">entangle</translation>
+ </component>

--- a/libraw-pkgconfig.patch
+++ b/libraw-pkgconfig.patch
@@ -1,0 +1,44 @@
+From bf4b0b6a3ec1579916475295ac42a5f98559a04b Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Fri, 12 Feb 2016 18:29:35 +0000
+Subject: [PATCH] Add pkg-config file to LibRaw
+
+Taken from the Fedora package.
+---
+ libraw.pc.in   | 5 +++--
+ libraw_r.pc.in | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/libraw.pc.in b/libraw.pc.in
+index 0e530b2..0c635f0 100644
+--- a/libraw.pc.in
++++ b/libraw.pc.in
+@@ -5,7 +5,8 @@ includedir=@includedir@
+ 
+ Name: libraw
+ Description: Raw image decoder library (non-thread-safe)
+-Requires: @PACKAGE_REQUIRES@
++Requires.private: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw@PC_OPENMP@
++Libs.private: -lstdc++
+ Cflags: -I${includedir}/libraw
+diff --git a/libraw_r.pc.in b/libraw_r.pc.in
+index a7f4535..c4e6028 100644
+--- a/libraw_r.pc.in
++++ b/libraw_r.pc.in
+@@ -5,7 +5,8 @@ includedir=@includedir@
+ 
+ Name: libraw
+ Description: Raw image decoder library (thread-safe)
+-Requires: @PACKAGE_REQUIRES@
++Requires.private: @PACKAGE_REQUIRES@
+ Version: @PACKAGE_VERSION@
+-Libs: -L${libdir} -lraw_r -lstdc++@PC_OPENMP@
++Libs: -L${libdir} -lraw_r@PC_OPENMP@
++Libs.private: -lstdc++
+ Cflags: -I${includedir}/libraw
+-- 
+2.5.0
+

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -4,6 +4,9 @@
     "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "entangle",
+    "rename-icon": "entangle",
+    "rename-desktop-file": "entangle.desktop",
+    "rename-appdata-file": "entangle.appdata.xml",
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.entangle_photo.Manager",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
+    "runtime-version": "3.34",
     "sdk": "org.gnome.Sdk",
     "command": "entangle",
     "finish-args": [
@@ -57,6 +57,16 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/libgudev/232/libgudev-232.tar.xz",
                     "sha256": "ee4cb2b9c573cdf354f6ed744f01b111d4b5bed3503ffa956cefff50489c7860"
+                }
+            ]
+        },
+        {
+            "name": "intltool",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "md5": "12e517cac2b57a0121cda351570f1e63"
                 }
             ]
         },

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -2,10 +2,8 @@
     "app-id": "org.entangle_photo.Manager",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.32",
-    "branch": "stable",
     "sdk": "org.gnome.Sdk",
     "command": "entangle",
-    "tags": [],
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",
@@ -15,10 +13,6 @@
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
-    ],
-    "build-options": {
-    },
-    "cleanup": [
     ],
     "modules": [
         {

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -14,14 +14,14 @@
         {
             "name": "libghoto2",
             "cleanup" : ["/bin", "/lib/udev", "/share/doc"],
+            "config-opts" : ["--disable-introspection", "--disable-docs"],
             "sources" : [
                 {
                     "type" : "archive",
                     "url" : "https://downloads.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
                     "sha256" : "d8af23364aa40fd8607f7e073df74e7ace05582f4ba13f1724d12d3c97e8852d"
                 }
-            ],
-            "config-opts" : ["--disable-introspection", "--disable-docs"]
+            ]
         },
         {
             "name": "gudev",
@@ -108,7 +108,6 @@
         {
             "name": "entangle",
             "buildsystem": "meson",
-            "config-opts": [],
             "sources": [
                 {
                     "type": "archive",

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -1,0 +1,153 @@
+{
+    "app-id": "org.entangle_photo.Manager",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.32",
+    "branch": "stable",
+    "sdk": "org.gnome.Sdk",
+    "command": "entangle",
+    "tags": [],
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=xdg-run/dconf",
+        "--filesystem=~/.config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "build-options": {
+    },
+    "cleanup": [
+    ],
+    "modules": [
+        {
+            "name": "libghoto2",
+            "cleanup" : ["/bin", "/lib/udev", "/share/doc"],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://datapacket.dl.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
+                    "sha256" : "d8af23364aa40fd8607f7e073df74e7ace05582f4ba13f1724d12d3c97e8852d"
+                }
+            ],
+            "config-opts" : ["--disable-introspection", "--disable-docs"]
+        },
+        {
+            "name": "systemd",
+            "buildsystem": "meson",
+            "config-opts" : ["--libdir=lib", "-Drootprefix=/app", "-Drootlibdir=/app/lib", "-Dsysconfdir=/app/etc",
+                             "-Dutmp=false", "-Dhibernate=false", "-Dldconfig=false", "-Dresolve=false", "-Defi=false",
+                             "-Dtpm=false", "-Denvironment-d=false", "-Dbinfmt=false", "-Dcoredump=false", "-Dlogind=false",
+                             "-Dhostnamed=false", "-Dlocaled=false", "-Dmachined=false", "-Dportabled=false", "-Dnetworkd=false",
+                             "-Dtimedated=false", "-Dtimesyncd=false", "-Dremote=false", "-Dnss-myhostname=false",
+                             "-Dnss-mymachines=false", "-Dnss-resolve=false", "-Dnss-systemd=false", "-Dfirstboot=false",
+                             "-Drandomseed=false", "-Dbacklight=false", "-Dvconsole=false", "-Dquotacheck=false", "-Dsysusers=false",
+                             "-Dtmpfiles=false", "-Dimportd=false", "-Dhwdb=false", "-Drfkill=false", "-Dman=false", "-Dhtml=false",
+                             "-Dbashcompletiondir=no", "-Dzshcompletiondir=no"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/systemd/systemd.git",
+                    "tag": "v242",
+                    "commit": "1e5d2d656420d0e755dbcf72aeba3c3aba54e956"
+                }
+            ],
+            "cleanup" : ["/bin", "/etc", "/lib/kernel", "/lib/modprobe.d", "/lib/rpm", "/lib/sysctl.d", "/lib/systemd", "/share"]
+        },
+        {
+            "name": "gudev",
+            "config-opts" : ["--disable-umockdev"],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libgudev/232/libgudev-232.tar.xz",
+                    "sha256": "ee4cb2b9c573cdf354f6ed744f01b111d4b5bed3503ffa956cefff50489c7860"
+                }
+            ]
+        },
+        {
+            "name": "libpeas",
+            "cleanup": [ "/bin/*", "/lib/peas-demo" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libpeas/1.22/libpeas-1.22.0.tar.xz",
+                    "sha256": "5b2fc0f53962b25bca131a5ec0139e6fef8e254481b6e777975f7a1d2702a962"
+                }
+            ]
+        },
+        {
+            "name": "exiv2",
+            "buildsystem": "cmake-ninja",
+            "cleanup": [ "/lib/exiv2" ],
+            "config-opts": [ "-DCMAKE_BUILD_TYPE=Release",
+                             "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",
+                             "-DEXIV2_BUILD_SAMPLES=OFF" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://exiv2.org/builds/exiv2-0.27.2-Source.tar.gz",
+                    "sha256": "2652f56b912711327baff6dc0c90960818211cf7ab79bb5e1eb59320b78d153f"
+                }
+            ]
+        },
+
+        {
+            "name": "gexiv2",
+            "cleanup" : ["/lib/girepository-1.0", "/share/gir-1.0"],
+            "config-opts" : ["--without-python2-girdir", "--without-python3-girdir"],
+            "build-options" : {
+                "env": {
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+                    "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+                }
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/gexiv2.git/",
+                    "commit" : "e3046adf3029db6dd6f3dc7edab30b18ff7d7014"
+                }
+            ]
+        },
+        {
+            "name": "libraw",
+            "config-opts": [ "--disable-examples",
+                             "--disable-jasper",
+                             "--disable-static",
+                             "--enable-jpeg",
+                             "--enable-lcms",
+                             "--enable-openmp" ],
+            "cleanup": [ "/share/doc" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.libraw.org/data/LibRaw-0.19.4.tar.gz",
+                    "sha256": "13c51cc5d679c36aed9c7db9a9673180e939a822e9d55b5bc28dd73113ff961f"
+                },
+                {
+                    "type": "patch",
+                    "path": "libraw-pkgconfig.patch"
+                }
+            ]
+        },
+        {
+            "name": "entangle",
+            "buildsystem": "meson",
+            "config-opts": [],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://entangle-photo.org/download/sources/entangle-2.0.tar.xz",
+                    "sha256": "7eafc72374178b85c7c2f28a5afaebe702f8f8733ba2bfc401a575464f42f65f",
+                    "git-init" : true
+                },
+                {
+                    "type": "patch",
+                    "path": "entangle-2.8-appdata.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -8,11 +8,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=x11",
-        "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--socket=wayland"
     ],
     "modules": [
         {
@@ -26,28 +22,6 @@
                 }
             ],
             "config-opts" : ["--disable-introspection", "--disable-docs"]
-        },
-        {
-            "name": "systemd",
-            "buildsystem": "meson",
-            "config-opts" : ["--libdir=lib", "-Drootprefix=/app", "-Drootlibdir=/app/lib", "-Dsysconfdir=/app/etc",
-                             "-Dutmp=false", "-Dhibernate=false", "-Dldconfig=false", "-Dresolve=false", "-Defi=false",
-                             "-Dtpm=false", "-Denvironment-d=false", "-Dbinfmt=false", "-Dcoredump=false", "-Dlogind=false",
-                             "-Dhostnamed=false", "-Dlocaled=false", "-Dmachined=false", "-Dportabled=false", "-Dnetworkd=false",
-                             "-Dtimedated=false", "-Dtimesyncd=false", "-Dremote=false", "-Dnss-myhostname=false",
-                             "-Dnss-mymachines=false", "-Dnss-resolve=false", "-Dnss-systemd=false", "-Dfirstboot=false",
-                             "-Drandomseed=false", "-Dbacklight=false", "-Dvconsole=false", "-Dquotacheck=false", "-Dsysusers=false",
-                             "-Dtmpfiles=false", "-Dimportd=false", "-Dhwdb=false", "-Drfkill=false", "-Dman=false", "-Dhtml=false",
-                             "-Dbashcompletiondir=no", "-Dzshcompletiondir=no"],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/systemd/systemd.git",
-                    "tag": "v242",
-                    "commit": "1e5d2d656420d0e755dbcf72aeba3c3aba54e956"
-                }
-            ],
-            "cleanup" : ["/bin", "/etc", "/lib/kernel", "/lib/modprobe.d", "/lib/rpm", "/lib/sysctl.d", "/lib/systemd", "/share"]
         },
         {
             "name": "gudev",

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -35,23 +35,18 @@
             ]
         },
         {
-            "name": "intltool",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
-                    "md5": "12e517cac2b57a0121cda351570f1e63"
-                }
-            ]
-        },
-        {
             "name": "libpeas",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dglade_catalog=false",
+                "-Ddemos=false"
+            ],
             "cleanup": [ "/bin/*", "/lib/peas-demo" ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libpeas/1.22/libpeas-1.22.0.tar.xz",
-                    "sha256": "5b2fc0f53962b25bca131a5ec0139e6fef8e254481b6e777975f7a1d2702a962"
+                    "url": "https://download.gnome.org/sources/libpeas/1.24/libpeas-1.24.0.tar.xz",
+                    "sha256": "0b9a00138c129a663de3eef5569b00ace03ce31d345f7af783768e9f35c8e6f9"
                 }
             ]
         },

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -115,8 +115,7 @@
                 {
                     "type": "archive",
                     "url": "http://entangle-photo.org/download/sources/entangle-2.0.tar.xz",
-                    "sha256": "7eafc72374178b85c7c2f28a5afaebe702f8f8733ba2bfc401a575464f42f65f",
-                    "git-init" : true
+                    "sha256": "7eafc72374178b85c7c2f28a5afaebe702f8f8733ba2bfc401a575464f42f65f"
                 },
                 {
                     "type": "patch",

--- a/org.entangle_photo.Manager.json
+++ b/org.entangle_photo.Manager.json
@@ -21,7 +21,7 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://datapacket.dl.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
+                    "url" : "https://downloads.sourceforge.net/project/gphoto/libgphoto/2.5.23/libgphoto2-2.5.23.tar.bz2",
                     "sha256" : "d8af23364aa40fd8607f7e073df74e7ace05582f4ba13f1724d12d3c97e8852d"
                 }
             ],


### PR DESCRIPTION
I'm trying to contribute [Entangle](https://entangle-photo.org) to flathub.

I proposed this upstream in the mailing list: https://groups.google.com/forum/#!topic/entangle-devel/R3-n_5nrVV8

Current status: it builds, the app launches, and the UI is displayed. But I couldn't yet connect my Canon camera, which works in Entangle (same app version) installed from Fedora packages. I tried passing `--device=all` but still doesn't work. Hopefully someone can help me to debug this.

All dependencies are borrowed from other apps already in flathub:

- libghoto2: from [Shotwell](https://github.com/flathub/org.gnome.Shotwell/blob/86f43c9f8943181b860d34576825ae2005e7dd62/org.gnome.Shotwell.json)

- gudev (which in turn requires systemd for udev): from [org.mixxx.Mixxx](https://github.com/flathub/org.mixxx.Mixxx/blob/c2c4c4cc0f0d9178d410457e3f725f22ac6fdb94/org.mixxx.Mixxx.yaml)

- libpeas: from [gedit](https://github.com/flathub/org.gnome.gedit/blob/41d61cce73789703b1468da13b065d3bf6eff0b9/org.gnome.gedit.json)

- exiv2 (required by gexiv2 but Shotwell had it from git and I preferred an archive): from [Photos](https://github.com/flathub/org.gnome.Photos/blob/5b8c8ffc9b3650c5efa6ac98875320be3dc62287/org.gnome.Photos.json)

- gexiv2 (which in turn requires exiv2): from [Shotwell](https://github.com/flathub/org.gnome.Shotwell/blob/86f43c9f8943181b860d34576825ae2005e7dd62/org.gnome.Shotwell.json)

- libraw (and libraw-pkgconfig.patch): from [Photos](https://github.com/flathub/org.gnome.Photos/blob/5b8c8ffc9b3650c5efa6ac98875320be3dc62287/org.gnome.Photos.json)

Also I verified that the desktop file pass validation, and I have patched the appstream file to validate. I also psoposed this patch upstream here: https://gitlab.com/entangle/entangle/merge_requests/6
