### PR TITLE
Add com.github.fwbuilder

### DIFF
--- a/com.github.fwbuilder.json
+++ b/com.github.fwbuilder.json
@@ -1,0 +1,42 @@
+{
+    "id": "com.github.fwbuilder",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.14",
+    "sdk": "org.kde.Sdk",
+    "command": "fwbuilder",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--filesystem=host",
+        "--device=dri",
+        "--socket=pulseaudio"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.a",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "fwbuilder",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [],
+            "sources": [
+                {
+                    "type": "git",
+                    "commit": "a5e14a966447c63bcf7b52a0202149e76bd5ed4a",
+                    "url": "https://github.com/fwbuilder/fwbuilder"
+                },
+                {
+                    "type": "patch",
+                    "path": "data-app-id.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/data-app-id.patch
+++ b/data-app-id.patch
@@ -1,0 +1,27 @@
+diff --git a/src/res/CMakeLists.txt b/src/res/CMakeLists.txt
+index 35830a23e..9bd9e1119 100644
+--- a/src/res/CMakeLists.txt
++++ b/src/res/CMakeLists.txt
+@@ -15,13 +15,13 @@ install(FILES ${help_files} DESTINATION ${FWB_INSTALL_DATADIR}/help/en_US)
+ install(DIRECTORY configlets DESTINATION ${FWB_INSTALL_DATADIR})
+ 
+ if (UNIX AND NOT APPLE)
+-    install(FILES fwbuilder.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+-    install(FILES Icons/16x16/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/16x16/apps)
+-    install(FILES Icons/24x24/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/24x24/apps)
+-    install(FILES Icons/32x32/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
+-    install(FILES Icons/48x48/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/48x48/apps)
+-    install(FILES Icons/72x72/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/72x72/apps)
+-    install(FILES Icons/128x128/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps)
+-    install(FILES Icons/256x256/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps)
+-    install(FILES Icons/512x512/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps)
++    install(FILES fwbuilder.desktop DESTINATION ${CMAKE_INSTALL_DATADIR}/applications RENAME com.github.fwbuilder.desktop)
++    install(FILES Icons/16x16/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/16x16/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/24x24/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/24x24/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/32x32/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/48x48/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/48x48/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/72x72/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/72x72/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/128x128/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/256x256/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps RENAME com.github.fwbuilder.png)
++    install(FILES Icons/512x512/fwbuilder.png DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps RENAME com.github.fwbuilder.png)
+ endif()


### PR DESCRIPTION
Building works but I was unable to get net-snmp optional dependency to build (linking error)

JSON with net-snmp:

```
{
    "id": "com.github.fwbuilder",
    "runtime": "org.kde.Platform",
    "runtime-version": "5.14",
    "sdk": "org.kde.Sdk",
    "command": "fwbuilder",
    "finish-args": [
        "--share=ipc",
        "--socket=x11",
        "--socket=wayland",
        "--filesystem=host",
        "--device=dri",
        "--socket=pulseaudio"
    ],
    "cleanup": [
        "/include",
        "/lib/pkgconfig",
        "/share/doc",
        "/share/man",
        "*.a",
        "*.la"
    ],
    "modules": [
        {
            "name": "net-snmp",
            "builddir": true,
            "config-opts": ["--disable-static", "--enable-shared"],
            "build-opts": ["-lncurses -ltinfo"],
            "sources": [
                {
                    "type": "git",
                    "commit": "c4d46f9f7b5b32bf1d6b61d09bdabaae4ff3cd7a",
                    "url": "https://github.com/net-snmp/net-snmp"
                }
            ]
        },
        {
            "name": "fwbuilder",
            "buildsystem": "cmake-ninja",
            "builddir": true,
            "config-opts": [],
            "sources": [
                {
                    "type": "git",
                    "commit": "a5e14a966447c63bcf7b52a0202149e76bd5ed4a",
                    "url": "https://github.com/fwbuilder/fwbuilder"
                },
                {
                    "type": "patch",
                    "path": "data-app-id.patch"
                }
            ]
        }
    ]
}
```
