### PR TITLE
README.md: add info about flathub beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ flatpak remote-add flathub https://flathub.org/repo/flathub.flatpakrepo
 flatpak install flathub org.gnome.Recipes
 ```
 
+To install applications from the beta branch, use the following:
+```
+flatpak remote-add flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo
+flatpak install flathub-beta org.godotengine.Godot
+```
+
 For more information and more applications see https://flathub.org
 
 Contributing to Flathub


### PR DESCRIPTION
At the moment, the only documentation is the original blog post:

https://blogs.gnome.org/alexl/2019/02/19/changes-in-flathub-land/