### PR TITLE
add scrcpy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder/
+test/
+repo/

--- a/com.Genymobile.scrcpy.json
+++ b/com.Genymobile.scrcpy.json
@@ -1,0 +1,68 @@
+{
+    "app-id": "com.Genymobile.Scrcpy",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "scrcpy",
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "version": "19.08",
+            "add-ld-path": "."
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
+    ],
+    "modules": [
+        {
+            "name": "scrcpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D scrcpy-server-v1.13 /app/share/scrcpy-server.jar",
+                "meson x --buildtype release --strip -Db_lto=true -Dprebuilt_server=/app/share/scrcpy-server.jar",
+                "ninja -C x",
+                "install -D x/app/scrcpy /app/bin/scrcpy",
+		"install -D com.Genymobile.scrcpy.metainfo.xml -t /app/share/metainfo"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Genymobile/scrcpy.git",
+                    "tag": "v1.13",
+                    "commit": "9babe268050cd8a791364e5edb346c3c15a6e575"
+                },
+                {
+                    "type": "file",
+                    "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.13/scrcpy-server-v1.13",
+                    "sha256": "5fee64ca1ccdc2f38550f31f5353c66de3de30c2e929a964e30fa2d005d5f885"
+                }
+            ]
+        },
+        
+        {
+            "name": "adb",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D adb /app/bin/adb"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dl.google.com/android/repository/platform-tools_r30.0.1-linux.zip",
+                    "sha256": "b30ee914045fe52b50f058d66baa10205500ea410f71457aec04b70ceb14da8b"
+                }
+            ]
+        }
+    ],
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=all",
+        "--filesystem=home",
+        "--env=SCRCPY_SERVER_PATH=/app/share/scrcpy-server.jar"
+        ]
+}
+

--- a/com.Genymobile.scrcpy.json
+++ b/com.Genymobile.scrcpy.json
@@ -36,6 +36,10 @@
                     "type": "file",
                     "url": "https://github.com/Genymobile/scrcpy/releases/download/v1.13/scrcpy-server-v1.13",
                     "sha256": "5fee64ca1ccdc2f38550f31f5353c66de3de30c2e929a964e30fa2d005d5f885"
+                },
+                {
+                    "type": "file",
+                    "path": "com.Genymobile.scrcpy.metainfo.xml"
                 }
             ]
         },

--- a/com.Genymobile.scrcpy.json
+++ b/com.Genymobile.scrcpy.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "com.Genymobile.Scrcpy",
+    "app-id": "com.Genymobile.scrcpy",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk",

--- a/com.Genymobile.scrcpy.metainfo.xml
+++ b/com.Genymobile.scrcpy.metainfo.xml
@@ -3,7 +3,7 @@
   <id>com.Genymobile.scrcpy</id>
   
   <name>scrcpy</name>
-  <summary>This application provides display and control of Android devices connected on USB (or over TCP/IP).</summary>
+  <summary>scrcpy provides display and control of Android devices connected on USB (or over TCP/IP).</summary>
   
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>Apache-2.0</project_license>
@@ -16,7 +16,7 @@
   
   <description>
     <p>
-      This application provides display and control of Android devices connected on USB (or over TCP/IP). It does not require any root access. It works on GNU/Linux, Windows and macOS.
+      scrcpy provides display and control of Android devices connected on USB (or over TCP/IP). It does not require any root access. It works on GNU/Linux, Windows and macOS.
     </p>
     <p>
       It focuses on:     lightness (native, displays only the device screen)     performance (30~60fps)     quality (1920×1080 or above)     low latency (35~70ms)     low startup time (~1 second to display the first image)     non-intrusiveness (nothing is left installed on the device)
@@ -29,5 +29,10 @@
       <image>https://github.com/Genymobile/scrcpy/raw/master/assets/screenshot-debian-600.jpg</image>
     </screenshot>
   </screenshots>
+  <releases>
+    <release date="2020-05-01" version="1.13"/>
+  </releases>
+  <url type="homepage">https://github.com/Genymobile/scrcpy</url>
+  <content_rating type="oars-1.1" />
 </component>
 

--- a/com.Genymobile.scrcpy.metainfo.xml
+++ b/com.Genymobile.scrcpy.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.Genymobile.scrcpy</id>
+  
+  <name>scrcpy</name>
+  <summary>This application provides display and control of Android devices connected on USB (or over TCP/IP).</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </recommends>
+  
+  <description>
+    <p>
+      This application provides display and control of Android devices connected on USB (or over TCP/IP). It does not require any root access. It works on GNU/Linux, Windows and macOS.
+    </p>
+    <p>
+      It focuses on:     lightness (native, displays only the device screen)     performance (30~60fps)     quality (1920×1080 or above)     low latency (35~70ms)     low startup time (~1 second to display the first image)     non-intrusiveness (nothing is left installed on the device)
+    </p>
+  </description>
+  
+  <launchable type="desktop-id">com.Genymobile.scrcpy.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/Genymobile/scrcpy/raw/master/assets/screenshot-debian-600.jpg</image>
+    </screenshot>
+  </screenshots>
+</component>
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "only-arches": ["x86_64"],
+  "skip-icons-check": true
+}


### PR DESCRIPTION
This application provides display and control of Android devices connected on USB (or over TCP/IP). It does not require any root access. It works on GNU/Linux, Windows and macOS.