### PR TITLE
Add org.gnome.GTG

### DIFF
--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -68,7 +68,7 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/getting-things-gnome/gtg",
-        "commit": "0afcb9b17839e5f3c005cbd33b4608daba20cfa5"
+        "commit": "75ac270d0322fd33e3e926ad847009adc13ac1b5"
       }
       ]
     }

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -9,8 +9,7 @@
     "--socket=fallback-x11",
     "--socket=wayland",
     "--share=network",
-    "--system-talk-name=org.freedesktop.login1",
-    "--own-name=org.gnome.GTG"
+    "--system-talk-name=org.freedesktop.login1"
   ],
   "cleanup": [
     "/include",

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -68,7 +68,7 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/getting-things-gnome/gtg",
-        "commit": "75ac270d0322fd33e3e926ad847009adc13ac1b5"
+        "commit": "8e371d7630642c9eec64a2390148918b38654d38"
       }
       ]
     }

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -58,7 +58,8 @@
       ],
       "sources": [{
         "type": "git",
-        "url": "https://github.com/getting-things-gnome/liblarch"
+        "url": "https://github.com/getting-things-gnome/liblarch",
+        "commit": "17bf0bd71247fc3b73f3b610f67f9b3ab3f02ba5"
       }]
     },
     {

--- a/org.gnome.GTG.json
+++ b/org.gnome.GTG.json
@@ -1,0 +1,77 @@
+{
+  "app-id": "org.gnome.GTG",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.36",
+  "sdk": "org.gnome.Sdk",
+  "command": "gtg",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--share=network",
+    "--system-talk-name=org.freedesktop.login1",
+    "--own-name=org.gnome.GTG"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/share/pkgconfig",
+    "/share/aclocal",
+    "/man",
+    "/share/man",
+    "/share/gtk-doc",
+    "/share/vala",
+    "*.la",
+    "*.a",
+    "*.pyc",
+    "*.pyo"
+  ],
+  "modules": [{
+      "name": "python-dbus",
+
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} dbus-python"
+      ],
+      "sources": [{
+        "type": "file",
+        "url": "https://files.pythonhosted.org/packages/3f/e7/4edb582d1ffd5ac3c84188deea32e960b5c8c0fe1da56ce70224f85ce542/dbus-python-1.2.8.tar.gz",
+        "sha256": "abf12bbb765e300bf8e2a1b2f32f85949eab06998dbda127952c31cb63957b6f"
+      }]
+    },
+    {
+      "name": "python3-pyxdg",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} pyxdg"
+      ],
+      "sources": [{
+        "type": "file",
+        "url": "https://files.pythonhosted.org/packages/47/6e/311d5f22e2b76381719b5d0c6e9dc39cd33999adae67db71d7279a6d70f4/pyxdg-0.26.tar.gz",
+        "sha256": "fe2928d3f532ed32b39c32a482b54136fe766d19936afc96c8f00645f9da1a06"
+      }]
+    },
+    {
+      "name": "liblarch",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python3 setup.py install --prefix /app"
+      ],
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/getting-things-gnome/liblarch"
+      }]
+    },
+    {
+      "name": "gtg",
+      "buildsystem": "meson",
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/getting-things-gnome/gtg",
+        "commit": "0afcb9b17839e5f3c005cbd33b4608daba20cfa5"
+      }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
This is a request to add Getting things Gnome. We're currently in beta (almost stable). Could this be added to the beta channel first? 

Repo: https://github.com/getting-things-gnome/gtg/
Homepage: https://wiki.gnome.org/Apps/GTG
