### PR TITLE
Add org.freedesktop.Sdk.Extension.node14

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.node14.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.node14.metainfo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.node14</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Node.js SDK extension</name>
+  <summary>Node.js SDK extension</summary>
+  <description>
+    <p>This SDK extension allows you to build and run Node.js-based apps.</p>
+  </description>
+  <url type="homepage">https://nodejs.org/</url>
+</component>

--- a/org.freedesktop.Sdk.Extension.node14.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.node14.metainfo.xml
@@ -9,4 +9,7 @@
     <p>This SDK extension allows you to build and run Node.js-based apps.</p>
   </description>
   <url type="homepage">https://nodejs.org/</url>
+  <releases>
+    <release version="14.15.1" date="2020-11-16"/>
+  </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.node14.yaml
+++ b/org.freedesktop.Sdk.Extension.node14.yaml
@@ -1,0 +1,57 @@
+app-id: org.freedesktop.Sdk.Extension.node14
+branch: '20.08'
+runtime: org.freedesktop.Sdk
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+  prefix: /usr/lib/sdk/node14
+  prepend-path: /usr/lib/sdk/node14/bin
+  prepend-ld-library-path: /usr/lib/sdk/node14/lib
+  strip: true
+cleanup:
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - /share/systemtap
+modules:
+  - name: node
+    sources:
+      - type: archive
+        url: https://nodejs.org/dist/latest-v14.x/node-v14.9.0.tar.xz
+        sha256: 012ef6b715306a56183696a878a4803c2edab4f25f1bf3f40425320cf28e6ef6
+        x-checker-data:
+          type: html
+          url: https://nodejs.org/dist/latest-v14.x/
+          url-pattern: (node-v[\d\.-]+.tar.xz)
+          version-pattern: node-v([\d\.-]+).tar.xz
+    config-opts:
+      - --openssl-use-def-ca-store
+      - --shared-openssl
+      - --shared-zlib
+      - --with-intl=system-icu
+
+  - name: scripts
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 {enable,install{,-sdk}}.sh -t ${FLATPAK_DEST}/
+      - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    sources:
+      - type: script
+        dest-filename: install.sh
+        commands:
+          - install -Dm 755 ${FLATPAK_DEST}/bin/node ${FLATPAK_DEST}/node/bin/node
+      - type: script
+        dest-filename: install-sdk.sh
+        commands:
+          - cp -r ${FLATPAK_DEST} ${FLATPAK_DEST}/node
+      - type: script
+        commands:
+          - export PATH=$PATH:/usr/lib/sdk/node14/bin
+          - export npm_config_nodedir=/usr/lib/sdk/node14
+        dest-filename: enable.sh
+      - type: file
+        path: org.freedesktop.Sdk.Extension.node14.metainfo.xml

--- a/org.freedesktop.Sdk.Extension.node14.yaml
+++ b/org.freedesktop.Sdk.Extension.node14.yaml
@@ -20,13 +20,14 @@ modules:
   - name: node
     sources:
       - type: archive
-        url: https://nodejs.org/dist/latest-v14.x/node-v14.9.0.tar.xz
-        sha256: 012ef6b715306a56183696a878a4803c2edab4f25f1bf3f40425320cf28e6ef6
+        url: https://nodejs.org/dist/latest-v14.x/node-v14.15.1.tar.xz
+        sha256: 0161436846f7578938ad87af197e0cf112452232723227f88d5a0efc34dec1bc
         x-checker-data:
           type: html
           url: https://nodejs.org/dist/latest-v14.x/
           url-pattern: (node-v[\d\.-]+.tar.xz)
           version-pattern: node-v([\d\.-]+).tar.xz
+        size: 33437304
     config-opts:
       - --openssl-use-def-ca-store
       - --shared-openssl
@@ -38,7 +39,8 @@ modules:
     build-commands:
       - install -Dm755 {enable,install{,-sdk}}.sh -t ${FLATPAK_DEST}/
       - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
+        ${FLATPAK_ID}
     sources:
       - type: script
         dest-filename: install.sh


### PR DESCRIPTION
Latest LTS version of Node.js
It's likely not needed for building electron apps, but is useful in IDEs for web developers.
Should be merged to branch `branch/20.08`.