### PR TITLE
add com.hack_computer.Sidetrack

### DIFF
--- a/com.hack_computer.Sidetrack.json
+++ b/com.hack_computer.Sidetrack.json
@@ -2,7 +2,7 @@
   "app-id": "com.hack_computer.Sidetrack",
   "add-extensions": {
       "com.hack_computer.Clippy.Extension": {
-          "version": "stable",
+          "version": "beta",
           "directory": "clippy",
           "no-autodownload": false,
           "autodelete": true

--- a/com.hack_computer.Sidetrack.json
+++ b/com.hack_computer.Sidetrack.json
@@ -46,7 +46,7 @@
         {
           "type": "git",
           "url": "https://github.com/endlessm/hack-toy-apps.git",
-          "commit": "6c6c141aa96a469928da3b393f454ff3abf081af",
+          "commit": "b416928be0a471f2289d561931d5a93cef4fa7fe",
           "branch": "master"
         }
       ]

--- a/com.hack_computer.Sidetrack.json
+++ b/com.hack_computer.Sidetrack.json
@@ -1,0 +1,55 @@
+{
+  "app-id": "com.hack_computer.Sidetrack",
+  "add-extensions": {
+      "com.hack_computer.Clippy.Extension": {
+          "version": "stable",
+          "directory": "clippy",
+          "no-autodownload": false,
+          "autodelete": true
+      }
+  },
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.36",
+  "sdk": "org.gnome.Sdk",
+  "command": "com.hack_computer.Sidetrack",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--device=dri",
+    "--own-name=com.hack_computer.Sidetrack",
+    "--env=GTK3_MODULES=/app/clippy/lib/libclippy-module.so",
+    "--talk-name=com.hack_computer.Clubhouse",
+    "--talk-name=com.hack_computer.GameStateService",
+    "--talk-name=com.hack_computer.HackSoundServer",
+    "--talk-name=org.gnome.Shell",
+    "--talk-name=com.hack_computer.HackableAppsManager",
+    "--talk-name=com.hack_computer.hack"
+  ],
+  "modules": [
+    {
+      "name": "clippy-ext",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir /app/clippy"
+      ],
+      "sources": []
+    },
+    {
+      "name": "toyapp",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dapp-id=com.hack_computer.Sidetrack"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/endlessm/hack-toy-apps.git",
+          "commit": "6c6c141aa96a469928da3b393f454ff3abf081af",
+          "branch": "master"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Please, merge into `beta` branch. I don't want to go directly to the `stable` repository when this app gets approved, lets move to `beta` at first if it's possible, because we want to test a bit the flathub version before we do the real release for the final user.

This application is part of the "hack experience" that we developed for the [hack computer](https://www.hack-computer.com/) project.

As part of the new [EndlessOS foundation](https://endlessos.com/) goal, we're trying to release and publish "Hack" to make it possible to use outside of Endless.

This PR includes the Sidetrack application. This application is a simple educative game to teach kids some basic programming concepts. The app works alone like a normal game and you can play up to level 14. In combination with the `com.hack_computer.Clubhouse` application and sidetrack quests, the user can go further and explore more levels, flip the app and **hack** the game to learn the basic concepts of instructions, planning and debugging.