### PR TITLE
Add org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports

### DIFF
--- a/distrho-fixes.patch
+++ b/distrho-fixes.patch
@@ -1,0 +1,33 @@
+diff -ur distrho-ports-2/libs/juce/source/modules/juce_graphics/colour/juce_PixelFormats.h distrho-ports-1/libs/juce/source/modules/juce_graphics/colour/juce_PixelFormats.h
+--- distrho-ports-2/libs/juce/source/modules/juce_graphics/colour/juce_PixelFormats.h	2018-04-04 12:45:01.000000000 -0400
++++ distrho-ports-1/libs/juce/source/modules/juce_graphics/colour/juce_PixelFormats.h	2020-04-28 10:38:10.259129506 -0400
+@@ -109,19 +109,6 @@
+     forcedinline uint8 getGreen() const noexcept      { return components.g; }
+     forcedinline uint8 getBlue() const noexcept       { return components.b; }
+ 
+-   #if JUCE_GCC
+-    // NB these are here as a workaround because GCC refuses to bind to packed values.
+-    forcedinline uint8& getAlpha() noexcept           { return comps [indexA]; }
+-    forcedinline uint8& getRed() noexcept             { return comps [indexR]; }
+-    forcedinline uint8& getGreen() noexcept           { return comps [indexG]; }
+-    forcedinline uint8& getBlue() noexcept            { return comps [indexB]; }
+-   #else
+-    forcedinline uint8& getAlpha() noexcept           { return components.a; }
+-    forcedinline uint8& getRed() noexcept             { return components.r; }
+-    forcedinline uint8& getGreen() noexcept           { return components.g; }
+-    forcedinline uint8& getBlue() noexcept            { return components.b; }
+-   #endif
+-
+     //==============================================================================
+     /** Copies another pixel colour over this one.
+ 
+@@ -340,9 +327,6 @@
+     {
+         uint32 internal;
+         Components components;
+-       #if JUCE_GCC
+-        uint8 comps[4];  // helper struct needed because gcc does not allow references to packed union members
+-       #endif
+     };
+ }
+ #ifndef DOXYGEN

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
 }

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.json
@@ -1,0 +1,62 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Lv2Plugins/DISTRHO-Ports",
+        "prepend-path": "/app/extensions/Lv2Plugins/DISTRHO-Ports/bin"
+    },
+    "modules": [
+        {
+            "name": "premake3",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make -C Src",
+                "install -Dm755 -t ${FLATPAK_DEST}/bin bin/premake"
+            ],
+            "cleanup": [
+                "/bin"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/premake/premake-3.x.git",
+                    "commit": "1d3651e96bcb5b8dc95e71303daf56b30aa2a6df"
+                }
+            ]
+        },
+        {
+            "name": "distrho-ports",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./scripts/premake-update.sh linux",
+                "make lv2"
+            ],
+            "post-install": [
+                "cp -av bin/lv2 ${FLATPAK_DEST}/",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/distrho-ports doc/GPL.txt doc/LGPL.txt"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/DISTRHO/DISTRHO-Ports/archive/2018-04-16.tar.gz",
+                    "sha256": "176ecff16f96d88a44a7e256ed3bea737a3a34218795d4a2d9bd6cb7dca08bc8"
+                },
+                {
+                    "type": "patch",
+                    "path": "distrho-fixes.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.DISTRHO-Ports</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>DISTRHO Plugin Ports</name>
+  <summary>DISTRHO Plugin Ports LV2</summary>
+  <url type="homepage">https://distrho.sourceforge.io/ports</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2018-04-16" version="2018.04.16" />
+  </releases>
+</component>


### PR DESCRIPTION
DISTRHO Ports is a set of audio plugins ported to Linux. This is the LV2 version.