### PR TITLE
Add org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "skip-icon-check": true
+    "skip-icons-check": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icon-check": true
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "runtime-version": "19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "branch": "19.08",
+    "build-options": {
+        "prefix": "/app/extensions/LadspaPlugins/ZamPlugins",
+        "prepend-pkg-config-path": "/app/extensions/LadspaPlugins/ZamPlugins/lib/pkgconfig"
+    },
+    "modules": [
+        "shared-modules/linux-audio/fftw3f-static.json",
+        {
+            "name": "zam-plugins",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make install PREFIX=${FLATPAK_DEST} LIBDIR=."
+            ],
+            "cleanup": [
+                "/vst",
+                "/lv2"
+            ],
+            "post_install": [
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/zam-plugins COPYING",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/zamaudio/zam-plugins.git",
+                    "tag": "3.12"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.json
@@ -16,8 +16,22 @@
             "name": "zam-plugins",
             "buildsystem": "simple",
             "build-commands": [
-                "make install PREFIX=${FLATPAK_DEST} LIBDIR=."
+                "make install PREFIX=${FLATPAK_DEST} LIBDIR=. NOOPT=${NOOPT}"
             ],
+            "build-options": {
+                "arch": {
+                    "aarch64": {
+                        "env": {
+                            "NOOPT": "true"
+                        }
+                    },
+                    "arm": {
+                        "env": {
+                            "NOOPT": "true"
+                        }
+                    }
+                }
+            },
             "cleanup": [
                 "/vst",
                 "/lv2"

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component type="addon">
+    <id>org.freedesktop.LinuxAudio.LadspaPlugins.ZamPlugins</id>
+    <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+    <name>ZamPlugins</name>
+    <summary>ZamAudio Plugins LADSPA</summary>
+    <project_license>GPL-2.0</project_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <update_contact>hub_AT_figuiere.net</update_contact>
+    <url type="homepage">http://www.zamaudio.com/?p=976</url>
+    <releases>
+        <release version="3.12" date="2019-12-15" />
+    </releases>
+</component>


### PR DESCRIPTION
Add ZamAudio plugins in LADSPA

The LADSPA version is built by pulseeffect in its flatpak.
It can also be use by video editors.