### PR TITLE
Add a QtSpim Flatpak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+_build/

--- a/net.sourceforge.QtSpim.metainfo.xml
+++ b/net.sourceforge.QtSpim.metainfo.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>net.sourceforge.QtSpim</id>
+  <launchable type="desktop-id">net.sourceforge.QtSpim.desktop</launchable>
+  <name>QtSpim</name>
+  <developer_name>James Larus</developer_name>
+  <summary>An easy to use, light-weight, on-demand virus scanner for Linux systems</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <url type="homepage">http://spimsimulator.sourceforge.net/</url>
+  <description>
+    <p>QtSpim is a self-contained simulator that runs MIPS32 programs. It reads and executes assembly language programs written for this processor. QtSpim also provides a simple debugger and minimal set of operating system services.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://a.fsdn.com/con/app/proj/spimsimulator/screenshots/313041.jpg/max/max/1</image>
+    </screenshot>
+  </screenshots>
+  <kudos>
+    <kudo>ModernToolkit</kudo>
+  </kudos>
+  <releases>
+    <release version="9.1.20" date="2017-08-29" />
+  </releases>
+  <content_rating type="oars-1.1">
+  </content_rating>
+  <update_contact>rymg19_at_gmail.com</update_contact>
+</component>

--- a/net.sourceforge.QtSpim.yaml
+++ b/net.sourceforge.QtSpim.yaml
@@ -1,0 +1,39 @@
+app-id: net.sourceforge.QtSpim
+runtime: org.kde.Platform
+runtime-version: '5.13'
+sdk: org.kde.Sdk
+command: qtspim
+finish-args:
+  - '--share=ipc'
+  - '--share=network'
+  - '--socket=x11'
+  - '--socket=wayland'
+modules:
+  - name: qtspim
+    buildsystem: qmake
+    subdir: QtSpim
+    no-make-install: true
+    post-install:
+      - 'install -Dm 755 QtSpim /app/bin/qtspim'
+      - 'install -Dm 644 ../Setup/NewIcon48x48.png /app/share/icons/hicolor/48x48/apps/net.sourceforge.QtSpim.png'
+      - 'install -Dm 644 ../Setup/NewIcon256x256.png /app/share/icons/hicolor/256x256/apps/net.sourceforge.QtSpim.png'
+      - >
+        desktop-file-install --dir=/app/share/applications
+        --set-icon=net.sourceforge.QtSpim
+        --set-key=Exec --set-value=qtspim
+        --set-key=Version --set-value=1.0
+        ../Setup/qtspim_debian_deployment/qtspim.desktop
+      - 'mv /app/share/applications/{qtspim,net.sourceforge.QtSpim}.desktop'
+      - 'install -Dm644 -t /app/share/metainfo ../net.sourceforge.QtSpim.metainfo.xml'
+    sources:
+      - type: svn
+        url: https://svn.code.sf.net/p/spimsimulator/code/
+        revision: r712
+      - type: shell
+        commands:
+          # Rebuild the parser because the provided version won't compile...
+          - 'rm -f QtSpim/{parser_yacc,scanner_lex}.*'
+          # ...but don't rebuild the help files because the build tool segfaults.
+          - 'sed -i /POST_TARGETDEPS/d QtSpim/QtSpim.pro'
+      - type: file
+        path: net.sourceforge.QtSpim.metainfo.xml

--- a/net.sourceforge.QtSpim.yaml
+++ b/net.sourceforge.QtSpim.yaml
@@ -4,6 +4,7 @@ runtime-version: '5.13'
 sdk: org.kde.Sdk
 command: qtspim
 finish-args:
+  - '--device=dri'
   - '--share=ipc'
   - '--share=network'
   - '--socket=x11'


### PR DESCRIPTION
Largely just created this since both me and someone else at my university on Fedora need to use QtSpim for computer org class, but there's nothing available other than a deb file.

Asked upstream but there has been no reply yet.