### PR TITLE
Add org.gnome.Solanum

### DIFF
--- a/org.gnome.Solanum.json
+++ b/org.gnome.Solanum.json
@@ -1,0 +1,58 @@
+{
+    "app-id" : "org.gnome.Solanum",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.36",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "command" : "solanum",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/rust-stable/bin",
+        "env" : {
+            "CARGO_HOME" : "/run/build/solanum/cargo"
+        }
+    },
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "libhandy",
+            "buildsystem": "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://gitlab.gnome.org/GNOME/libhandy/-/archive/0.90.0/libhandy-0.90.0.tar.gz",
+                    "sha256": "3ba14c80ee808011b6e1cb78f3502b27ca761ada76d4ccee397252e26eaab368"
+                }
+            ]
+        },
+        {
+            "name" : "solanum",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://gitlab.gnome.org/BrainBlasted/Solanum/uploads/232919dc564d27c3d2cc9cb426a9e140/solanum-1.0.1.tar.xz",
+                    "sha256" : "a554f3b21415368bbd84b50eaeb9129209b190a4398a8bc5fcb44b64e8403d9e"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Solanum is an app that provides a pomodor timer for GNOME.