### PR TITLE
Add com.github.fontmatrix.Fontmatrix

### DIFF
--- a/com.github.fontmatrix.Fontmatrix.appdata.xml
+++ b/com.github.fontmatrix.Fontmatrix.appdata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2020 Fontmatrix developers -->
+<component type="desktop">
+ <id>com.github.fontmatrix.Fontmatrix</id>
+ <metadata_license>CC0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Fontmatrix</name>
+ <summary>A a font management application</summary>
+ <description>
+   <p>Fontmatrix is a font management application for Linux, macOS, and Windows.</p>
+   <p>It helps keeping your font collection in order, allowing you to
+   enable and disable availability of fonts and font families in your
+   system. This is typically in demand by designers who tend to have
+   huge collections of typefaces.</p>
+ </description>
+ <content_rating type="oars-1.1" />
+ <launchable type="desktop-id">com.github.fontmatrix.Fontmatrix.desktop</launchable>
+ <translation type="qt">fontmatrix</translation>
+ <screenshots>
+  <screenshot type="default">
+   <image>https://raw.githubusercontent.com/fontmatrix/fontmatrix/v0.9.100/screenshot.png</image>
+   <caption>The main Fontmatrix window</caption>
+  </screenshot>
+ </screenshots>
+ <update_contact>undertype-users_AT_gna.org</update_contact>
+ <url type="homepage">https://github.com/fontmatrix/fontmatrix</url>
+ <url type="bugtracker">https://github.com/fontmatrix/fontmatrix/issues</url>
+ <releases>
+   <release version="0.9.100" date="2020-09-15" />
+ </releases>
+</component>

--- a/com.github.fontmatrix.Fontmatrix.json
+++ b/com.github.fontmatrix.Fontmatrix.json
@@ -1,0 +1,47 @@
+{
+    "id": "com.github.fontmatrix.Fontmatrix",
+    "runtime": "org.kde.Platform",
+    "base": "io.qt.qtwebkit.BaseApp",
+    "base-version": "5.14",
+    "sdk": "org.kde.Sdk//5.14",
+    "runtime-version": "5.14",
+    "rename-icon": "fontmatrix",
+    "rename-desktop-file": "fontmatrix.desktop",
+    "command": "fontmatrix",
+    "finish-args": [
+        /* X11 + XShm access */
+        "--share=ipc",
+        "--socket=x11",
+        "--device=dri",
+        "--env=QT_QPA_PLATFORM=xcb",
+        "--env=QT_AUTO_SCREEN_SCALE_FACTOR=1",
+        "--env=TMPDIR=/var/tmp"
+    ],
+    "cleanup": [
+        "/share/man"
+    ],
+    "cleanup-commands": [
+        "/app/cleanup-BaseApp.sh"
+    ],
+    "modules": [
+        {
+            "name": "fontmatrix",
+            "buildsystem": "cmake-ninja",
+            "post-install": [
+                "install -Dm644 -t /app/share/metainfo com.github.fontmatrix.Fontmatrix.appdata.xml",
+                "install -Dm644 -t /app/share/license/fontmatrix COPYING AUTHORS"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/fontmatrix/fontmatrix/archive/v0.9.100.tar.gz",
+                    "sha256": "241021e24b0e2cdbc4bdf516d41ddfd23675a5a098bdaa0f7564d866cd292659"
+                },
+                {
+                    "type": "file",
+                    "path": "com.github.fontmatrix.Fontmatrix.appdata.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-    "skip-icons-check": true
+    "skip-icons-check": true,
+    "only-arches": ["aarch64", "x86_64"]
 }


### PR DESCRIPTION
I use KDE 5.14 runtime as there is no qtwebkit base app for 5.15. (unless I can use qtwebengine which I haven't tried).

Notified upstream:
https://github.com/fontmatrix/fontmatrix/issues/28

It's considered maitenance mode (but useful).