### PR TITLE
DOSBox-X flatpak support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -8,7 +8,7 @@ command: dosbox-x
 finish-args:	# flatpak permissions
   - --device=all	# needed for gamepads and serial/parallel
   - --share=ipc	        # needed for X11
-  - --share=network	# needed for networking (NE2000, IPX)
+  - --share=network	# needed for networking (IPX)
   - --socket=x11
   - --socket=pulseaudio
   - --filesystem=home
@@ -29,17 +29,6 @@ modules:
   
 # Build FluidSynth
   - "shared-modules/linux-audio/fluidsynth2.json"
-
-# Build libpcap for NE2000 (and run setcap at the end)
-  - name: libpcap
-    cleanup:
-      - "/include"
-      - "/share"
-      - "/lib/pkgconfig"
-    sources:
-      - type: archive
-        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
-        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
 
 # Build DOSBox-X SDL2
   - name: dosbox-x

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -1,0 +1,61 @@
+app-id: com.dosbox_x.DOSBox-X
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+
+command: dosbox-x
+
+finish-args:	# flatpak permissions
+  - --device=all	# needed for gamepads and serial/parallel
+  - --share=ipc	        # needed for X11
+  - --share=network	# needed for networking (NE2000, IPX)
+  - --socket=x11
+  - --nosocket=wayland  # not compatible with wayland at this point
+  - --socket=pulseaudio
+  - --filesystem=home
+
+cleanup:
+  - '/include'
+  - '/lib/pkgconfig'
+  - '/share/aclocal'
+  - '/share/man'
+  - '*.la'
+  - '*.a'
+  - '/share/doc'
+
+modules:
+
+# Build Mesa GLU
+  - "shared-modules/glu/glu-9.json"
+  
+# Build FluidSynth
+  - "shared-modules/linux-audio/fluidsynth2.json"
+
+# Build libpcap for NE2000 (and run setcap at the end)
+  - name: libpcap
+    cleanup:
+      - "/include"
+      - "/share"
+      - "/lib/pkgconfig"
+    sources:
+      - type: archive
+        url: https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz
+        sha256: 635237637c5b619bcceba91900666b64d56ecb7be63f298f601ec786ce087094
+
+# Build DOSBox-X SDL2
+  - name: dosbox-x
+    config-opts:
+      - --enable-core-inline
+      - --enable-debug=heavy
+      - --enable-sdl2
+    sources:
+      - type: archive
+        url: https://github.com/joncampbell123/dosbox-x/archive/dosbox-x-v0.83.6.tar.gz
+        sha256: 874450dd6f879376ce803984f7614b0edf4eb9d04117c9a88cbb3d60ce69abf0
+    make-args:
+       - -j3
+    post-install:
+      - install -Dm644 /app/share/applications/dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 /app/share/metainfo/dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - sed -i s/Icon=.*/Icon=${FLATPAK_ID}/ /app/share/applications/${FLATPAK_ID}.desktop

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -58,5 +58,4 @@ modules:
       - install -Dm644 /app/share/applications/dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 /app/share/metainfo/dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-        #      - sed -i s/Icon=.*/Icon=${FLATPAK_ID}/ /app/share/applications/${FLATPAK_ID}.desktop
       - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -5,10 +5,10 @@ sdk: org.freedesktop.Sdk
 
 command: dosbox-x
 
-finish-args:	# flatpak permissions
-  - --device=all	# needed for gamepads and serial/parallel
-  - --share=ipc	        # needed for X11
-  - --share=network	# needed for networking (IPX)
+finish-args: # flatpak permissions
+  - --device=all # needed for gamepads and serial/parallel
+  - --share=ipc  # needed for X11
+  - --share=network # needed for networking (IPX)
   - --socket=x11
   - --socket=pulseaudio
   - --filesystem=home

--- a/com.dosbox_x.DOSBox-X.yaml
+++ b/com.dosbox_x.DOSBox-X.yaml
@@ -58,4 +58,5 @@ modules:
       - install -Dm644 /app/share/applications/dosbox-x.desktop /app/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 /app/share/icons/hicolor/scalable/apps/dosbox-x.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
       - install -Dm644 /app/share/metainfo/dosbox-x.metainfo.xml /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
-      - sed -i s/Icon=.*/Icon=${FLATPAK_ID}/ /app/share/applications/${FLATPAK_ID}.desktop
+        #      - sed -i s/Icon=.*/Icon=${FLATPAK_ID}/ /app/share/applications/${FLATPAK_ID}.desktop
+      - desktop-file-edit --set-key=Icon --set-value=${FLATPAK_ID} /app/share/applications/${FLATPAK_ID}.desktop


### PR DESCRIPTION
Flatpak support for the DOSBox-X project, which is a greatly enhanced DOSBox fork.
https://github.com/joncampbell123/dosbox-x

The main developer of DOSBox-X is @joncampbell123 and the largest contributor is @Wengier please add them to this project such that they can make updates.

I have one issue that I don't know how to solve, or if it is even possible. DOSBox-X supports optional NE2000 network emulation, and uses libpcap for that purpose. However for that to work the user needs to have either root permissions, or what we normally suggest is to use setcap to give the necessary permissions to the dosbox-x binary.

e.g.
``setcap cap_net_raw=ep dosbox-x``

This obviously fails as it requires root permissions. I don't know if there is perhaps a solution using polkit?