### PR TITLE
Yaru light

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Yaru-light
+
+This is the flatpak version of Yaru theme light variant.

--- a/org.gtk.Gtk3theme.Yaru-light.appdata.xml
+++ b/org.gtk.Gtk3theme.Yaru-light.appdata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+    <id>org.gtk.Gtk3theme.Yaru-light</id>
+    <metadata_license>CC-BY-SA-4.0</metadata_license>
+    <name>Yaru-light Gtk Theme</name>
+    <summary>Yaru-light theme</summary>
+    <description>
+        <p>Yaru-light theme</p>
+    </description>
+    <url type="homepage">https://github.com/ubuntu/yaru</url>
+</component>

--- a/org.gtk.Gtk3theme.Yaru-light.json
+++ b/org.gtk.Gtk3theme.Yaru-light.json
@@ -1,0 +1,91 @@
+{
+  "id": "org.gtk.Gtk3theme.Yaru-light",
+  "branch": "3.22",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "19.08",
+  "sdk": "org.freedesktop.Sdk",
+  "build-extension": true,
+  "appstream-compose": false,
+  "separate-locales": false,
+  "build-options": {
+    "prefix": "/usr/share/runtime/share/themes/Yaru-light/gtk-3.0"
+  },
+  "modules": [
+    {
+      "name": "sassc",
+      "config-opts": ["--with-libsass=/usr/share/runtime/share/themes/Yaru-light/gtk-3.0"],
+      "cleanup": ["*"],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/sass/sassc/archive/3.5.0.tar.gz",
+          "sha256": "26f54e31924b83dd706bc77df5f8f5553a84d51365f0e3c566df8de027918042"
+        },
+        {
+          "type": "script",
+          "dest-filename": "autogen.sh",
+          "commands": ["autoreconf -si"]
+        }
+      ],
+      "modules": [
+        {
+          "name": "libsass",
+          "cleanup": ["*"],
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://github.com/sass/libsass/archive/3.5.4.tar.gz",
+              "sha256": "5f61cbcddaf8e6ef7a725fcfa5d05297becd7843960f245197ebb655ff868770"
+            },
+            {
+              "type": "script",
+              "dest-filename": "autogen.sh",
+              "commands": ["autoreconf -si"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Yaru-light",
+      "buildsystem": "meson",
+      "build-options": {
+        "prefix": "/usr/share/runtime",
+        "append-path": "/usr/share/runtime/share/themes/Yaru-light/gtk-3.0/bin",
+        "config-opts": [ "-Dicons=false", "-Dgnome-shell=false", "-Dsounds=false", "-Dsessions=false", "-Ddefault=false", "-Ddark=false"  ]
+      },
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/ubuntu/yaru.git",
+          "commit": "b768e58e4e3ad4abeaebb04fd63bc5d0f2342477"
+        },
+        {
+            "type": "shell",
+            "//": "Rename gtk-3.20 folder as gtk-3.0, and modify meson.build accordingly",
+            "commands": [
+              "rm -r gtk/src/light/gtk-3.0",
+              "mv gtk/src/light/gtk-3.20 gtk/src/light/gtk-3.0",
+              "sed -i -e \"s/subdir('gtk-3.0')//\" gtk/src/light/meson.build",
+              "sed -i -e \"s/subdir('gtk-3.20')/subdir('gtk-3.0')/\" gtk/src/light/meson.build",
+              "sed -i -e \"s/gtk-3.20/gtk-3.0/\" gtk/src/light/gtk-3.0/meson.build"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm644 org.gtk.Gtk3theme.Yaru-light.appdata.xml ${FLATPAK_DEST}/share/appdata/org.gtk.Gtk3theme.Yaru-light.appdata.xml",
+        "appstream-compose --basename=org.gtk.Gtk3theme.Yaru-light --prefix=${FLATPAK_DEST} --origin=flatpak org.gtk.Gtk3theme.Yaru-light"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.gtk.Gtk3theme.Yaru-light.appdata.xml"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is the flatpak version of Yaru theme light variant.

Yaru default theme is already at https://github.com/flathub/org.gtk.Gtk3theme.Yaru
Yaru dark variant theme is already at https://github.com/flathub/org.gtk.Gtk3theme.Yaru-dark