### PR TITLE
Add org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
 }

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.json
@@ -1,0 +1,40 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension//19.08",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Lv2Plugins/DPF-Plugins",
+        "prepend-path": "/app/extensions/Lv2Plugins/DPF-Plugins/bin"
+    },
+    "modules": [
+        {
+            "name": "dpf-plugins",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make"
+            ],
+            "post-install": [
+                "install -d ${FLATPAK_DEST}/lv2",
+                "cp -av bin/*.lv2 ${FLATPAK_DEST}/lv2",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/dpf-plugins LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/DISTRHO/DPF-Plugins/archive/v1.3.tar.gz",
+                    "sha256": "0e26726bc8c722325d7e847ffe3b452852991e31ce457855291e3dea70840929"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.DPF-Plugins</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>DPF Plugins</name>
+  <summary>DPF Plugins LV2</summary>
+  <url type="homepage">https://distrho.sourceforge.io/plugins</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2019-07-14" version="1.3" />
+  </releases>
+</component>


### PR DESCRIPTION
DISTRHO Plugins are a set of audio plugins for DAW. This is the LV2 version.