### PR TITLE
Add LLVM 11 as a freedesktop SDK extension

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "skip-appstream-check": true,
+  "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.llvm11.json
+++ b/org.freedesktop.Sdk.Extension.llvm11.json
@@ -1,0 +1,112 @@
+{
+  "id": "org.freedesktop.Sdk.Extension.llvm11",
+  "branch": "20.08",
+  "runtime": "org.freedesktop.Sdk",
+  "build-extension": true,
+  "sdk": "org.freedesktop.Sdk",
+  "runtime-version": "20.08",
+  "separate-locales": false,
+  "appstream-compose": false,
+  "build-options": {
+    "prefix": "/usr/lib/sdk/llvm11"
+  },
+  "modules": [
+    {
+      "name": "llvm",
+      "buildsystem": "cmake-ninja",
+      "subdir": "llvm",
+      "builddir": true,
+      "build-options": {
+        "arch": {
+          "aarch64": {
+            "config-opts": [
+              "-DFFI_INCLUDE_DIR=/usr/lib/aarch64-linux-gnu/libffi-3.2.1/include",
+              "-DLLVM_DEFAULT_TARGET_TRIPLE=aarch64",
+              "-DLLVM_TARGETS_TO_BUILD='AArch64'"
+            ]
+          },
+          "x86_64": {
+            "config-opts": [
+              "-DFFI_INCLUDE_DIR=/usr/lib/x86_64-linux-gnu/libffi-3.2.1/include",
+              "-DLLVM_DEFAULT_TARGET_TRIPLE=x86_64",
+              "-DLLVM_TARGETS_TO_BUILD='X86;AMDGPU;NVPTX'"
+            ]
+          }
+        },
+        "cflags": "-g1",
+        "cxxflags": "-g1",
+        "env": {
+          "CC": "clang",
+          "CXX": "clang++"
+        },
+        "ldflags": "-fuse-ld=lld"
+      },
+      "config-opts": [
+        "-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld'",
+        "-DLLVM_ENABLE_ASSERTIONS:BOOL=OFF",
+        "-DBUILD_SHARED_LIBS:BOOL=OFF",
+        "-DLLVM_BUILD_LLVM_DYLIB:BOOL=ON",
+        "-DLLVM_LINK_LLVM_DYLIB:BOOL=ON",
+        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+        "-DLLVM_LIBDIR_SUFFIX=''",
+        "-DLLVM_ENABLE_LIBCXX:BOOL=OFF",
+        "-DLLVM_ENABLE_ZLIB:BOOL=ON",
+        "-DLLVM_ENABLE_FFI:BOOL=ON",
+        "-DLLVM_ENABLE_RTTI:BOOL=ON",
+        "-DLLVM_INCLUDE_TESTS:BOOL=OFF",
+        "-DLLVM_INCLUDE_EXAMPLES:BOOL=OFF",
+        "-DLLVM_INCLUDE_UTILS:BOOL=ON",
+        "-DLLVM_INSTALL_UTILS:BOOL=ON",
+        "-DLLVM_INCLUDE_DOCS:BOOL=OFF",
+        "-DLLVM_ENABLE_DOXYGEN:BOOL=OFF",
+        "-DLLVM_BUILD_EXTERNAL_COMPILER_RT:BOOL=ON",
+        "-DLLVM_BINUTILS_INCDIR=/usr/include",
+        "-DLLVM_INSTALL_TOOLCHAIN_ONLY:BOOL=OFF",
+        "-DCMAKE_C_FLAGS_RELWITHDEBINFO='-DNDEBUG'",
+        "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO='-DNDEBUG'"
+      ],
+      "cleanup": [
+        "/include/lld",
+        "*.a",
+        "*.a.syms"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-project-11.0.0.tar.xz",
+          "sha256": "b7b639fc675fa1c86dd6d0bc32267be9eb34451748d2efd03f674b773000e92b"
+        },
+        {
+          "type": "patch",
+          "path": "patches/llvm/llvm-no-rpath.patch"
+        },
+        {
+          "type": "patch",
+          "path": "patches/llvm/llvm-fix-tsan-build.patch"
+        },
+        {
+          "type": "patch",
+          "path": "patches/llvm/llvm-shared-tablegen.patch"
+        },
+        {
+          "type": "patch",
+          "path": "patches/llvm/llvm-fix-cmake-warning-standalone-compiler-rt-builds.patch"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml",
+        "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.freedesktop.Sdk.Extension.llvm11.metainfo.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.freedesktop.Sdk.Extension.llvm11.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.llvm11.metainfo.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+    <id>org.freedesktop.Sdk.Extension.llvm11</id>
+    <extends>org.freedesktop.Sdk</extends>
+    <name>LLVM 11</name>
+    <summary>LLVM 11 stable compiler and tools extension for the flatpak Freedesktop SDK</summary>
+    <project_license>Apache-2.0 WITH LLVM-exception</project_license>
+    <metadata_license>CC0-1.0</metadata_license>
+    <url type="homepage">https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm11</url>
+    <releases>
+        <release version="11.0.0" date="2020-10-12"/>
+    </releases>
+</component>

--- a/patches/llvm/llvm-fix-cmake-warning-standalone-compiler-rt-builds.patch
+++ b/patches/llvm/llvm-fix-cmake-warning-standalone-compiler-rt-builds.patch
@@ -1,0 +1,40 @@
+From 8e9622f96120842852f37bfaeea738b4b4ed5cb0 Mon Sep 17 00:00:00 2001
+From: Pierre Gousseau <pierre.gousseau@sony.com>
+Date: Thu, 8 Oct 2020 09:45:59 +0100
+Subject: [PATCH] [cmake] Fix cmake warning in standalone compiler-rt builds.
+
+```
+cd compiler-rt/build
+cmake -G Ninja ../ -DCOMPILER_RT_STANDALONE_BUILD=ON
+-DLLVM_CONFIG_PATH=<...>llvm-project/build/bin/llvm-config
+-DCOMPILER_RT_INCLUDE_TESTS=ON
+```
+
+```
+-- check-shadowcallstack does nothing.
+Traceback (most recent call last):
+  File "<string>", line 22, in <module>
+  IndexError: list index out of range
+  -- Configuring done
+  -- Generating done
+```
+
+Reviewed By: thakis
+
+Differential Revision: https://reviews.llvm.org/D88957
+---
+ llvm/cmake/modules/AddLLVM.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index e57abea42753..4e9b1f6c2332 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -1494,6 +1494,7 @@ def relpath(p):\n
+     if os.path.splitdrive(p)[0] != os.path.splitdrive(base)[0]: return p\n
+     if haslink(p) or haslink(base): return p\n
+     return os.path.relpath(p, base)\n
++if len(sys.argv) < 3: sys.exit(0)\n
+ sys.stdout.write(';'.join(relpath(p) for p in sys.argv[2].split(';')))"
+     ${basedir}
+     ${pathlist_escaped}

--- a/patches/llvm/llvm-fix-tsan-build.patch
+++ b/patches/llvm/llvm-fix-tsan-build.patch
@@ -1,0 +1,14 @@
+diff --git a/compiler-rt/lib/tsan/dd/dd_interceptors.cpp b/compiler-rt/lib/tsan/dd/dd_interceptors.cpp
+index 35a0beb1919..724ea47acaa 100644
+--- a/compiler-rt/lib/tsan/dd/dd_interceptors.cpp
++++ b/compiler-rt/lib/tsan/dd/dd_interceptors.cpp
+@@ -6,6 +6,9 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#undef _FORTIFY_SOURCE
++#define _FORTIFY_SOURCE 0
++
+ #include "dd_rtl.h"
+ #include "interception/interception.h"
+ #include "sanitizer_common/sanitizer_procmaps.h"

--- a/patches/llvm/llvm-no-rpath.patch
+++ b/patches/llvm/llvm-no-rpath.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 0df6845aaa7..c73be702b93 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -1671,7 +1671,7 @@ function(llvm_setup_rpath name)
+     set(_install_name_dir INSTALL_NAME_DIR "@rpath")
+     set(_install_rpath "@loader_path/../lib" ${extra_libdir})
+   elseif(UNIX)
+-    set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
++    set(_install_rpath ${extra_libdir})
+     if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
+       set_property(TARGET ${name} APPEND_STRING PROPERTY
+                    LINK_FLAGS " -Wl,-z,origin ")

--- a/patches/llvm/llvm-shared-tablegen.patch
+++ b/patches/llvm/llvm-shared-tablegen.patch
@@ -1,0 +1,97 @@
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index fd69786544a..3f0090d0305 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -591,6 +591,8 @@ function(llvm_add_library name)
+        ${LLVM_LINK_COMPONENTS}
+        )
+     endif()
++  elseif (${name} STREQUAL "LLVMTableGenShared" AND LLVM_BUILD_LLVM_DYLIB)
++    target_link_libraries(${name} PRIVATE LLVM)
+   else()
+     # Components have not been defined explicitly in CMake, so add the
+     # dependency information for this library as defined by LLVMBuild.
+@@ -726,8 +728,10 @@ macro(add_llvm_library name)
+       if(${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+           (in_llvm_libs AND "llvm-libraries" IN_LIST LLVM_DISTRIBUTION_COMPONENTS) OR
+           NOT LLVM_DISTRIBUTION_COMPONENTS)
+-        set(export_to_llvmexports EXPORT LLVMExports)
+-        set_property(GLOBAL PROPERTY LLVM_HAS_EXPORTS True)
++        if(ARG_MODULE OR ARG_SHARED OR BUILD_SHARED_LIBS)
++          set(export_to_llvmexports EXPORT LLVMExports)
++          set_property(GLOBAL PROPERTY LLVM_HAS_EXPORTS True)
++        endif()
+       endif()
+ 
+       install(TARGETS ${name}
+@@ -742,7 +746,10 @@ macro(add_llvm_library name)
+                                  COMPONENT ${name})
+       endif()
+     endif()
+-    set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
++    if(ARG_MODULE OR ARG_SHARED OR BUILD_SHARED_LIBS)
++      set_property(GLOBAL APPEND PROPERTY LLVM_EXPORTS ${name})
++    else()
++    endif()
+   endif()
+   if (ARG_MODULE)
+     set_target_properties(${name} PROPERTIES FOLDER "Loadable modules")
+diff --git a/llvm/lib/TableGen/CMakeLists.txt b/llvm/lib/TableGen/CMakeLists.txt
+index 1ece8145952..0fd727a9f35 100644
+--- a/llvm/lib/TableGen/CMakeLists.txt
++++ b/llvm/lib/TableGen/CMakeLists.txt
+@@ -1,3 +1,24 @@
++if (LLVM_BUILD_LLVM_DYLIB)
++  add_llvm_library(LLVMTableGenShared
++    Error.cpp
++    JSONBackend.cpp
++    Main.cpp
++    Record.cpp
++    SetTheory.cpp
++    StringMatcher.cpp
++    TableGenBackend.cpp
++    TGLexer.cpp
++    TGParser.cpp
++
++    SHARED
++
++    ADDITIONAL_HEADER_DIRS
++    ${LLVM_MAIN_INCLUDE_DIR}/llvm/TableGen
++
++    OUTPUT_NAME LLVMTableGen
++  )
++endif()
++
+ add_llvm_component_library(LLVMTableGen
+   Error.cpp
+   JSONBackend.cpp
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index 6c31df3e173..edd5ae0da57 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -688,6 +688,13 @@ int main(int argc, char **argv) {
+       };
+ 
+       if (LinkMode == LinkModeShared && LinkDyLib) {
++        for (unsigned i = 0, e = RequiredLibs.size(); i != e; ++i) {
++	  if (RequiredLibs[i] == "LLVMTableGen") {
++	    PrintForLib(RequiredLibs[i]);
++	    OS << ' ';
++	    break ;
++	  }
++	}
+         PrintForLib(DyLibName);
+       } else {
+         for (unsigned i = 0, e = RequiredLibs.size(); i != e; ++i) {
+diff --git a/llvm/utils/llvm-build/llvmbuild/main.py b/llvm/utils/llvm-build/llvmbuild/main.py
+index 99b82ad5e20..a1cbf8f796d 100644
+--- a/llvm/utils/llvm-build/llvmbuild/main.py
++++ b/llvm/utils/llvm-build/llvmbuild/main.py
+@@ -359,6 +359,7 @@ subdirectories = %s
+         root_entries = set(e[0] for e in entries)
+         for _,_,deps,_ in entries:
+             root_entries -= set(deps)
++        root_entries.remove('tablegen')
+         entries.append(('all', None, sorted(root_entries), True))
+ 
+         entries.sort()


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Not needed**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *Patches took from freedesktop SDK or already applied upstream*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Basically, I tried to stick to https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/elements/components/llvm.bst as much as possible.

Should be merged in `branch/20.08`.

Needed for building newer versions of `net.rpcs3.RPCS3`.
