### PR TITLE
Add org.freedesktop.LinuxAudio.Plugins.swh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "skip-appstream-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "skip-icons-check": true,
-    "skip-appstream-check": true
+    "skip-icons-check": true
 }

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.swh.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.swh.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prepend-pkg-config-path": "/app/extensions/LadspaPlugins/swh/lib/pkgconfig",
+        "prefix": "/app/extensions/LadspaPlugins/swh"
+    },
+    "modules": [
+        "shared-modules/linux-audio/fftw3f-static.json",
+        {
+            "name": "swh",
+            "build-options": {
+                "env": {
+                    "CFLAGS": "-fPIC"
+                }
+            },
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.swh --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/swh/ COPYING"
+            ],
+            "config-opts": [
+                "--libdir=${FLATPAK_DEST}"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/swh/ladspa/archive/v0.4.17.tar.gz",
+                    "sha256": "d1b090feec4c5e8f9605334b47faaad72db7cc18fe91d792b9161a9e3b821ce7"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.LadspaPlugins.swh</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>Swh LADSPA plugins</name>
+  <summary>Swh LADSPA plugins</summary>
+  <url type="homepage">http://plugin.org.uk/</url>
+  <project_license>GPL-2.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2016-11-01" version="0.4.17" />
+  </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
   <id>org.freedesktop.LinuxAudio.LadspaPlugins.swh</id>
-  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
-  <name>Swh LADSPA plugins</name>
-  <summary>Swh LADSPA plugins</summary>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+  <name>SWH</name>
+  <summary>SWH LADSPA plugins</summary>
   <url type="homepage">http://plugin.org.uk/</url>
   <project_license>GPL-2.0+</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.freedesktop.LinuxAudio.Plugins.swh.json
+++ b/org.freedesktop.LinuxAudio.Plugins.swh.json
@@ -13,6 +13,35 @@
     "modules": [
         "shared-modules/linux-audio/fftw3f-static.json",
         {
+            "name": "swh-lv2",
+            "buildsystem": "simple",
+            "build-options": {
+                "env": {
+                    "CFLAGS": "-fPIC",
+                    "PREFIX": "${FLATPAK_DEST}"
+                }
+            },
+            "build-commands": [
+                "make",
+                "make install-system"
+            ],
+            "post-install": [
+                "strip ${FLATPAK_DEST}/lv2/*.lv2/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/swh-lv2/ COPYING"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/swh/lv2/archive/v1.0.16.tar.gz",
+                    "sha256": "bc24512de6e2fb7a493226e2e01a80ba8462a318b15c3b0fd0cd914b018c3548"
+                },
+                {
+                    "type": "patch",
+                    "path": "swh-lv2-build-fixes.patch"
+                }
+            ]
+        },
+        {
             "name": "swh",
             "build-options": {
                 "env": {

--- a/org.freedesktop.LinuxAudio.Plugins.swh.json
+++ b/org.freedesktop.LinuxAudio.Plugins.swh.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+    "id": "org.freedesktop.LinuxAudio.Plugins.swh",
     "branch": "19.08",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
     "runtime-version": "19.08",
@@ -7,8 +7,8 @@
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
-        "prepend-pkg-config-path": "/app/extensions/LadspaPlugins/swh/lib/pkgconfig",
-        "prefix": "/app/extensions/LadspaPlugins/swh"
+        "prepend-pkg-config-path": "/app/extensions/Plugins/swh/lib/pkgconfig",
+        "prefix": "/app/extensions/Plugins/swh"
     },
     "modules": [
         "shared-modules/linux-audio/fftw3f-static.json",
@@ -20,8 +20,8 @@
                 }
             },
             "post-install": [
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.swh --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.swh",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.swh --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.swh",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/swh/ COPYING"
             ],
             "config-opts": [
@@ -35,7 +35,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.swh.metainfo.xml"
+                    "path": "org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml"
                 }
             ]
         }

--- a/org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml
@@ -3,12 +3,16 @@
   <id>org.freedesktop.LinuxAudio.Plugins.swh</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>SWH</name>
-  <summary>SWH LADSPA plugins</summary>
+  <summary>SWH LADSPA and LV2 plugins</summary>
   <url type="homepage">http://plugin.org.uk/</url>
-  <project_license>GPL-2.0+</project_license>
+  <project_license>GPL-2.0+ AND GPL-3.0+</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
-    <release date="2016-11-01" version="0.4.17" />
+    <release date="2016-11-01" version="0.4.17">
+      <description>
+        <p>LADSPA version 0.4.17 and LV2 version 1.0.16</p>
+      </description>
+    </release>
   </releases>
 </component>

--- a/org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.swh.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.freedesktop.LinuxAudio.LadspaPlugins.swh</id>
+  <id>org.freedesktop.LinuxAudio.Plugins.swh</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>SWH</name>
   <summary>SWH LADSPA plugins</summary>

--- a/swh-lv2-build-fixes.patch
+++ b/swh-lv2-build-fixes.patch
@@ -1,0 +1,10 @@
+--- swh-lv2/Makefile	2016-01-04 10:42:33.000000000 -0500
++++ swh-lv2/Makefile-new	2020-04-24 23:43:43.276798197 -0400
+@@ -1,5 +1,5 @@
+-PREFIX = /usr/local
+-INSTALL_DIR = $(PREFIX)/lib/lv2
++PREFIX ?= /usr/local
++INSTALL_DIR = $(PREFIX)/lv2
+ 
+ VERSION = 1.0.16
+ 


### PR DESCRIPTION
This replaces org.freedesktop.LinuxAudio.LadspaPlugins.swh and org.freedesktop.LinuxAudio.Lv2Plugins.swh that I will deprecate EOL