### PR TITLE
Add JabRef (org.jabref.jabref)

### DIFF
--- a/org.jabref.jabref.desktop
+++ b/org.jabref.jabref.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=JabRef
+GenericName=BibTeX Editor
+Comment=JabRef is an open source bibliography reference manager. The native file format used by JabRef is BibTeX, the standard LaTeX bibliography format.
+Type=Application
+Terminal=false
+Icon=org.jabref.jabref
+Exec=JabRef %U
+Keywords=bibtex;biblatex;latex;bibliography
+Categories=Office;
+StartupWMClass=org-jabref-JabRefMain
+MimeType=text/x-bibtex;

--- a/org.jabref.jabref.json
+++ b/org.jabref.jabref.json
@@ -1,0 +1,35 @@
+{
+    "app-id" : "org.jabref.jabref",
+    "runtime" : "org.freedesktop.Platform",
+    "runtime-version" : "18.08",
+    "sdk" : "org.freedesktop.Sdk",
+    "command" : "JabRef",
+    "modules" : [
+        {
+            "name" : "JabRef",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "tar -xzf JabRef-portable_linux.tar.gz --directory=/app/ --strip-components=1",
+                "install -D -m0644 /app/lib/JabRef.png /app/share/icons/hicolor/64x64/apps/org.jabref.jabref.png",
+                "install -D -m0644 org.jabref.jabref.desktop /app/share/applications/org.jabref.jabref.desktop"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "url": "http://builds.jabref.org/master/JabRef-portable_linux.tar.gz",
+                    "sha256": "be69feee0536fa8500dda867290dbeeeda6191c60e636a0b6e254fbaac02d471"
+                },
+                {
+                    "type": "file",
+                    "path": "org.jabref.jabref.desktop"
+                }
+            ]
+        }
+    ],
+    "finish-args" : [
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--share=network",
+        "--filesystem=home"
+    ]
+}


### PR DESCRIPTION
JabRef is the leading open source editor for BibTeX files. We would ❤️ to available at the flathub store.

Kudos to @desi for the flatpack config -> https://github.com/JabRef/jabref/pull/5409