### PR TITLE
Add org.parlatype.Parlatype

### DIFF
--- a/org.parlatype.Parlatype.json
+++ b/org.parlatype.Parlatype.json
@@ -1,0 +1,45 @@
+{
+    "app-id": "org.parlatype.Parlatype",
+
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.36",
+    "sdk": "org.gnome.Sdk",
+
+    "command": "parlatype",
+
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+
+    	"--filesystem=home:ro",
+
+        "--talk-name=org.freedesktop.secrets",
+
+        "--talk-name=org.gnome.SettingsDaemon.MediaKeys"
+    ],
+    "cleanup": [
+        "*.la",
+        "*.a",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name": "parlatype",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dasr=false"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/gkarsay/parlatype/releases/download/v2.0/parlatype-2.0.tar.gz",
+                    "sha256": "f9833d244f8744f7a9983d680005462d02d062c2538423cb443279da2cc5e2d1"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This app is already on Flathub under its old ID https://github.com/flathub/com.github.gkarsay.parlatype. As its homepage moved, the ID has changed accordingly to the new URI. 

This is the first stable release under the new ID. The manifest is simpler than the old one, because I removed a rather experimental feature and its 2 modules and there is only one left.

I will follow the steps given on https://discourse.flathub.org/t/how-to-change-an-app-id/124 to retire the old ID.