### PR TITLE
Add org.freedesktop.LinuxAudio.LadspaPlugins.swh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "skip-appstream-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-icons-check": true,
-    "skip-appstream-check": true
+    "skip-icons-check": true
 }

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.swh.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.swh.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prepend-pkg-config-path": "/app/extensions/LadspaPlugins/swh/lib/pkgconfig",
+        "prefix": "/app/extensions/LadspaPlugins/swh"
+    },
+    "modules": [
+        "shared-modules/linux-audio/fftw3f-static.json",
+        {
+            "name": "swh",
+            "build-options": {
+                "env": {
+                    "CFLAGS": "-fPIC"
+                }
+            },
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.swh --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/swh/ COPYING"
+            ],
+            "config-opts": [
+                "--libdir=${FLATPAK_DEST}"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/swh/ladspa/archive/v0.4.17.tar.gz",
+                    "sha256": "d1b090feec4c5e8f9605334b47faaad72db7cc18fe91d792b9161a9e3b821ce7"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.LadspaPlugins.swh</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>Swh LADSPA plugins</name>
+  <summary>Swh LADSPA plugins</summary>
+  <url type="homepage">http://plugin.org.uk/</url>
+  <project_license>GPL-2.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2016-11-01" version="0.4.17" />
+  </releases>
+</component>


### PR DESCRIPTION
This is the first set of LADSPA plugins:
- LMMS can use them.
- Hydrogen can use them.

The following apps (mostly video editore) alread ship them (by building the separate package) and will be able to use the flatpak plugins when the PR I'll submit get merged.
- kdenlive
- shotcut
- Flowblade

Audacity also support LADSPA