### PR TITLE
Add World Possible ScriptLauncher manifest

### DIFF
--- a/org.worldpossible.ScriptLauncher.yml
+++ b/org.worldpossible.ScriptLauncher.yml
@@ -1,0 +1,32 @@
+app-id: org.worldpossible.ScriptLauncher
+runtime: org.gnome.Platform
+runtime-version: '3.38'
+sdk: org.gnome.Sdk
+command: worldpossible-scriptlauncher
+
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=fallback-x11
+  # Wayland access
+  - --socket=wayland
+  # We need to be able to run commands on the host to execute scripts chosen by the user
+  - --talk-name=org.freedesktop.Flatpak
+  - --filesystem=host
+
+cleanup:
+  - /include
+  - /man
+  - /share/man
+  - "*.la"
+  - "*.a"
+
+modules:
+  - name: worldpossible-scriptlauncher
+    buildsystem: meson
+    builddir: true
+    sources:
+      - type: git
+        tag: 1.0
+        commit: 4d63b65f9e5f8c1959571f0e2388443489f88fc8
+        url: https://github.com/endlessm/worldpossible-scriptlauncher

--- a/org.worldpossible.ScriptLauncher.yml
+++ b/org.worldpossible.ScriptLauncher.yml
@@ -27,6 +27,6 @@ modules:
     builddir: true
     sources:
       - type: git
-        tag: 1.0
-        commit: 4d63b65f9e5f8c1959571f0e2388443489f88fc8
+        tag: 1.0.1
+        commit: baa8c0a4856ef9ef97ccf0d891ddc479b41b3f0c
         url: https://github.com/endlessm/worldpossible-scriptlauncher


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

This is a copy of the upstream manifest
(https://github.com/endlessm/worldpossible-updutil/) with the branch
changed from main to the latest commit so the build is reproducible (or
at least that part of it is).

ScriptLauncher is an app we at Endless OS Foundation (endlessos.org)
created for World Possible (worldpossible.org) to assist them in their
administration of Endless OS computers that they have deployed in
various places (mostly for educational purposes in offline
environments). The function of it is to execute a Bash script as root
without requiring use of the Command Line Interface (though it can also
execute other things like Python scripts provided they have correct
permissions set and a correct shebang line). The reason World Possible
needs this is that they often have to make changes to deployed computers
such as installing or removing content, and the people available to push
the changes to each computer are not always experienced with the Linux
CLI.

Some consideration has been given to deploying changes with a technology
such as Ansible, but for now they are using shell scripts.

This utility requires an administrator password be entered to execute
the script as root, so it does not provide any privilege escalation.

It also has a few other features such as showing the output from the
script, but it is basically at MVP status.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
