### PR TITLE
Initial commit - WireShare

### DIFF
--- a/org.team_hermes.WireShare.yaml
+++ b/org.team_hermes.WireShare.yaml
@@ -1,0 +1,35 @@
+id: org.team_hermes.WireShare
+branch: 6.0
+runtime: org.freedesktop.Platform
+runtime-version: 19.08
+sdk: org.freedesktop.Sdk
+command: /app/WireShare.sh
+modules:
+  - name: wireshare
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://nmatavka@bitbucket.org/nmatavka/hermes-wireshare-flatpak.git
+        branch: master
+    build-commands:
+      - install WireShare.sh /app/WireShare.sh
+      - install WireShare.jar /app/WireShare.jar
+      - mkdir -p /app/share/icons/
+      - cp -r hicolor /app/share/icons
+      - cp -r jre-linux /app/jre
+      - cp -r lib64 /app/lib
+      - mkdir -p /app/share
+      - cp -r applications /app/share/applications
+finish-args:
+  - --env=PATH=/app/jre/bin:/usr/bin
+  - --share=ipc
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+  - --socket=fallback-x11
+  - --filesystem=home
+       
+
+
+
+

--- a/org.team_hermes.WireShare.yaml
+++ b/org.team_hermes.WireShare.yaml
@@ -1,5 +1,4 @@
 id: org.team_hermes.WireShare
-branch: 6.0
 runtime: org.freedesktop.Platform
 runtime-version: 19.08
 sdk: org.freedesktop.Sdk
@@ -29,7 +28,6 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=home
        
-
 
 
 

--- a/org.team_hermes.WireShare.yaml
+++ b/org.team_hermes.WireShare.yaml
@@ -1,6 +1,6 @@
 id: org.team_hermes.WireShare
 runtime: org.freedesktop.Platform
-runtime-version: 19.08
+runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
 command: /app/WireShare.sh
 modules:
@@ -28,6 +28,5 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=home
        
-
 
 


### PR DESCRIPTION
I tried doing a pull request against new-pr, but GitHub wouldn't let me do that, so I'm doing the closest thing I can.

This is the manifest for WireShare, a Java app with a tremendously long history, and one that has shaped Internet culture as experienced by the Millennial Generation.  You may have heard of LimeWire, the program that became synonymous with music "piracy" and ultimately succumbed to a relentless campaign waged in the media, the courts, and every other public forum by the RIAA.  WireShare is LimeWire all grown up, with its ambitions focussed no longer on copyright infringement, but on rapid public dissemination of large files.  

HERMES WireShare is one of only three Gnutella servents (server/clients) in active development, together with Shareaza and gtk-Gnutella.  It is also by far the most commonly used.