### PR TITLE
Add org.gnome.Screenshot

### DIFF
--- a/metainfo.patch
+++ b/metainfo.patch
@@ -1,0 +1,20 @@
+diff -u /var/home/deathwish/src/flatpak/org.gnome.Screenshot/a/src/org.gnome.Screenshot.metainfo.xml.in /var/home/deathwish/src/flatpak/org.gnome.Screenshot/b/src/org.gnome.Screenshot.metainfo.xml.in
+--- a/src/org.gnome.Screenshot.metainfo.xml.in	2020-03-10 09:52:30.000000000 +0100
++++ b/src/org.gnome.Screenshot.metainfo.xml.in	2020-09-09 20:18:42.965479884 +0200
+@@ -27,7 +27,7 @@
+   <url type="donation">http://www.gnome.org/friends/</url>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://git.gnome.org/browse/gnome-screenshot/plain/src/gnome-screenshot.png</image>
++      <image>https://gitlab.gnome.org/GNOME/gnome-screenshot/-/raw/master/data/screenshots/gnome-screenshot-3.38-2.png</image>
+     </screenshot>
+   </screenshots>
+   <releases>
+@@ -46,4 +46,5 @@
+   <project_group>GNOME</project_group>
+   <compulsory_for_desktop>GNOME</compulsory_for_desktop>
+   <translation type="gettext">gnome-screenshot</translation>
++  <content_rating type="oars-1.0" />
+ </component>
+
+Diff finished.  Wed Sep  9 20:26:50 2020

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -21,10 +21,7 @@
         "/share/gtk-doc",
         "/include",
         "/lib/pkgconfig",
-        "/share/pkgconfig",
-        "/man",
-        "*.la",
-        "*.a"
+        "/man"
     ],
     "modules" : [
         {
@@ -34,11 +31,13 @@
                 "/lib/gnome-settings-daemon-3.0",
                 "/share/doc",
                 "/share/gdm",
-                "/share/gnome"
+                "/share/gnome",
+                "*.la"
             ],
             "config-opts" : [
                 "--disable-alsa",
                 "--disable-null",
+                "--disable-static",
                 "--disable-oss"
             ],
             "sources" : [

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -76,6 +76,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/gnome-screenshot/3.36/gnome-screenshot-3.36.0.tar.xz",
                     "sha256": "33495d892707179254b743f8f70c9a82cde5c5f2c7ea3db634a2ba7ea7331266"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "metainfo.patch"
                 }
             ]
         }

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -1,0 +1,83 @@
+{
+    "app-id" : "org.gnome.Screenshot",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.36",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "gnome-screenshot",
+    "x-run-args" : [
+        "--interactive"
+    ],
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--talk-name=org.gnome.Shell.Screenshot",
+        "--filesystem=home"
+    ],
+    "cleanup" : [
+        "/share/vala",
+        "/share/man",
+        "/share/gtk-doc",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/pkgconfig",
+        "/man",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "libcanberra-gtk3",
+            "cleanup" : [
+                "/bin",
+                "/lib/gnome-settings-daemon-3.0",
+                "/share/doc",
+                "/share/gdm",
+                "/share/gnome"
+            ],
+            "config-opts" : [
+                "--disable-alsa",
+                "--disable-null",
+                "--disable-oss"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+                    "sha256" : "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+                }
+            ]
+        },
+        {
+            "name" : "libhandy",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dexamples=false",
+                "-Dglade_catalog=disabled",
+                "-Dintrospection=disabled",
+                "-Dtests=false",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/libhandy/0.91/libhandy-0.91.0.tar.xz",
+                    "sha256": "cfc1c1cc272d6932ef253fbed07b69a655b33e7c49fb66806beedb7199128c86"
+                }
+            ]
+        },
+        {
+            "name" : "gnome-screenshot",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gnome-screenshot/3.36/gnome-screenshot-3.36.0.tar.xz",
+                    "sha256": "33495d892707179254b743f8f70c9a82cde5c5f2c7ea3db634a2ba7ea7331266"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.Screenshot.json
+++ b/org.gnome.Screenshot.json
@@ -62,15 +62,14 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libhandy/0.91/libhandy-0.91.0.tar.xz",
-                    "sha256": "cfc1c1cc272d6932ef253fbed07b69a655b33e7c49fb66806beedb7199128c86"
+                    "url": "https://download.gnome.org/sources/libhandy/1.0/libhandy-1.0.0.tar.xz",
+                    "sha256": "a9398582f47b7d729205d6eac0c068fef35aaf249fdd57eea3724f8518d26699"
                 }
             ]
         },
         {
             "name" : "gnome-screenshot",
             "buildsystem" : "meson",
-            "builddir" : true,
             "sources" : [
                 {
                     "type": "archive",


### PR DESCRIPTION
Please review the cleanups. I saw that most of them were actually removed by flatpak builder so they might be non-redundant. Using https://gitlab.gnome.org/GNOME/gnome-screenshot/-/blob/master/org.gnome.Screenshot.json as a base.