### PR TITLE
Add org.gtkhash.gtkhash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.flatpak-builder

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.gtkhash.gtkhash.yaml
+++ b/org.gtkhash.gtkhash.yaml
@@ -7,7 +7,6 @@ command: gtkhash
 finish-args:
   # X11 + XShm access
   - --share=ipc
-  - --socket=x11
   - --socket=fallback-x11
   # Wayland access
   - --socket=wayland

--- a/org.gtkhash.gtkhash.yaml
+++ b/org.gtkhash.gtkhash.yaml
@@ -1,0 +1,35 @@
+app-id: org.gtkhash.gtkhash
+runtime: org.freedesktop.Platform
+runtime-version: '19.08'
+sdk: org.freedesktop.Sdk
+command: gtkhash
+
+rename-desktop-file: gtkhash.desktop
+rename-appdata-file: gtkhash.appdata.xml
+rename-icon: gtkhash
+copy-icon: true # GtkAboutDialog uses logo-icon-name:PACKAGE
+
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=x11
+  # Wayland access
+  - --socket=wayland
+  # Allow opening files from cmdline, drag-and-drop
+  - --filesystem=host:ro
+
+modules:
+  - shared-modules/intltool/intltool-0.51.json
+
+  - name: gtkhash
+    sources:
+      - type: archive
+        url: https://github.com/tristanheaven/gtkhash/releases/download/v1.3/gtkhash-1.3.tar.xz
+        sha256: a94b12165bfa2ebec7270ce3bb8fb27da8a0624fb48ecfc0b68bcaf8c40db7af
+    buildsystem: autotools
+    config-opts:
+      - --enable-gcrypt
+      - --enable-linux-crypto
+      - --disable-blake2
+      - --disable-dependency-tracking
+      - --disable-silent-rules

--- a/org.gtkhash.gtkhash.yaml
+++ b/org.gtkhash.gtkhash.yaml
@@ -4,19 +4,15 @@ runtime-version: '19.08'
 sdk: org.freedesktop.Sdk
 command: gtkhash
 
-rename-desktop-file: gtkhash.desktop
-rename-appdata-file: gtkhash.appdata.xml
-rename-icon: gtkhash
-copy-icon: true # GtkAboutDialog uses logo-icon-name:PACKAGE
-
 finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
+  - --socket=fallback-x11
   # Wayland access
   - --socket=wayland
-  # Allow opening files from cmdline, drag-and-drop
-  - --filesystem=host:ro
+  # Allow opening files from cmdline, drag-and-drop, file chooser
+  - --filesystem=host
 
 modules:
   - shared-modules/intltool/intltool-0.51.json
@@ -24,12 +20,12 @@ modules:
   - name: gtkhash
     sources:
       - type: archive
-        url: https://github.com/tristanheaven/gtkhash/releases/download/v1.3/gtkhash-1.3.tar.xz
-        sha256: a94b12165bfa2ebec7270ce3bb8fb27da8a0624fb48ecfc0b68bcaf8c40db7af
+        url: https://github.com/tristanheaven/gtkhash/releases/download/v1.4/gtkhash-1.4.tar.xz
+        sha256: 20b57dbb8f6c6d7323f573c111a11640603a422c5f9da7b302a4981e4adc37c4
     buildsystem: autotools
     config-opts:
       - --enable-gcrypt
-      - --enable-linux-crypto
       - --disable-blake2
       - --disable-dependency-tracking
+      - --disable-native-file-chooser # https://github.com/flatpak/xdg-desktop-portal/issues/463
       - --disable-silent-rules


### PR DESCRIPTION
Add org.gtkhash.gtkhash

Known issue: GtkFileChooserNative doesn't allow access to files in the same directory as the one selected by the user.