### PR TITLE
Add  org.desmume.DeSmuME

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/org.desmume.DeSmuME.json
+++ b/org.desmume.DeSmuME.json
@@ -1,0 +1,53 @@
+{
+    "app-id": "org.desmume.DeSmuME",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "20.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "desmume",
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "/bin/pcap-config",
+        "/include",
+        "/lib/libpcap.a",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    "modules": [
+        "shared-modules/SDL/SDL-1.2.15.json",
+        {
+            "name": "pcap",
+            "buildsystem": "autotools",
+            "config-opts": [
+                "--disable-shared",
+                "--disable-dbus"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.tcpdump.org/release/libpcap-1.9.1.tar.gz",
+                    "sha512": "ae0d6b0ad8253e7e059336c0f4ed3850d20d7d2f4dc1d942c2951f99a5443a690f0cc42c6f8fdc4a0ccb19e9e985192ba6f399c4bde2c7076e420f547fddfb08"
+                }
+            ]
+        },
+        {
+            "name": "desmume",
+            "buildsystem": "meson",
+            "subdir": "desmume/src/frontend/posix/",
+            "config-opts": [
+                "-Dfrontend-cli=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/TASVideos/desmume",
+                    "commit": "25d71947796144a0a72bbd25818e447102dd1a3c"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
DeSmuME is a [Nintendo DS](https://en.wikipedia.org/wiki/Nintendo_DS) [emulator](https://en.wikipedia.org/wiki/Emulator) written in C++ using GTK.

DeSmuME hasn’t seen a release [since 2015-04-15](http://desmume.org/2015/04/15/desmume-0-9-11-released/) but has been progressing a lot in master since then, hence the `git` source. The maintainer would prefer not to do a release ever again.