### PR TITLE
Package for "com.github.marinm.songrec"

### DIFF
--- a/com.github.marinm.songrec.json
+++ b/com.github.marinm.songrec.json
@@ -15,8 +15,7 @@
         "--device=dri",
         "--filesystem=host:ro",
         "--filesystem=/tmp:ro",
-        "--filesystem=xdg-config",
-        "--filesystem=xdg-cache",
+        "--filesystem=xdg-data",
         "--socket=pulseaudio"
     ],
     "build-options": {

--- a/com.github.marinm.songrec.json
+++ b/com.github.marinm.songrec.json
@@ -15,7 +15,6 @@
         "--device=dri",
         "--filesystem=host:ro",
         "--filesystem=/tmp:ro",
-        "--filesystem=xdg-data",
         "--socket=pulseaudio"
     ],
     "build-options": {

--- a/com.github.marinm.songrec.json
+++ b/com.github.marinm.songrec.json
@@ -1,0 +1,47 @@
+{
+    "app-id": "com.github.marinm.songrec",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "20.08",
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "command": "songrec",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host:ro",
+        "--filesystem=/tmp:ro",
+        "--filesystem=xdg-config",
+        "--filesystem=xdg-cache",
+        "--socket=pulseaudio"
+    ],
+    "build-options": {
+        "append-path" : "/usr/lib/sdk/rust-stable/bin",
+        "env" : {
+            "CARGO_HOME" : "/run/build/songrec/.cargo"
+        }
+    },
+    "modules": [
+        {
+            "name": "rust-flatpak",
+            "buildsystem": "simple",
+            "build-commands": [
+                "cargo --offline fetch --verbose",
+                "cargo --offline build --release --verbose",
+                "install -Dm755 ./target/release/songrec -t /app/bin/",
+                "cp -ra ./packaging/rootfs/usr/share /app/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/marin-m/SongRec/releases/download/0.1.1/songrec_tarball_0.1.1_for_flathub_build.tar.gz",
+                    "sha256": "c57c4c9fde94e54a7791a6e8a9964399f5b7ca2cd0552b1ad2f1e485202dfb50"
+                }
+            ]
+        }
+    ]
+}

--- a/com.github.marinm.songrec.json
+++ b/com.github.marinm.songrec.json
@@ -13,8 +13,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
-        "--filesystem=host:ro",
-        "--filesystem=/tmp:ro",
+        "--filesystem=home:ro",
         "--socket=pulseaudio"
     ],
     "build-options": {
@@ -36,8 +35,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/marin-m/SongRec/releases/download/0.1.1/songrec_tarball_0.1.1_for_flathub_build.tar.gz",
-                    "sha256": "c57c4c9fde94e54a7791a6e8a9964399f5b7ca2cd0552b1ad2f1e485202dfb50"
+                    "url": "https://github.com/marin-m/SongRec/releases/download/0.1.2/songrec_tarball_0.1.2_for_flathub_build.tar.gz",
+                    "sha256": "ff1f20b223ba49182a95e19b1e4b6cbc43e93a4b9004eb4e22f2cf4314ea52fb"
                 }
             ]
         }

--- a/com.github.marinm.songrec.json
+++ b/com.github.marinm.songrec.json
@@ -27,7 +27,7 @@
     },
     "modules": [
         {
-            "name": "rust-flatpak",
+            "name": "songrec",
             "buildsystem": "simple",
             "build-commands": [
                 "cargo --offline fetch --verbose",


### PR DESCRIPTION
Hello,

This is the pull request for the Flatpak package of [SongRec](https://github.com/marin-m/SongRec), a graphical Shazam client I wrote.

It was recently featured on a few Linux-related news websites:

* https://www.linuxuprising.com/2020/10/identify-songs-on-your-linux-desktop.html
* http://www.tuxmachines.org/node/143523
* https://gnulinux.ch/songrec-ein-freier-shazam-client

The tarball downloaded by the Flatpak manifest was generated using this script: [`generate_dist_tarball_for_flathub.sh`](https://github.com/marin-m/SongRec/blob/872553e/packaging/flatpak/generate_dist_tarball_for_flathub.sh)