### PR TITLE
Add org.gnome.Boxes.Extension.OsinfoDb

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-icons-check": true
+}

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -9,6 +9,20 @@
     "appstream-compose" : false,
     "modules" : [
         {
+            "name" : "appdata",
+            "buildsystem" : "simple",
+            "build-commands" : [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml",
+                "appstream-compose --basename=org.gnome.Boxes.Extension.OsinfoDb --prefix=${FLATPAK_DEST} --origin=flatpak org.gnome.Boxes.Extension.OsinfoDb"
+            ],
+            "sources" : [
+                {
+                    "type" : "file",
+                    "path" : "org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml"
+                }
+            ]
+        },
+        {
             "name" : "osinfo-db",
             "buildsystem" : "simple",
             "builddir": true,

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -1,0 +1,27 @@
+{
+    "id" : "org.gnome.Boxes.Extension.OsinfoDb",
+    "branch" : "master",
+    "runtime" : "org.gnome.Boxes",
+    "runtime-version" : "stable",
+    "sdk" : "org.gnome.Sdk//3.36",
+    "build-extension" : true,
+    "separate-locales" : false,
+    "appstream-compose" : false,
+    "modules" : [
+        {
+            "name" : "osinfo-db",
+            "buildsystem" : "simple",
+            "builddir": true,
+            "build-commands" : [
+                "make",
+                "osinfo-db-import --dir /app/share/osinfo/ osinfo-db-*.tar.xz"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.com/libosinfo/osinfo-db.git"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -1,6 +1,5 @@
 {
     "id" : "org.gnome.Boxes.Extension.OsinfoDb",
-    "branch" : "master",
     "runtime" : "org.gnome.Boxes",
     "runtime-version" : "stable",
     "sdk" : "org.gnome.Sdk//3.38",

--- a/org.gnome.Boxes.Extension.OsinfoDb.json
+++ b/org.gnome.Boxes.Extension.OsinfoDb.json
@@ -3,7 +3,7 @@
     "branch" : "master",
     "runtime" : "org.gnome.Boxes",
     "runtime-version" : "stable",
-    "sdk" : "org.gnome.Sdk//3.36",
+    "sdk" : "org.gnome.Sdk//3.38",
     "build-extension" : true,
     "separate-locales" : false,
     "appstream-compose" : false,
@@ -33,7 +33,8 @@
             "sources" : [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.com/libosinfo/osinfo-db.git"
+                    "url" : "https://gitlab.com/libosinfo/osinfo-db.git",
+                    "branch" : "ad59de78615257cd8b9884df48f7e4ff398e538c"
                 }
             ]
         }

--- a/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
+++ b/org.gnome.Boxes.Extension.OsinfoDb.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.gnome.Boxes.Extension.OsinfoDb</id>
+  <extends>org.gnome.Boxes.desktop</extends>
+  <name>GNOME Boxes Osinfo DB</name>
+  <summary>Operating system database used by GNOME Boxes</summary>
+  <url type="homepage">https://libosinfo.org/</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <update_contact>felipeborges_AT_gnome.org</update_contact>
+</component>


### PR DESCRIPTION
This is a GNOME Boxes extension that will update the operating system's data that Boxes uses for setting up virtual machines.