### PR TITLE
Add org.srb2.SRB2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.srb2.SRB2.desktop
+++ b/org.srb2.SRB2.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Sonic Robo Blast 2
+Comment=A 3D Sonic the Hedgehog fangame based on a modified version of Doom Legacy
+TryExec=srb2
+Exec=srb2
+Icon=org.srb2.SRB2
+Terminal=false
+Categories=Game;

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -27,6 +27,10 @@
       <li>Customization: SRB2 includes the ability to create your own levels, characters, game modes, and with knowledge of programming, even a whole new game.</li>
       <li>…and so much more!</li>
     </ul>
+    <p>
+      Commercial assets are required to run the game. Check the project's
+      website for instructions.
+    </p>
   </description>
   <launchable type="desktop-id">org.srb2.SRB2.desktop</launchable>
   <screenshots>

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Copyright 2020 Flathub maintainers -->
+<component type="desktop-application">
+  <id>org.srb2.SRB2</id>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <name>Sonic Robo Blast 2</name>
+  <summary>A 3D Sonic the Hedgehog fangame based on a modified version of Doom Legacy</summary>
+  <description>
+    <p>
+      Sonic Robo Blast 2 is a free 3D Sonic the Hedgehog fan-game built using
+      a modified version of the Doom Legacy source port of Doom. SRB2 is
+      closely inspired by the original Sonic games from the Sega Genesis, and
+      attempts to recreate their design in 3D.
+    </p>
+    <p>
+      SRB2’s features include, but are not limited to:
+    </p>
+    <ul>
+      <li>Beautiful 3D Enviroment, with free movement in all directions.</li>
+      <li>Old-school platforming, complete with rings, springs, hazards, reversible gravity and other obstacles.</li>
+      <li>Three playable characters: Sonic, Tails, Knuckles – each with their own unique abilities.</li>
+      <li>Over 20 levels to play, featuring a variety of locations, from green meadows, to deep underwater ruins, mines, mountains and space stations…</li>
+      <li>Fast-paced multiplayer fun with 2 player splitscreen or up to 32 players online in nine different game modes.</li>
+      <li>Configurable graphics and control options – play with a modern WSAD + Mouse FPS control setup, a relaxed gamepad setup, or anything in between!</li>
+      <li>Original Soundtrack produced by some of the best Sonic music artists on the Internet.</li>
+      <li>Customization: SRB2 includes the ability to create your own levels, characters, game modes, and with knowledge of programming, even a whole new game.</li>
+      <li>…and so much more!</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">org.srb2.SRB2.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.srb2.org/wp-content/uploads/srb2-title.png</image>
+      <caption>Title screen</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.srb2.org/wp-content/uploads/21-gfz2.png</image>
+      <caption>Singleplayer (Sonic)</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.srb2.org/wp-content/uploads/21-dsz2.png</image>
+      <caption>Singleplayer (Tails)</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.srb2.org/wp-content/uploads/21-thz2.png</image>
+      <caption>Singleplayer (Knuckles)</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.srb2.org/media_data/coop1.png</image>
+      <caption>Multiplayer</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://www.srb2.org</url>
+  <provides>
+    <binary>srb2kart</binary>
+  </provides>
+  <releases>
+    <release version="2.2.2" date="2020-02-23" />
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">moderate</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
+</component>

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -53,7 +53,7 @@
   </screenshots>
   <url type="homepage">https://www.srb2.org</url>
   <provides>
-    <binary>srb2kart</binary>
+    <binary>srb2</binary>
   </provides>
   <releases>
     <release version="2.2.2" date="2020-02-23" />

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -56,7 +56,7 @@
     <binary>srb2</binary>
   </provides>
   <releases>
-    <release version="2.2.3" date="2020-05-10" />
+    <release version="2.2.4" date="2020-05-11" />
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -56,7 +56,7 @@
     <binary>srb2</binary>
   </provides>
   <releases>
-    <release version="2.2.2" date="2020-02-23" />
+    <release version="2.2.3" date="2020-05-10" />
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --persist=.srb2
 modules:
   - shared-modules/glu/glu-9.json
+
   - name: game-music-emu
     buildsystem: cmake-ninja
     cleanup:
@@ -23,6 +24,7 @@ modules:
       - type: archive
         url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
         sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
+
   - name: libopenmpt
     config-opts:
       - --disable-examples
@@ -41,6 +43,7 @@ modules:
       - type: archive
         url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.4.12+release.autotools.tar.gz
         sha256: 0ccd64476e6c8a084277e7093c4034d702e7999eeffd31adc89b33685e725e60
+
   - name: srb2
     buildsystem: simple
     build-commands:

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -60,7 +60,7 @@ modules:
         commit: feced5ec3c469b2842c70e50663373dcd2d0cd2f
       - type: script
         commands:
-          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --text "Game assets not found, please add them to your ~/.srb2 folder. See https://www.srb2.org/download/" --ok-label "Close" --width=400'
+          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --title "Missing game assets" --text "Game assets not found, please add them to your ~/.srb2 folder. See https://www.srb2.org/download/" --ok-label "Close" --width=400'
           - 'lsdl2srb2 "$@"'
         dest-filename: srb2.sh
       - type: file

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -45,8 +45,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/STJr/SRB2
-        tag: SRB2_release_2.2.3
-        commit: 225095afa2fb1c61d12cf96c1b7c56cb4dbb4350
+        tag: SRB2_release_2.2.4
+        commit: feced5ec3c469b2842c70e50663373dcd2d0cd2f
       - type: file
         path: org.srb2.SRB2.desktop
       - type: file

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -47,6 +47,11 @@ modules:
         url: https://github.com/STJr/SRB2
         tag: SRB2_release_2.2.4
         commit: feced5ec3c469b2842c70e50663373dcd2d0cd2f
+      - type: script
+        commands:
+          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --text "Game assets not found, please add them to your ~/.srb2 folder. See " --ok-label "Close" --width=400'
+          - 'lsdl2srb2 "$@"'
+        dest-filename: srb2.sh
       - type: file
         path: org.srb2.SRB2.desktop
       - type: file
@@ -54,7 +59,8 @@ modules:
     buildsystem: simple
     build-commands:
       - 'make -C src -j $FLATPAK_BUILDER_N_JOBS LINUX64=1 NOUPX=1 SDL=1'
-      - 'install -D -m 755 bin/Linux64/Release/lsdl2srb2 $FLATPAK_DEST/bin/srb2'
+      - 'install -D -m 755 -t $FLATPAK_DEST/bin bin/Linux64/Release/lsdl2srb2'
       - 'install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png'
+      - 'install -D -m 755 srb2.sh $FLATPAK_DEST/bin/srb2'
       - 'install -D -m 644 -t $FLATPAK_DEST/share/applications $FLATPAK_ID.desktop'
       - 'install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml'

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -43,9 +43,10 @@ modules:
       - /share/doc
   - name: srb2
     sources:
-      - type: archive
-        url: https://github.com/STJr/SRB2/archive/SRB2_release_2.2.2.tar.gz
-        sha256: f2bb0922becb55bc2d3b833d624b02e7d8306142c8c6c988df32d9e3b3d9b5ac
+      - type: git
+        url: https://github.com/STJr/SRB2
+        tag: SRB2_release_2.2.3
+        commit: 225095afa2fb1c61d12cf96c1b7c56cb4dbb4350
       - type: file
         path: org.srb2.SRB2.desktop
       - type: file

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -60,7 +60,7 @@ modules:
         commit: feced5ec3c469b2842c70e50663373dcd2d0cd2f
       - type: script
         commands:
-          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --title "Missing game assets" --text "Game assets not found, please add them to your ~/.srb2 folder. See https://www.srb2.org/download/" --ok-label "Close" --width=400'
+          - 'ls ~/.srb2/srb2.pk3 || zenity --error --title "Missing game assets" --text "Game assets not found, please add them to your ~/.var/app/org.srb2.SRB2/.srb2 folder. See https://www.srb2.org/download/ for download instructions." --ok-label "Close" --width=400'
           - 'lsdl2srb2 "$@"'
         dest-filename: srb2.sh
       - type: file

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -1,0 +1,59 @@
+app-id: org.srb2.SRB2
+runtime: org.freedesktop.Platform
+runtime-version: '19.08'
+sdk: org.freedesktop.Sdk
+command: srb2
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --device=all
+  - --persist=.srb2
+modules:
+  - shared-modules/glu/glu-9.json
+  - name: game-music-emu
+    sources:
+      - type: archive
+        url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
+        sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
+    buildsystem: cmake-ninja
+    cleanup:
+      - /include
+      - /lib/*.so
+      - /lib/pkgconfig
+  - name: libopenmpt
+    sources:
+      - type: archive
+        url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.4.12+release.autotools.tar.gz
+        sha256: 0ccd64476e6c8a084277e7093c4034d702e7999eeffd31adc89b33685e725e60
+    config-opts:
+      - --disable-examples
+      - --disable-openmpt123
+      - --disable-static
+      - --disable-tests
+      - --without-portaudio
+      - --without-portaudiocpp
+    cleanup:
+      - /include
+      - /lib/*.la
+      - /lib/*.so
+      - /lib/pkgconfig
+      - /share/doc
+  - name: srb2
+    sources:
+      - type: archive
+        url: https://github.com/STJr/SRB2/archive/SRB2_release_2.2.2.tar.gz
+        sha256: f2bb0922becb55bc2d3b833d624b02e7d8306142c8c6c988df32d9e3b3d9b5ac
+      - type: file
+        path: org.srb2.SRB2.desktop
+      - type: file
+        path: org.srb2.SRB2.metainfo.xml
+    buildsystem: simple
+    build-commands:
+      - 'make -C src -j $FLATPAK_BUILDER_N_JOBS LINUX64=1 NOUPX=1 SDL=1'
+      - 'install -D -m 755 bin/Linux64/Release/lsdl2srb2 $FLATPAK_DEST/bin/srb2'
+      - 'install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png'
+      - 'install -D -m 644 -t $FLATPAK_DEST/share/applications $FLATPAK_ID.desktop'
+      - 'install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml'

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -60,7 +60,7 @@ modules:
         commit: feced5ec3c469b2842c70e50663373dcd2d0cd2f
       - type: script
         commands:
-          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --text "Game assets not found, please add them to your ~/.srb2 folder. See " --ok-label "Close" --width=400'
+          - 'ls $HOME/.srb2/srb2.pk3 || zenity --error --text "Game assets not found, please add them to your ~/.srb2 folder. See https://www.srb2.org/download/" --ok-label "Close" --width=400'
           - 'lsdl2srb2 "$@"'
         dest-filename: srb2.sh
       - type: file

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -14,20 +14,16 @@ finish-args:
 modules:
   - shared-modules/glu/glu-9.json
   - name: game-music-emu
-    sources:
-      - type: archive
-        url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
-        sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
     buildsystem: cmake-ninja
     cleanup:
       - /include
       - /lib/*.so
       - /lib/pkgconfig
-  - name: libopenmpt
     sources:
       - type: archive
-        url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.4.12+release.autotools.tar.gz
-        sha256: 0ccd64476e6c8a084277e7093c4034d702e7999eeffd31adc89b33685e725e60
+        url: https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz
+        sha256: aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d
+  - name: libopenmpt
     config-opts:
       - --disable-examples
       - --disable-openmpt123
@@ -41,7 +37,19 @@ modules:
       - /lib/*.so
       - /lib/pkgconfig
       - /share/doc
+    sources:
+      - type: archive
+        url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.4.12+release.autotools.tar.gz
+        sha256: 0ccd64476e6c8a084277e7093c4034d702e7999eeffd31adc89b33685e725e60
   - name: srb2
+    buildsystem: simple
+    build-commands:
+      - 'make -C src -j $FLATPAK_BUILDER_N_JOBS LINUX64=1 NOUPX=1 SDL=1'
+      - 'install -D -m 755 -t $FLATPAK_DEST/bin bin/Linux64/Release/lsdl2srb2'
+      - 'install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png'
+      - 'install -D -m 755 srb2.sh $FLATPAK_DEST/bin/srb2'
+      - 'install -D -m 644 -t $FLATPAK_DEST/share/applications $FLATPAK_ID.desktop'
+      - 'install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml'
     sources:
       - type: git
         url: https://github.com/STJr/SRB2
@@ -56,11 +64,3 @@ modules:
         path: org.srb2.SRB2.desktop
       - type: file
         path: org.srb2.SRB2.metainfo.xml
-    buildsystem: simple
-    build-commands:
-      - 'make -C src -j $FLATPAK_BUILDER_N_JOBS LINUX64=1 NOUPX=1 SDL=1'
-      - 'install -D -m 755 -t $FLATPAK_DEST/bin bin/Linux64/Release/lsdl2srb2'
-      - 'install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png'
-      - 'install -D -m 755 srb2.sh $FLATPAK_DEST/bin/srb2'
-      - 'install -D -m 644 -t $FLATPAK_DEST/share/applications $FLATPAK_ID.desktop'
-      - 'install -D -m 644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml'


### PR DESCRIPTION
Add [Sonic Robo Blast 2](https://www.srb2.org/), a 3D Sonic fangame based on the Doom engine. 

The game is notoriously difficult to install on Linux (apart from a PPA if on an Ubuntu derivative), so a Flatpak alternative will be welcome by the community.

The game requires separate installation of proprietary assets within the `~/.srb2` folder. Suggestions as to how to communicate this part effectively are welcome.

![Capture d’écran de 2020-05-06 12-04-17](https://user-images.githubusercontent.com/1964655/81165958-2b70d200-8f93-11ea-8000-32176c687078.png)
