### PR TITLE
rename old org.gyunaev.Birdtray to com.ulduzsoft.Birdtray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build/

--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,12 @@
+--- ./src/res/com.ulduzsoft.Birdtray.appdata-old.xml	2019-11-25 11:22:08.000000000 +0200
++++ ./src/res/com.ulduzsoft.Birdtray.appdata.xml	2019-11-25 11:27:37.638587282 +0200
+@@ -23,6 +23,9 @@
+       <li>Can monitor that Thunderbird is running, and indicate it if you accidentally closed it.</li>
+       <li>Has configurable "New Email" functionality, allowing pre-configured email templates.</li>
+     </ul>
++    <p>
++      The feature to "Start Thunderbird when Birdtray starts" needs the flathub thunderbird installed by default. The default thunderbird directory is "~/.var/app/org.mozilla.Thunderbird/.thunderbird".
++    </p>
+   </description>
+ 
+   <categories>

--- a/com.ulduzsoft.Birdtray.json
+++ b/com.ulduzsoft.Birdtray.json
@@ -1,0 +1,40 @@
+{
+    "app-id": "com.ulduzsoft.Birdtray",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.13",
+    "sdk": "org.kde.Sdk",
+    "command": "birdtray",
+    "finish-args": [
+      "--share=ipc",
+      "--socket=x11",
+      "--socket=wayland",
+      "--device=dri",
+      "--filesystem=~/.thunderbird",
+      "--filesystem=~/.var/app/org.mozilla.Thunderbird/.thunderbird",
+      "--talk-name=org.freedesktop.Flatpak",
+      "--talk-name=org.freedesktop.Notifications",
+      "--talk-name=org.kde.StatusNotifierWatcher",
+      "--own-name=org.kde.StatusNotifierItem-2-2"
+    ],
+    "modules": [
+        {
+            "name": "birdtray",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DOPT_THUNDERBIRD_CMDLINE=/usr/bin/flatpak-spawn --host org.mozilla.Thunderbird"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/gyunaev/birdtray.git",
+                    "commit": "60abcc2b5eac604f15d6609273ad6a7093758cb8"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This changes the name from my last submitted org.gyunaev.Birdtray (https://github.com/flathub/org.gyunaev.Birdtray) to com.ulduzsoft.Birdtray which is acceptable by the upstream developers. All changes (appdata, screenshots, etc...) are now included in the upstream project.

If I've understood correctly, after this is merged I should add to the old repository a **flathub.json** file:
```
{
    "end-of-life": "Application has been renamed to com.ulduzsoft.Birdtray",
    "end-of-life-rebase": "com.ulduzsoft.Birdtray"
}
```
Tell me if I have to add this in the beta branch that I have in the old repository too, or if I can just delete the beta branch.