### PR TITLE
Add org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.json
@@ -1,0 +1,51 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Lv2Plugins/GxPlugins",
+        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/GxPlugins/lib/pkgconfig"
+    },
+    "cleanup": [
+        "/lib/lv2"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "gxplugins",
+            "buildsystem": "simple",
+            "build-commands": [
+                "sed -i -e s#~/.lv2#/lv2#g */Makefile",
+                "make",
+                "make install"
+            ],
+            "build-options": {
+                "cxxflags": "`pkg-config --cflags lv2`",
+                "env": {
+                    "PREFIX": "${FLATPAK_DEST}",
+                    "DESTDIR": "${FLATPAK_DEST}"
+                }
+            },
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/gxplugins/ LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/brummer10/GxPlugins.lv2/releases/download/v0.7/GxPlugins_0.7.tar.gz",
+                    "sha256": "adda1bbe6201061d63eb6301c3c297b3f2e25ee2c4e9174429c7429f1350670c"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.GxPlugins</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>GxPlugins</name>
+  <summary>GxPlugins Guitar amp LV2 plugin</summary>
+  <url type="homepage">https://github.com/brummer10/GxPlugins.lv2</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2019-05-31" version="0.7.0" />
+  </releases>
+</component>


### PR DESCRIPTION
LV2 plugins for Guitar amp simulation from the Guitarix team.