### PR TITLE
Add org.gimp.GIMP.Plugin.Resynthesizer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.gimp.GIMP.Plugin.Resynthesizer.json
+++ b/org.gimp.GIMP.Plugin.Resynthesizer.json
@@ -1,0 +1,47 @@
+{
+    "id": "org.gimp.GIMP.Plugin.Resynthesizer",
+    "branch": "2-3.36",
+    "runtime": "org.gimp.GIMP",
+    "runtime-version": "stable",
+    "sdk": "org.gnome.Sdk//3.36",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Resynthesizer",
+        "prepend-path": "/app/extensions/Resynthesizer/bin"
+    },
+    "cleanup": [
+        "/bin",
+        "/share/man"
+    ],
+    "modules": [
+        "shared-modules/intltool/intltool-0.51.json",
+        {
+            "name": "resynthesizer",
+            "build-options": {
+                "env": {
+                    "ACLOCAL_FLAGS": "-I /app/extensions/Resynthesizer/share/aclocal",
+                    "GIMP_LIBDIR": "${FLATPAK_DEST}"
+                }
+            },
+            "post-install": [
+                "install -Dm644 gimp-resynthesizer.metainfo.xml ${FLATPAK_DEST}/share/metainfo/org.gimp.GIMP.Plugin.Resynthesizer.metainfo.xml",
+                "appstream-compose --basename=org.gimp.GIMP.Plugin.Resynthesizer --prefix=${FLATPAK_DEST} --origin=flatpak org.gimp.GIMP.Plugin.Resynthesizer",
+                "mkdir $FLATPAK_DEST/help",
+                "mv $FLATPAK_DEST/share/resynthesizer/help $FLATPAK_DEST/help/resynthesizer",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/resynthesizer COPYING"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/bootchk/resynthesizer/archive/v2.0.3.tar.gz",
+                    "sha256": "798678095c34b101c880eb350b31e9a6ff9748707d6ad9063cdee26c38016450"
+                },
+                {
+                    "type": "patch",
+                    "path": "resynthesizer.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/resynthesizer.patch
+++ b/resynthesizer.patch
@@ -1,0 +1,45 @@
+diff --git a/configure.ac b/configure.ac
+index b66c985..09e6340 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -63,7 +63,7 @@ PKG_CHECK_MODULES(GIMP,
+ AC_SUBST(GIMP_CFLAGS)
+ AC_SUBST(GIMP_LIBS)
+ 
+-GIMP_LIBDIR=`$PKG_CONFIG --variable=gimplibdir gimp-2.0`
++GIMP_LIBDIR?=`$PKG_CONFIG --variable=gimplibdir gimp-2.0`
+ AC_SUBST(GIMP_LIBDIR)
+ 
+ 
+@@ -89,7 +89,7 @@ AC_CHECK_LIB(gthread-2.0, g_thread_init)
+ dnl lkk 2011 I copied this from the main gimp configure.in
+ dnl where $PACKAGE is gimp and gimp_plugin_version is 2.0
+ dnl gimpplugindir="$libdir/$PACKAGE/gimp_plugin_version"
+-gimpplugindir="$libdir/gimp/2.0"
++gimpplugindir="$GIMP_LIBDIR"
+ AC_SUBST(gimpplugindir)
+ 
+ LOCALEDIR='${datadir}/locale'
+diff --git a/gimp-resynthesizer.metainfo.xml b/gimp-resynthesizer.metainfo.xml
+index 91bdcd2..a3fb7ac 100644
+--- a/gimp-resynthesizer.metainfo.xml
++++ b/gimp-resynthesizer.metainfo.xml
+@@ -2,8 +2,8 @@
+ <!-- Copyright 2016 Lloyd Konneker <bootch@nc.rr.com>
+ -->
+ <component type="addon">
+-<id>gimp-resynthesizer</id>
+-<extends>gimp.desktop</extends>
++<id>org.gimp.GIMP.Plugin.Resynthesizer</id>
++<extends>org.gimp.GIMP.desktop</extends>
+ <name>Resynthesizer</name>
+ <summary>Set of GIMP plug-ins that heal (in-paint), synthesize texture, theme an image, and more</summary>
+ <url type="homepage">http://logarithmic.net/pfh/resynthesizer</url>
+@@ -12,4 +12,7 @@
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-3.0+</project_license>
+ <updatecontact>bootch_AT_nc.rr.com</updatecontact>
++<releases>
++  <release date="2018-01-09"  version="2.0.3"/>
++</releases>
+ ​</component>

--- a/resynthesizer.patch
+++ b/resynthesizer.patch
@@ -31,7 +31,7 @@ index 91bdcd2..a3fb7ac 100644
 -<id>gimp-resynthesizer</id>
 -<extends>gimp.desktop</extends>
 +<id>org.gimp.GIMP.Plugin.Resynthesizer</id>
-+<extends>org.gimp.GIMP.desktop</extends>
++<extends>org.gimp.GIMP</extends>
  <name>Resynthesizer</name>
  <summary>Set of GIMP plug-ins that heal (in-paint), synthesize texture, theme an image, and more</summary>
  <url type="homepage">http://logarithmic.net/pfh/resynthesizer</url>


### PR DESCRIPTION
This is the first GIMP Plugin to be packaged for GIMP as a flatpak. It was requested in https://github.com/flathub/org.gimp.GIMP/issues/22 

This is waiting on changes in https://github.com/flathub/org.gimp.GIMP/pull/75 to land as it is still being discussed with the maintainer of the Flatpak.
Once it lands this should be able to be built.