### PR TITLE
Add io.github.antimicrox.antimicrox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+repo/
+.flatpak-builder/

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -1,0 +1,24 @@
+app-id: io.github.antimicrox.antimicrox
+runtime: org.kde.Platform
+runtime-version: '5.11'
+sdk: org.kde.Sdk
+command: antimicrox
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=x11
+  - --device=dri
+  # Gamepads
+  - --device=all
+
+
+modules:
+  - name: antimicrox
+    buildsystem: cmake
+    post-install:
+      - gtk-update-icon-cache --force --ignore-theme-index "${FLATPAK_DEST}/share/antimicrox/icons/hicolor"
+    sources:
+      - type: git
+        url: https://github.com/AntiMicroX/antimicrox.git
+        tag: 3.1
+        commit: 58cbb66bb4e079ca3e08de991ebed6a51d755426

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -7,7 +7,6 @@ finish-args:
   # X11 + XShm access
   - --share=ipc
   - --socket=x11
-  - --device=dri
   # Gamepads
   - --device=all
 

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -20,5 +20,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/AntiMicroX/antimicrox.git
-        tag: 3.1
-        commit: 58cbb66bb4e079ca3e08de991ebed6a51d755426
+        branch: 128x128-icon
+        commit: c01c8451f6d5d35f497533b814d404cdf889b27c

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -1,6 +1,6 @@
 app-id: io.github.antimicrox.antimicrox
 runtime: org.kde.Platform
-runtime-version: '5.11'
+runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: antimicrox
 finish-args:

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -20,5 +20,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/AntiMicroX/antimicrox.git
-        branch: 128x128-icon
-        commit: af7577fea8f8998c8560e467d52c4ae9c032bdcb
+        branch: master
+        commit: b97ffc7e93b4cd8028464c7894852bf63015a8f5

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -20,5 +20,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/AntiMicroX/antimicrox.git
-        branch: master
-        commit: b97ffc7e93b4cd8028464c7894852bf63015a8f5
+        tag: 3.1.1
+        commit: 298fb960b710985649900c87f6389fc389f67d1e

--- a/io.github.antimicrox.antimicrox.yml
+++ b/io.github.antimicrox.antimicrox.yml
@@ -21,4 +21,4 @@ modules:
       - type: git
         url: https://github.com/AntiMicroX/antimicrox.git
         branch: 128x128-icon
-        commit: c01c8451f6d5d35f497533b814d404cdf889b27c
+        commit: af7577fea8f8998c8560e467d52c4ae9c032bdcb


### PR DESCRIPTION
Needs `--device=all` to access various gamepads.
Tested functionality, appears to be working fine.
Needs a `gtk-update-icon-cache` postinstall to be able and show icons inside the app.