### PR TITLE
Add org.freedesktop.LinuxAudio.Plugins.LSP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.Plugins.LSP.json
+++ b/org.freedesktop.LinuxAudio.Plugins.LSP.json
@@ -41,7 +41,10 @@
             "no-make-install": true,
             "post-install": [
                 "make install_ladspa install_lv2 install_vst",
+                "strip ${FLATPAK_DEST}/ladspa/*.so",
+                "strip ${FLATPAK_DEST}/lv2/*.lv2/*.so",
                 "mv ${FLATPAK_DEST}/vst ${FLATPAK_DEST}/lxvst",
+                "strip ${FLATPAK_DEST}/lxvst/*/*.so",
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.LSP.metainfo.xml",
                 "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.LSP --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.LSP",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/lsp LICENSE.txt"

--- a/org.freedesktop.LinuxAudio.Plugins.LSP.json
+++ b/org.freedesktop.LinuxAudio.Plugins.LSP.json
@@ -1,0 +1,62 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Plugins.LSP",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prepend-pkg-config-path": "/app/extensions/Plugins/LSP/lib/pkgconfig",
+        "prefix": "/app/extensions/Plugins/LSP"
+    },
+    "cleanup": [
+        "/lib/lv2"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "lsp",
+            "no-autogen": true,
+            "build-options": {
+                "arch": {
+                    "arm": {
+                        "make-args": [
+                            "BUILD_PROFILE=armv7a"
+                        ]
+                    },
+                    "aarch64": {
+                        "make-args": [
+                            "BUILD_PROFILE=aarch64"
+                        ]
+                    }
+                },
+                "cppflags": "`pkg-config --cflags lv2`",
+                "env": {
+                    "PREFIX": "${FLATPAK_DEST}",
+                    "LIB_PATH": "${FLATPAK_DEST}",
+                    "BUILD_MODULES": "ladspa lv2 vst"
+                }
+            },
+            "no-make-install": true,
+            "post-install": [
+                "make install_ladspa install_lv2 install_vst",
+                "mv ${FLATPAK_DEST}/vst ${FLATPAK_DEST}/lxvst",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.LSP.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.LSP --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.LSP",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/lsp LICENSE.txt"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/sadko4u/lsp-plugins.git",
+                    "tag": "lsp-plugins-1.1.22"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Plugins.LSP.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Plugins.LSP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.LSP.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Plugins.LSP</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+  <name>LSP</name>
+  <summary>Linux Studio Plugins LADSPA/LV2/VST</summary>
+  <description>
+    <p>Linux Studio Plugins include the following plugins in LADSPA, LV2 and VST
+    with mono (M), stereo (S), left-right (LR) and mid-side (MS) variants:</p>
+    <ul>
+      <li>Limiter M / S</li>
+      <li>Dynamic processor LR / MS / M / S</li>
+      <li>Expander LR / MS / M / S</li>
+      <li>Gate LR / MS / M / S</li>
+      <li>Graphic Equalizer x16 and x32 LR / MS / M / S</li>
+      <li>Impulse Response M / S</li>
+      <li>Impulse Reverb M / S</li>
+      <li>Sampler M / S</li>
+      <li>Compressor LR / MS / M / S</li>
+      <li>Latency Meter</li>
+      <li>Multiband expander x8 LR / MS / M / S</li>
+      <li>Multiband gate x8 LR / MS / M / S</li>
+      <li>Multiband cmpressor x8 LR / MS / M / S</li>
+      <li>Oscillator Mono</li>
+      <li>Parametric Equalizer x16 LR / MS / M / S</li>
+      <li>Parametric Equalizer x32 LR / MS / M / S</li>
+      <li>Phase detector</li>
+      <li>Profiler M / S</li>
+      <li>Room builder M / S</li>
+      <li>Multi-sampler x12 Direct out / stereo</li>
+      <li>Multi-sampler x24 Direct out / stereo</li>
+      <li>Multi-sampler x48 Direct out / stereo</li>
+      <li>Sidechain multiband expander x8 LR / MS / M / S</li>
+      <li>Sidechain multiband gate x8 LR / MS / M / S</li>
+      <li>Sidechain multiband compressor x8 LR / MS / M / S</li>
+      <li>Sidechain Limiter M / S</li>
+      <li>Sidechain Dynamic processor LR / MS / M / S</li>
+      <li>Sidechain Expander LR / MS / M / S</li>
+      <li>Sidechain Gate LR / MS / M / S</li>
+      <li>Sidechain Compressor LR / MS / M / S</li>
+      <li>Slapback Delay M / S</li>
+      <li>Spectrum Analyzer x1</li>
+      <li>Spectrum Analyzer x2</li>
+      <li>Spectrum Analyzer x4</li>
+      <li>Spectrum Analyzer x8</li>
+      <li>Spectrum Analyzer x12</li>
+      <li>Spectrum Analyzer x16</li>
+      <li>Trigger MIDI M / S</li>
+      <li>Trigger M / S</li>
+      <li>Delay Compensator M / S</li>
+      <li>Delay Compensator x2 Stereo</li>
+    </ul>
+  </description>
+  <url type="homepage">https://lsp-plug.in/</url>
+  <project_license>LGPL-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2020-05-30" version="1.1.22" />
+    <release date="2020-05-16" version="1.1.21" />
+  </releases>
+</component>


### PR DESCRIPTION
This supercede org.freedesktop.LinuxAudio.{Lv2,Ladspa}Plugins.LSP that I will EOL asap. Sorry for this change, I think it for the better.

This includes the VST version of the plugin.

Bottom line with the recent changes I did to the plugin extension points, instead of adding a 3rd package from the same source, I will instead remove two and add one.

Thanks !