### PR TITLE
Add org.ksnip.ksnip

### DIFF
--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -7,13 +7,11 @@ rename-icon: ksnip
 rename-appdata-file: ksnip.appdata.xml
 rename-desktop-file: ksnip.desktop
 finish-args:
-  - "--socket=wayland"
-  - "--socket=fallback-x11"
-  - "--share=ipc"
-  - "--device=dri"
-  - "--filesystem=host"
-  - "--share=network"
-  - "--own-name=org.ksnip"
+  - --socket=x11
+  - --share=ipc
+  - --device=dri
+  - --filesystem=host
+  - --share=network
 cleanup:
   - "*.a"
   - "/include"

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -24,14 +24,18 @@ modules:
     sources:
       - type: git
         url: https://github.com/ksnip/kColorPicker.git
+        tag: v0.1.4
   - name: kImageAnnotator
     buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://github.com/ksnip/kImageAnnotator.git
+        tag: v0.3.2
   - name: ksnip
     buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://github.com/ksnip/ksnip.git
-        #tag: v1.7.2
+        commit: 813b1048b5bfa5fb09a5aa838912e4b26c8b0c9c
+        # Enable the tag when the changes are in a new tag
+        # tag: v1.7.2

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -13,6 +13,7 @@ finish-args:
   - --filesystem=host
   - --share=network
   - --own-name=org.kde.*
+  - --talk-name=org.freedesktop.Notifications
 cleanup:
   - "*.a"
   - "/include"

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -4,8 +4,6 @@ runtime-version: '5.14'
 sdk: org.kde.Sdk
 command: ksnip
 rename-icon: ksnip
-rename-appdata-file: ksnip.appdata.xml
-rename-desktop-file: ksnip.desktop
 finish-args:
   - --socket=x11
   - --share=ipc
@@ -33,9 +31,7 @@ modules:
         url: https://github.com/ksnip/kImageAnnotator.git
   - name: ksnip
     buildsystem: cmake-ninja
-    post-install:
-      - install -Dm644 /app/share/pixmaps/ksnip.svg /app/share/icons/hicolor/scalable/apps/ksnip.svg
     sources:
       - type: git
         url: https://github.com/ksnip/ksnip.git
-        tag: v1.7.1
+        #tag: v1.7.2

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --device=dri
   - --filesystem=host
   - --share=network
+  - --own-name=org.kde.*
 cleanup:
   - "*.a"
   - "/include"

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -1,0 +1,41 @@
+app-id: org.ksnip.ksnip
+runtime: org.kde.Platform
+runtime-version: '5.14'
+sdk: org.kde.Sdk
+command: ksnip
+rename-icon: ksnip
+rename-appdata-file: ksnip.appdata.xml
+rename-desktop-file: ksnip.desktop
+finish-args:
+  - "--socket=wayland"
+  - "--socket=fallback-x11"
+  - "--share=ipc"
+  - "--device=dri"
+  - "--filesystem=host"
+  - "--share=network"
+  - "--own-name=org.ksnip"
+cleanup:
+  - "*.a"
+  - "/include"
+  - "/lib/cmake"
+  - "/lib/mkspecs"
+  - "/mkspecs"
+modules:
+  - name: kColorPicker
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/ksnip/kColorPicker.git
+  - name: kImageAnnotator
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/ksnip/kImageAnnotator.git
+  - name: ksnip
+    buildsystem: cmake-ninja
+    post-install:
+      - install -Dm644 /app/share/pixmaps/ksnip.svg /app/share/icons/hicolor/scalable/apps/ksnip.svg
+    sources:
+      - type: git
+        url: https://github.com/ksnip/ksnip.git
+        tag: v1.7.1


### PR DESCRIPTION
This is a working declaration for the ksnip flatpak.
The remaining issues are:
- The file portal will not give the proper (executable) access to the selected files.
  Also if the file-chooser is set to select directories it will not show any files/folders in the users home
  A workaround using the `filesystem=host` permission solves this issue.
  `filesystem=home` could be used, simply removing the access to non /home/<user> directories (right?)
- On wayland it will not take the screenshot (or show the indicator icon)

The first issue has been previously reported at https://github.com/flatpak/xdg-desktop-portal/issues/517