### PR TITLE
Add org.kde.kwrite (Kwrite)

### DIFF
--- a/org.kde.kwrite.json
+++ b/org.kde.kwrite.json
@@ -1,0 +1,30 @@
+{
+    "id": "org.kde.kwrite",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.14",
+    "sdk": "org.kde.Sdk",
+    "command": "kwrite",
+    "rename-icon": "kwrite",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=cups",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host"
+    ],
+
+    "modules": [
+        {
+            "name": "kate",
+            "buildsystem": "cmake-ninja",
+            "sources":  [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/20.04.3/src/kate-20.04.3.tar.xz",
+                    "sha256": "38d92f2b95032cd20bd5b78ada2ee25fc9c06593047d063c28419df0839bc334"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.kwrite.json
+++ b/org.kde.kwrite.json
@@ -13,7 +13,15 @@
         "--device=dri",
         "--filesystem=host"
     ],
-
+    "cleanup": [
+        "/bin/kate",
+        "/lib/pkgconfig",
+        "/lib/plugins",
+        "/share/doc",
+        "/share/kateproject",
+        "/share/man",
+        "/share/plasma"
+    ],
     "modules": [
         {
             "name": "kate",


### PR DESCRIPTION
This is a special case as this application is probably already provided by org.kde.kate (Kate). Can we provide several application with the same flatpak or do we have to make one for each like this one? The manifest is almost the same.