### PR TITLE
Add org.mozilla.Firefox.BaseApp

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-appstream-check": true
+}

--- a/org.mozilla.Firefox.BaseApp.json
+++ b/org.mozilla.Firefox.BaseApp.json
@@ -1,0 +1,32 @@
+{
+    "app-id": "org.mozilla.Firefox.BaseApp",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk",
+    "separate-locales": false,
+    "cleanup": [
+        "*.la",
+        "/bin",
+        "/etc",
+        "/include",
+        "/libexec",
+        "/share/gtk-doc",
+        "/share/man"
+    ],
+    "modules": [
+      {
+          "name": "dbus-glib",
+          "config-opts": [
+              "--disable-static",
+              "--disable-gtk-doc"
+          ],
+          "sources": [
+              {
+                  "type": "archive",
+                  "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
+                  "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
+              }
+          ]
+      }
+    ]
+}


### PR DESCRIPTION
Firefox requires some extra dependencies not provided by the
Freedesktop SDK. However the Firefox app CI will not be built with
flatpak-builder. So we need to move the build of these dependencies
to flathub.

CC @ramcq