### PR TITLE
Add org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
@@ -1,0 +1,46 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/AVLDrums/lib/pkgconfig",
+        "prefix": "/app/extensions/Lv2Plugins/AVLDrums"
+    },
+    "cleanup": [
+        "/lib/lv2",
+        "/lib/libGLU*"
+    ],
+    "modules": [
+        "shared-modules/glu/glu-9.json",
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "avldrums",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make submodules",
+                "make",
+                "make install PREFIX=/app/extensions/Lv2Plugins/AVLDrums LV2DIR=/app/extensions/Lv2Plugins/AVLDrums/lv2"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/avldrums COPYING"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/x42/avldrums.lv2.git",
+                    "tag": "v0.4.1"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
@@ -20,6 +20,20 @@
         {
             "name": "avldrums",
             "buildsystem": "simple",
+            "build-options": {
+                "arch": {
+                    "arm": {
+                        "env": {
+                            "OPTIMIZATIONS": "-ffast-math -fomit-frame-pointer -O3 -fno-finite-math-only -DNDEBUG"
+                        }
+                    },
+                    "aarch64": {
+                        "env": {
+                            "OPTIMIZATIONS": "-ffast-math -fomit-frame-pointer -O3 -fno-finite-math-only -DNDEBUG"
+                        }
+                    }
+                }
+            },
             "build-commands": [
                 "make submodules",
                 "make",

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.json
@@ -21,6 +21,10 @@
             "name": "avldrums",
             "buildsystem": "simple",
             "build-options": {
+                "env": {
+                    "PREFIX": "/app/extensions/Lv2Plugins/AVLDrums",
+                    "LV2DIR": "/app/extensions/Lv2Plugins/AVLDrums/lv2"
+                },
                 "arch": {
                     "arm": {
                         "env": {
@@ -37,7 +41,7 @@
             "build-commands": [
                 "make submodules",
                 "make",
-                "make install PREFIX=/app/extensions/Lv2Plugins/AVLDrums LV2DIR=/app/extensions/Lv2Plugins/AVLDrums/lv2"
+                "make install"
             ],
             "post-install": [
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.metainfo.xml",

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.AVLDrums</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>AVLinux Drumkits</name>
+  <summary>AVLinux Drumkits LV2 plugin</summary>
+  <url type="homepage">http://x42-plugins.com/x42/x42-avldrums</url>
+  <project_license>GPL-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2019-12-02" version="0.4.1" />
+  </releases>
+</component>


### PR DESCRIPTION
This is a DrumKit LV2 plugin for Linux audio apps. With Ardour #831 almost ready, this would be an important plugin.