### PR TITLE
Add Org.qgis.qgis-ltr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.flatpak-builder/
+repo/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Flatpak QGIS packaging
+
+Just flatpak packaging for QGIS.
+
+## I need more python modules!
+Often you will need extra python modules to run extra plugins. We can't possibly package them all with
+the application. To get them in your system, you can install them locally as follows:
+
+```
+flatpak run --command=pip3 org.qgis.qgis install scipy --user
+```
+
+Where `scipy` is the package you want, replace it with whatever you think it might be necessary.
+
+If you feel like it definitely should be bundled, don't hesitate to report an issue in this repository.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+## The LTR version of QGIS copied from https://github.com/flathub/org.qgis.qgis 
+The purpose of this repo is to maintain the LTR version of QGIS.
+
 # Flatpak QGIS packaging
 
 Just flatpak packaging for QGIS.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-## The LTR version of QGIS copied from https://github.com/flathub/org.qgis.qgis 
 The purpose of this repo is to maintain the LTR version of QGIS.
 
 # Flatpak QGIS packaging

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "only-arches": ["aarch64", "x86_64"],
+    "skip-appstream-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-    "only-arches": ["aarch64", "x86_64"],
-    "skip-appstream-check": true
+    "only-arches": ["aarch64", "x86_64"]
 }

--- a/org.qgis.qgis-ltr.json
+++ b/org.qgis.qgis-ltr.json
@@ -1,0 +1,614 @@
+{
+    "id" : "org.qgis.qgis-ltr",
+    "branch" : "stable",
+    "base": "io.qt.qtwebkit.BaseApp",
+    "base-version": "5.12",
+    "runtime" : "org.kde.Platform",
+    "runtime-version" : "5.12",
+    "sdk" : "org.kde.Sdk",
+    "command" : "qgis",
+    "rename-icon": "qgis",
+    "finish-args" : [
+        "--env=LD_LIBRARY_PATH=/app/lib:/app/grass76/lib",
+        "--share=ipc",
+        "--share=network",
+        "--socket=x11",
+        "--filesystem=host",
+        "--device=dri"
+    ],
+    "separate-locales" : false,
+    "build-options" : {
+        "env" : {
+            "PYTHONPATH" : "/app/lib/python3.7/site-packages:/usr/lib/python3.7/site-packages"
+        }
+    },
+    "modules" : [
+        {
+            "name" : "qgis",
+            "buildsystem" : "cmake-ninja",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/qgis/QGIS.git",
+                    "branch" : "final-3_10_9"
+                }
+            ],
+            "config-opts" : [
+                "-DWITH_3D=TRUE",
+                "-DGRASS_PREFIX7=/app/grass76",
+                "-DQWT_LIBRARY=/app/lib/libqwt.so"
+            ],
+            "modules" : [
+                {
+                    "name" : "proj",
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/OSGeo/PROJ.git",
+                            "branch" : "6.3.1"
+                        }
+                    ]
+                },
+                {
+                    "name" : "geos",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://download.osgeo.org/geos/geos-3.7.3.tar.bz2",
+                            "sha256" : "02035ae4e0ad711fa5a5556d7712530029edacac364b5b9c3ade0ded865fca7e"
+                        }
+                    ]
+                },
+                {
+                    "name" : "spatialindex",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://download.osgeo.org/libspatialindex/spatialindex-src-1.8.5.tar.bz2",
+                            "sha256" : "31ec0a9305c3bd6b4ad60a5261cba5402366dd7d1969a8846099717778e9a50a"
+                        }
+                    ]
+                },
+                {
+                    "name" : "spatialite",
+                    "config-opts" : [
+                        "--enable-libxml2",
+                        "CFLAGS=-DACCEPT_USE_OF_DEPRECATED_PROJ_API_H=1"
+                    ],
+                    "rm-configure": true,
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://www.gaia-gis.it/gaia-sins/libspatialite-sources/libspatialite-4.3.0a.tar.gz",
+                            "sha256" : "88900030a4762904a7880273f292e5e8ca6b15b7c6c3fb88ffa9e67ee8a5a499"
+                        },
+                        {
+                            "type": "script",
+                            "dest-filename": "autogen.sh",
+                            "commands": [
+                                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                            ]
+                        }
+                    ],
+                    "modules" : [
+                        {
+                            "name" : "freexl",
+                            "rm-configure": true,
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "http://www.gaia-gis.it/gaia-sins/freexl-sources/freexl-1.0.5.tar.gz",
+                                    "sha256" : "3dc9b150d218b0e280a3d6a41d93c1e45f4d7155829d75f1e5bf3e0b0de6750d"
+                                },
+                                {
+                                    "type": "script",
+                                    "dest-filename": "autogen.sh",
+                                    "commands": [
+                                        "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "postgresql",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://ftp.postgresql.org/pub/source/v12.2/postgresql-12.2.tar.bz2",
+                            "sha256" : "ad1dcc4c4fc500786b745635a9e1eba950195ce20b8913f50345bb7d5369b5de"
+                        }
+                    ]
+                },
+                {
+                    "name" : "gdal",
+                    "config-opts" : [
+                        "--with-python=python3"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://download.osgeo.org/gdal/3.0.4/gdal-3.0.4.tar.xz",
+                            "sha256" : "5569a4daa1abcbba47a9d535172fc335194d9214fdb96cd0f139bb57329ae277"
+                        }
+                    ],
+                    "modules" : [
+                        {
+                            "name" : "swig",
+                            "config-opts" : [
+                                "--without-boost",
+                                "--without-pcre",
+                                "--without-alllang",
+                                "--with-python3"
+                            ],
+                            "cleanup" : [
+                                "/bin",
+                                "/share/swig"
+                            ],
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "http://prdownloads.sourceforge.net/swig/swig-3.0.12.tar.gz",
+                                    "sha256" : "7cf9f447ae7ed1c51722efc45e7f14418d15d7a1e143ac9f09a668999f4fc94d"
+                                }
+                            ]
+                        },
+		        {
+			    "name" : "hdf5",
+		            "no-autogen" : true,
+			    "sources" : [
+			        {
+				    "type" : "archive",
+                    "url" : "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2",
+				    "sha256" : "09d6301901685201bb272a73e21c98f2bf7e044765107200b01089104a47c3bd"
+				}
+		            ]
+		        },
+		        {
+			    "name" : "netcdf",
+		            "no-autogen" : true,
+			    "sources" : [
+			        {
+			            "type" : "archive",
+				    "url" : "https://github.com/Unidata/netcdf-c/archive/v4.7.3.tar.gz",
+				    "sha256" : "05d064a2d55147b83feff3747bea13deb77bef390cb562df4f9f9f1ce147840d"
+			        }
+			    ]
+			}
+                    ]
+                },
+                {
+                    "name" : "qca",
+                    "buildsystem" : "cmake-ninja",
+                    "config-opts" : [
+                        "-DBUILD_TESTS=OFF",
+                        "-DQT4_BUILD=OFF",
+                        "-DQCA_SUFFIX=qt5"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://download.kde.org/stable/qca/2.2.1/qca-2.2.1.tar.xz",
+                            "sha256" : "d716d2d8e3ed8d95bbdb061f03081d7d032206f746a30a4d29d72196f50e7b02"
+                        }
+                    ]
+                },
+                {
+                    "name" : "qwt",
+                    "buildsystem" : "qmake",
+                    "config-opts" : [
+                        "-after",
+                        "QWT_INSTALL_PREFIX=/app"
+                    ],
+                    "cleanup" : [
+                        "/doc",
+                        "/features",
+                        "/plugins",
+                        "/include",
+                        "/lib/pkgconfig"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://sourceforge.net/projects/qwt/files/qwt/6.1.4/qwt-6.1.4.zip",
+                            "sha256" : "77a5d17972865a45ca2f77b16aecd4fc7d7f913f9c705530eb586de51079abaa"
+                        },
+                        {
+                            "type" : "shell",
+                            "commands" : [
+                                "sed 's/QWT_INSTALL_PREFIX\\s*=\\s*\\/usr\\/local\\/qwt-$$QWT_VERSION/QWT_INSTALL_PREFIX=\\/app/g' -i qwtconfig.pri",
+                                "sed 's/#QWT_CONFIG\\s*+=\\s*QwtPkgConfig/QWT_CONFIG+=QwtPkgConfig/g' -i qwtconfig.pri"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "libzip",
+                    "buildsystem": "cmake-ninja",
+                    "cleanup" : [
+                        "/bin",
+                        "/include",
+                        "/lib/pkgconfig",
+                        "/share/man",
+                        "/lib/*.la"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://libzip.org/download/libzip-1.6.1.tar.xz",
+                            "sha256" : "705dac7a671b3f440181481e607b0908129a9cf1ddfcba75d66436c0e7d33641"
+                        }
+                    ]
+                },
+                {
+                    "name" : "gsl",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://ftp.halifax.rwth-aachen.de/gnu/gsl/gsl-2.6.tar.gz",
+                            "sha256" : "b782339fc7a38fe17689cb39966c4d821236c28018b6593ddb6fd59ee40786a8"
+                        }
+                    ]
+                },
+                {
+                    "name" : "pyqt5",
+                    "config-opts" : [
+                        "--disable-static",
+                        "--enable-x11"
+                    ],
+                    "build-options":{
+                        "env":{
+                            "QMAKEPATH": "/app/lib"
+                        }
+                    },
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.11.3/PyQt5_gpl-5.11.3.zip",
+                            "sha256" : "7cacf0712d76a702e0e2102a65f411fd72e7f64a851a47a72c03fbafbe447aae"
+                        },
+                        {
+                            "type": "script",
+                            "commands": [
+                                "python3 configure.py --assume-shared --confirm-license --no-designer-plugin --no-qml-plugin --sysroot=/app --qsci-api --qsci-api-destdir=/app/qsci --sipdir=/app/share/sip --sip=/app/bin/sip --sip-incdir=/app/include QMAKE_CFLAGS_RELEASE='-I/usr/include/python3.7m/' QMAKE_CXXFLAGS_RELEASE='-I/usr/include/python3.7m/'"
+                            ],
+                            "dest-filename": "configure"
+                        }
+                    ],
+                    "modules" : [
+                        {
+                            "name" : "sip",
+                            "sources" : [
+                                {
+                                    "type" : "archive",
+                                    "url" : "https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.13/sip-4.19.13.tar.gz",
+                                    "sha256" : "e353a7056599bf5fbd5d3ff9842a6ab2ea3cf4e0304a0f925ec5862907c0d15e"
+                                },
+                                {
+                                    "type": "script",
+                                    "commands": [
+                                        "python3 configure.py --sip-module PyQt5.sip -b ${FLATPAK_DEST}/bin -d ${FLATPAK_DEST}/lib/python3.7/site-packages -e ${FLATPAK_DEST}/include -v ${FLATPAK_DEST}/share/sip --stubsdir=${FLATPAK_DEST}/lib/python3.7/site-packages"
+                                    ],
+                                    "dest-filename": "configure"
+                                }
+                            ],
+                            "cleanup" : [
+                                "/bin",
+                                "/include"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "qscintilla",
+                    "buildsystem" : "simple",
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://sourceforge.net/projects/pyqt/files/QScintilla2/QScintilla-2.10.8/QScintilla_gpl-2.10.8.tar.gz",
+                            "sha256" : "46cd5b4e609ca5e13130ba8cc7028d44fd1dc5b037f97c492899006ed0c992eb"
+                        }
+                    ],
+                    "build-commands" : [
+                        "sed -e 's|\\(target.path\\) = .*|\\1 = /app/lib|' -i Qt4Qt5/qscintilla.pro",
+                        "sed -e 's|\\(header.path\\) = .*|\\1 = /app/include|' -i Qt4Qt5/qscintilla.pro",
+                        "sed -e 's|\\(trans.path\\) = .*|\\1 = /app/share/qt5/translations|' -i Qt4Qt5/qscintilla.pro",
+                        "sed -e 's|\\(qsci.path\\) = .*|\\1 = /app/share/qt5|' -i Qt4Qt5/qscintilla.pro",
+                        "sed -e 's|\\(features.path\\) = .*|\\1 = /app/lib/qt5/mkspecs/features|' -i Qt4Qt5/qscintilla.pro",
+                        "sed -e \"s|qmake = {'CONFIG': 'qscintilla2'}|qmake = {'CONFIG': 'qscintilla2', 'QT': 'widgets printsupport'}|\" -i Python/configure.py",
+                        "cd Qt4Qt5 && qmake && make -j ${FLATPAK_BUILDER_N_JOBS:-`nproc`}",
+                        "cd Python && python3 configure.py --pyqt=PyQt5 -n ../Qt4Qt5/ -o ../Qt4Qt5/ --pyqt-sipdir=/app/share/sip --destdir=/app/lib/python3.7/site-packages/PyQt5 --apidir=/app/qsci/api/python --no-stubs --no-dist-info && make -j ${FLATPAK_BUILDER_N_JOBS:-`nproc`} && make install",
+                        "cd Qt4Qt5 && make install"
+                    ]
+                },
+                {
+                    "name" : "qtkeychain",
+                    "buildsystem" : "cmake-ninja",
+                    "config-opts" : [
+                        "-DCMAKE_INSTALL_LIBDIR=/app/lib",
+                        "-DLIB_INSTALL_DIR=/app/lib",
+                        "-DBUILD_TRANSLATIONS=NO"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://github.com/frankosterfeld/qtkeychain/archive/v0.10.0.tar.gz",
+                            "sha256" : "5f916cd97843de550467db32d2e10f218b904af5b21cfdfcc7c6425d7dfc3ec2"
+                        }
+                    ]
+                },
+                {
+                    "name": "python-six",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} six"
+                    ],
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "https://pypi.python.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz",
+                            "sha256": "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+                        }
+                    ]
+                },
+                {
+                    "name": "python-future",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} future"
+                    ],
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "https://files.pythonhosted.org/packages/00/2b/8d082ddfed935f3608cc61140df6dcbf0edea1bc3ab52fb6c29ae3e81e85/future-0.16.0.tar.gz",
+                            "sha256": "e39ced1ab767b5936646cedba8bcce582398233d6a627067d4c6a454c90cfedb"
+                        }
+                    ]
+                },
+                {
+                    "name" : "python-owslib",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "pip3 install --prefix=/app python_dateutil-2.6.1-py2.py3-none-any.whl",
+                        "pip3 install --prefix=/app pytz-2018.4-py2.py3-none-any.whl",
+                        "pip3 install --prefix=/app requests-2.14.2-py2.py3-none-any.whl",
+                        "pip3 install --prefix=/app pyproj-1.9.6.tar.gz",
+                        "pip3 install --prefix=/app OWSLib-0.16.0.tar.gz"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "file",
+                            "url" : "https://pypi.python.org/packages/4b/0d/7ed381ab4fe80b8ebf34411d14f253e1cf3e56e2820ffa1d8844b23859a2/python_dateutil-2.6.1-py2.py3-none-any.whl",
+                            "sha256" : "95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c"
+                        },
+                        {
+                            "type" : "file",
+                            "url" : "https://files.pythonhosted.org/packages/dc/83/15f7833b70d3e067ca91467ca245bae0f6fe56ddc7451aa0dc5606b120f2/pytz-2018.4-py2.py3-none-any.whl",
+                            "sha256" : "65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555"
+                        },
+                        {
+                            "type" : "file",
+                            "url" : "https://pypi.python.org/packages/e4/b0/286e8a936158e5cc5791d5fa3bc4b1d5a7e1ff4e5b3f3766b63d8e97708a/requests-2.14.2-py2.py3-none-any.whl",
+                            "sha256" : "3b39cde35be51762885631cf586f4dc2284951b44d479a4454020758d767cc2f"
+                        },
+                        {
+                            "type" : "file",
+                            "url" : "https://files.pythonhosted.org/packages/26/8c/1da0580f334718e04f8bbf74f0515a7fb8185ff96b2560ce080c11aa145b/pyproj-1.9.6.tar.gz",
+                            "sha256" : "e0c02b1554b20c710d16d673817b2a89ff94738b0b537aead8ecb2edc4c4487b"
+                        },
+                        {
+                            "type" : "file",
+                            "url" : "https://files.pythonhosted.org/packages/ac/71/ff2fbfa64fca17069ce30fac324533aa686c5cb64e6b5f522faed558848f/OWSLib-0.16.0.tar.gz",
+                            "sha256" : "ec95a5e93c145a5d84b0074b9ea27570943486552a669151140debf08a100554"
+                        }
+                    ]
+                },
+                {
+                    "name" : "python-psycopg2",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "python3 setup.py build",
+                        "python3 setup.py install --prefix=/app --root=/ --optimize=1"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "http://initd.org/psycopg/tarballs/PSYCOPG-2-7/psycopg2-2.7.5.tar.gz",
+                            "sha256" : "eccf962d41ca46e6326b97c8fe0a6687b58dfc1a5f6540ed071ff1474cea749e"
+                        }
+                    ]
+                },
+                {
+                    "name" : "gisgrass",
+                    "cleanup" : [
+                        "/include",
+                        "/lib/pkgconfig",
+                        "/share/man",
+                        "/lib/*.la"
+                    ],
+                    "config-opts" : [
+                        "--prefix=/app",
+                        "--with-freetype-includes=/usr/include/freetype2",
+                        "--with-readline",
+                        "--with-pthread",
+                        "--with-nls",
+                        "--with-geos",
+                        "--with-sqlite=yes",
+                        "--with-python=yes",
+                        "--with-postgres"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://grass.osgeo.org/grass76/source/grass-7.6.1.tar.gz",
+                            "sha256" : "9e25c99cafd16ed8f5e2dca75b5a10dc2af0568dbedf3fc39f1c5a0a9c840b0b"
+                        }
+                    ],
+                    "modules": [
+                        "shared-modules/glu/glu-9.0.0.json"
+                    ]
+                },
+                {
+                    "name" : "saga-gis",
+                    "subdir": "saga-gis",
+                    "config-opts": [
+                        "--enable-python",
+                        "--disable-odbc"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "git://git.code.sf.net/p/saga-gis/code",
+                            "branch" : "release-7.5.0"
+                        },
+                        {
+                            "type": "patch",
+                            "path": "patches/saga-gis.patch"
+                        },
+                        {
+                            "type": "script",
+                            "dest-filename": "saga-gis/autogen.sh",
+                            "commands": [
+                                "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                            ]
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "name": "wxWidgets",
+                            "cleanup": [
+                                "/bin",
+                                "/share/bakefile"
+                            ],
+                            "config-opts": [
+                                "--with-opengl",
+                                "--with-libjpeg",
+                                "--with-libtiff",
+                                "--with-libpng",
+                                "--with-zlib",
+                                "--disable-sdltest",
+                                "--enable-unicode",
+                                "--enable-display",
+                                "--enable-propgrid",
+                                "--disable-webkit",
+                                "--disable-webview",
+                                "--disable-webviewwebkit",
+                                "--with-expat=builtin",
+                                "--with-libiconv=/usr" ],
+                            "build-options" : {
+                                "cxxflags":"-std=c++0x"
+                            },
+                            "sources": [
+                                {
+                                    "type": "archive",
+                                    "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2",
+                                    "sha256":"fffc1d34dac54ff7008df327907984b156c50cff5a2f36ee3da6052744ab554a"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name" : "PyYAML",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "python3 setup.py install --prefix=/app --root=/"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://pypi.python.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz#md5=4c129761b661d181ebf7ff4eb2d79950",
+                            "sha256" : "592766c6303207a20efc445587778322d7f73b161bd994f227adaa341ba212ab"
+                        }
+                    ]
+                },
+                {
+                    "name": "numpy",
+                    "buildsystem": "simple",
+                    "sources": [
+                            {
+                                "type": "archive",
+                                "url": "https://github.com/numpy/numpy/releases/download/v1.14.3/numpy-1.14.3.tar.gz",
+                                "sha256": "cfcfc7a9a8ba4275c60a815c683d59ac5e7aa9362d76573b6cc4324ffb1235fa"
+                            }
+                    ],
+                    "build-commands": [
+                        "python3 setup.py build",
+                        "python3 setup.py install --prefix /app"
+                    ]
+                },
+                {
+                    "name" : "python3-markupsafe",
+                    "buildsystem" : "simple",
+                    "ensure-writable" : [
+                        "/lib/python*/site-packages/easy-install.pth"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "archive",
+                            "url" : "https://pypi.python.org/packages/4d/de/32d741db316d8fdb7680822dd37001ef7a448255de9699ab4bfcbdf4172b/MarkupSafe-1.0.tar.gz",
+                            "sha256" : "a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+                        }
+                    ],
+                    "build-commands" : [
+                        "python3 setup.py build",
+                        "python3 setup.py install --prefix /app"
+                    ]
+                },
+                {
+                    "name" : "python3-jinja2",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "pip3 install --prefix=/app Jinja2-2.9.5-py2.py3-none-any.whl"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "file",
+                            "url" : "https://pypi.python.org/packages/3c/d1/49d69bc23d0e0c7612248dd8f5391bd043648865132309616c280ca1c837/Jinja2-2.9.5-py2.py3-none-any.whl",
+                            "sha256" : "a7b7438120dbe76a8e735ef7eba6048eaf4e0b7dbc530e100812f8ec462a4d50"
+                        }
+                    ]
+                },
+                {
+                    "name" : "python3-pygments",
+                    "buildsystem" : "simple",
+                    "build-commands" : [
+                        "pip3.7 install --prefix=/app Pygments-2.2.0-py2.py3-none-any.whl"
+                    ],
+                    "sources" : [
+                        {
+                            "type" : "file",
+                            "url" : "https://pypi.python.org/packages/02/ee/b6e02dc6529e82b75bb06823ff7d005b141037cb1416b10c6f00fc419dca/Pygments-2.2.0-py2.py3-none-any.whl",
+                            "sha256" : "78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d"
+                        }
+                    ]
+                },
+                {
+                    "name": "exiv2",
+                    "cleanup": [ "/bin" ],
+                    "buildsystem": "cmake-ninja",
+                    "config-opts" : [
+                        "-DCMAKE_BUILD_TYPE=Release",
+                        "-DEXIV2_BUILD_EXIV2_COMMAND=OFF",
+                        "-DEXIV2_BUILD_SAMPLES=OFF"
+                    ],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/Exiv2/exiv2/",
+                            "branch" : "0.27"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "env-python",
+            "buildsystem": "simple",
+            "build-commands": [
+                "ln -s /usr/bin/python3 /app/bin/python"
+            ]
+        }
+    ]
+}

--- a/org.qgis.qgis-ltr.json
+++ b/org.qgis.qgis-ltr.json
@@ -446,7 +446,7 @@
                         }
                     ],
                     "modules": [
-                        "shared-modules/glu/glu-9.0.0.json"
+                        "shared-modules/glu/glu-9.json"
                     ]
                 },
                 {

--- a/patches/saga-gis.patch
+++ b/patches/saga-gis.patch
@@ -1,0 +1,13 @@
+diff --git a/saga-gis/src/tools/io/io_gdal/MLB_Interface.cpp b/saga-gis/src/tools/io/io_gdal/MLB_Interface.cpp
+index 9464d086e..270ac6ce2 100644
+--- a/saga-gis/src/tools/io/io_gdal/MLB_Interface.cpp
++++ b/saga-gis/src/tools/io/io_gdal/MLB_Interface.cpp
+@@ -139,7 +139,7 @@ CSG_Tool *		Create_Tool(int i)
+ 	case  9:	return( new CGDAL_Import_WMS );
+ 	case 11:	return( new CGDAL_Import_ASTER );
+ 
+-	#ifdef USE_GDAL_V2
++	#ifdef GDAL_V2_1_OR_NEWER
+ 	case 12:	return( new CGDAL_BuildVRT );
+ 	#endif
+ 	case 13:	return( new CGDAL_Import_VRT );


### PR DESCRIPTION
The Org.qgis.qgis contains the latest version of QGIS. This version is not a "production" environment for GIS projects. Purpose of this repo is to add the latest stable LTR version of QGIS. For example in Arch linux there are qgis and qgis-ltr packages - https://www.archlinux.org/packages/community/x86_64/qgis/  and https://aur.archlinux.org/packages/qgis-ltr/?O=20&PP=10