### PR TITLE
Add org.freedesktop.sdk.extension.haskell

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "skip-appstream-check": true,
-    "skip-icons-check": true,
-    "only-arches": ["x86_64"]
+    "skip-icons-check": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "skip-appstream-check": true,
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
+}

--- a/org.freedesktop.Sdk.Extension.haskell.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.haskell.appdata.xml
@@ -2,7 +2,7 @@
 <component type="runtime">
   <id>org.freedesktop.Sdk.Extension.haskell</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
+  <project_license>BSD-3-Clause</project_license>
   <name>Haskell Sdk extension</name>
   <summary>Extension providing the latest stable release of GHC 8</summary>
   <url type="homepage">https://www.haskell.org/</url>

--- a/org.freedesktop.Sdk.Extension.haskell.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.haskell.appdata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.haskell</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-with-GCC-exception</project_license>
+  <name>Haskell Sdk extension</name>
+  <summary>Extension providing the latest stable release of GHC 8</summary>
+  <url type="homepage">https://www.haskell.org/</url>
+</component>

--- a/org.freedesktop.Sdk.Extension.haskell.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.haskell.appdata.xml
@@ -2,7 +2,7 @@
 <component type="runtime">
   <id>org.freedesktop.Sdk.Extension.haskell</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-2.0-with-GCC-exception</project_license>
+  <project_license>MIT</project_license>
   <name>Haskell Sdk extension</name>
   <summary>Extension providing the latest stable release of GHC 8</summary>
   <url type="homepage">https://www.haskell.org/</url>

--- a/org.freedesktop.Sdk.Extension.haskell.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.haskell.appdata.xml
@@ -3,7 +3,7 @@
   <id>org.freedesktop.Sdk.Extension.haskell</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>BSD-3-Clause</project_license>
-  <name>Haskell Sdk extension</name>
-  <summary>Extension providing the latest stable release of GHC 8</summary>
+  <name>Haskell platform Sdk extension</name>
+  <summary>Extension providing the latest stable release of the Haskell platform</summary>
   <url type="homepage">https://www.haskell.org/</url>
 </component>

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -12,7 +12,11 @@
     },
     "modules": [
         {
-            "name": "numa",
+            "name": "libnuma",
+            "buildsystem": "autotools",
+            "make-args": [
+                "install"
+            ],
             "only-arches": [
                 "aarch64"
             ],

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -8,6 +8,7 @@
     "separate-locales": false,
     "appstream-compose": false,
     "build-options": {
+        "prepend-ld-library-path": "/usr/lib/sdk/haskell/lib/",
         "prefix": "/usr/lib/sdk/haskell"
     },
     "modules": [
@@ -22,15 +23,10 @@
             ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/numactl/numactl/releases/download/v2.0.13/numactl-2.0.13.tar.gz",
-                    "x-checker-data": {
-                        "type": "html",
-                        "url": "https://github.com/numactl/numactl/releases/latest",
-                        "version-pattern": "/numactl/stack/releases/tag/v((?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+))",
-                        "url-template": "https://github.com/numactl/numactl/releases/download/v$version/stack-$version-linux-x86_64.tar.gz"
-                    },
-                    "sha256": "991e254b867eb5951a44d2ae0bf1996a8ef0209e026911ef6c3ef4caf6f58c9a"
+                    "type": "git",
+                    "url": "https://github.com/numactl/numactl.git",
+                    "tag": "v2.0.13",
+                    "commit": "5d9f16722e3df49dc618a9f361bd482559695db7"
                 }
             ],
             "cleanup": [

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -20,10 +20,18 @@
             "sources": [
                 {
                     "type": "archive",
-                    "only-arches": ["x86_64"],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-deb9-linux.tar.xz",
-                    "sha512": "0df7c24e095bc60f761c953a292506c5068d84cef4b78bcf598eccd6d2397dd39b809576c37eca649c192eebfbf8d5b44ca3be06e149ef46bfd20e8690d6024a"
-
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-fedora27-linux.tar.xz",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.haskell.org/ghc/download.html",
+                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-fedora27-linux.tar.xz"
+                    },
+                    "sha256": "3c4cd72b4806045779739e8f5d1658e30e57123d88c2c8966422cdbcae448470",
+                    "size": 214693280
                 }
             ]
         },
@@ -33,10 +41,19 @@
             "sources": [
                 {
                     "type": "archive",
-                    "only-arches": ["x86_64"],
+                    "only-arches": [
+                        "x86_64"
+                    ],
                     "url": "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz",
-                    "sha512": "af80b166f15485745fb738b72ea17588dba41c605cefa2690c81604f0e43af1c74decef6946ea72fb114f940176db4a965d432a79fdfb8c28dab1d81e5a2ad50",
-                    "strip-components": 0
+                    "strip-components": 0,
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.haskell.org/cabal/download.html",
+                        "version-pattern": "version ((?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+))",
+                        "url-template": "https://downloads.haskell.org/~cabal/cabal-install-$version/cabal-install-$version-x86_64-unknown-linux.tar.xz"
+                    },
+                    "sha256": "32d1f7cf1065c37cb0ef99a66adb405f409b9763f14c0926f5424ae408c738ac",
+                    "size": 4363200
                 }
             ],
             "build-commands": [
@@ -49,9 +66,18 @@
             "sources": [
                 {
                     "type": "archive",
-                    "only-arches": ["x86_64"],
+                    "only-arches": [
+                        "x86_64"
+                    ],
                     "url": "https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz",
-                    "sha512": "eef99b5a1f7593ca884708a05bcf6f7c3e8a5ade4f71b6a802c961bdc346aa560861762b238d8cd6b3c8b85e45334235ef5eaf97126df5970863dca701d83298"
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://github.com/commercialhaskell/stack/releases/latest",
+                        "version-pattern": "/commercialhaskell/stack/releases/tag/v((?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+))",
+                        "url-template": "https://github.com/commercialhaskell/stack/releases/download/v$version/stack-$version-linux-x86_64.tar.gz"
+                    },
+                    "sha256": "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d",
+                    "size": 14478645
                 }
             ],
             "build-commands": [
@@ -78,16 +104,16 @@
             "name": "appdata",
             "buildsystem": "simple",
             "build-commands": [
-               "mkdir -p ${FLATPAK_DEST}/share/appdata",
-               "cp org.freedesktop.Sdk.Extension.haskell.appdata.xml ${FLATPAK_DEST}/share/appdata",
-               "appstream-compose --basename=org.freedesktop.Sdk.Extension.haskell --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.haskell"
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.haskell.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose --basename=org.freedesktop.Sdk.Extension.haskell --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.haskell"
             ],
             "sources": [
-               {
-                  "type": "file",
-                  "path": "org.freedesktop.Sdk.Extension.haskell.appdata.xml"
-               }
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.haskell.appdata.xml"
+                }
             ]
-         }
+        }
     ]
 }

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -1,8 +1,8 @@
 {
     "id": "org.freedesktop.Sdk.Extension.haskell",
-    "branch": "19.08",
+    "branch": "20.08",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "19.08",
+    "runtime-version": "20.08",
     "build-extension": true,
     "sdk": "org.freedesktop.Sdk",
     "separate-locales": false,

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -21,23 +21,71 @@
                 {
                     "type": "archive",
                     "only-arches": [
-                        "x86_64"
+                        "arm"
                     ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-fedora27-linux.tar.xz",
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-armv7-deb9-linux.tar.xz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://www.haskell.org/ghc/download.html",
                         "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-fedora27-linux.tar.xz"
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-armv7-deb9-linux.tar.xz"
                     },
-                    "sha256": "3c4cd72b4806045779739e8f5d1658e30e57123d88c2c8966422cdbcae448470",
-                    "size": 214693280
+                    "sha256": "afe1bde2b0d6deb0320b9460fffe5d9427e302df85aec866b9c1458777d52b28",
+                    "size": 342015984
+                },
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "aarch64"
+                    ],
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-aarch64-deb9-linux.tar.xz",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.haskell.org/ghc/download.html",
+                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-aarch64-deb9-linux.tar.xz"
+                    },
+                    "sha256": "c099011e07999db917e797fb5d89c31f075a562556ab99be8ab0accbf2a94db7",
+                    "size": 313033012
+                },
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "i386"
+                    ],
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-i386-deb9-linux.tar.xz",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.haskell.org/ghc/download.html",
+                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-i386-deb9-linux.tar.xz"
+                    },
+                    "sha256": "8b53eef2c827b5f634d72920a93c0c9dd66ea288691a2bfe28def45d3c686ee2",
+                    "size": 215852640
+                },   
+                {
+                    "type": "archive",
+                    "only-arches": [
+                        "x86_64"
+                    ],
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-deb9-linux.tar.xz",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://www.haskell.org/ghc/download.html",
+                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-deb9-linux.tar.xz"
+                    },
+                    "sha256": "d1cf7886f27af070f3b7dbe1975a78b43ef2d32b86362cbe953e79464fe70761",
+                    "size": 212806588
                 }
             ]
         },
         {
             "name": "cabal",
             "buildsystem": "simple",
+            "only-arches": [
+                "x86_64"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -63,6 +111,9 @@
         {
             "name": "stack",
             "buildsystem": "simple",
+            "only-arches": [
+                "x86_64"
+            ],
             "sources": [
                 {
                     "type": "archive",

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -105,15 +105,15 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz",
+                    "url": "https://github.com/commercialhaskell/stack/releases/download/v2.3.3/stack-2.3.3-linux-x86_64.tar.gz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://github.com/commercialhaskell/stack/releases/latest",
                         "version-pattern": "/commercialhaskell/stack/releases/tag/v((?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+))",
                         "url-template": "https://github.com/commercialhaskell/stack/releases/download/v$version/stack-$version-linux-x86_64.tar.gz"
                     },
-                    "sha256": "b753cd21d446aea16a221326ec686e3acdf1b146c714a77b5d27fd855475554d",
-                    "size": 14478645
+                    "sha256": "e7329c75d9c7ea168eb12caa954102e451906f350604a18d6e852ac81da5a2be",
+                    "size": 14478157
                 }
             ],
             "build-commands": [

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -61,13 +61,6 @@
                 {
                     "type": "script",
                     "commands": [
-                        ""
-                    ],
-                    "dest-filename": "install.sh"
-                },
-                {
-                    "type": "script",
-                    "commands": [
                         "export PATH=$PATH:/usr/lib/sdk/haskell/bin"
                     ],
                     "dest-filename": "enable.sh"

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -20,8 +20,10 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.haskell.org/~ghc/latest/ghc-8.10.1-x86_64-fedora27-linux.tar.xz",
-                    "sha512": "12e3c6816fb1306bd8450fd9a0463967de59ccf24190e76d12aa659e35deb404a4a809f5b6369ffba8771b9f26a3358c19db4261b0f0ab4d52a066f16e68ff1b"
+                    "only-arches": ["x86_64"],
+                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-deb9-linux.tar.xz",
+                    "sha512": "0df7c24e095bc60f761c953a292506c5068d84cef4b78bcf598eccd6d2397dd39b809576c37eca649c192eebfbf8d5b44ca3be06e149ef46bfd20e8690d6024a"
+
                 }
             ]
         },
@@ -31,6 +33,7 @@
             "sources": [
                 {
                     "type": "archive",
+                    "only-arches": ["x86_64"],
                     "url": "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz",
                     "sha512": "af80b166f15485745fb738b72ea17588dba41c605cefa2690c81604f0e43af1c74decef6946ea72fb114f940176db4a965d432a79fdfb8c28dab1d81e5a2ad50",
                     "strip-components": 0
@@ -46,7 +49,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://get.haskellstack.org/stable/linux-x86_64.tar.gz",
+                    "only-arches": ["x86_64"],
+                    "url": "https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz",
                     "sha512": "eef99b5a1f7593ca884708a05bcf6f7c3e8a5ade4f71b6a802c961bdc346aa560861762b238d8cd6b3c8b85e45334235ef5eaf97126df5970863dca701d83298"
                 }
             ],

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -12,6 +12,28 @@
     },
     "modules": [
         {
+            "name": "numa",
+            "only-arches": [
+                "aarch64"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/numactl/numactl/releases/download/v2.0.13/numactl-2.0.13.tar.gz",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://github.com/numactl/numactl/releases/latest",
+                        "version-pattern": "/numactl/stack/releases/tag/v((?:\\d+\\.)?(?:\\d+\\.)?(?:\\d+))",
+                        "url-template": "https://github.com/numactl/numactl/releases/download/v$version/stack-$version-linux-x86_64.tar.gz"
+                    },
+                    "sha256": "991e254b867eb5951a44d2ae0bf1996a8ef0209e026911ef6c3ef4caf6f58c9a"
+                }
+            ],
+            "cleanup": [
+                "/bin"
+            ]
+        },
+        {
             "name": "ghc",
             "buildsystem": "autotools",
             "make-args": [

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -23,60 +23,45 @@
                     "only-arches": [
                         "arm"
                     ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-armv7-deb9-linux.tar.xz",
+                    "url": "https://downloads.haskell.org/~ghc/8.10.2/ghc-8.10.2-armv7-deb10-linux.tar.xz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://www.haskell.org/ghc/download.html",
                         "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-armv7-deb9-linux.tar.xz"
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-armv7-deb10-linux.tar.xz"
                     },
-                    "sha256": "afe1bde2b0d6deb0320b9460fffe5d9427e302df85aec866b9c1458777d52b28",
-                    "size": 342015984
+                    "sha256": "bb9c97826b1f4d7a8ef8bce0616b612f1ded10480ef10fcf7fb4e6d10a6681c8",
+                    "size": 341245768
                 },
                 {
                     "type": "archive",
                     "only-arches": [
                         "aarch64"
                     ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-aarch64-deb9-linux.tar.xz",
+                    "url": "https://downloads.haskell.org/~ghc/8.10.2/ghc-8.10.2-aarch64-deb10-linux.tar.xz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://www.haskell.org/ghc/download.html",
                         "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-aarch64-deb9-linux.tar.xz"
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-aarch64-deb10-linux.tar.xz"
                     },
-                    "sha256": "c099011e07999db917e797fb5d89c31f075a562556ab99be8ab0accbf2a94db7",
-                    "size": 313033012
+                    "sha256": "5cf24189077e6e2dce2aa16367ad8a53f603e751a15010dfb23d067206e55593",
+                    "size": 310742020
                 },
-                {
-                    "type": "archive",
-                    "only-arches": [
-                        "i386"
-                    ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-i386-deb9-linux.tar.xz",
-                    "x-checker-data": {
-                        "type": "html",
-                        "url": "https://www.haskell.org/ghc/download.html",
-                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-i386-deb9-linux.tar.xz"
-                    },
-                    "sha256": "8b53eef2c827b5f634d72920a93c0c9dd66ea288691a2bfe28def45d3c686ee2",
-                    "size": 215852640
-                },   
                 {
                     "type": "archive",
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.1/ghc-8.10.1-x86_64-deb9-linux.tar.xz",
+                    "url": "https://downloads.haskell.org/~ghc/8.10.2/ghc-8.10.2-x86_64-deb10-linux.tar.xz",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://www.haskell.org/ghc/download.html",
                         "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-deb9-linux.tar.xz"
+                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-x86_64-deb10-linux.tar.xz"
                     },
-                    "sha256": "d1cf7886f27af070f3b7dbe1975a78b43ef2d32b86362cbe953e79464fe70761",
-                    "size": 212806588
+                    "sha256": "94513d82c38c848f489113a75fa5ef4e5a8e3ecfaa74ca90e2620d2193ff1632",
+                    "size": 213280584
                 }
             ]
         },

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -1,0 +1,96 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.haskell",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.Sdk",
+    "runtime-version": "19.08",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/lib/sdk/haskell"
+    },
+    "modules": [
+        {
+            "name": "ghc",
+            "buildsystem": "autotools",
+            "make-args": [
+                "install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.haskell.org/~ghc/latest/ghc-8.10.1-x86_64-fedora27-linux.tar.xz",
+                    "sha512": "12e3c6816fb1306bd8450fd9a0463967de59ccf24190e76d12aa659e35deb404a4a809f5b6369ffba8771b9f26a3358c19db4261b0f0ab4d52a066f16e68ff1b"
+                }
+            ]
+        },
+        {
+            "name": "cabal",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.haskell.org/~cabal/cabal-install-3.2.0.0/cabal-install-3.2.0.0-x86_64-unknown-linux.tar.xz",
+                    "sha512": "af80b166f15485745fb738b72ea17588dba41c605cefa2690c81604f0e43af1c74decef6946ea72fb114f940176db4a965d432a79fdfb8c28dab1d81e5a2ad50",
+                    "strip-components": 0
+                }
+            ],
+            "build-commands": [
+                "install -C ./cabal ${FLATPAK_DEST}/bin/"
+            ]
+        },
+        {
+            "name": "stack",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://get.haskellstack.org/stable/linux-x86_64.tar.gz",
+                    "sha512": "eef99b5a1f7593ca884708a05bcf6f7c3e8a5ade4f71b6a802c961bdc346aa560861762b238d8cd6b3c8b85e45334235ef5eaf97126df5970863dca701d83298"
+                }
+            ],
+            "build-commands": [
+                "install -C ./stack ${FLATPAK_DEST}/bin/"
+            ]
+        },
+        {
+            "name": "scripts",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "script",
+                    "commands": [
+                        ""
+                    ],
+                    "dest-filename": "install.sh"
+                },
+                {
+                    "type": "script",
+                    "commands": [
+                        "export PATH=$PATH:/usr/lib/sdk/haskell/bin"
+                    ],
+                    "dest-filename": "enable.sh"
+                }
+            ],
+            "build-commands": [
+                "cp enable.sh ${FLATPAK_DEST}"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+               "mkdir -p ${FLATPAK_DEST}/share/appdata",
+               "cp org.freedesktop.Sdk.Extension.haskell.appdata.xml ${FLATPAK_DEST}/share/appdata",
+               "appstream-compose --basename=org.freedesktop.Sdk.Extension.haskell --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.haskell"
+            ],
+            "sources": [
+               {
+                  "type": "file",
+                  "path": "org.freedesktop.Sdk.Extension.haskell.appdata.xml"
+               }
+            ]
+         }
+    ]
+}

--- a/org.freedesktop.Sdk.Extension.haskell.json
+++ b/org.freedesktop.Sdk.Extension.haskell.json
@@ -43,21 +43,6 @@
                 {
                     "type": "archive",
                     "only-arches": [
-                        "arm"
-                    ],
-                    "url": "https://downloads.haskell.org/~ghc/8.10.2/ghc-8.10.2-armv7-deb10-linux.tar.xz",
-                    "x-checker-data": {
-                        "type": "html",
-                        "url": "https://www.haskell.org/ghc/download.html",
-                        "version-pattern": "((?:\\d+\\.)(?:\\d+\\.)(?:\\d+))",
-                        "url-template": "https://downloads.haskell.org/~ghc/$version/ghc-$version-armv7-deb10-linux.tar.xz"
-                    },
-                    "sha256": "bb9c97826b1f4d7a8ef8bce0616b612f1ded10480ef10fcf7fb4e6d10a6681c8",
-                    "size": 341245768
-                },
-                {
-                    "type": "archive",
-                    "only-arches": [
                         "aarch64"
                     ],
                     "url": "https://downloads.haskell.org/~ghc/8.10.2/ghc-8.10.2-aarch64-deb10-linux.tar.xz",


### PR DESCRIPTION
Adds the Haskell compiler GHC, cabal and stack as a sdk extension.

[Haskell](https://www.haskell.org/)
[Cabal](https://www.haskell.org/cabal/)
[Stack](https://docs.haskellstack.org/en/stable/README/)

I'm not sure how to handle the different licenses. Where should these be added?
[Haskell license](https://gitlab.haskell.org/ghc/ghc/blob/master/LICENSE)
[Cabal license](https://github.com/haskell/cabal/blob/master/LICENSE)
[Stack license](https://github.com/commercialhaskell/stack/blob/master/LICENSE)