### PR TITLE
Add Gromit-MPX

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/net.christianbeier.Gromit-MPX.yml
+++ b/net.christianbeier.Gromit-MPX.yml
@@ -1,6 +1,6 @@
 id: net.christianbeier.Gromit-MPX
 runtime: org.gnome.Platform # using GNOME for the time being as we need dconf for setting hotkeys under Wayland
-runtime-version: '3.36'
+runtime-version: '3.38'
 sdk: org.gnome.Sdk
 command: gromit-mpx
 finish-args:
@@ -21,8 +21,8 @@ modules:
       - glib-compile-schemas /app/share/glib-2.0/schemas
     sources:
       - type: archive
-        url: https://github.com/GNOME/gnome-settings-daemon/archive/GNOME_SETTINGS_DAEMON_3_36_1.tar.gz
-        sha256: e345411f79b4a1175349e144cc772c7a9eb7ab9ae3a542a73609bee471b72748
+        url: https://github.com/GNOME/gnome-settings-daemon/archive/GNOME_SETTINGS_DAEMON_3_38_1.tar.gz
+        sha256: 736a961ccdb314b9a157e29710743563dc67652ebc3ca69c0f37df2776863523
   - name: gromit-mpx
     buildsystem: cmake
     sources:

--- a/net.christianbeier.Gromit-MPX.yml
+++ b/net.christianbeier.Gromit-MPX.yml
@@ -1,0 +1,31 @@
+id: net.christianbeier.Gromit-MPX
+runtime: org.gnome.Platform # using GNOME for the time being as we need dconf for setting hotkeys under Wayland
+runtime-version: '3.36'
+sdk: org.gnome.Sdk
+command: gromit-mpx
+finish-args:
+  - --socket=x11
+  # this is the dconf hole for setting hotkeys under Wayland
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+modules:
+  - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
+  # ship media-keys schema for settings hotkeys under Wayland
+  - name: media-keys
+    buildsystem: simple
+    build-commands:
+      - install -D data/org.gnome.settings-daemon.plugins.media-keys.gschema.xml.in /app/share/glib-2.0/schemas/org.gnome.settings-daemon.plugins.media-keys.gschema.xml
+      - sed -i -e 's/@GETTEXT_PACKAGE@/gnome-settings-daemon/g' /app/share/glib-2.0/schemas/org.gnome.settings-daemon.plugins.media-keys.gschema.xml
+      - glib-compile-schemas /app/share/glib-2.0/schemas
+    sources:
+      - type: archive
+        url: https://github.com/GNOME/gnome-settings-daemon/archive/GNOME_SETTINGS_DAEMON_3_36_1.tar.gz
+        sha256: e345411f79b4a1175349e144cc772c7a9eb7ab9ae3a542a73609bee471b72748
+  - name: gromit-mpx
+    buildsystem: cmake
+    sources:
+      - type: git
+        url: https://github.com/bk138/gromit-mpx.git
+        commit: bbbf33682507f52c6c87e369cb11dc5ecf964e41


### PR DESCRIPTION
Gromit-MPX is an on-screen annotation tool that works with any Unix
desktop environment under X11 as well as Wayland.