### PR TITLE
add org.freedesktop.Sdk.Extension.rust-nightly

### DIFF
--- a/org.freedesktop.Sdk.Extension.rust-nightly.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2019 Bilal Elmoussaoui <bil.elmoussaoui@gmail.com> -->
+<component type="runtime">
+	<id>
+		org.freedesktop.Sdk.Extension.rust-nightly
+	</id>
+	<metadata_license>
+		CC0-1.0
+	</metadata_license>
+	<name>
+		Rust nightly Sdk extension
+	</name>
+	<summary>
+		Rust nightly compiler and tools
+	</summary>
+	<description>
+		Rust nightly compiler and tools
+	</description>
+	<project_license>
+		Apache-2.0 AND MIT
+	</project_license>
+	<url type="homepage">
+		https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-nightly/
+	</url>
+	<url type="bugtracker">
+		https://github.com/flathub/org.freedesktop.Sdk.Extension.rust-nightly/
+	</url>
+	<translation />
+	<update_contact>
+		bil.elmoussaoui@gmail.com
+	</update_contact>
+</component>

--- a/org.freedesktop.Sdk.Extension.rust-nightly.yml
+++ b/org.freedesktop.Sdk.Extension.rust-nightly.yml
@@ -1,0 +1,55 @@
+id: org.freedesktop.Sdk.Extension.rust-nightly
+branch: "19.08"
+runtime: org.freedesktop.Sdk
+build-extension: true
+sdk: org.freedesktop.Sdk
+runtime-version: "19.08"
+sdk-extensions: []
+separate-locales: false
+appstream-compose: false
+build-options:
+  prefix: "/usr/lib/sdk/rust-nightly"
+cleanup:
+  - "/share/info"
+  - "/share/man"
+modules:
+  - name: rust
+    buildsystem: simple
+    cleanup:
+      - "/share/doc/rust/html"
+    sources:
+      - type: archive
+        only-arches:
+          - arm
+        url: https://static.rust-lang.org/dist/2019-11-02/rust-nightly-arm-unknown-linux-gnueabi.tar.gz
+        sha256: 8f620536e601c13cf06736f67b3d0a8e4944d1db32c0d4db718c34c6708c2253
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://static.rust-lang.org/dist/2019-11-02/rust-nightly-aarch64-unknown-linux-gnu.tar.gz
+        sha256: ab8636b88b5a72b9dcae70b6b547e0da6e3ba2db456719376d335aa17b29f136
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://static.rust-lang.org/dist/2019-11-02/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+        sha256: ba3f59d2c19f64473212e721e07549841482efd37db045ef0cc894eb0e88a051
+    build-commands:
+      - "./install.sh --prefix=/usr/lib/sdk/rust-nightly --disable-ldconfig --verbose"
+  - name: scripts
+    sources:
+      - type: script
+        commands:
+          - export PATH=$PATH:/usr/lib/sdk/rust-nightly/bin
+        dest-filename: enable.sh
+    buildsystem: simple
+    build-commands:
+      - cp enable.sh /usr/lib/sdk/rust-nightly/
+  - name: appdata
+    buildsystem: simple
+    build-commands:
+      - mkdir -p ${FLATPAK_DEST}/share/metainfo
+      - cp ${FLATPAK_ID}.appdata.xml ${FLATPAK_DEST}/share/metainfo
+      - appstream-compose --basename ${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    sources:
+      - type: file
+        path: org.freedesktop.Sdk.Extension.rust-nightly.appdata.xml


### PR DESCRIPTION
This will be useful for either developers using Silverblue or just want to use the latest features from Rust. We have for now Karapulse that targets Rust nightly and soon Shortwave and probably others.

I'm planning to update this each two weeks. There are definitely other people from the Rust community that could/would help co-maintain this.
