### PR TITLE
Add org.gnome.Connections

### DIFF
--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -73,7 +73,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/felipeborges/gnome-connections.git",
-					  "tag": "v3.37.1"
+                    "tag": "v3.37.1"
                 }
             ]
         }

--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.Connections",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "master",
+    "runtime-version": "3.36",
     "sdk": "org.gnome.Sdk",
     "command": "gnome-connections",
     "finish-args": [

--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -72,7 +72,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://gitlab.gnome.org/felipeborges/gnome-connections.git"
+                    "url": "https://gitlab.gnome.org/felipeborges/gnome-connections.git",
+					  "tag": "v3.37.1"
                 }
             ]
         }

--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -1,0 +1,80 @@
+{
+    "app-id": "org.gnome.Connections",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-connections",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name" : "gtk-vnc",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/gtk-vnc/1.0/gtk-vnc-1.0.0.tar.xz",
+                    "sha256" : "a81a1f1a79ad4618027628ffac27d3391524c063d9411c7a36a5ec3380e6c080"
+                }
+            ]
+        },
+        {
+            "name" : "freerdp",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DWITH_OPENH264=ON",
+                "-DCMAKE_INSTALL_PREFIX=/app",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://pub.freerdp.com/releases/freerdp-2.0.0-rc4.tar.gz",
+                    "sha256" : "bd1cd5579765b2d6b444508cafc7b3669c68ff2246941a081e771f744b150f6a"
+                }
+            ]
+        },
+        {
+            "name" : "gtk-frdp",
+            "config-opts" : [
+                "--libdir=/app/lib"
+            ],
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/gnome/gtk-frdp.git"
+                }
+            ]
+        },
+        {
+            "name": "gnome-connections",
+            "builddir": true,
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/felipeborges/gnome-connections.git"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.Connections.json
+++ b/org.gnome.Connections.json
@@ -61,7 +61,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.gnome.org/gnome/gtk-frdp.git"
+                    "url" : "https://gitlab.gnome.org/gnome/gtk-frdp.git",
+                    "tag" : "v3.37.1"
                 }
             ]
         },


### PR DESCRIPTION
https://gitlab.gnome.org/felipeborges/gnome-connections

GNOME Connections is a brand new app that is a VNC and RDP client. It is based on GNOME Boxes and is part of a long-term plan of splitting off remote connection functionalities from GNOME Boxes into a dedicated application.