### PR TITLE
org.freedesktop.sdk.extension.mono6

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+BASE_GACS="System System.Core System.Xml System.Configuration I18N I18N.CJK I18N.MidEast I18N.Other I18N.Rare I18N.West Accessibility Mono.Cairo Mono.Posix Mono.CSharp"
+
+mkdir -p /app/etc /app/bin /app/lib/mono/4.5 /app/lib/mono/gac
+cp /usr/lib/sdk/mono6/bin/mono /app/bin/mono
+cp /usr/lib/sdk/mono6/lib/libMonoPosixHelper.so /app/lib/
+cp /usr/lib/sdk/mono6/lib/mono/4.5/*.dll* /app/lib/mono/4.5/
+rm -f /app/lib/mono/4.5/Microsoft.CodeAnalysis*
+cp -ar /usr/lib/sdk/mono6/etc/mono /app/etc
+
+for G in $BASE_GACS $@; do
+    cp -ar /usr/lib/sdk/mono6/lib/mono/gac/$G /app/lib/mono/gac/
+    rm -f /app/lib/mono/gac/$G/*/*.pdb
+done

--- a/org.freedesktop.Sdk.Extension.mono6.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.mono6.appdata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.mono6</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Mono 6.x Sdk extension</name>
+  <summary>Mono runtime, compiler and tools</summary>
+  <url type="homepage">https://www.mono-project.com/</url>
+  <url type="bugtracker">https://github.com/flathub/org.freedesktop.Sdk.Extension.mono6</url>
+  <releases>
+    <release version="6.10.0.104" date="2020-04-30" />
+  </releases>
+</component>

--- a/org.freedesktop.Sdk.Extension.mono6.json
+++ b/org.freedesktop.Sdk.Extension.mono6.json
@@ -1,0 +1,62 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.mono6",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "19.08",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "modules": [
+        {
+            "name": "mono",
+            "build-options" : {
+                "prefix": "${FLATPAK_DEST}"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.mono-project.com/sources/mono/mono-6.10.0.104.tar.xz",
+                    "sha256": "b8d6eb70a252d2efad8384d66b529883dc59e581565d617fa57f8e79317e332c"
+                }
+            ]
+        },
+        {
+            "name": "scripts",
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "install.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "export PATH=$PATH:${FLATPAK_DEST}/bin",
+                        "export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${FLATPAK_DEST}/lib",
+                        "export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}${FLATPAK_DEST}/lib/pkgconfig",
+                        "export MONO_GAC_PREFIX=/app"
+                    ],
+                    "dest-filename": "use.sh"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "install use.sh install.sh ${FLATPAK_DEST}/"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp ${FLATPAK_ID}.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose  --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.mono6.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Release Mono 6.x as separate package as requested in https://github.com/flathub/org.freedesktop.Sdk.Extension.mono5/pull/12#issuecomment-621085574.