### PR TITLE
Add org.godotengine.godot.BaseApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.flatpak-builder
+/builddir

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "skip-arches": ["aarch64"],
+  "skip-appstream-check": true
+}

--- a/godot-i386-disable-O3.patch
+++ b/godot-i386-disable-O3.patch
@@ -1,0 +1,12 @@
+diff -up godot-release-template-1/platform/x11/detect.py.O2 godot-release-template-1/platform/x11/detect.py
+--- godot-release-template-1/platform/x11/detect.py.O2	2019-03-11 09:58:09.934768314 +0100
++++ godot-release-template-1/platform/x11/detect.py	2019-03-11 09:58:17.139663676 +0100
+@@ -86,7 +86,7 @@ def configure(env):
+ 
+     if (env["target"] == "release"):
+         if (env["optimize"] == "speed"): #optimize for speed (default)
+-            env.Prepend(CCFLAGS=['-O3'])
++            env.Prepend(CCFLAGS=['-O2'])
+         else: #optimize for size
+             env.Prepend(CCFLAGS=['-Os'])
+ 

--- a/org.godotengine.godot.BaseApp.yaml
+++ b/org.godotengine.godot.BaseApp.yaml
@@ -1,0 +1,67 @@
+app-id: org.godotengine.godot.BaseApp
+branch: '3.1'
+runtime: org.freedesktop.Platform
+runtime-version: '19.08'
+sdk: org.freedesktop.Sdk
+command: godot-runner
+
+build-options:
+  arch:
+    x86_64:
+      env:
+        # Only enable link-time optimization when targeting x86_64
+        # (causes issues on other architectures)
+        SCONS_FLAGS_EXTRA: use_lto=yes
+
+  env:
+    # Will be appended to the version string displayed in the command-line help
+    BUILD_NAME: flathub
+
+    # SCons flags common to all builds
+    # Shouldn't be quoted when used as it's a single string, not an array
+    SCONS_FLAGS: >
+      platform=x11
+      CCFLAGS=-I/app/include
+      prefix=/app
+      unix_global_settings_path=/app
+      progress=no
+      builtin_freetype=no
+      builtin_libogg=no
+      builtin_libpng=no
+      builtin_libtheora=no
+      builtin_libvorbis=no
+      builtin_libwebp=no
+      builtin_libvpx=no
+      builtin_zlib=no
+      udev=no
+
+modules:
+  - shared-modules/glu/glu-9.json
+
+  - name: scons
+    buildsystem: simple
+    cleanup: ['*']
+
+    sources:
+      - type: archive
+        sha256: 4cea417fdd7499a36f407923d03b4b7000b0f9e8fd7b31b316b9ce7eba9143a5
+        url: https://downloads.sourceforge.net/project/scons/scons/3.1.1/scons-3.1.1.tar.gz
+
+    build-commands:
+      - python3 setup.py install --prefix=/app
+
+  - name: godot-runner
+    buildsystem: simple
+
+    sources:
+      - type: archive
+        sha256: fb85065c4430b8f43fa057f5348dacbb3975e2018cd722f97039293f1428d009
+        url: https://downloads.tuxfamily.org/godotengine/3.1.2/godot-3.1.2-stable.tar.xz
+
+      - type: patch
+        path: godot-i386-disable-O3.patch
+        only-arches: [i386]
+
+    build-commands:
+      - python3 /app/bin/scons $SCONS_FLAGS $SCONS_FLAGS_EXTRA tools=no target=release -j "$FLATPAK_BUILDER_N_JOBS"
+      - install -Dm755 bin/godot.x11.opt.* /app/bin/godot-runner


### PR DESCRIPTION
This base application can be used to build Flatpaks of Godot projects.

Any project that doesn't use Mono or C++ modules should work.

The binary is installed as `/app/bin/godot-runner`; it's up to the application Flatpak to use it.

I plan to submit [an application](https://github.com/OverloadedOrama/Pixelorama) that uses this base app ASAP :slightly_smiling_face: