### PR TITLE
Add org.small_tech.Gnomit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Gnomit Flatpak App Manifest for Flathub
+
+This repository is __automatically updated__ by the Gnomit [deployment script](https://github.com/small-tech/gnomit/blob/master/publish-to-flathub).
+
+  - Please do not manually update this repository.
+  - Please do not open issues or send or accept pull requests here.
+
+Issues and pull requests are welcome on [the Gnomit Github mirror](https://github.com/small-tech/gnomit).

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "publish-delay-hours": 0
+}

--- a/org.small_tech.Gnomit.appdata.xml
+++ b/org.small_tech.Gnomit.appdata.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.small_tech.Gnomit</id>
+  <launchable type="desktop-id">org.small_tech.Gnomit.desktop</launchable>
+  <name>Gnomit</name>
+  <developer_name>Aral Balkan, Small Technology Foundation</developer_name>
+  <update_contact>hello@small-tech.org</update_contact>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <summary>Git commit message editor</summary>
+  <description>
+    <p>Gnomit is a simple Git commit message editor for Gnome, inspired by the excellent Komet app on macOS.</p>
+    <p>Features:</p>
+    <ul>
+      <li>Highlights overflow of subject line when it exceeds 69 characters.</li>
+      <li>Inserts empty line between subject line and rest of message.</li>
+      <li>Has spell checking.</li>
+      <li>Select All selects only your commit message, not the Git commit comment.</li>
+      <li>Displays project folder and branch in window header.</li>
+      <li>Git Commit comment is not editable</li>
+      <li>Dark theme support: the overflow highlight is adjusted according to your theme.</li>
+      <li>Supports git commit messages, merge messages, tag messages, git add -p messages, and rebase -i messages.</li>
+    </ul>
+  </description>
+  <url type="homepage">https://github.com/small-tech/gnomit</url>
+  <url type="bugtracker">https://github.com/small-tech/gnomit/issues</url>
+  <url type="donation">https://small-tech.org/fund/</url>
+  <url type="help">https://small-tech.org/</url>
+  <icon type="remote" width="512px" height="512px">https://ar.al/org.small_tech.Gnomit.png</icon>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://ar.al/2018/10/19/gnomit-1.0.4/gnomit.png</image>
+      <caption>Main editor window</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release date="2020-04-23" version="2.0.0">
+      <description>
+        <p>This is the first release of Gnomit under Small Technology Foundation.</p>
+        <p>We have a new icon and there a number of small bug fixes and general improvements.</p>
+      </description>
+    </release>
+    <release date="2020-04-22" version="1.1.0">
+      <description>
+        <p>A number of housekeeping updates thanks to Sonny Piers that fix a warning, update dependencies, hide the desktop entry, and reduce permissions.</p>
+        <p>This is the last release that will use the App ID ind.ie.Gnomit. Future updates will be released under org.small_tech.Gnomit.</p>
+      </description>
+    </release>
+    <release date="2018-12-11" version="1.0.7">
+      <description>
+        <p>Add explicit support for git merge messages and remove the command-line warning about them.</p>
+        <p>Update GNOME runtime to version 3.30.</p>
+      </description>
+    </release>
+    <release date="2018-10-27" version="1.0.6">
+      <description>
+        <p>In addition to git commit messages and tag messages, Gnomit now also supports git add -p messages and rebase -i messages. A big thank-you to Philip Chimento for reporting those issues.</p>
+      </description>
+    </release>
+    <release date="2018-10-22" version="1.0.5">
+      <description>
+        <p>Dark theme support.</p>
+      </description>
+    </release>
+    <release date="2018-10-19" version="1.0.4">
+      <description>
+        <p>Gnomit has a new look thanks to Sergey Bugaev.</p>
+      </description>
+    </release>
+    <release date="2018-08-26" version="1.0.3">
+      <description>
+        <p>Gnomit is now Unicode-aware 🤓</p>
+        <p>Also, fixes a couple of minor bugs.</p>
+      </description>
+    </release>
+    <release date="2018-08-26" version="1.0.2">
+      <description>
+        <p>Implements support for tag messages and gracefully handles auto-generated commit message bodies longer than a single line.</p>
+      </description>
+    </release>
+    <release date="2018-08-23" version="1.0.1">
+      <description>
+        <p>First release.</p>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1" />
+</component>
+
+

--- a/org.small_tech.Gnomit.desktop
+++ b/org.small_tech.Gnomit.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Gnomit
+Exec=org.small_tech.Gnomit
+Terminal=false
+Type=Application
+Categories=Development;Utility;RevisionControl;TextEditor;GNOME;GTK;
+StartupNotify=true
+Icon=org.small_tech.Gnomit
+NoDisplay=true

--- a/org.small_tech.Gnomit.json
+++ b/org.small_tech.Gnomit.json
@@ -1,0 +1,66 @@
+{
+    "app-id" : "org.small_tech.Gnomit",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.36",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "org.small_tech.Gnomit",
+    "x-run-args" : [
+        "small-tech/gnomit/gjs/tests/message-with-body"
+    ],
+    "finish-args" : [
+        "--filesystem=host",
+        /* X11 + XShm access */
+        "--share=ipc", "--socket=x11", "--socket=fallback-x11",
+        /* Wayland access */
+        "--socket=wayland"
+    ],
+    "build-options" : {
+        "env" : {
+            "V" : "1"
+        }
+    },
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "gspell",
+            "config-opts" : [
+                "--disable-vala",
+                "--disable-static",
+                "--disable-gtk-doc"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gspell/1.8/gspell-1.8.3.tar.xz",
+                    "sha256" : "5ae514dd0216be069176accf6d0049d6a01cfa6a50df4bc06be85f7080b62de8"
+                }
+            ],
+            "cleanup" : [
+                "/bin"
+            ]
+        },
+        {
+            "name" : "gnomit",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://source.small-tech.org/gnome/gnomit/gjs.git",
+                    "tag" : "2.0.0",
+                    "commit" : "fb6c1b4be935c4140e0602a26ffe7c771e20384d"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi there,

I’m migrating Gnomit from ind.ie.Gnomit to org.small_tech.Gnomit following the name change of our organisation from Ind.ie to Small Technology Foundation (https://small-tech.org).

The last version, at ind.ie.Gnomit was 1.1.0. This is 2.0.0, the first release with the new app ID.

Once I’ve submitted this, I will also update the previous app with an EOL indicator.

Thanks + lots of love from the Emerald Isle :)