### PR TITLE
Add com.jetbrains.PyCharm.Packages.PyOpenGL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
+++ b/com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.jetbrains.PyCharm.Packages.PyOpenGL</id>
+  <extends>com.jetbrains.PyCharm-Community</extends>
+  <name>PyOpenGL</name>
+  <summary>PyOpenGL is the most common cross platform Python binding to OpenGL and related APIs.</summary>
+  <url type="homepage">http://pyopengl.sourceforge.net/</url>
+  <project_license>BSD-3-Clause</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>sakcheen+flathub_AT_gmail.com</update_contact>
+  <releases>
+    <release date="2020-01-04" version="3.1.5" />
+  </releases>
+</component>

--- a/com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
+++ b/com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
@@ -3,7 +3,7 @@
   <id>com.jetbrains.PyCharm.Packages.PyOpenGL</id>
   <extends>com.jetbrains.PyCharm-Community</extends>
   <name>PyOpenGL</name>
-  <summary>PyOpenGL is the most common cross platform Python binding to OpenGL and related APIs.</summary>
+  <summary>Python binding to OpenGL and related APIs</summary>
   <url type="homepage">http://pyopengl.sourceforge.net/</url>
   <project_license>BSD-3-Clause</project_license>
   <metadata_license>CC0-1.0</metadata_license>

--- a/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
+++ b/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
@@ -35,15 +35,10 @@ modules:
     build-commands:
       - pip3 install --no-index --find-links="file://${PWD}" --target=${FLATPAK_DEST}/python
         PyOpenGL
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/b8/73/31c8177f3d236e9a5424f7267659c70ccea604dab0585bfcd55828397746/PyOpenGL-3.1.5.tar.gz
         sha256: 4107ba0d0390da5766a08c242cf0cf3404c377ed293c5f6d701e457c57ba3424
-
-  - name: metainfo
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
-    sources:
       - type: file
         path: com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml

--- a/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
+++ b/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
@@ -1,0 +1,49 @@
+id: com.jetbrains.PyCharm.Packages.PyOpenGL
+branch: "20.08"
+runtime: com.jetbrains.PyCharm-Community
+runtime-version: stable
+sdk: org.freedesktop.Sdk//20.08
+build-extension: true
+appstream-compose: false
+build-options: 
+  prefix: ${FLATPAK_DEST}
+  env:
+    CPATH: :/app/packages/PyOpenGL/include
+modules:
+  - shared-modules/glew/glew.json
+  - shared-modules/glu/glu-9.json
+
+  - name: freeglut
+    builddir: true
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DOpenGL_GL_PREFERENCE=LEGACY
+      - -DFREEGLUT_BUILD_DEMOS=OFF
+      - -DCMAKE_INSTALL_LIBDIR:PATH=/app/packages/PyOpenGL/lib
+      - -DFREEGLUT_BUILD_STATIC_LIBS=OFF
+      - -Wno-dev
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/freeglut/freeglut-3.2.1.tar.gz
+        sha256: d4000e02102acaf259998c870e25214739d1f16f67f99cb35e4f46841399da68
+      - type: patch
+        path: freeglut-3.2.1-gcc10_fix-1.patch
+
+  - name: PyOpenGL
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --target=${FLATPAK_DEST}/python
+        PyOpenGL
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b8/73/31c8177f3d236e9a5424f7267659c70ccea604dab0585bfcd55828397746/PyOpenGL-3.1.5.tar.gz
+        sha256: 4107ba0d0390da5766a08c242cf0cf3404c377ed293c5f6d701e457c57ba3424
+
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
+    sources:
+      - type: file
+        path: com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml

--- a/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
+++ b/com.jetbrains.PyCharm.Packages.PyOpenGL.yaml
@@ -6,7 +6,7 @@ sdk: org.freedesktop.Sdk//20.08
 build-extension: true
 appstream-compose: false
 build-options: 
-  prefix: ${FLATPAK_DEST}
+  prefix: /app/packages/PyOpenGL/
   env:
     CPATH: :/app/packages/PyOpenGL/include
 modules:
@@ -33,9 +33,11 @@ modules:
   - name: PyOpenGL
     buildsystem: simple
     build-commands:
-      - pip3 install --no-index --find-links="file://${PWD}" --target=${FLATPAK_DEST}/python
+      - pip3 install --no-index --find-links="file://${PWD}" --target=/app/packages/PyOpenGL/python
         PyOpenGL
-      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
+    post-install:
+      - install -Dm644 --target=${FLATPAK_DEST}/share/metainfo/ com.jetbrains.PyCharm.Packages.PyOpenGL.metainfo.xml
+      - appstream-compose --basename=com.jetbrains.PyCharm.Packages.PyOpenGL --prefix=${FLATPAK_DEST} --origin=flatpak com.jetbrains.PyCharm.Packages.PyOpenGL
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/b8/73/31c8177f3d236e9a5424f7267659c70ccea604dab0585bfcd55828397746/PyOpenGL-3.1.5.tar.gz

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": "true"
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": "true"
+    "skip-icons-check": "true",
+    "only-arches": ["x86_64"]
 }

--- a/freeglut-3.2.1-gcc10_fix-1.patch
+++ b/freeglut-3.2.1-gcc10_fix-1.patch
@@ -1,0 +1,53 @@
+Submitted By:            Pierre Labastie <pierre dot labastie at neuf dot fr>
+Date:                    2020-05-19
+Initial Package Version: 3.2.1
+Upstream Status:         Committed
+Origin:                  Upstream https://sourceforge.net/p/freeglut/code/1863/
+Description:             Fixes "multiple defition" issues
+
+--- a/src/fg_gl2.c
++++ b/src/fg_gl2.c
+@@ -26,6 +26,20 @@
+ #include <GL/freeglut.h>
+ #include "fg_internal.h"
+ #include "fg_gl2.h"
++
++#ifndef GL_ES_VERSION_2_0
++/* GLES2 has the corresponding entry points built-in, and these fgh-prefixed
++ * names are defined in fg_gl2.h header to reference them, for any other case,
++ * define them as function pointers here.
++ */
++FGH_PFNGLGENBUFFERSPROC fghGenBuffers;
++FGH_PFNGLDELETEBUFFERSPROC fghDeleteBuffers;
++FGH_PFNGLBINDBUFFERPROC fghBindBuffer;
++FGH_PFNGLBUFFERDATAPROC fghBufferData;
++FGH_PFNGLENABLEVERTEXATTRIBARRAYPROC fghEnableVertexAttribArray;
++FGH_PFNGLDISABLEVERTEXATTRIBARRAYPROC fghDisableVertexAttribArray;
++FGH_PFNGLVERTEXATTRIBPOINTERPROC fghVertexAttribPointer;
++#endif
+ 
+ void FGAPIENTRY glutSetVertexAttribCoord3(GLint attrib) {
+   if (fgStructure.CurrentWindow != NULL)
+--- a/src/fg_gl2.h
++++ b/src/fg_gl2.h
+@@ -67,13 +67,13 @@
+ typedef void (APIENTRY *FGH_PFNGLDISABLEVERTEXATTRIBARRAYPROC) (GLuint);
+ typedef void (APIENTRY *FGH_PFNGLVERTEXATTRIBPOINTERPROC) (GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const GLvoid *pointer);
+ 
+-FGH_PFNGLGENBUFFERSPROC fghGenBuffers;
+-FGH_PFNGLDELETEBUFFERSPROC fghDeleteBuffers;
+-FGH_PFNGLBINDBUFFERPROC fghBindBuffer;
+-FGH_PFNGLBUFFERDATAPROC fghBufferData;
+-FGH_PFNGLENABLEVERTEXATTRIBARRAYPROC fghEnableVertexAttribArray;
+-FGH_PFNGLDISABLEVERTEXATTRIBARRAYPROC fghDisableVertexAttribArray;
+-FGH_PFNGLVERTEXATTRIBPOINTERPROC fghVertexAttribPointer;
++extern FGH_PFNGLGENBUFFERSPROC fghGenBuffers;
++extern FGH_PFNGLDELETEBUFFERSPROC fghDeleteBuffers;
++extern FGH_PFNGLBINDBUFFERPROC fghBindBuffer;
++extern FGH_PFNGLBUFFERDATAPROC fghBufferData;
++extern FGH_PFNGLENABLEVERTEXATTRIBARRAYPROC fghEnableVertexAttribArray;
++extern FGH_PFNGLDISABLEVERTEXATTRIBARRAYPROC fghDisableVertexAttribArray;
++extern FGH_PFNGLVERTEXATTRIBPOINTERPROC fghVertexAttribPointer;
+ 
+ #    endif
+ 


### PR DESCRIPTION
This Python module requires glew, glu, and glut and won't install well with regular pip in the sandbox as a consequence. This extension will solve this by installing the module and it's requirements.