### PR TITLE
misc: add a shared-module update action

### DIFF
--- a/.github/workflows/shared-modules-updater.yml
+++ b/.github/workflows/shared-modules-updater.yml
@@ -1,0 +1,12 @@
+name: 'Check and update shared-modules'
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  shared-modules-auto-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: flathub/actions/shared-modules-auto-pr@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.FLATHUBBOT_TOKEN }}


### PR DESCRIPTION
This adds a Github action to automatically bump all the apps using shared-modules when this repository gets updated. It doesn't check if the used modules by the app were updated or not yet, but that shouldn't be an issue for a first run I guess.

Depends on https://github.com/flathub/actions/pull/7
Fixes https://github.com/flathub/shared-modules/issues/92