### PR TITLE
Add org.raspberrypi.rpi-imager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build/

--- a/org.raspberrypi.rpi-imager.metainfo.xml
+++ b/org.raspberrypi.rpi-imager.metainfo.xml
@@ -28,7 +28,7 @@
       download the file again.
     </p>
   </description>
-  <launchable type="desktop-id">rpi-imager.desktop</launchable>
+  <launchable type="desktop-id">org.raspberrypi.rpi-imager.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <image>https://www.raspberrypi.org/app/uploads/2020/03/RPI_intro-e1583228263677.png</image>

--- a/org.raspberrypi.rpi-imager.metainfo.xml
+++ b/org.raspberrypi.rpi-imager.metainfo.xml
@@ -31,20 +31,24 @@
   <launchable type="desktop-id">org.raspberrypi.rpi-imager.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://www.raspberrypi.org/app/uploads/2020/03/RPI_intro-e1583228263677.png</image>
-      <caption>Default view</caption>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-MAIN.png</image>
+      <caption>Main window</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-OS-300x196.png</image>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-OS.png</image>
       <caption>Choose OS</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-SD-300x196.png</image>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-SD.png</image>
       <caption>Choose SD</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-WRITE-300x196.png</image>
-      <caption>Write SD</caption>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-WRITE.png</image>
+      <caption>Write in progress</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://downloads.raspberrypi.org/imager/IMAGING-UTILITY-DONE.png</image>
+      <caption>Write done</caption>
     </screenshot>
   </screenshots>
   <url type="homepage">https://github.com/raspberrypi/rpi-imager</url>

--- a/org.raspberrypi.rpi-imager.metainfo.xml
+++ b/org.raspberrypi.rpi-imager.metainfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--Copyright 2020 Flathub maintainers-->
+<component type="desktop">
+  <id>org.raspberrypi.rpi-imager</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <name>Raspberry Pi Imager</name>
+  <summary>Raspberry Pi imaging utility</summary>
+  <description>
+    <p>
+      Raspberry Pi Imager downloads a .JSON file from the Raspberry Pi
+      website with a list of all current download options, ensuring you are
+      always installing the most up-to-date version.
+    </p>
+    <p>
+      Once you’ve selected an operating system from the available options,
+      the utility reads the relevant file directly from the Raspberry Pi
+      website and writes it straight to the SD card. This speeds up the
+      process quite considerably compared to the standard process of reading
+      it from the website, writing it to a file on your hard drive, and then,
+      as a separate step, reading it back from the hard drive and writing it
+      to the SD card.
+    </p>
+    <p>
+      During this process, Raspberry Pi Imager also caches the downloaded
+      operating system image – that is to say, it saves a local copy on your
+      computer, so you can program additional SD cards without having to
+      download the file again.
+    </p>
+  </description>
+  <launchable type="desktop-id">rpi-imager.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.raspberrypi.org/app/uploads/2020/03/RPI_intro-e1583228263677.png</image>
+      <caption>Default view</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-OS-300x196.png</image>
+      <caption>Choose OS</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-SD-300x196.png</image>
+      <caption>Choose SD</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.raspberrypi.org/app/uploads/2020/03/IMAGING-UTILITY-WRITE-300x196.png</image>
+      <caption>Write SD</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/raspberrypi/rpi-imager</url>
+  <provides>
+    <binary>rpi-imager</binary>
+  </provides>
+  <releases>
+    <release version="1.2" date="2020-03-10" />
+  </releases>
+  <content_rating type="oars-1.1" />
+</component>

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -1,0 +1,32 @@
+app-id: org.raspberrypi.rpi-imager
+branch: stable
+runtime: org.kde.Platform
+runtime-version: '5.14'
+sdk: org.kde.Sdk
+command: rpi-imager
+rename-desktop-file: rpi-imager.desktop
+rename-icon: rpi-imager
+finish-args:
+  - --device=dri
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=x11
+  - --filesystem=xdg-download
+  - --talk-name=org.a11y.*
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.UDisks2
+modules:
+  - name: rpi-imager
+    sources:
+      - type: archive
+        url: https://github.com/raspberrypi/rpi-imager/archive/v1.2.tar.gz
+        sha256: 69c67d6a92629d6c701c0ffe29b3033032e9b808fe9948c8abcc83409fec93d8
+      - type: file
+        path: org.raspberrypi.rpi-imager.metainfo.xml
+    buildsystem: cmake-ninja
+    post-install:
+      - 'mkdir -p $FLATPAK_DEST/share/icons/hicolor/128x128/apps'
+      - 'mv $FLATPAK_DEST/share/pixmaps/rpi-imager.png $FLATPAK_DEST/share/icons/hicolor/128x128/apps'
+      - 'rmdir $FLATPAK_DEST/share/pixmaps'
+      - 'install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml'

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -9,7 +9,6 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --socket=wayland
   - --socket=fallback-x11
   - --filesystem=xdg-download
   - --talk-name=org.a11y.*

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -10,7 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --filesystem=xdg-download
   - --talk-name=org.a11y.*
   - --talk-name=org.freedesktop.Notifications

--- a/org.raspberrypi.rpi-imager.yaml
+++ b/org.raspberrypi.rpi-imager.yaml
@@ -1,5 +1,4 @@
 app-id: org.raspberrypi.rpi-imager
-branch: stable
 runtime: org.kde.Platform
 runtime-version: '5.14'
 sdk: org.kde.Sdk


### PR DESCRIPTION
Flatpak packaging for the [Raspberry Pi Imager](https://www.raspberrypi.org/blog/raspberry-pi-imager-imaging-utility/).

The AppStream metadata have been submitted and validated upstream.

I have submitted a PR upstream to install the application icon at the right location. For now, it's done in the post-install.