### PR TITLE
Add com.jetbrains.PyCharm.Extensions.Python2-7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
+++ b/com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
@@ -5,7 +5,7 @@
   <name>Python 2.7</name>
   <summary>Extension for PyCharm</summary>
   <url type="homepage">https://www.python.org/</url>
-  <project_license>PSF-2.0</project_license>
+  <project_license>Python-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <update_contact>sakcheen+flathub_AT_gmail.com</update_contact>
   <releases>

--- a/com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
+++ b/com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.jetbrains.PyCharm.Extensions.Python2-7</id>
+  <extends>com.jetbrains.PyCharm-Community</extends>
+  <name>Python 2.7</name>
+  <summary>Extension for PyCharm</summary>
+  <url type="homepage">https://www.python.org/</url>
+  <project_license>PSF-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>sakcheen+flathub_AT_gmail.com</update_contact>
+  <releases>
+    <release date="2020-04-20" version="2.7.18" />
+  </releases>
+</component>

--- a/com.jetbrains.PyCharm.Extensions.Python2-7.yaml
+++ b/com.jetbrains.PyCharm.Extensions.Python2-7.yaml
@@ -6,14 +6,15 @@ sdk: org.freedesktop.Sdk//20.08
 build-extension: true
 appstream-compose: false
 build-options: 
-  prefix: ${FLATPAK_DEST}
+  prefix: /app/extensions/Python2-7
 modules:
   - shared-modules/python2.7/python-2.7.json
   
   - name: metainfo
     buildsystem: simple
     build-commands:
-      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
+      - install -Dm644 --target=${FLATPAK_DEST}/share/metainfo/ com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
+      - appstream-compose --basename=com.jetbrains.PyCharm.Extensions.Python2-7 --prefix=${FLATPAK_DEST} --origin=flatpak com.jetbrains.PyCharm.Extensions.Python2-7
     sources:
       - type: file
         path: com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml

--- a/com.jetbrains.PyCharm.Extensions.Python2-7.yaml
+++ b/com.jetbrains.PyCharm.Extensions.Python2-7.yaml
@@ -1,0 +1,19 @@
+id: com.jetbrains.PyCharm.Extensions.Python2-7
+branch: "20.08"
+runtime: com.jetbrains.PyCharm-Community
+runtime-version: stable
+sdk: org.freedesktop.Sdk//20.08
+build-extension: true
+appstream-compose: false
+build-options: 
+  prefix: ${FLATPAK_DEST}
+modules:
+  - shared-modules/python2.7/python-2.7.json
+  
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml
+    sources:
+      - type: file
+        path: com.jetbrains.PyCharm.Extensions.Python2-7.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": "true"
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-    "skip-icons-check": "true"
+    "skip-icons-check": "true",
     "only-arches": ["x86_64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
     "skip-icons-check": "true"
+    "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Add Python 2.7 as an extension point for PyCharm.

It'd be nice if this could also be shared with PyCharm-Professional, but I'm not entirely sure how to do that.

Depends on https://github.com/flathub/com.jetbrains.PyCharm-Community/pull/99