### PR TITLE
Add com.orama_interactive.Pixelorama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.flatpak-builder
+/builddir

--- a/com.orama_interactive.Pixelorama.yaml
+++ b/com.orama_interactive.Pixelorama.yaml
@@ -1,0 +1,56 @@
+app-id: com.orama_interactive.Pixelorama
+base: org.godotengine.godot.BaseApp
+base-version: '3.1'
+runtime: org.freedesktop.Platform
+runtime-version: "19.08"
+default-branch: stable
+sdk: org.freedesktop.Sdk
+command: pixelorama
+rename-icon: icon
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --filesystem=home
+  - --device=dri
+
+modules:
+  - name: pixelorama
+    buildsystem: simple
+
+    sources:
+      - type: archive
+        url: https://github.com/Orama-Interactive/Pixelorama/releases/download/v0.5/Pixelorama.Linux.64-bit.zip
+        sha256: a069764f834be59670a333affcf95401678efaf18493735dc27478822f2356f8
+        strip-components: 0
+
+      - type: script
+        dest-filename: pixelorama.sh
+        commands:
+          # `cd` is needed so that Pixelorama can find the `Brushes/` directory
+          - cd /app/bin/
+          # Use the `Dummy` audio driver to avoid error messages when starting the application from a terminal
+          - /app/bin/godot-runner --audio-driver Dummy --main-pack /app/bin/pixelorama.pck "$@"
+
+      # TODO: Replace commit hashes below with a stable tag reference once a release
+      #       includes the required files
+
+      - type: file
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/45868536369e3df4651681df8ccfb4141d05cbcb/icon.png
+        sha256: 7c0b5a957e9b3d6a696b617eed62f753f1ecd10a6417a0a76289aaaf2c4ac663
+
+      - type: file
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/45868536369e3df4651681df8ccfb4141d05cbcb/Misc/Linux/com.orama_interactive.Pixelorama.desktop
+        sha256: 99bd15e3b91c85975da2aa9cc624e82485da26be48d6ddab40e62116771457d0
+
+      - type: file
+        url: https://github.com/Orama-Interactive/Pixelorama/raw/45868536369e3df4651681df8ccfb4141d05cbcb/Misc/Linux/com.orama_interactive.Pixelorama.appdata.xml
+        sha256: 39e7d79431e697bf9d20854447ea92c43ddfba3d072927dd61c40047cc41dc64
+
+    build-commands:
+      - install -Dm755 pixelorama.sh /app/bin/pixelorama
+      - install -Dm644 Pixelorama.pck /app/bin/pixelorama.pck
+      - mv Brushes/ /app/bin/Brushes/
+      - install -Dm644 icon.png -t /app/share/icons/hicolor/256x256/apps/
+      - install -Dm644 com.orama_interactive.Pixelorama.desktop -t /app/share/applications/
+      - install -Dm644 com.orama_interactive.Pixelorama.appdata.xml -t /app/share/appdata/

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-arches": ["aarch64"]
+}


### PR DESCRIPTION
Follow-up to #1299.

[Pixelorama](https://github.com/OverloadedOrama/Pixelorama) is an open source sprite editor based on Godot Engine.