### PR TITLE
Add com.github.huluti.Curtail

### DIFF
--- a/com.github.huluti.Curtail.json
+++ b/com.github.huluti.Curtail.json
@@ -1,0 +1,67 @@
+{
+    "app-id": "com.github.huluti.Curtail",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.38",
+    "sdk": "org.gnome.Sdk",
+    "command": "curtail",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--filesystem=home"
+    ],
+    "modules": [
+        {
+            "name":"jpegoptim",
+            "sources":[{
+                "type": "archive",
+                "url": "https://github.com/tjko/jpegoptim/archive/RELEASE.1.4.6.tar.gz",
+                "sha256": "c44dcfac0a113c3bec13d0fc60faf57a0f9a31f88473ccad33ecdf210b4c0c52"
+            }]
+        },
+        {
+            "name": "optipng",
+            "build-options": {
+                "config-opts": [
+                    "--with-system-libs"
+                ]
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.7/optipng-0.7.7.tar.gz",
+                    "sha256": "4f32f233cef870b3f95d3ad6428bfe4224ef34908f1b42b0badf858216654452"
+                }
+            ]
+        },
+        {
+            "name": "pngquant",
+            "buildsystem": "simple",
+            "build-commands": [
+                "sh configure --prefix=/app",
+                "make",
+                "make install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://pngquant.org/pngquant-2.12.5-src.tar.gz",
+                    "sha256": "3638936cf6270eeeaabcee42e10768d78e4dc07cac9310307835c1f58b140808"
+                }
+            ]
+        },
+        {
+            "name": "curtail",
+            "builddir": true,
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Huluti/Curtail",
+                    "tag": "1.0.0",
+                    "commit": "c50f8c3d6e09d370336180b5115d0dac9a1d443d"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Hi! [ImCompressor](https://flathub.org/apps/details/com.github.huluti.ImCompressor) is renamed to Curtail and have a new icon thank's to the Gnome Circle initiative. I have changed the app-id so here's a new submission.

Once this manifest is approved I'll mark ImCompressor EOL to do the transition.

Say me if I made a mistake in any process.

Thank's in advance!