### PR TITLE
Add org.gimp.GIMP.Manual

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.gimp.GIMP.Manual.json
+++ b/org.gimp.GIMP.Manual.json
@@ -54,11 +54,9 @@
             ]
         },
         {
-            "name": "locales",
+            "name": "metadata",
             "buildsystem": "simple",
             "build-commands": [
-                "install -d ${FLATPAK_DEST}/share/runtime/locale",
-                "cd /app/share/gimp/2.0/help/ && for i in ca da de el es fi fr it ja ko nl nn pt_BR ro ru zh_CN; do mv $i share/runtime/locale/ && ln -sf share/runtime/locale/$i ; done"
             ],
             "post-install": [
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gimp.GIMP.Manual.metainfo.xml",

--- a/org.gimp.GIMP.Manual.json
+++ b/org.gimp.GIMP.Manual.json
@@ -44,6 +44,12 @@
                     "type": "archive",
                     "url": "https://download.gimp.org/pub/gimp/help/gimp-help-2.10.0.tar.bz2",
                     "sha256": "03804fed071b49e5810edd8327868659dfd9932fbf34d34189d56bd0ad539118"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "cp /usr/share/automake-1.16/{config.guess,config.sub} ."
+                    ]
                 }
             ]
         },

--- a/org.gimp.GIMP.Manual.json
+++ b/org.gimp.GIMP.Manual.json
@@ -24,10 +24,6 @@
             "modules": [
                 {
                     "name": "python2-libxml2",
-                    "build-options": {
-                        "env": {
-                        }
-                    },
                     "cleanup": [
                         "*"
                     ],
@@ -52,9 +48,11 @@
             ]
         },
         {
-            "name": "appdata",
+            "name": "locales",
             "buildsystem": "simple",
             "build-commands": [
+                "install -d ${FLATPAK_DEST}/share/runtime/locale",
+                "cd /app/share/gimp/2.0/help/ && for i in ca da de el es fi fr it ja ko nl nn pt_BR ro ru zh_CN; do mv $i share/runtime/locale/ && ln -sf share/runtime/locale/$i ; done"
             ],
             "post-install": [
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gimp.GIMP.Manual.metainfo.xml",

--- a/org.gimp.GIMP.Manual.json
+++ b/org.gimp.GIMP.Manual.json
@@ -1,0 +1,71 @@
+{
+    "id": "org.gimp.GIMP.Manual",
+    "branch": "2.10",
+    "runtime": "org.gimp.GIMP",
+    "runtime-version": "stable",
+    "sdk": "org.gnome.Sdk//3.36",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/share/gimp/2.0/help",
+        "prepend-path": "/app/share/gimp/2.0/help/bin",
+        "env": {
+            "PYTHONPATH": "/app/share/gimp/2.0/help/lib/python2.7/site-packages/"
+        }
+    },
+    "cleanup": [
+        "/bin",
+        "/lib"
+    ],
+    "modules": [
+        "shared-modules/python2.7/python-2.7.json",
+        {
+            "name": "gimp-help",
+            "modules": [
+                {
+                    "name": "python2-libxml2",
+                    "build-options": {
+                        "env": {
+                        }
+                    },
+                    "cleanup": [
+                        "*"
+                    ],
+                    "config-opts": [
+                        "--with-python=/app/share/gimp/2.0/help"
+                    ],
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "ftp://xmlsoft.org/libxml2/libxml2-2.9.9.tar.gz",
+                            "sha256": "94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871"
+                        }
+                    ]
+                }
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gimp.org/pub/gimp/help/gimp-help-2.10.0.tar.bz2",
+                    "sha256": "03804fed071b49e5810edd8327868659dfd9932fbf34d34189d56bd0ad539118"
+                }
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gimp.GIMP.Manual.metainfo.xml",
+                "appstream-compose --basename=org.gimp.GIMP.Manual --prefix=${FLATPAK_DEST} --origin=flatpak org.gimp.GIMP.Manual"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.gimp.GIMP.Manual.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gimp.GIMP.Manual.metainfo.xml
+++ b/org.gimp.GIMP.Manual.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.gimp.GIMP.Manual</id>
+  <extends>org.gimp.GIMP.desktop</extends>
+  <name>GIMP User Manual</name>
+  <summary>GIMP User Manual</summary>
+  <url type="homepage">https://gimp.org/</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <updatecontact>hub_AT_figuiere.net</updatecontact>
+  <releases>
+    <release date="2020-03-19" version="2.10"/>
+  </releases>
+​</component>


### PR DESCRIPTION
It is blocked by https://github.com/flathub/org.gimp.GIMP/pull/78

Closes https://github.com/flathub/org.gimp.GIMP/issues/1

Abot the choice of having a different package for the manual :

1. it's a different source package
2. it's big
3. it takes a while to be built
4. it's not updated as often

Flatpak still install things automatically.