### PR TITLE
Add org.freedesktop.LinuxAudio.LadspaPlugins.CMT

### DIFF
--- a/build-fixes.patch
+++ b/build-fixes.patch
@@ -1,0 +1,20 @@
+--- CMT/src/Makefile	2019-01-03 10:08:22.000000000 -0500
++++ CMT/src/Makefile-new	2020-04-21 21:45:27.861132115 -0400
+@@ -4,7 +4,7 @@
+ #
+ # Change this if you want to install somewhere else.
+ 
+-INSTALL_PLUGINS_DIR	=	/usr/lib/ladspa/
++INSTALL_PLUGINS_DIR	=	/app/extensions/LadspaPlugins/CMT/ladspa/
+ 
+ ###############################################################################
+ #
+@@ -76,7 +76,7 @@
+ 		$(PLUGIN_OBJECTS)					
+ 
+ install:	$(PLUGIN_LIB)
+-	cp $(PLUGIN_LIB) $(INSTALL_PLUGINS_DIR)
++	mkdir -p $(INSTALL_PLUGINS_DIR) && cp $(PLUGIN_LIB) $(INSTALL_PLUGINS_DIR)
+ 
+ test:	/tmp/test.wav ../../ladspa_sdk/snd/noise.wav always
+ 	@echo ---------------------------------------------

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.CMT.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.CMT.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.CMT",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/LadspaPlugins/CMT"
+    },
+    "modules": [
+        {
+            "name": "cmt",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "make install"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ../org.freedesktop.LinuxAudio.LadspaPlugins.CMT.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.CMT --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.CMT",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/cmt/ ../doc/COPYING"
+            ],
+            "subdir": "src",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.ladspa.org/download/cmt_1.17.tgz",
+                    "sha256": "eb56d7abebfdf8a6d0ad65d012238c9fc394dd41eeca11900812a8cb6b07ad1f"
+                },
+                {
+                    "type": "patch",
+                    "path": "build-fixes.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.CMT.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.CMT.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.CMT.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.LadspaPlugins.CMT</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>CMT LADSPA</name>
+  <summary>Computer Music Plugin LADSPA</summary>
+  <url type="homepage">http://ladspa.org/cmt/overview.html</url>
+  <project_license>GPL-2.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2009-01-03" version="1.17" />
+  </releases>
+</component>


### PR DESCRIPTION
CMT aka Computer Music Toolkit is another set of popular LADSPA plugins.

gsequencer build them in its flatpak. Once this is available we can fix that too.