### PR TITLE
Add org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/makefile.patch
+++ b/makefile.patch
@@ -1,0 +1,17 @@
+diff --git a/Makefile b/Makefile
+index eb94b0e..b322874 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,9 +1,11 @@
++PREFIX ?= /usr
++LV2_DIR ?= /lib/lv2
+ OBJECTS = so-666.o so-kl5.o so-404.o sosynth.o
+ LIBRARY = libsosynth.so
+ TTLS = so-666.ttl so-kl5.ttl so-404.ttl manifest.ttl
+ CC = gcc
+ CFLAGS += -Wall -O3 -ffast-math -lm `pkg-config --cflags --libs lv2` -fPIC
+-INSTALLDIR = $(DESTDIR)/usr/lib/lv2/
++INSTALLDIR = $(DESTDIR)$(PREFIX)$(LV2_DIR)/
+ INSTALLNAME = so-synth.lv2/
+ $(LIBRARY) : $(OBJECTS)
+ 	$(CC) $(CFLAGS) $(OBJECTS) -shared -o $@

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.json
@@ -1,0 +1,52 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "append-pkg-config-path": "/app/extensions/Lv2Plugins/SoSynthLV2/lib/pkgconfig",
+        "prefix": "/app/extensions/Lv2Plugins/SoSynthLV2"
+    },
+    "cleanup": [
+        "/lib/lv2"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "sosynth",
+            "buildsystem": "simple",
+            "build-options": {
+                "env": {
+                    "PREFIX": "${FLATPAK_DEST}"
+                }
+            },
+            "build-commands": [
+                "make",
+                "make LV2_DIR=/lv2 install"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2 --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2",
+                "install -Dm644 -t $FLATPAK_DEST/share/licences/sosynth LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/jeremysalwen/So-synth-LV2/archive/upstream/1.5.tar.gz",
+                    "sha256": "1ab4d33e798a1637523d05959c745aa46fea3bf1edd2687531edcab35a0b27c8"
+                },
+                {
+                    "type": "patch",
+                    "path": "makefile.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.SoSynthLV2</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>So Synth LV2</name>
+  <summary>So Synth LV2 plugin</summary>
+  <url type="homepage">https://github.com/jeremysalwen/So-synth-LV2</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2020-01-05" version="1.5" />
+    <release date="2011-06-06" version="1.4" />
+  </releases>
+</component>


### PR DESCRIPTION
This is to be built with the base app as per pr #1460

SoSynth LV2 is a simple LV2 synth plugin.

Ardour PR #831 will be modified to ~~build against the base app and~~ use these plugins.