### PR TITLE
Add org.freedesktop.LinuxAudio.Plugins.Geonkick

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
     "skip-icons-check": true,
-    "only-arches": ["x86_64"]
+    "skip-arches": ["arm"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
 }

--- a/geonkick-build-fix.patch
+++ b/geonkick-build-fix.patch
@@ -1,5 +1,5 @@
---- geonkick/plugin/lv2/CMakeLists.txt	2020-05-13 13:19:31.000000000 -0400
-+++ geonkick/plugin/lv2/CMakeLists.txt-new	2020-05-24 16:45:05.138976427 -0400
+--- a/plugin/lv2/CMakeLists.txt	2020-05-13 13:19:31.000000000 -0400
++++ b/plugin/lv2/CMakeLists.txt	2020-05-24 16:45:05.138976427 -0400
 @@ -6,9 +6,8 @@
    ${GKICK_LV2_SOURCES})
  
@@ -12,3 +12,16 @@
 -install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/lv2/geonkick.lv2)
 +install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2)
 +install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2/geonkick.lv2)
+diff --git a/src/percussion_state.cpp b/src/percussion_state.cpp
+index d77f7ce..fbef3b1 100644
+--- a/src/percussion_state.cpp
++++ b/src/percussion_state.cpp
+@@ -30,7 +30,7 @@ PercussionState::PercussionState()
+         : appVersion{GEONKICK_VERSION}
+         , kickId{0}
+         , kickName{"Default"}
+-        , playingKey{-1}
++        , playingKey{(char)-1}
+         , outputChannel{0}
+         , kickEnabled{true}
+         , percussionMuted{false}

--- a/geonkick-build-fix.patch
+++ b/geonkick-build-fix.patch
@@ -8,8 +8,8 @@
  target_link_libraries(geonkick_lv2 "-lredkite -lX11 -lsndfile -lrt -lm -ldl -lpthread -lcairo")
  add_dependencies(geonkick_lv2 api_plugin)
  
--install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/lv2)
--install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/lv2/geonkick.lv2)
+-install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/lv2)
+-install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/lv2/geonkick.lv2)
 +install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2)
 +install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2/geonkick.lv2)
 diff --git a/src/percussion_state.cpp b/src/percussion_state.cpp

--- a/geonkick-build-fix.patch
+++ b/geonkick-build-fix.patch
@@ -1,0 +1,14 @@
+--- geonkick/plugin/lv2/CMakeLists.txt	2020-05-13 13:19:31.000000000 -0400
++++ geonkick/plugin/lv2/CMakeLists.txt-new	2020-05-24 16:45:05.138976427 -0400
+@@ -6,9 +6,8 @@
+   ${GKICK_LV2_SOURCES})
+ 
+ target_link_libraries(geonkick_lv2  geonkick_common api_plugin)
+-target_link_libraries(geonkick_lv2 "-lstdc++fs")
+ target_link_libraries(geonkick_lv2 "-lredkite -lX11 -lsndfile -lrt -lm -ldl -lpthread -lcairo")
+ add_dependencies(geonkick_lv2 api_plugin)
+ 
+-install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/lv2)
+-install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/lv2/geonkick.lv2)
++install(DIRECTORY ${GKICK_LV2_DIR}/geonkick.lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2)
++install(TARGETS geonkick_lv2 DESTINATION ${CMAKE_INSTALL_PREFIX}/lv2/geonkick.lv2)

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
@@ -63,6 +63,7 @@
             "name": "geonkick",
             "buildsystem": "cmake-ninja",
             "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_PREFIX=/app/extensions/Lv2Plugins/Geonkick",
                 "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Lv2Plugins/Geonkick/lib",
                 "-DGKICK_STANDALONE=NO"
@@ -72,6 +73,7 @@
                 "ldflags": "-L/app/extensions/Lv2Plugins/Geonkick/lib"
             },
             "post-install": [
+                "strip ${FLATPAK_DEST}/lv2/*.lv2/*.so",
                 "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml",
                 "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/geonkick LICENSE"

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
@@ -79,8 +79,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.2.1.tar.gz",
-                    "sha256": "96688927dc8a54029a3352d4819dc81a538bfd38022be8f58c48be3ebc89d374"
+                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.2.3.tar.gz",
+                    "sha256": "8fba21e6547c426f852927666610bbd65a357cbc21e8893279cbd6b27053e4cd"
                 },
                 {
                     "type": "patch",

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
@@ -32,8 +32,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/redkite/archive/v0.8.1.tar.gz",
-                    "sha256": "d723adb2e7adbdfb9dc2c83d6f5950dc6dd131e071518a3e5f9ff933acacf7de"
+                    "url": "https://github.com/iurie-sw/redkite/archive/v1.0.0.tar.gz",
+                    "sha256": "1cbd5490890779869d900bf910a1734b09000f3062764ce482d798f91f816d21"
                 }
             ]
         },
@@ -79,8 +79,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.1.1.tar.gz",
-                    "sha256": "65e87eb80201cf7e760ad7ec92f2a0787e87f15ac2574e16fd9b4fc1a64f9326"
+                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.2.1.tar.gz",
+                    "sha256": "96688927dc8a54029a3352d4819dc81a538bfd38022be8f58c48be3ebc89d374"
                 },
                 {
                     "type": "patch",

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.json
@@ -1,0 +1,96 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prepend-path": "/app/extensions/Lv2Plugins/Geonkick/bin",
+        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/Geonkick/lib/pkgconfig",
+        "prefix": "/app/extensions/Lv2Plugins/Geonkick"
+    },
+    "cleanup": [
+        "/lib/lv2",
+        "/lib/libGLU*"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "redkite",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Lv2Plugins/Geonkick",
+                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Lv2Plugins/Geonkick/lib"
+            ],
+            "cleanup": [
+                "/bin",
+                "/lib",
+                "/include"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/iurie-sw/redkite/archive/v0.8.1.tar.gz",
+                    "sha256": "d723adb2e7adbdfb9dc2c83d6f5950dc6dd131e071518a3e5f9ff933acacf7de"
+                }
+            ]
+        },
+        {
+            "name": "rapidjson",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DRAPIDJSON_BUILD_DOC=OFF",
+                "-DRAPIDJSON_BUILD_EXAMPLES=OFF",
+                "-DRAPIDJSON_BUILD_TESTS=OFF",
+                "-DRAPIDJSON_BUILD_THIRDPARTY_GTEST=OFF"
+            ],
+            "cleanup": [
+                "/include",
+                "/lib",
+                "/share/doc"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://mirrors.kodi.tv/build-deps/sources/rapidjson-1.1.0.tar.gz",
+                    "sha256": "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
+                }
+            ]
+        },
+        {
+            "name": "geonkick",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Lv2Plugins/Geonkick",
+                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Lv2Plugins/Geonkick/lib",
+                "-DGKICK_STANDALONE=NO"
+            ],
+            "build-options": {
+                "cxxflags": "-I/app/extensions/Lv2Plugins/Geonkick/include",
+                "ldflags": "-L/app/extensions/Lv2Plugins/Geonkick/lib"
+            },
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/geonkick LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.1.1.tar.gz",
+                    "sha256": "65e87eb80201cf7e760ad7ec92f2a0787e87f15ac2574e16fd9b4fc1a64f9326"
+                },
+                {
+                    "type": "patch",
+                    "path": "geonkick-build-fix.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
@@ -9,6 +9,25 @@
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
+    <release date="2020-06-12" version="2.2.3">
+      <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.2.3</url>
+      <description>
+        <ul>
+          <li>Fix setting compiler flags</li>
+        </ul>
+      </description>
+    </release>
+    <release date="2020-06-12" version="2.2.2">
+      <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.2.2</url>
+      <description>
+        <p>Improvements</p>
+        <ul>
+          <li>Follow the XDG standard for directories.</li>
+          <li>Search for presets in the $XDG_DATA_DIRS and $XDG_CONFIG_HOME.</li>
+          <li>Use GEONKICK_DATA_DIR when geonkick is installed in non a nonstandard path.</li>
+        </ul>
+      </description>
+    </release>
     <release date="2020-06-11" version="2.2.1">
       <description>
         <p>Fixes</p>

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
   <id>org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick</id>
-  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>Geonkick</name>
   <summary>Geonkick drums LV2 plugin</summary>
   <url type="homepage">https://gitlab.com/iurie-sw/geonkick</url>

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
@@ -9,6 +9,36 @@
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
+    <release date="2020-06-11" version="2.2.1">
+      <description>
+        <p>Fixes</p>
+        <ul>
+          <li>Fix crash when .local/geonkick path can't be created</li>
+          <li>Fix loading presets from .local/geonkick/presets</li>
+        </ul>
+      </description>
+    </release>
+    <release date="2020-06-11" version="2.2.0">
+      <description>
+        <p>New features</p>
+        <ul>
+          <li>Kit mixer</li>
+          <li>Preset browser</li>
+          <li>Factory presets (installed under /usr/share/geonkick/presets or /usr/local/share/geonkick/presets)</li>
+          <li>Distortion volume envelope</li>
+        </ul>
+        <p>Improvements</p>
+        <ul>
+          <li>Range channels from 1 - 16 instead of 0 - 15</li>
+          <li>Added visual effect for play button and some other buttons</li>
+        </ul>
+        <p>Fixes</p>
+        <ul>
+          <li>Fix loading WAVEFORMATEX samples</li>
+          <li>Other small fixes</li>
+        </ul>
+      </description>
+    </release>
     <release date="2020-05-13" version="2.1.1">
       <description>
         <p>Fixes:</p>

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>Geonkick</name>
+  <summary>Geonkick drums LV2 plugin</summary>
+  <url type="homepage">https://gitlab.com/iurie-sw/geonkick</url>
+  <project_license>GPL-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2020-05-13" version="2.1.1">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Fix install of *.desktop file.</li>
+          <li>Fix finding Redkite lib64 in FindRedkite.cmake.</li>
+          <li>Add loading WAVEX samples.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
@@ -82,8 +82,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.3.1.tar.gz",
-                    "sha256": "7559d4f6b2b480e2e61f00adb7a7b5ee523b5dc5dbc12d7cde2750ee2eda933d"
+                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.3.2.tar.gz",
+                    "sha256": "8952ac8497d6b238befa91391155b8bd1f9ef8bf41452f15a34a36a3417aea39"
                 },
                 {
                     "type": "patch",

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
@@ -27,13 +27,14 @@
             "cleanup": [
                 "/bin",
                 "/lib",
+                "/share/man",
                 "/include"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/redkite/archive/v1.0.0.tar.gz",
-                    "sha256": "1cbd5490890779869d900bf910a1734b09000f3062764ce482d798f91f816d21"
+                    "url": "https://github.com/iurie-sw/redkite/archive/v1.0.1.tar.gz",
+                    "sha256": "d868c467334ef28bf50d6b2e8f126e8b0e8d1df158d258faa86942b2426ff25d"
                 }
             ]
         },
@@ -81,8 +82,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.2.3.tar.gz",
-                    "sha256": "8fba21e6547c426f852927666610bbd65a357cbc21e8893279cbd6b27053e4cd"
+                    "url": "https://github.com/iurie-sw/geonkick/archive/v2.3.1.tar.gz",
+                    "sha256": "7559d4f6b2b480e2e61f00adb7a7b5ee523b5dc5dbc12d7cde2750ee2eda933d"
                 },
                 {
                     "type": "patch",

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick",
+    "id": "org.freedesktop.LinuxAudio.Plugins.Geonkick",
     "branch": "19.08",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
     "runtime-version": "19.08",
@@ -7,9 +7,9 @@
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
-        "prepend-path": "/app/extensions/Lv2Plugins/Geonkick/bin",
-        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/Geonkick/lib/pkgconfig",
-        "prefix": "/app/extensions/Lv2Plugins/Geonkick"
+        "prepend-path": "/app/extensions/Plugins/Geonkick/bin",
+        "prepend-pkg-config-path": "/app/extensions/Plugins/Geonkick/lib/pkgconfig",
+        "prefix": "/app/extensions/Plugins/Geonkick"
     },
     "cleanup": [
         "/lib/lv2",
@@ -21,8 +21,8 @@
             "name": "redkite",
             "buildsystem": "cmake-ninja",
             "config-opts": [
-                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Lv2Plugins/Geonkick",
-                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Lv2Plugins/Geonkick/lib"
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Plugins/Geonkick",
+                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Plugins/Geonkick/lib"
             ],
             "cleanup": [
                 "/bin",
@@ -64,18 +64,18 @@
             "buildsystem": "cmake-ninja",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Lv2Plugins/Geonkick",
-                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Lv2Plugins/Geonkick/lib",
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Plugins/Geonkick",
+                "-DCMAKE_INSTALL_LIBDIR=/app/extensions/Plugins/Geonkick/lib",
                 "-DGKICK_STANDALONE=NO"
             ],
             "build-options": {
-                "cxxflags": "-I/app/extensions/Lv2Plugins/Geonkick/include",
-                "ldflags": "-L/app/extensions/Lv2Plugins/Geonkick/lib"
+                "cxxflags": "-I/app/extensions/Plugins/Geonkick/include",
+                "ldflags": "-L/app/extensions/Plugins/Geonkick/lib"
             },
             "post-install": [
                 "strip ${FLATPAK_DEST}/lv2/*.lv2/*.so",
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.Geonkick --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.Geonkick",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/geonkick LICENSE"
             ],
             "sources": [
@@ -90,7 +90,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick.metainfo.xml"
+                    "path": "org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml"
                 }
             ]
         }

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
@@ -9,6 +9,36 @@
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
+    <release date="2020-07-24" version="2.3.1">
+      <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.3.1</url>
+      <description>
+        <p>Fixes: add lv2:requiredFeature urid:map</p>
+      </description>
+    </release>
+    <release date="2020-07-24" version="2.3.0">
+      <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.3.0</url>
+      <description>
+        <p>Features:</p>
+        <ul>
+           <li>Reset to default button</li>
+           <li>Add stereo output channels for LV2, VST and standalone</li>
+        </ul>
+        <p>Improvements:</p>
+        <ul>
+          <li>Added compiler optimization flags and fast math</li>
+          <li>Process audio routines for LV2, VST and standalone was made more efficient,
+          now DSP should take less CPU</li>
+        </ul>
+        <p>Fixes:</p>
+        <ul>
+          <li>Fix loading other audio format subtypes for samples</li>
+          <li>Reset to default shortcut</li>
+          <li>FHS friendly LV2 and VST3 plugin installation paths</li>
+          <li>Don't copy mute and solo settings when copy/paste percussion</li>
+          <li>Reverse sawtooth</li>
+        </ul>
+      </description>
+    </release>
     <release date="2020-06-12" version="2.2.3">
       <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.2.3</url>
       <description>

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
@@ -9,6 +9,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
+    <release date="2020-07-25" version="2.3.2">
+      <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.3.2</url>
+    </release>
     <release date="2020-07-24" version="2.3.1">
       <url>https://github.com/iurie-sw/geonkick/releases/tag/v2.3.1</url>
       <description>

--- a/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.Geonkick.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick</id>
+  <id>org.freedesktop.LinuxAudio.Plugins.Geonkick</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>Geonkick</name>
   <summary>Geonkick drums LV2 plugin</summary>


### PR DESCRIPTION
This replaces org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick (see deprecation in https://github.com/flathub/org.freedesktop.LinuxAudio.Lv2Plugins.Geonkick/pull/5 ) ~~and update to the newest upstream version.~~ (reverted the new upstream until I fix the build flags that assume sse2 on aarch64)