### PR TITLE
Add org.gnome.BreakTimer

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true
+}
+

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -72,7 +72,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/gnome-break-timer.git",
-                    "commit": "8625f78251cf51eb7e3d930a1d49f1c7dd4c757d"
+                    "tag": "2.0.2"
                 }
             ]
         }

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -1,0 +1,87 @@
+{
+    "id" : "org.gnome.BreakTimer",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.38",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "gnome-break-timer-settings",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--talk-name=org.gnome.ControlCenter",
+        "--talk-name=org.gnome.Shell",
+        "--talk-name=org.gnome.Mutter.IdleMonitor",
+        "--talk-name=org.gnome.ScreenSaver",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "build-options" : {
+        "cflags" : "-O2 -g",
+        "cxxflags" : "-O2 -g",
+        "env" : {
+            "V" : "1"
+        }
+    },
+    "modules" : [
+        {
+            "name" : "libcanberra",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://0pointer.de/lennart/projects/libcanberra/libcanberra-0.30.tar.xz",
+                    "sha256" : "c2b671e67e0c288a69fc33dc1b6f1b534d07882c2aceed37004bf48c601afa72"
+                }
+            ],
+            "config-opts" : [
+                "--disable-alsa",
+                "--disable-null",
+                "--disable-oss"
+            ]
+        },
+        {
+            "name" : "gsound",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/gsound.git",
+                    "branch" : "master"
+                }
+            ]
+        },
+        {
+            "name" : "intltool",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256" : "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ],
+            "cleanup" : [
+                "*"
+            ]
+        },
+        {
+            "name" : "sound-theme-freedesktop",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "http://people.freedesktop.org/~mccann/dist/sound-theme-freedesktop-0.8.tar.bz2",
+                    "sha256" : "cb518b20eef05ec2e82dda1fa89a292c1760dc023aba91b8aa69bafac85e8a14"
+                }
+            ]
+        },
+        {
+            "name" : "gnome-break-timer",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/gnome-break-timer.git",
+                    "commit": "8625f78251cf51eb7e3d930a1d49f1c7dd4c757d"
+                }
+            ]
+        }
+    ]
+}

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -15,13 +15,6 @@
         "--talk-name=org.gnome.ScreenSaver",
         "--talk-name=org.freedesktop.Notifications"
     ],
-    "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
-        "env" : {
-            "V" : "1"
-        }
-    },
     "modules" : [
         {
             "name" : "libcanberra",

--- a/org.gnome.BreakTimer.json
+++ b/org.gnome.BreakTimer.json
@@ -6,7 +6,7 @@
     "command" : "gnome-break-timer-settings",
     "finish-args" : [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--talk-name=org.gnome.ControlCenter",


### PR DESCRIPTION
This adds GNOME Break Timer to Flathub:

https://gitlab.gnome.org/GNOME/gnome-break-timer/

It needs to talk with `org.gnome.Shell`, `org.gnome.Mutter.IdleMonitor`, and `org.gnome.ScreenSaver` in order to keep track of how much someone is currently using their computer. It needs to talk with `org.gnome.ControlCenter` to provide a shortcut to the Applications settings panel in the event that the application hasn't been given permission to run in the background.

I opted to not use intltool from shared-modules in order to keep this manifest file consistent with the one upstream (https://gitlab.gnome.org/GNOME/gnome-break-timer/-/blob/master/build-aux/flatpak/org.gnome.BreakTimer.Devel.json). Please let me know if you would prefer I use shared-modules there :)