### PR TITLE
Add io.mrarm.mcpelauncher client

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "only-arches": [ "x86_64", "i386", "arm" ],
+    "skip-appstream-check": true
+}

--- a/io.mrarm.mcpelauncher-client.json
+++ b/io.mrarm.mcpelauncher-client.json
@@ -1,0 +1,46 @@
+{
+    "id": "io.mrarm.mcpelauncher-client",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.12",
+    "sdk": "org.kde.Sdk",
+    "command": "mcpelauncher-client",
+    "build-options" : {
+        "cflags": "-O2 -g -DNDEBUG",
+        "cxxflags": "-O2 -g -DNDEBUG",
+        "config-opts": [ "-DGAMEWINDOW_SYSTEM=GLFW", "-DCMAKE_THREAD_LIBS_INIT=-lpthread", "-DCMAKE_HAVE_THREADS_LIBRARY=1", "-DCMAKE_USE_PTHREADS_INIT=1" ]
+    },
+    "finish-args": [
+        "--socket=x11",
+        "--share=network",
+        "--filesystem=host",
+        "--share=ipc",
+        "--device=dri",
+        "--socket=pulseaudio",
+        "--device=all",
+        "--talk-name=org.freedesktop.Flatpak"
+     ],
+    "modules": [
+        {
+            "name": "msa-daemon",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/bin/",
+                "echo '#!/bin/bash' > /app/bin/msa-daemon",
+                "echo 'flatpak-spawn --host flatpak --filesystem=~/.var/app/$FLATPAK_ID run app/io.mrarm.msa-daemon// \"$@\"' >> /app/bin/msa-daemon",
+                "chmod +x /app/bin/msa-daemon"
+            ]
+        },
+        {
+            "name": "mcpelauncher-client",
+            "sources": [
+                {
+                    "type": "git",
+                    "path": "/home/christopher/mcpelauncher-clegacy",
+                    "branch": "master",
+                    "disable-shallow-clone": true
+                }
+            ],
+            "buildsystem": "cmake-ninja"
+        }
+    ]
+}

--- a/io.mrarm.mcpelauncher-client.json
+++ b/io.mrarm.mcpelauncher-client.json
@@ -35,7 +35,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "path": "/home/christopher/mcpelauncher-clegacy",
+                    "url": "/home/christopher/mcpelauncher-clegacy",
                     "branch": "master",
                     "disable-shallow-clone": true
                 }

--- a/io.mrarm.mcpelauncher-client.json
+++ b/io.mrarm.mcpelauncher-client.json
@@ -24,6 +24,7 @@
         "--talk-name=org.freedesktop.Flatpak"
      ],
     "modules": [
+        "pydeps.json",
         {
             "name": "msa-daemon",
             "buildsystem": "simple",

--- a/io.mrarm.mcpelauncher-client.json
+++ b/io.mrarm.mcpelauncher-client.json
@@ -9,6 +9,10 @@
         "cxxflags": "-O2 -g -DNDEBUG",
         "config-opts": [ "-DGAMEWINDOW_SYSTEM=GLFW", "-DCMAKE_THREAD_LIBS_INIT=-lpthread", "-DCMAKE_HAVE_THREADS_LIBRARY=1", "-DCMAKE_USE_PTHREADS_INIT=1" ]
     },
+    "cleanup": [
+        "/include",
+        "/lib"
+    ],
     "finish-args": [
         "--socket=x11",
         "--share=network",
@@ -31,16 +35,78 @@
             ]
         },
         {
-            "name": "mcpelauncher-client",
+            "name": "mcpelauncher-client32",
             "sources": [
                 {
                     "type": "git",
-                    "url": "/home/christopher/mcpelauncher-clegacy",
-                    "branch": "master",
+                    "url": "https://github.com/ChristopherHX/mcpelauncher-manifest.git",
+                    "branch": "flatpak",
                     "disable-shallow-clone": true
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cd mcpelauncher-linux-bin && git checkout armhf",
+                        "cd minecraft-symbols/tools && python3 ./process_headers.py --armhf"
+                    ],
+                    "only-arches": [ "arm" ]
                 }
             ],
-            "buildsystem": "cmake-ninja"
+            "buildsystem": "cmake-ninja",
+            "only-arches": [ "i386", "arm" ]
+        },
+        {
+            "name": "mcpelauncher-client",
+            "sources": [
+                {
+                    "type": "archive",
+                    "path": "/home/christopher/Downloads/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz",
+                    "url": "https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz",
+                    "sha512": "860669cb0054c376e7ca5a8fbb8c5e2f44d1075b7e3049efd02daaf61d4f6cb4a1c4c2902ebe4c1fe38f6aeffc5ead17a8ba0c9a4aeaa983b73e2b43afe99be2"
+                },
+                {
+                    "type": "file",
+                    "path": "/home/christopher/Downloads/libtinfo5_6.0+20160213-1ubuntu1_amd64.deb",
+                    "url": "http://mirrors.kernel.org/ubuntu/pool/main/n/ncurses/libtinfo5_6.0+20160213-1ubuntu1_amd64.deb",
+                    "sha512": "a58f8d272924b9cb14eb64f9600e6c7edab3b9bd5c12edf3f5de25fa184a1cdb2173891e217f9002b841df7a9fb05f50ae6913d9820713335c24025941f20a35"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "ar x libtinfo5_6.0+20160213-1ubuntu1_amd64.deb",
+                        "tar -xf data.tar.xz",
+                        "cp -r ./lib/x86_64-linux-gnu/* ./lib/"
+                    ]
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/minecraft-linux/mcpelauncher-manifest.git",
+                    "branch": "ngflatpak"
+                }
+            ],
+            "buildsystem": "cmake-ninja",
+            "build-options" : {
+                "prepend-path": "/run/build/mcpelauncher-client/bin",
+                "config-opts": [ "-DCMAKE_C_FLAGS=-DNDEBUG", "-DCMAKE_CXX_FLAGS=-DNDEBUG", "-DBUILD_FAKE_JNI_TESTS=OFF", "-DBUILD_FAKE_JNI_EXAMPLES=OFF", "-DBUILD_BARON_EXAMPLES=OFF" ],
+                "env": {
+                    "CC": "clang",
+                    "CXX": "clang++"
+                }
+            },
+            "only-arches": [ "x86_64" ]
+        },
+        {
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "io.mrarm.mcpelauncher-client.metainfo.xml"
+                }
+            ],
+            "name": "compat",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 io.mrarm.mcpelauncher-client.metainfo.xml /app/share/metainfo/io.mrarm.mcpelauncher-client.metainfo.xml"
+            ]
         }
     ]
 }

--- a/io.mrarm.mcpelauncher-client.metainfo.xml
+++ b/io.mrarm.mcpelauncher-client.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component>
+    <id>io.mrarm.mcpelauncher-client</id>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>GPL-3.0</project_license>
+    <name>Minecraft Android game launcher</name>
+    <summary>Launch the game via the cli</summary>
+    <url type="homepage">https://mcpelauncher.readthedocs.io</url>
+    <project_group>minecraft-linux</project_group>
+</component>

--- a/pydeps.json
+++ b/pydeps.json
@@ -1,0 +1,112 @@
+{
+    "name": "pydeps",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-biplist",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} biplist==1.0.3"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3e/56/2db170a498c9c6545cda16e93c2f2ef9302da44802787b45a8a520d01bdb/biplist-1.0.3.tar.gz",
+                    "sha256": "4c0549764c5fe50b28042ec21aa2e14fe1a2224e239a1dae77d9e7f3932aa4c6"
+                }
+            ]
+        },
+        {
+            "name": "python3-ds-store",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} ds-store==1.1.2"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/42/19/cabae650ad5f97367796495c8748ca748cfde6a05c10ead0382f369075d3/mac_alias-2.0.7.tar.gz",
+                    "sha256": "c485e3eb9d600208cc0aa906282f0d575a535395306289bcdb4096599189e223"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7a/58/e3caf42daddef72a7c92778dba181ff37edd04fb64869eea504ee6b6ea8f/ds_store-1.1.2.tar.gz",
+                    "sha256": "f569659cfd66b21273c5a2405d5e1e0f54fddebf627130329f01404f271a074c"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3e/56/2db170a498c9c6545cda16e93c2f2ef9302da44802787b45a8a520d01bdb/biplist-1.0.3.tar.gz",
+                    "sha256": "4c0549764c5fe50b28042ec21aa2e14fe1a2224e239a1dae77d9e7f3932aa4c6"
+                }
+            ]
+        },
+        {
+            "name": "python3-Jinja2",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} Jinja2==2.11.2"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/64/a7/45e11eebf2f15bf987c3bc11d37dcc838d9dc81250e67e4c5968f6008b6c/Jinja2-2.11.2.tar.gz",
+                    "sha256": "89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/30/9e/f663a2aa66a09d838042ae1a2c5659828bb9b41ea3a6efa20a20fd92b121/Jinja2-2.11.2-py2.py3-none-any.whl",
+                    "sha256": "f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
+                    "sha256": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+                }
+            ]
+        },
+        {
+            "name": "python3-mac-alias",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} mac-alias==2.0.7"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/42/19/cabae650ad5f97367796495c8748ca748cfde6a05c10ead0382f369075d3/mac_alias-2.0.7.tar.gz",
+                    "sha256": "c485e3eb9d600208cc0aa906282f0d575a535395306289bcdb4096599189e223"
+                }
+            ]
+        },
+        {
+            "name": "python3-MarkupSafe",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} MarkupSafe==1.1.1"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b9/2e/64db92e53b86efccfaea71321f597fa2e1b2bd3853d8ce658568f7a13094/MarkupSafe-1.1.1.tar.gz",
+                    "sha256": "29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"
+                }
+            ]
+        },
+        {
+            "name": "python3-ply",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} ply==3.11"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl",
+                    "sha256": "096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"
+                }
+            ]
+        }
+    ],
+    "only-arches": [ "arm" ]
+}


### PR DESCRIPTION
The actual Mincraft Android gamelauncher.
Cannot upgrade runtime from 5.12
 - the stable launcher for version 0.12 to 1.16 is 32bit only,
 - multilib is complicated in flatpak.
 - x86_64 is experimental and only supports 1.14.60.5+

Downloader https://github.com/flathub/flathub/pull/1594