### PR TITLE
Add org.octave.Octave_64_64.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/fltk-ninja-build-error.patch
+++ b/fltk-ninja-build-error.patch
@@ -1,0 +1,12 @@
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 22ec9ab54b7c..abf6ebd95ea5 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -64,7 +64,6 @@ CREATE_EXAMPLE(file_chooser file_chooser.cxx "fltk;fltk_images")
+ CREATE_EXAMPLE(fonts fonts.cxx fltk)
+ CREATE_EXAMPLE(forms forms.cxx "fltk;fltk_forms")
+ CREATE_EXAMPLE(hello hello.cxx fltk)
+-CREATE_EXAMPLE(help help.cxx "fltk;fltk_images")
+ CREATE_EXAMPLE(icon icon.cxx fltk)
+ CREATE_EXAMPLE(iconize iconize.cxx fltk)
+ CREATE_EXAMPLE(image image.cxx fltk)

--- a/octave-appdata-64-bit.patch
+++ b/octave-appdata-64-bit.patch
@@ -1,0 +1,81 @@
+diff -r 75a90bfc14b1 etc/icons/org.octave.Octave.appdata.xml
+--- a/etc/icons/org.octave.Octave.appdata.xml	Fri Jan 31 10:45:13 2020 -0800
++++ b/etc/icons/org.octave.Octave.appdata.xml	Wed Feb 12 22:57:48 2020 +0900
+@@ -19,7 +19,7 @@
+   <https://www.gnu.org/licenses/>.
+ -->
+ <component type="desktop-application">
+-  <id>org.octave.Octave.desktop</id>
++  <id>org.octave.Octave_64_64.desktop</id>
+   <metadata_license>FSFAP</metadata_license>
+   <project_license>GPL-3.0+</project_license>
+   <name>GNU Octave</name>
+@@ -35,6 +35,13 @@
+   <summary xml:lang="zh">数值计算交互式编程环境</summary>
+   <description>
+     <p>
++      This version of GNU Octave uses 64-bit linear algebra for large data.
++      Unless your computer has more than ~32GB of memory and you need to solve
++      linear algebra problems with arrays containing more than ~2 billion
++      elements, this version will offer no advantage over the default GNU
++      Octave version.
++    </p>
++    <p>
+       GNU Octave is a high-level interpreted language, primarily intended for
+       numerical computations. It provides capabilities for the numerical
+       solution of linear and nonlinear problems, and for performing other
+@@ -44,28 +51,6 @@
+       non-interactive programs. The Octave language is quite similar to
+       Matlab so that most programs are easily portable.
+     </p>
+-    <p xml:lang="de">
+-      GNU Octave ist eine höhere, interpretierte Programmiersprache, die
+-      hauptsächlich für numerische Berechnungen gedacht ist. Sie bietet
+-      Funktionen für die numerische Lösung linearer und nichtlinearer Probleme
+-      und für die Durchführung anderer numerischer Experimente. Darüber hinaus
+-      bietet es umfangreiche Grafikfunktionen zur Datenvisualisierung und
+-      -manipulation. Octave wird normalerweise mittels einer interaktiven
+-      Befehlszeile verwendet, kann aber auch zum Schreiben nicht interaktiver
+-      Programme verwendet werden. Die Octave-Programmiersprache ist sehr
+-      ähnlich zu Matlab, so dass die meisten Programme leicht übertragbar sind.
+-    </p>
+-    <p xml:lang="fr">
+-      GNU Octave est un langage de programmation interprété, destiné
+-      principalement au calcul numérique. Il fournit des fonctionnalités
+-      pour la résolution de problèmes linéaires et non-linéaires, et pour toutes
+-      sortes d'expériences numériques.  Il s'accompagne d'un système complet
+-      de visualisation et de manipulation des données. Octave s’utilise
+-      généralement via son environnement en lignes de commandes interactif,
+-      mais il peut aussi être utilisé pour écrire des programmes non
+-      interactifs. Le langage Octave est très similaire à Matlab de telle sorte
+-      que les programmes Matlab sont très faciles à porter sous Octave.
+-    </p>
+     <p>
+       Octave has extensive tools for solving common numerical linear algebra
+       problems, finding the roots of nonlinear equations, integrating ordinary
+@@ -75,25 +60,6 @@
+       Octave's own language, or using dynamically loaded modules written in
+       C++, C, Fortran, or other languages.
+     </p>
+-    <p xml:lang="de">
+-      Octave verfügt über umfangreiche Werkzeuge zur Lösung gängiger
+-      numerischer linearer Probleme der Algebra, zum Auffinden der Nullstellen
+-      nichtlinearer Gleichungen, zur Integration gewöhnlicher Funktionen, zur
+-      Manipulation von Polynomen und zur Integration gewöhnlicher
+-      Differentialgleichungen und differential-algebraischer Gleichungen. Es
+-      ist leicht erweiter- und anpassbar mittels benutzerdefinierter
+-      Funktionen, die in Octaves eigener Programmiersprache geschrieben wurden,
+-      oder über dynamisch geladene, in C++, C, Fortran oder anderen Sprachen
+-      geschriebene Module.
+-    </p>
+-    <p xml:lang="fr">
+-      Octave dispose de nombreux outils pour résoudre les problèmes classiques
+-      d'algèbre linéaire, trouver les racines d'équations non-linéaires,
+-      intégrer les fonctions ordinaires et les équations différentielles.
+-      Il peut très facilement être étendu en définissant de nouvelles
+-      fonctions écrites en langage Octave ou en utilisant des modules
+-      chargés dynamiquement, écrits en C++, C, Fortran ou autres langages.
+-    </p>
+   </description>
+
+   <screenshots>

--- a/org.octave.Octave_64_64.yaml
+++ b/org.octave.Octave_64_64.yaml
@@ -355,3 +355,5 @@ modules:
   - type: archive
     url: https://ftpmirror.gnu.org/octave/octave-5.2.0.tar.xz
     sha256: 2757b5cc1854c9326d6c99d2900c7cec2909ac7ed500212d170d0df592bfd26b
+  - type: patch
+    path: octave-appdata-64-bit.patch

--- a/org.octave.Octave_64_64.yaml
+++ b/org.octave.Octave_64_64.yaml
@@ -1,0 +1,357 @@
+app-id: org.octave.Octave_64_64
+runtime: org.kde.Sdk
+runtime-version: '5.14'
+sdk: org.kde.Sdk
+command: octave
+rename-icon: octave
+sdk-extensions:
+- org.freedesktop.Sdk.Extension.openjdk11
+finish-args:
+- --socket=wayland
+- --socket=x11
+- --share=ipc
+- --device=dri
+- --socket=pulseaudio
+- --share=network
+- --filesystem=host
+- --filesystem=xdg-config/kdeglobals:ro # gives application access to kdeglobals
+- --talk-name=com.canonical.AppMenu.Registrar # gives application access to dbus menu
+- --talk-name=org.freedesktop.Flatpak # allows spawning processes on the host via flatpak-spawn --host
+- --env=PATH=/app/bin:/usr/bin:/app/jre/bin
+- --env=CPPFLAGS=-I/app/include # required for building some Octave forge packages
+- --env=LDFLAGS=-L/app/lib # required for building some Octave forge packages
+- --env=OCTAVE_HOME=/app
+cleanup:
+- /bin/*lpr*.sh
+- /bin/GraphicsMagick*config
+- /bin/fltk-config
+- /bin/gif2h5
+- /bin/glpsol
+- /bin/h5*
+- /bin/isympy
+- /bin/qconvex
+- /bin/qdelaunay
+- /bin/qhalf
+- /bin/qhull
+- /bin/qvoronoi
+- /bin/rbox
+- /com
+- /examples
+- /include/QSci
+- /lib/cmake
+- /lib/lib*.a
+- /lib/lib*.la
+- /lib/lib*.settings
+- /lib/libqhull_*
+- /lib/octave/*/lib*.la
+- /man
+- /share/applications/fluid.desktop
+- /share/doc
+- /share/fltk
+- /share/hdf5_examples
+- /share/man
+- /share/units/locale_map.txt
+- fluid
+- fluid.*
+build-options:
+  env:
+    PATH: /app/bin:/usr/bin:/usr/lib/sdk/openjdk11/bin
+    PYTHON: python3
+modules:
+
+# gfortran is part of the Freedesktop Sdk 18.08:
+# https://github.com/flathub/org.freedesktop.Sdk.Extension.gfortran-62/issues/3
+
+- name: openblas
+  no-autogen: true
+  make-args:
+  - DYNAMIC_ARCH=1
+  - FC=gfortran
+  - NO_CBLAS=1
+  - NO_LAPACKE=1
+  - USE_OPENMP=0    ## OpenMP off by default, this hack skips 'test_fork' which crashes on i386
+  - BINARY=64
+  - INTERFACE64=1
+  - CONSISTENT_FPCSR=1
+  make-install-args:
+  - PREFIX=/app
+  sources:
+  - type: archive
+    url: https://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz
+    sha256: e64c8fe083832ffbc1459ab6c72f71d53afd3b36e8497c922a15a06b72e9002f
+
+- shared-modules/glu/glu-9.json
+
+- name: fltk
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  - -DOPTION_BUILD_SHARED_LIBS=ON
+  - -DFLTK_LIBDIR:PATH=lib
+  - -DOpenGL_GL_PREFERENCE=GLVND
+  build-options:
+    cflags: -fPIC
+    cxxflags: -fPIC
+  sources:
+  - type: archive
+    url: https://www.fltk.org/pub/fltk/1.3.5/fltk-1.3.5-source.tar.gz
+    sha256: 8729b2a055f38c1636ba20f749de0853384c1d3e9d1a6b8d4d1305143e115702
+  - type: patch
+    path: fltk-ninja-build-error.patch
+
+- name: gnuplot
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/gnuplot/files/gnuplot/5.2.6/gnuplot-5.2.6.tar.gz
+    sha256: 35dd8f013139e31b3028fac280ee12d4b1346d9bb5c501586d1b5a04ae7a94ee
+
+- name: ghostscript
+  config-opts:
+  - --disable-cups
+  build-options:
+    ldflags: -L/app/lib
+    arch:
+      aarch64:
+        cppflags: -DPNG_ARM_NEON_OPT=0
+  sources:
+  - type: archive
+    url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz
+    sha256: 90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598
+    # newer libpng version required to build on ARM
+  - type: shell
+    commands:
+    - rm -rf libpng
+  - type: archive
+    url: https://sourceforge.net/projects/libpng/files/libpng16/1.6.36/libpng-1.6.36.tar.xz
+    sha256: eceb924c1fa6b79172fdfd008d335f0e59172a86a66481e09d4089df872aa319
+    dest: libpng
+
+- name: gl2ps
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  - -DOpenGL_GL_PREFERENCE=GLVND
+  sources:
+  - type: archive
+    url: http://geuz.org/gl2ps/src/gl2ps-1.4.0.tgz
+    sha256: 03cb5e6dfcd87183f3b9ba3b22f04cd155096af81e52988cc37d8d8efe6cf1e2
+
+- name: qhull
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  sources:
+  - type: archive
+    url: https://github.com/qhull/qhull/archive/v7.3.0.tar.gz
+    sha256: 05a2311d8e6397c96802ee5a9d8db32b83dac7e42e2eb2cd81c5547c18e87de6
+
+- name: epstool
+  skip-arches:
+  - i386
+  - arm
+  - aarch64
+  no-autogen: true
+  no-parallel-make: true
+  make-install-args:
+  - EPSTOOL_BASE=/app
+  sources:
+  - type: archive
+    # upstream archive has broken permissions, cf. https://launchpad.net/ubuntu/+source/epstool/3.09-1
+    url: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/epstool/3.09-1/epstool_3.09.orig.tar.xz
+    sha256: 1e85249d1a44f9418b1f95a3aebd8b0784dab8e49deb6417ac9b996ca08f6011
+
+- name: hdf5
+  no-autogen: true
+  sources:
+  - type: archive
+    url: https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2
+    sha256: 1267ff06aaedc04ca25f7c6026687ea2884b837043431195f153401d942b28df
+
+- name: qrupdate
+  no-autogen: true
+  make-args:
+  - solib
+  - BLAS=-lopenblas
+  - LAPACK=
+  make-install-args:
+  - PREFIX=/app
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/qrupdate/files/qrupdate/1.2/qrupdate-1.1.2.tar.gz
+    sha256: e2a1c711dc8ebc418e21195833814cb2f84b878b90a2774365f0166402308e08
+  - type: shell
+    commands:
+    - sed -e 's|FFLAGS=-fimplicit-none -O3 -funroll-loops|FFLAGS=-fimplicit-none -O3 -funroll-loops -fdefault-integer-8 -L/app/lib|' -i Makeconf
+
+- name: suitesparse
+  make-args:
+  - UMFPACK_CONFIG=-D'LONGBLAS=long'
+  - CHOLMOD_CONFIG=-D'LONGBLAS=long'
+  - LAPACK=
+  - library
+  make-install-args:
+  - LAPACK=
+  - INSTALL_LIB=/app/lib
+  - INSTALL_INCLUDE=/app/include
+  - library
+  no-autogen: true
+  sources:
+  - type: archive
+    url: http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-5.4.0.tar.gz
+    sha256: 374dd136696c653e34ef3212dc8ab5b61d9a67a6791d5ec4841efb838e94dbd1
+  - type: patch
+    path: suitesparse-reduce-build.patch
+
+- name: glpk
+  sources:
+  - type: archive
+    url: https://ftpmirror.gnu.org/glpk/glpk-4.65.tar.gz
+    sha256: 4281e29b628864dfe48d393a7bedd781e5b475387c20d8b0158f329994721a10
+
+- name: portaudio
+  sources:
+  - type: archive
+    url: http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz
+    sha256: f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
+
+- name: graphicsmagick
+  config-opts:
+  - --enable-shared
+  - --with-quantum-depth=16
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/1.3.31/GraphicsMagick-1.3.31.tar.xz
+    sha256: 096bbb59d6f3abd32b562fc3b34ea90d88741dc5dd888731d61d17e100394278
+
+- name: arpack-ng
+  config-opts:
+  - INTERFACE64=1
+  sources:
+  - type: archive
+    url: https://github.com/opencollab/arpack-ng/archive/3.7.0.tar.gz
+    sha256: 972e3fc3cd0b9d6b5a737c9bf6fd07515c0d6549319d4ffb06970e64fa3cc2d6
+
+- name: fftw3
+  no-autogen: true
+  config-opts:
+  - --enable-shared
+  - --enable-threads
+  sources:
+  - type: archive
+    url: http://www.fftw.org/fftw-3.3.8.tar.gz
+    sha256: 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
+
+- name: fftw3f
+  no-autogen: true
+  config-opts:
+  - --enable-shared
+  - --enable-threads
+  - --enable-float
+  sources:
+  - type: archive
+    url: http://www.fftw.org/fftw-3.3.8.tar.gz
+    sha256: 6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
+
+- name: qscintilla
+  buildsystem: simple
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.10.8/QScintilla_gpl-2.10.8.tar.gz
+    sha256: 46cd5b4e609ca5e13130ba8cc7028d44fd1dc5b037f97c492899006ed0c992eb
+  build-commands:
+  - sed -e 's|\(target.path\) = .*|\1 = /app/lib|' -i Qt4Qt5/qscintilla.pro
+  - sed -e 's|\(header.path\) = .*|\1 = /app/include|' -i Qt4Qt5/qscintilla.pro
+  - sed -e 's|\(trans.path\) = .*|\1 = /app/share/qt5/translations|' -i Qt4Qt5/qscintilla.pro
+  - sed -e 's|\(qsci.path\) = .*|\1 = /app/share/qt5|' -i Qt4Qt5/qscintilla.pro
+  - sed -e 's|\(features.path\) = .*|\1 = /app/lib/qt5/mkspecs/features|' -i Qt4Qt5/qscintilla.pro
+  - cd Qt4Qt5 && qmake && make install
+
+- name: sundials
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+  - -DKLU_ENABLE=ON
+  - -DKLU_INCLUDE_DIR:PATH=/app/include
+  - -DKLU_LIBRARY_DIR:PATH=/app/lib
+  builddir: true
+  sources:
+  - type: archive
+    url: https://github.com/LLNL/sundials/archive/v2.7.0.tar.gz
+    sha256: 2cbedd5b4063078c7b060b346a3150e31fc2e9fea336aeb930a7c6b556b123c8
+
+- name: openjdk
+  buildsystem: simple
+  build-commands:
+  - /usr/lib/sdk/openjdk11/install.sh
+
+- name: mpmath # dependency of sympy
+  buildsystem: simple
+  sources:
+  - type: archive
+    url: https://github.com/fredrik-johansson/mpmath/archive/1.1.0.tar.gz
+    sha256: 16c01d589bcb1be5cab3a07de2855b578e5fc4a7882fb61a15f2aaf118fdd06e
+  build-commands:
+  - python3 ./setup.py install --prefix=/app
+
+- name: sympy # dependency of the symbolic package
+  buildsystem: simple
+  sources:
+  - type: archive
+    url: https://github.com/sympy/sympy/archive/sympy-1.3.tar.gz
+    sha256: d73d8424f254640969dcb3d50f0a4b41857643fb592a1c3e0c545a9343571a70
+  build-commands:
+  - python3 ./setup.py install --prefix=/app
+
+- name: texinfo
+  config-opts:
+  - --disable-nls
+  sources:
+  - type: archive
+    url: https://ftpmirror.gnu.org/texinfo/texinfo-6.5.tar.xz
+    sha256: 77774b3f4a06c20705cc2ef1c804864422e3cf95235e965b1f00a46df7da5f62
+  - type: patch
+    path: texinfo-perl-528.patch
+
+- name: units # dependency of the miscellaneous package
+  config-opts:
+  - PYTHON=/usr/bin/python3
+  sources:
+  - type: archive
+    url: https://ftpmirror.gnu.org/units/units-2.19.tar.gz
+    sha256: 4262136bdfc152b63ff5a9b93a7d80ce18b5e8bebdcffddc932dda769e306556
+  - type: patch
+    path: units-install-info.patch
+  post-install:
+  - mv -f /app/com/units/currency.units /app/share/units/currency.units
+
+- name: zeromq # dependency of the zeromq package
+  buildsystem: cmake-ninja
+  builddir: true
+  config-opts:
+  - -DWITH_DOC=OFF
+  sources:
+  - type: archive
+    url: https://github.com/zeromq/libzmq/archive/v4.3.0.tar.gz
+    sha256: 4bcd112222cc0e8083c81196f60b486d9a7d57f810b0121c478ee3aeac1c19a4
+
+- name: octave
+  build-options:
+    cflags: -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong -grecord-gcc-switches
+    cflags-override: true
+    cxxflags: -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong -grecord-gcc-switches
+    cxxflags-override: true
+    env:
+      QCOLLECTIONGENERATOR: qhelpgenerator-qt5 # workaround for https://savannah.gnu.org/bugs/?55187
+  config-opts:
+  - --disable-silent-rules
+  - --with-blas=openblas
+  - --with-java-homedir=/app/jre
+  - --with-java-includedir=/usr/lib/sdk/openjdk11/jvm/openjdk-11/include
+  - --enable-64
+  - F77_INTEGER_8_FLAG=-fdefault-integer-8
+  cleanup:
+  - /share/icons/hicolor/1024x1024 # workaround for https://savannah.gnu.org/bugs/?55836
+  sources:
+  - type: archive
+    url: https://ftpmirror.gnu.org/octave/octave-5.2.0.tar.xz
+    sha256: 2757b5cc1854c9326d6c99d2900c7cec2909ac7ed500212d170d0df592bfd26b

--- a/suitesparse-reduce-build.patch
+++ b/suitesparse-reduce-build.patch
@@ -1,0 +1,65 @@
+diff --git a/Makefile b/Makefile
+index 7d7d12d665bd..e7ec5c048309 100644
+--- a/Makefile
++++ b/Makefile
+@@ -38,8 +38,8 @@
+ # (note that CSparse is not installed; CXSparse is installed instead)
+ install: metisinstall
+ 	( cd SuiteSparse_config && $(MAKE) install )
+-	( cd GraphBLAS && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' install )
+-	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' install )
++#	( cd GraphBLAS && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' install )
++#	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' install )
+ 	( cd AMD && $(MAKE) install )
+ 	( cd BTF && $(MAKE) install )
+ 	( cd CAMD && $(MAKE) install )
+@@ -47,15 +47,15 @@
+ 	( cd COLAMD && $(MAKE) install )
+ 	( cd CHOLMOD && $(MAKE) install )
+ 	( cd CXSparse && $(MAKE) install )
+-	( cd LDL && $(MAKE) install )
++#	( cd LDL && $(MAKE) install )
+ 	( cd KLU && $(MAKE) install )
+ 	( cd UMFPACK && $(MAKE) install )
+-	( cd RBio && $(MAKE) install )
++#	( cd RBio && $(MAKE) install )
+ ifneq (,$(GPU_CONFIG))
+ 	( cd SuiteSparse_GPURuntime && $(MAKE) install )
+ 	( cd GPUQREngine && $(MAKE) install )
+ endif
+-	( cd SPQR && $(MAKE) install )
++#	( cd SPQR && $(MAKE) install )
+ #	( cd PIRO_BAND && $(MAKE) install )
+ #	( cd SKYLINE_SVD && $(MAKE) install )
+ 	$(CP) README.txt $(INSTALL_DOC)/SuiteSparse_README.txt
+@@ -116,8 +116,8 @@
+ # the static library
+ library: metis
+ 	( cd SuiteSparse_config && $(MAKE) )
+-	( cd GraphBLAS && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
+-	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
++#	( cd GraphBLAS && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
++#	( cd Mongoose  && $(MAKE) CMAKE_OPTIONS='$(CMAKE_OPTIONS)' library )
+ 	( cd AMD && $(MAKE) library )
+ 	( cd BTF && $(MAKE) library )
+ 	( cd CAMD && $(MAKE) library )
+@@ -125,16 +125,16 @@
+ 	( cd COLAMD && $(MAKE) library )
+ 	( cd CHOLMOD && $(MAKE) library )
+ 	( cd KLU && $(MAKE) library )
+-	( cd LDL && $(MAKE) library )
++#	( cd LDL && $(MAKE) library )
+ 	( cd UMFPACK && $(MAKE) library )
+ 	( cd CSparse && $(MAKE) library )
+ 	( cd CXSparse && $(MAKE) library )
+-	( cd RBio && $(MAKE) library )
++#	( cd RBio && $(MAKE) library )
+ ifneq (,$(GPU_CONFIG))
+ 	( cd SuiteSparse_GPURuntime && $(MAKE) library )
+ 	( cd GPUQREngine && $(MAKE) library )
+ endif
+-	( cd SPQR && $(MAKE) library )
++#	( cd SPQR && $(MAKE) library )
+ #	( cd PIRO_BAND && $(MAKE) library )
+ #	( cd SKYLINE_SVD && $(MAKE) library )
+ 

--- a/texinfo-perl-528.patch
+++ b/texinfo-perl-528.patch
@@ -1,0 +1,32 @@
+>From 1f27900352e04ff4f19bec1c1e9635adad2be31c Mon Sep 17 00:00:00 2001
+From: Niko Tyni <ntyni@debian.org>
+Date: Fri, 18 May 2018 10:40:00 +0100
+Subject: [PATCH] Fix unescaped left braces in regexps, deprecated since Perl
+ 5.27.8
+
+This fixes test failures on recent Perl versions.
+---
+ tp/Texinfo/Parser.pm | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tp/Texinfo/Parser.pm b/tp/Texinfo/Parser.pm
+index dc32ca2..c577aa9 100644
+--- a/tp/Texinfo/Parser.pm
++++ b/tp/Texinfo/Parser.pm
+@@ -5478,11 +5478,11 @@ sub _parse_special_misc_command($$$$)
+     }
+   } elsif ($command eq 'clickstyle') {
+     # REMACRO
+-    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*/) {
++    if ($line =~ /^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*/) {
+       $args = ['@'.$1];
+       $self->{'clickstyle'} = $1;
+       $remaining = $line;
+-      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)({})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
++      $remaining =~ s/^\s+@([[:alnum:]][[:alnum:]\-]*)(\{\})?\s*(\@(c|comment)((\@|\s+).*)?)?//;
+       $has_comment = 1 if (defined($4));
+     } else {
+       $self->line_error (sprintf($self->__(
+-- 
+2.17.0
+

--- a/units-install-info.patch
+++ b/units-install-info.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile.in b/Makefile.in
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -167,7 +167,7 @@ install-info: units.info
+	if test -f $(DESTDIR)$(infodir)/dir; then \
+	  if $(SHELL) -c 'install-info --version' >/dev/null 2>&1; then \
+	    install-info --dir-file=$(DESTDIR)$(infodir)/dir \
+-	               $(DESTDIR)$(infodir)/units.info; \
++	               $(DESTDIR)$(infodir)/units.info || :; \
+	  else true; fi \
+	else true; fi
+ 


### PR DESCRIPTION
This application "org.octave.Octave_64_64" is a demanded variant of GNU Octave https://github.com/flathub/org.octave.Octave, which enables to treat matrices beyond 32 GB of main memory.

For MS Windows, the GNU Octave project creates a similar set of variants (https://www.gnu.org/software/octave/download.html)

- octave-5.2.0_1-w64-installer.exe
- octave-5.2.0_1-w64-64-installer.exe

The idea is that I synchronize this new application with https://github.com/flathub/org.octave.Octave (maintained by https://github.com/mtmiller).  Only the app ID and the configuration are different.

Thank you for your time and help.