### PR TITLE
Add org.freedesktop.LinuxAudio.Plugins.TAP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/build-fixes.patch
+++ b/build-fixes.patch
@@ -1,0 +1,13 @@
+--- tap/Makefile	2017-11-16 09:49:42.000000000 -0500
++++ tap/Makefile-new	2020-04-21 21:57:46.261111758 -0400
+@@ -23,8 +23,8 @@
+ # Change this if you want to install somewhere else. In particular
+ # you may wish to remove the middle "local/" part of the path.
+ 
+-INSTALL_PLUGINS_DIR	=	/usr/local/lib/ladspa/
+-INSTALL_LRDF_DIR	=	/usr/local/share/ladspa/rdf/
++INSTALL_PLUGINS_DIR	=	/app/extensions/LadspaPlugins/TAP/ladspa/
++INSTALL_LRDF_DIR	=	/app/extensions/LadspaPlugins/TAP/ladspa/rdf/
+ 
+ # NO EDITING below this line is required
+ # if all you want to do is install and use the plugins.

--- a/build-fixes.patch
+++ b/build-fixes.patch
@@ -6,8 +6,8 @@
  
 -INSTALL_PLUGINS_DIR	=	/usr/local/lib/ladspa/
 -INSTALL_LRDF_DIR	=	/usr/local/share/ladspa/rdf/
-+INSTALL_PLUGINS_DIR	=	/app/extensions/LadspaPlugins/TAP/ladspa/
-+INSTALL_LRDF_DIR	=	/app/extensions/LadspaPlugins/TAP/ladspa/rdf/
++INSTALL_PLUGINS_DIR	=	/app/extensions/Plugins/TAP/ladspa/
++INSTALL_LRDF_DIR	=	/app/extensions/Plugins/TAP/ladspa/rdf/
  
  # NO EDITING below this line is required
  # if all you want to do is install and use the plugins.

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.json
@@ -1,0 +1,42 @@
+{
+    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.TAP",
+    "branch": "19.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "19.08",
+    "sdk": "org.freedesktop.Sdk//19.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/LadspaPlugins/TAP"
+    },
+    "modules": [
+        {
+            "name": "tap",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make",
+                "make install"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.TAP --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.TAP",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/tap COPYING"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/tap-plugins/tap-plugins/1.0.0/tap-plugins-1.0.0.tar.gz",
+                    "sha256": "ea94d8b20d8056e1b9ec6d252846713780fd2a268f3a3a772c362a10950d80cd"
+                },
+                {
+                    "type": "patch",
+                    "path": "build-fixes.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.json
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.json
@@ -25,8 +25,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://downloads.sourceforge.net/project/tap-plugins/tap-plugins/1.0.0/tap-plugins-1.0.0.tar.gz",
-                    "sha256": "ea94d8b20d8056e1b9ec6d252846713780fd2a268f3a3a772c362a10950d80cd"
+                    "url": "https://github.com/tomszilagyi/tap-plugins/archive/v1.0.1.tar.gz",
+                    "sha256": "89c932bea903589db2717ca4d87013fea404b4123fc71acba5bc7cba18d3ecbb"
                 },
                 {
                     "type": "patch",

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
@@ -9,6 +9,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
+    <release date="2019-01-20" version="1.0.1" />
     <release date="2017-11-16" version="1.0.0" />
   </releases>
 </component>

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
   <id>org.freedesktop.LinuxAudio.LadspaPlugins.TAP</id>
-  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
-  <name>Tom's Audio Processing LADSPA</name>
-  <summary>Tom's Audio Processing LADSPA plugin</summary>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+  <name>TAP-plugins</name>
+  <summary>Tom's Audio Processing LADSPA plugins</summary>
   <url type="homepage">http://tap-plugins.sourceforge.net/</url>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.LadspaPlugins.TAP</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension.desktop</extends>
+  <name>Tom's Audio Processing LADSPA</name>
+  <summary>Tom's Audio Processing LADSPA plugin</summary>
+  <url type="homepage">http://tap-plugins.sourceforge.net/</url>
+  <project_license>GPL-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2017-11-16" version="1.0.0" />
+  </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.Plugins.TAP.json
+++ b/org.freedesktop.LinuxAudio.Plugins.TAP.json
@@ -7,9 +7,49 @@
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
+        "prepend-pkg-config-path": "/app/extensions/Plugins/TAP/lib/pkgconfig",
         "prefix": "/app/extensions/Plugins/TAP"
     },
+    "cleanup": [
+        "/lib/lv2"
+    ],
     "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "tap-lv2",
+            "buildsystem": "simple",
+            "build-options": {
+                "env": {
+                    "CFLAGS": "`pkg-config --cflags lv2`"
+                },
+                "arch": {
+                    "aarch64": {
+                        "env":{
+                            "NOOPT": "true"
+                        }
+                    },
+                    "arm": {
+                        "env": {
+                            "NOOPT": "true"
+                        }
+                    }
+                }
+            },
+            "build-commands": [
+                "make NOOPT=${NOOPT}",
+                "make install INSTALL_PATH=/app/extensions/Plugins/TAP/lv2"
+            ],
+            "post-install": [
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/tap-lv2 COPYING"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/moddevices/tap-lv2.git",
+                    "commit": "cab6e0dfb2ce20e4ad34b067d1281ec0b193598a"
+                }
+            ]
+        },
         {
             "name": "tap",
             "buildsystem": "simple",

--- a/org.freedesktop.LinuxAudio.Plugins.TAP.json
+++ b/org.freedesktop.LinuxAudio.Plugins.TAP.json
@@ -1,5 +1,5 @@
 {
-    "id": "org.freedesktop.LinuxAudio.LadspaPlugins.TAP",
+    "id": "org.freedesktop.LinuxAudio.Plugins.TAP",
     "branch": "19.08",
     "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
     "runtime-version": "19.08",
@@ -7,7 +7,7 @@
     "build-extension": true,
     "appstream-compose": false,
     "build-options": {
-        "prefix": "/app/extensions/LadspaPlugins/TAP"
+        "prefix": "/app/extensions/Plugins/TAP"
     },
     "modules": [
         {
@@ -18,8 +18,8 @@
                 "make install"
             ],
             "post-install": [
-                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml",
-                "appstream-compose --basename=org.freedesktop.LinuxAudio.LadspaPlugins.TAP --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.LadspaPlugins.TAP",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.TAP --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.TAP",
                 "install -Dm644 -t $FLATPAK_DEST/share/licenses/tap COPYING"
             ],
             "sources": [
@@ -34,7 +34,7 @@
                 },
                 {
                     "type": "file",
-                    "path": "org.freedesktop.LinuxAudio.LadspaPlugins.TAP.metainfo.xml"
+                    "path": "org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml"
                 }
             ]
         }

--- a/org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml
@@ -3,13 +3,17 @@
   <id>org.freedesktop.LinuxAudio.Plugins.TAP</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>TAP-plugins</name>
-  <summary>Tom's Audio Processing LADSPA plugins</summary>
+  <summary>Tom's Audio Processing LADSPA and LV2 plugins</summary>
   <url type="homepage">http://tap-plugins.sourceforge.net/</url>
   <project_license>GPL-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>hub_AT_figuiere.net</update_contact>
   <releases>
-    <release date="2019-01-20" version="1.0.1" />
+    <release date="2019-01-20" version="1.0.1">
+      <description>
+        <p>LADSPA version 1.0.1, LV2 version 1.0.0</p>
+      </description>
+    </release>
     <release date="2017-11-16" version="1.0.0" />
   </releases>
 </component>

--- a/org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.TAP.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="addon">
-  <id>org.freedesktop.LinuxAudio.LadspaPlugins.TAP</id>
+  <id>org.freedesktop.LinuxAudio.Plugins.TAP</id>
   <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
   <name>TAP-plugins</name>
   <summary>Tom's Audio Processing LADSPA plugins</summary>


### PR DESCRIPTION
This replaces org.freedesktop.LinuxAudio.LadspaPlugins.TAP and org.freedesktop.LinuxAudio.Lv2Plugins.TAP that I will deprecate.