### PR TITLE
Add org.freedesktop.LinuxAudio.Plugins.VL1Emulator

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "skip-arches": ["arm"]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.json
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.json
@@ -1,0 +1,46 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "runtime-version": "19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "branch": "19.08",
+    "build-options": {
+        "prefix": "/app/extensions/Lv2Plugins/VL1Emulator"
+    },
+    "modules": [
+        {
+            "name": "vl1",
+            "buildsystem": "simple",
+            "config_opts": [],
+            "build-options": {
+                "env": {
+                    "PREFIX": "${FLATPAK_DEST}",
+                    "LV2_DIR": "${FLATPAK_DEST}/lv2",
+                    "BUILD_VST2": "false"
+                }
+            },
+            "build-commands": [
+                "make",
+                "make install"
+            ],
+            "cleanup": [],
+            "post_install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/linuxmao-org/VL1-emulator/releases/download/v1.1.0.0/VL1-emulator-1.1.0.0.tar.gz",
+                    "sha256": "73fc8c4850c2cf1d5213253fd3ee9c364e26a63ae307c57a86ef017ef4fa1352"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component type="addon">
+    <id>org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator</id>
+    <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+    <name>VL1Emulator</name>
+    <summary>VL1 Emulator, An emulator of Casio VL-Tone VL1, based on source code by PolyValens</summary>
+    <project_license>MIT OR CC0-1.0</project_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <update_contact>hub_AT_figuiere_net</update_contact>
+    <url type="homepage">http://www.polyvalens.com/blog/vl-1/</url>
+    <url type="bugtracker">https://github.com/linuxmao-org/VL1-emulator/issues</url>
+    <releases>
+        <release version="1.1.0" date="2020-01-15" />
+    </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.Plugins.VL1Emulator.json
+++ b/org.freedesktop.LinuxAudio.Plugins.VL1Emulator.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator",
+    "id": "org.freedesktop.LinuxAudio.Plugins.VL1Emulator",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
     "sdk": "org.freedesktop.Sdk//19.08",
     "runtime-version": "19.08",
@@ -7,7 +7,7 @@
     "appstream-compose": false,
     "branch": "19.08",
     "build-options": {
-        "prefix": "/app/extensions/Lv2Plugins/VL1Emulator"
+        "prefix": "/app/extensions/Plugins/VL1Emulator"
     },
     "modules": [
         {
@@ -27,8 +27,8 @@
             ],
             "cleanup": [],
             "post_install": [
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator"
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.VL1Emulator.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.VL1Emulator --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.VL1Emulator"
             ],
             "sources": [
                 {
@@ -38,7 +38,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator.metainfo.xml"
+                    "path": "org.freedesktop.LinuxAudio.Plugins.VL1Emulator.metainfo.xml"
                 }
             ]
         }

--- a/org.freedesktop.LinuxAudio.Plugins.VL1Emulator.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.VL1Emulator.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component type="addon">
-    <id>org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator</id>
+    <id>org.freedesktop.LinuxAudio.Plugins.VL1Emulator</id>
     <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
     <name>VL1Emulator</name>
-    <summary>VL1 Emulator, An emulator of Casio VL-Tone VL1, based on source code by PolyValens</summary>
+    <summary>An emulator of Casio VL-Tone VL1 as LV2 plugin</summary>
     <project_license>MIT OR CC0-1.0</project_license>
     <metadata_license>CC0-1.0</metadata_license>
     <update_contact>hub_AT_figuiere_net</update_contact>


### PR DESCRIPTION
This replaces org.freedesktop.LinuxAudio.Lv2Plugins.VL1Emulator that I will deprecate.