### PR TITLE
Initial System app

### DIFF
--- a/com.hack_computer.OperatingSystemApp.json
+++ b/com.hack_computer.OperatingSystemApp.json
@@ -13,12 +13,10 @@
   "sdk": "org.gnome.Sdk",
   "command": "com.hack_computer.OperatingSystemApp",
   "finish-args": [
-    "--share=ipc",
     "--socket=fallback-x11",
     "--socket=wayland",
     "--socket=pulseaudio",
     "--device=dri",
-    "--own-name=com.hack_computer.OperatingSystemApp",
     "--env=GTK3_MODULES=/app/clippy/lib/libclippy-module.so",
     "--talk-name=com.hack_computer.Clubhouse",
     "--talk-name=com.hack_computer.GameStateService",
@@ -37,7 +35,7 @@
       "sources": []
     },
     {
-      "name": "toyapp",
+      "name": "com.hack_computer.OperatingSystemApp",
       "buildsystem": "meson",
       "config-opts": [
         "-Dapp-id=com.hack_computer.OperatingSystemApp"
@@ -46,8 +44,7 @@
         {
           "type": "git",
           "url": "https://github.com/endlessm/hack-toy-apps.git",
-          "commit": "b416928be0a471f2289d561931d5a93cef4fa7fe",
-          "branch": "master"
+          "commit": "2eecbacedd148f5023e0d996524965b69452da0a"
         }
       ]
     }

--- a/com.hack_computer.OperatingSystemApp.json
+++ b/com.hack_computer.OperatingSystemApp.json
@@ -1,0 +1,55 @@
+{
+  "app-id": "com.hack_computer.OperatingSystemApp",
+  "add-extensions": {
+      "com.hack_computer.Clippy.Extension": {
+          "version": "beta",
+          "directory": "clippy",
+          "no-autodownload": false,
+          "autodelete": true
+      }
+  },
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.36",
+  "sdk": "org.gnome.Sdk",
+  "command": "com.hack_computer.OperatingSystemApp",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--device=dri",
+    "--own-name=com.hack_computer.OperatingSystemApp",
+    "--env=GTK3_MODULES=/app/clippy/lib/libclippy-module.so",
+    "--talk-name=com.hack_computer.Clubhouse",
+    "--talk-name=com.hack_computer.GameStateService",
+    "--talk-name=com.hack_computer.HackSoundServer",
+    "--talk-name=org.gnome.Shell",
+    "--talk-name=com.hack_computer.HackableAppsManager",
+    "--talk-name=com.hack_computer.hack"
+  ],
+  "modules": [
+    {
+      "name": "clippy-ext",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir /app/clippy"
+      ],
+      "sources": []
+    },
+    {
+      "name": "toyapp",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dapp-id=com.hack_computer.OperatingSystemApp"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/endlessm/hack-toy-apps.git",
+          "commit": "b416928be0a471f2289d561931d5a93cef4fa7fe",
+          "branch": "master"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Please, merge into `beta` branch. I don't want to go directly to the `stable` repository when this app gets approved, lets move to `beta` at first if it's possible, because we want to test a bit the flathub version before we do the real release for the final user.

This application is part of the "hack experience" that we developed for the [hack computer](https://www.hack-computer.com/) project.

As part of the new [EndlessOS foundation](https://endlessos.com/) goal, we're trying to release and publish "Hack" to make it possible to use outside of Endless.

This PR includes the Operating system application. This application is a simple educative app with clickable regions that will trigger some bubbles with text about the computer internals, the kernel, the memory, etc.

The app works alone like a normal app and you can use it without the clubhouse installed. In combination with the `com.hack_computer.Clubhouse` application, the user can go further, flip the app and **hack** the system, being able to change the desktop cursor icon and activate the wobbly windows effect.