### PR TITLE
Add org.plomgrading.PlomClient

### DIFF
--- a/PlomClient.workaround
+++ b/PlomClient.workaround
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# TODO: flatpak workaround:
+# TODO: pip install from src gives different script than install from whl.
+# TODO: The src one checks all dependences, even ones we don't need for client.
+# TODO: Instead, copy this file from the whl-based install and use that for flatpak.
+
+import re
+import sys
+
+from plom.scripts.client import main
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# org.plomgrading.PlomClient: Flatpak support
+
+This a Flatpak manifest for the [Plom](https://plomgrading.org) Client.
+
+
+## Credits
+
+Module for building PyQt5 is a copy-pasta from [vidcutter].
+
+For the python dependencies, I used [flatpak-pip-generator].  Doesn't seem
+to have an installer: I just copied the single Python file off github.
+
+[vidcutter]: https://github.com/flathub/com.ozmartians.VidCutter/blob/master/com.ozmartians.VidCutter.json
+[flatpak-pip-generator]: https://github.com/flatpak/flatpak-builder-tools/blob/master/pip/flatpak-pip-generator

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -30,9 +30,6 @@
         },
         "pyqt5.json",
         "python3-toml.json",
-        "python3-requests_toolbelt.json",
-        {
-            "name": "other-modules"
-        }
+        "python3-requests_toolbelt.json"
     ]
 }

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -7,6 +7,7 @@
     "finish-args": [
         "--socket=x11",
         "--socket=ipc",
+        "--socket=wayland",
         "--socket=dri",
         "--share=network"
     ],

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -6,6 +6,8 @@
     "command": "PlomClient",
     "finish-args": [
         "--socket=x11",
+        "--socket=ipc",
+        "--socket=dri",
         "--share=network"
     ],
     "modules": [

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -5,10 +5,10 @@
     "sdk": "org.kde.Sdk",
     "command": "PlomClient",
     "finish-args": [
-        "--socket=x11",
-        "--socket=ipc",
         "--socket=wayland",
-        "--socket=dri",
+        "--socket=x11",
+        "--share=ipc",
+        "--device=dri",
         "--share=network"
     ],
     "modules": [

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -9,6 +9,9 @@
         "--share=network"
     ],
     "modules": [
+        "pyqt5.json",
+        "python3-toml.json",
+        "python3-requests_toolbelt.json",
         {
             "name": "Plom",
             "buildsystem": "simple",
@@ -27,9 +30,6 @@
                     "path": "PlomClient.workaround"
                 }
             ]
-        },
-        "pyqt5.json",
-        "python3-toml.json",
-        "python3-requests_toolbelt.json"
+        }
     ]
 }

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -1,0 +1,46 @@
+{
+    "app-id": "org.plomgrading.PlomClient",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.14",
+    "sdk": "org.kde.Sdk",
+    "command": "PlomClient",
+    "finish-args": [
+        "--socket=x11",
+        "--share=network"
+    ],
+    "modules": [
+        {
+            "name": "hello",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D PlomClient.workaround /app/bin/PlomClient"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "PlomClient.workaround"
+                }
+            ]
+        },
+        {
+            "name": "Plom",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app --no-deps ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://files.pythonhosted.org/packages/f2/9c/7f80c20dbd4ccca1463da4ca5b7b44364259dd0a34e50b9966744d412c68/plom-0.4.2.tar.gz",
+                    "sha256": "9da10be8193dc9b70359d3ff8144eef13e7ece4a636251753465569d7663a413"
+                }
+            ]
+        },
+        "pyqt5.json",
+        "python3-toml.json",
+        "python3-requests_toolbelt.json",
+        {
+            "name": "other-modules"
+        }
+    ]
+}

--- a/org.plomgrading.PlomClient.json
+++ b/org.plomgrading.PlomClient.json
@@ -10,29 +10,21 @@
     ],
     "modules": [
         {
-            "name": "hello",
-            "buildsystem": "simple",
-            "build-commands": [
-                "install -D PlomClient.workaround /app/bin/PlomClient"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "path": "PlomClient.workaround"
-                }
-            ]
-        },
-        {
             "name": "Plom",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --prefix=/app --no-deps ."
+                "pip3 install --prefix=/app --no-deps .",
+                "install -D PlomClient.workaround /app/bin/PlomClient"
             ],
             "sources": [
                 {
                     "type": "archive",
                     "url": "https://files.pythonhosted.org/packages/f2/9c/7f80c20dbd4ccca1463da4ca5b7b44364259dd0a34e50b9966744d412c68/plom-0.4.2.tar.gz",
                     "sha256": "9da10be8193dc9b70359d3ff8144eef13e7ece4a636251753465569d7663a413"
+                },
+                {
+                    "type": "file",
+                    "path": "PlomClient.workaround"
                 }
             ]
         },

--- a/pyqt5.json
+++ b/pyqt5.json
@@ -1,0 +1,30 @@
+{
+    "name": "PyQt5",
+    "cleanup": ["/bin/sip", "/include", "/lib/python3.7/site-packages/*.pyi"],
+    "config-opts": ["--disable-static", "--enable-x11"],
+    "buildsystem": "simple",
+    "build-commands": [
+        "python3 configure.py --confirm-license --no-docstrings --assume-shared --no-sip-files --no-qml-plugin --no-tools --no-qsci-api -d ${FLATPAK_DEST}/lib/python3.7/site-packages --sip=${FLATPAK_DEST}/bin/sip --sip-incdir=${FLATPAK_DEST}/include --stubsdir=${FLATPAK_DEST}/lib/python3.7/site-packages --disable=QtSensors --disable=QtWebEngine --disable=QtQuick --disable=QtQml --disable=QtTest --disable=QtWebChannel --disable=QtWebEngineCore --disable=QWebEngineWidgets --disable=QtQuickWidgets --disable=QtSql --disable=QtXmlPatterns --disable=QtMultimedia --disable=QtMultimediaWidgets --disable=QtLocation --disable=QtDesigner --disable=QtOpenGL --disable=QtBluetooth --disable=QtWebKit --disable=QtWebKitWidgets --disable=QtNfc --disable=QtPositioning",
+        "make -j $(nproc)",
+        "make install"
+    ],
+    "sources": [{
+        "type": "archive",
+        "url": "https://www.riverbankcomputing.com/static/Downloads/PyQt5/5.13.2/PyQt5-5.13.2.tar.gz",
+        "sha256": "adc17c077bf233987b8e43ada87d1e0deca9bd71a13e5fd5fc377482ed69c827"
+    }],
+      "modules": [{
+        "name": "sip",
+        "buildsystem": "simple",
+        "build-commands": [
+            "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.7/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.7/site-packages",
+            "make",
+            "make install"
+        ],
+        "sources": [{
+            "type": "archive",
+            "url": "https://www.riverbankcomputing.com/static/Downloads/sip/4.19.21/sip-4.19.21.tar.gz",
+            "sha256": "6af9979ab41590e8311b8cc94356718429ef96ba0e3592bdd630da01211200ae"
+        }]
+    }]
+}

--- a/pyqt5.json
+++ b/pyqt5.json
@@ -5,7 +5,7 @@
     "buildsystem": "simple",
     "build-commands": [
         "python3 configure.py --confirm-license --no-docstrings --assume-shared --no-sip-files --no-qml-plugin --no-tools --no-qsci-api -d ${FLATPAK_DEST}/lib/python3.7/site-packages --sip=${FLATPAK_DEST}/bin/sip --sip-incdir=${FLATPAK_DEST}/include --stubsdir=${FLATPAK_DEST}/lib/python3.7/site-packages --disable=QtSensors --disable=QtWebEngine --disable=QtQuick --disable=QtQml --disable=QtTest --disable=QtWebChannel --disable=QtWebEngineCore --disable=QWebEngineWidgets --disable=QtQuickWidgets --disable=QtSql --disable=QtXmlPatterns --disable=QtMultimedia --disable=QtMultimediaWidgets --disable=QtLocation --disable=QtDesigner --disable=QtOpenGL --disable=QtBluetooth --disable=QtWebKit --disable=QtWebKitWidgets --disable=QtNfc --disable=QtPositioning",
-        "make -j $(nproc)",
+        "make -j $FLATPAK_BUILDER_N_JOBS",
         "make install"
     ],
     "sources": [{

--- a/python3-requests_toolbelt.json
+++ b/python3-requests_toolbelt.json
@@ -1,0 +1,39 @@
+{
+    "name": "python3-requests_toolbelt",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} requests_toolbelt"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/89/e3/afebe61c546d18fb1709a61bee788254b40e736cff7271c7de5de2dc4128/idna-2.9-py2.py3-none-any.whl",
+            "sha256": "a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl",
+            "sha256": "fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e8/74/6e4f91745020f967d09332bb2b8b9b10090957334692eb88ea4afe91b77f/urllib3-1.25.8-py2.py3-none-any.whl",
+            "sha256": "2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b9/63/df50cac98ea0d5b006c55a399c3bf1db9da7b5a24de7890bc9cfd5dd9e99/certifi-2019.11.28-py2.py3-none-any.whl",
+            "sha256": "017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1a/70/1935c770cb3be6e3a8b78ced23d7e0f3b187f5cbfab4749523ed65d7c9b1/requests-2.23.0-py2.py3-none-any.whl",
+            "sha256": "43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/60/ef/7681134338fc097acef8d9b2f8abe0458e4d87559c689a8c306d0957ece5/requests_toolbelt-0.9.1-py2.py3-none-any.whl",
+            "sha256": "380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"
+        }
+    ]
+}

--- a/python3-toml.json
+++ b/python3-toml.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-toml",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} toml"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl",
+            "sha256": "235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+        }
+    ]
+}


### PR DESCRIPTION
[Plom](plomgrading.org) is a system for giving tests on paper, but marking and returning them online.  This flatpak is for the QT-based Client.

I am one of the upstream developers.  This is my first flatpak.

#### Notes

One oddity is that the tarball (on PyPi) is for the entire system (including backend server) but here I'm only packaging the Client.  The server has (many) additional dependencies which the client does not need.  I had to workaround the checking of these dependencies (b/c of a Python difference between installing from a wheel versus installing from tarball).  Feel free to let me know if that approach looks wrong!  We don't want to split them upstream (although we may do so later!)