### PR TITLE
Added org.freedesktop.LinuxAudio.Plugins.ArtyFX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
 }

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.json
@@ -1,0 +1,52 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "branch": "19.08",
+    "build-options": {
+        "prefix": "/app/extensions/Lv2Plugins/ArtyFX",
+        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/ArtyFX/lib/pkgconfig"
+    },
+    "cleanup": [
+        "/lib/lv2"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "artyfx",
+            "buildsystem": "cmake-ninja",
+            "config_opts": [],
+            "cleanup": [],
+            "post_install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/openAVproductions/openAV-ArtyFX/archive/release-1.3.tar.gz",
+                    "sha256": "a2a8d02b47bea44d0053cd4f8c6411f68a6fe9b9e4348a4139cd9bfd70105c00"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/001-artyfx-lv2.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/002-artyfx-lv2.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/003-artyfx-build.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component type="addon">
+    <id>org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX</id>
+    <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+    <name>ArtyFX</name>
+    <summary>ArtyFX LV2 plugin suite</summary>
+    <project_license>GPL-2.0</project_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <update_contact>hub_AT_figuiere.net</update_contact>
+    <url type="homepage">http://openavproductions.com/artyfx/</url>
+    <releases>
+        <release version="1.3" date="2016-12-24" />
+    </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.Plugins.ArtyFX.json
+++ b/org.freedesktop.LinuxAudio.Plugins.ArtyFX.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX",
+    "id": "org.freedesktop.LinuxAudio.Plugins.ArtyFX",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
     "runtime-version": "19.08",
     "sdk": "org.freedesktop.Sdk//19.08",
@@ -7,8 +7,8 @@
     "appstream-compose": false,
     "branch": "19.08",
     "build-options": {
-        "prefix": "/app/extensions/Lv2Plugins/ArtyFX",
-        "prepend-pkg-config-path": "/app/extensions/Lv2Plugins/ArtyFX/lib/pkgconfig"
+        "prefix": "/app/extensions/Plugins/ArtyFX",
+        "prepend-pkg-config-path": "/app/extensions/Plugins/ArtyFX/lib/pkgconfig"
     },
     "cleanup": [
         "/lib/lv2"
@@ -21,8 +21,8 @@
             "config_opts": [],
             "cleanup": [],
             "post_install": [
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX"
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.ArtyFX.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.ArtyFX --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.ArtyFX"
             ],
             "sources": [
                 {
@@ -44,7 +44,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX.metainfo.xml"
+                    "path": "org.freedesktop.LinuxAudio.Plugins.ArtyFX.metainfo.xml"
                 }
             ]
         }

--- a/org.freedesktop.LinuxAudio.Plugins.ArtyFX.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.ArtyFX.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component type="addon">
-    <id>org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX</id>
+    <id>org.freedesktop.LinuxAudio.Plugins.ArtyFX</id>
     <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
     <name>ArtyFX</name>
     <summary>ArtyFX LV2 plugin suite</summary>

--- a/patches/001-artyfx-lv2.patch
+++ b/patches/001-artyfx-lv2.patch
@@ -1,0 +1,52 @@
+diff --git a/friza/gui/ui.cxx b/friza/gui/ui.cxx
+index 0768fb7..9e5763f 100644
+--- a/friza/gui/ui.cxx
++++ b/friza/gui/ui.cxx
+@@ -46,7 +46,7 @@ typedef struct {
+ 	LV2UI_Controller controller;
+ } GUI;
+ 
+-LV2UI_Handle friza_instantiate(const struct _LV2UI_Descriptor * descriptor,
++LV2UI_Handle friza_instantiate(const struct LV2UI_Descriptor * descriptor,
+                                const char * plugin_uri,
+                                const char * bundle_path,
+                                LV2UI_Write_Function write_function,
+diff --git a/friza/gui/ui.hxx b/friza/gui/ui.hxx
+index 9db0f5a..6c15dcc 100644
+--- a/friza/gui/ui.hxx
++++ b/friza/gui/ui.hxx
+@@ -18,7 +18,7 @@
+  * MA 02110-1301, USA.
+  */
+ 
+-extern LV2UI_Handle friza_instantiate(const struct _LV2UI_Descriptor * descriptor,
++extern LV2UI_Handle friza_instantiate(const struct LV2UI_Descriptor * descriptor,
+                                       const char * plugin_uri,
+                                       const char * bundle_path,
+                                       LV2UI_Write_Function write_function,
+diff --git a/src/avtk/lv2/testUi.cxx b/src/avtk/lv2/testUi.cxx
+index 0917856..efd35e7 100644
+--- a/src/avtk/lv2/testUi.cxx
++++ b/src/avtk/lv2/testUi.cxx
+@@ -10,7 +10,7 @@
+ #include "../test_ui.hxx"
+ 
+ 
+-static LV2UI_Handle avtk_instantiate(const struct _LV2UI_Descriptor * descriptor,
++static LV2UI_Handle avtk_instantiate(const struct LV2UI_Descriptor * descriptor,
+                                      const char * plugin_uri,
+                                      const char * bundle_path,
+                                      LV2UI_Write_Function write_function,
+diff --git a/src/ui/lv2_ui.cxx b/src/ui/lv2_ui.cxx
+index 8d74b4c..d8c8869 100644
+--- a/src/ui/lv2_ui.cxx
++++ b/src/ui/lv2_ui.cxx
+@@ -33,7 +33,7 @@
+ #include "whaaa.hxx"
+ 
+ 
+-static LV2UI_Handle artyfx_instantiate(const struct _LV2UI_Descriptor * descriptor,
++static LV2UI_Handle artyfx_instantiate(const struct LV2UI_Descriptor * descriptor,
+                                        const char * plugin_uri,
+                                        const char * bundle_path,
+                                        LV2UI_Write_Function write_function,

--- a/patches/002-artyfx-lv2.patch
+++ b/patches/002-artyfx-lv2.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ui/lv2_ui.cxx b/src/ui/lv2_ui.cxx
+index d8c8869..907f513 100644
+--- a/src/ui/lv2_ui.cxx
++++ b/src/ui/lv2_ui.cxx
+@@ -33,7 +33,7 @@
+ #include "whaaa.hxx"
+ 
+ 
+-static LV2UI_Handle artyfx_instantiate(const struct LV2UI_Descriptor * descriptor,
++static LV2UI_Handle artyfx_instantiate(const LV2UI_Descriptor * descriptor,
+                                        const char * plugin_uri,
+                                        const char * bundle_path,
+                                        LV2UI_Write_Function write_function,

--- a/patches/003-artyfx-build.patch
+++ b/patches/003-artyfx-build.patch
@@ -1,0 +1,25 @@
+--- artyfx-5/CMakeLists.txt	2016-12-24 14:36:45.000000000 -0500
++++ artyfx-5/CMakeLists.txt-new	2020-06-20 23:39:39.943932728 -0400
+@@ -82,7 +82,7 @@
+   add_dependencies( artyfx_ui avtk )
+   target_link_libraries( artyfx_ui "-lavtk -lcairo -lX11" )
+   set_target_properties( artyfx_ui PROPERTIES PREFIX "")
+-  install (TARGETS artyfx_ui DESTINATION lib/lv2/artyfx.lv2/)
++  install (TARGETS artyfx_ui DESTINATION lv2/artyfx.lv2/)
+ ENDIF()
+ 
+ IF(BUILD_BENCH)
+@@ -94,10 +94,10 @@
+ set_target_properties(artyfx PROPERTIES PREFIX "")
+ 
+ # add the install targets
+-install (TARGETS artyfx    DESTINATION lib/lv2/artyfx.lv2/)
++install (TARGETS artyfx    DESTINATION lv2/artyfx.lv2/)
+ 
+ FILE(GLOB modF "artyfx.lv2/modgui/*")
+ FILE(GLOB ttls "artyfx.lv2/*.ttl"   )
+ 
+-install(FILES     ${modF} DESTINATION lib/lv2/artyfx.lv2/modgui/)
+-install(FILES     ${ttls} DESTINATION lib/lv2/artyfx.lv2/)
++install(FILES     ${modF} DESTINATION lv2/artyfx.lv2/modgui/)
++install(FILES     ${ttls} DESTINATION lv2/artyfx.lv2/)


### PR DESCRIPTION
This will replace org.freedesktop.LinuxAudio.Lv2Plugins.ArtyFX that I will deprecate.