### PR TITLE
Add org.kicad.KiCad

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/fix-rectifier-demo-for-ngspice-32.patch
+++ b/fix-rectifier-demo-for-ngspice-32.patch
@@ -1,0 +1,504 @@
+From 48150389b11b297eae2f461a4e6398e949c0e4ae Mon Sep 17 00:00:00 2001
+From: Johannes Maibaum <jmaibaum@gmail.com>
+Date: Sat, 6 Jun 2020 13:59:30 +0200
+Subject: [PATCH] Add diode model to rectifier demo (ngspice-32 fix)
+
+Patch by Holger Vogt
+
+Fixes https://gitlab.com/kicad/code/kicad/issues/4453
+---
+ demos/simulation/rectifier/diode.mod          |   2 +
+ .../simulation/rectifier/rectifier-cache.lib  | 202 ++++++-------
+ demos/simulation/rectifier/rectifier.sch      | 266 +++++++++---------
+ 3 files changed, 240 insertions(+), 230 deletions(-)
+ create mode 100644 demos/simulation/rectifier/diode.mod
+
+diff --git a/demos/simulation/rectifier/diode.mod b/demos/simulation/rectifier/diode.mod
+new file mode 100644
+index 000000000..73b61653e
+--- /dev/null
++++ b/demos/simulation/rectifier/diode.mod
+@@ -0,0 +1,2 @@
++*generic diode model
++.model 1N4148 D
+diff --git a/demos/simulation/rectifier/rectifier-cache.lib b/demos/simulation/rectifier/rectifier-cache.lib
+index 5af522f8a..bf2727eda 100644
+--- a/demos/simulation/rectifier/rectifier-cache.lib
++++ b/demos/simulation/rectifier/rectifier-cache.lib
+@@ -1,101 +1,101 @@
+-EESchema-LIBRARY Version 2.4
+-#encoding utf-8
+-#
+-# C
+-#
+-DEF C C 0 10 N Y 1 F N
+-F0 "C" 25 100 50 H V L CNN
+-F1 "C" 25 -100 50 H V L CNN
+-F2 "" 38 -150 50 H V C CNN
+-F3 "" 0 0 50 H V C CNN
+-$FPLIST
+- C?
+- C_????_*
+- C_????
+- SMD*_c
+- Capacitor*
+- Capacitors_ThroughHole:C_Radial_D10_L13_P5
+- Capacitors_SMD:C_0805
+- Capacitors_SMD:C_1206
+-$ENDFPLIST
+-DRAW
+-P 2 0 1 20 -80 -30 80 -30 N
+-P 2 0 1 20 -80 30 80 30 N
+-X ~ 1 0 150 110 D 40 40 1 1 P
+-X ~ 2 0 -150 110 U 40 40 1 1 P
+-ENDDRAW
+-ENDDEF
+-#
+-# D
+-#
+-DEF D D 0 40 N N 1 F N
+-F0 "D" 0 100 50 H V C CNN
+-F1 "D" 0 -100 50 H V C CNN
+-F2 "" 0 0 50 H V C CNN
+-F3 "" 0 0 50 H V C CNN
+-$FPLIST
+- Diode_*
+- D-Pak_TO252AA
+- *SingleDiode
+- *_Diode_*
+- *SingleDiode*
+-$ENDFPLIST
+-DRAW
+-P 2 0 1 6 -50 50 -50 -50 N
+-P 3 0 1 0 50 50 -50 0 50 -50 F
+-X K 1 -150 0 100 R 50 50 1 1 P
+-X A 2 150 0 100 L 50 50 1 1 P
+-ENDDRAW
+-ENDDEF
+-#
+-# GND
+-#
+-DEF GND #PWR 0 0 Y Y 1 F P
+-F0 "#PWR" 0 -150 50 H I C CNN
+-F1 "GND" 0 -123 30 H V C CNN
+-F2 "" 0 0 60 H V C CNN
+-F3 "" 0 0 60 H V C CNN
+-DRAW
+-P 6 0 1 0 0 0 0 -50 50 -50 0 -100 -50 -50 0 -50 N
+-X GND 1 0 0 0 D 20 30 1 1 W N
+-ENDDRAW
+-ENDDEF
+-#
+-# R
+-#
+-DEF R R 0 0 N Y 1 F N
+-F0 "R" 80 0 50 V V C CNN
+-F1 "R" 0 0 50 V V C CNN
+-F2 "" -70 0 50 V V C CNN
+-F3 "" 0 0 50 H V C CNN
+-$FPLIST
+- R_*
+- Resistor_*
+-$ENDFPLIST
+-DRAW
+-S -40 -100 40 100 0 1 10 N
+-X ~ 1 0 150 50 D 50 50 1 1 P
+-X ~ 2 0 -150 50 U 50 50 1 1 P
+-ENDDRAW
+-ENDDEF
+-#
+-# VSOURCE
+-#
+-DEF ~VSOURCE V 0 40 Y Y 1 F N
+-F0 "V" 200 200 50 H V C CNN
+-F1 "VSOURCE" 250 100 50 H I C CNN
+-F2 "" 0 0 50 H V C CNN
+-F3 "" 0 0 50 H V C CNN
+-F4 "Value" 0 0 60 H I C CNN "Fieldname"
+-F5 "V" 0 0 60 H I C CNN "Spice_Primitive"
+-F6 "1 2" -300 200 60 H I C CNN "Spice_Node_Sequence"
+-DRAW
+-C 0 0 100 0 1 0 N
+-P 2 0 1 0 0 -75 0 75 N
+-P 4 0 1 0 0 75 -25 25 25 25 0 75 F
+-X ~ 1 0 200 100 D 50 50 1 1 I
+-X ~ 2 0 -200 100 U 50 50 1 1 I
+-ENDDRAW
+-ENDDEF
+-#
+-#End Library
++EESchema-LIBRARY Version 2.4
++#encoding utf-8
++#
++# rectifier_schlib_C
++#
++DEF rectifier_schlib_C C 0 10 N Y 1 F N
++F0 "C" 25 100 50 H V L CNN
++F1 "rectifier_schlib_C" 25 -100 50 H V L CNN
++F2 "" 38 -150 50 H V C CNN
++F3 "" 0 0 50 H V C CNN
++$FPLIST
++ C?
++ C_????_*
++ C_????
++ SMD*_c
++ Capacitor*
++ Capacitors_ThroughHole:C_Radial_D10_L13_P5
++ Capacitors_SMD:C_0805
++ Capacitors_SMD:C_1206
++$ENDFPLIST
++DRAW
++P 2 0 1 20 -80 -30 80 -30 N
++P 2 0 1 20 -80 30 80 30 N
++X ~ 1 0 150 110 D 40 40 1 1 P
++X ~ 2 0 -150 110 U 40 40 1 1 P
++ENDDRAW
++ENDDEF
++#
++# rectifier_schlib_D
++#
++DEF rectifier_schlib_D D 0 40 N N 1 F N
++F0 "D" 0 100 50 H V C CNN
++F1 "rectifier_schlib_D" 0 -100 50 H V C CNN
++F2 "" 0 0 50 H V C CNN
++F3 "" 0 0 50 H V C CNN
++$FPLIST
++ Diode_*
++ D-Pak_TO252AA
++ *SingleDiode
++ *_Diode_*
++ *SingleDiode*
++$ENDFPLIST
++DRAW
++P 2 0 1 6 -50 50 -50 -50 N
++P 3 0 1 0 50 50 -50 0 50 -50 F
++X K 1 -150 0 100 R 50 50 1 1 P
++X A 2 150 0 100 L 50 50 1 1 P
++ENDDRAW
++ENDDEF
++#
++# rectifier_schlib_GND
++#
++DEF rectifier_schlib_GND #PWR 0 0 Y Y 1 F P
++F0 "#PWR" 0 -150 50 H I C CNN
++F1 "rectifier_schlib_GND" 0 -123 30 H V C CNN
++F2 "" 0 0 60 H V C CNN
++F3 "" 0 0 60 H V C CNN
++DRAW
++P 6 0 1 0 0 0 0 -50 50 -50 0 -100 -50 -50 0 -50 N
++X GND 1 0 0 0 D 20 30 1 1 W N
++ENDDRAW
++ENDDEF
++#
++# rectifier_schlib_R
++#
++DEF rectifier_schlib_R R 0 0 N Y 1 F N
++F0 "R" 80 0 50 V V C CNN
++F1 "rectifier_schlib_R" 0 0 50 V V C CNN
++F2 "" -70 0 50 V V C CNN
++F3 "" 0 0 50 H V C CNN
++$FPLIST
++ R_*
++ Resistor_*
++$ENDFPLIST
++DRAW
++S -40 -100 40 100 0 1 10 N
++X ~ 1 0 150 50 D 50 50 1 1 P
++X ~ 2 0 -150 50 U 50 50 1 1 P
++ENDDRAW
++ENDDEF
++#
++# rectifier_schlib_VSOURCE
++#
++DEF rectifier_schlib_VSOURCE V 0 40 Y Y 1 F N
++F0 "V" 200 200 50 H V C CNN
++F1 "rectifier_schlib_VSOURCE" 250 100 50 H I C CNN
++F2 "" 0 0 50 H V C CNN
++F3 "" 0 0 50 H V C CNN
++F4 "Value" 0 0 60 H I C CNN "Fieldname"
++F5 "V" 0 0 60 H I C CNN "Spice_Primitive"
++F6 "1 2" -300 200 60 H I C CNN "Spice_Node_Sequence"
++DRAW
++C 0 0 100 0 1 0 N
++P 2 0 1 0 0 -75 0 75 N
++P 4 0 1 0 0 75 -25 25 25 25 0 75 F
++X ~ 1 0 200 100 D 50 50 1 1 I
++X ~ 2 0 -200 100 U 50 50 1 1 I
++ENDDRAW
++ENDDEF
++#
++#End Library
+diff --git a/demos/simulation/rectifier/rectifier.sch b/demos/simulation/rectifier/rectifier.sch
+index 815cb2992..d1ba00fe5 100644
+--- a/demos/simulation/rectifier/rectifier.sch
++++ b/demos/simulation/rectifier/rectifier.sch
+@@ -1,129 +1,137 @@
+-EESchema Schematic File Version 4
+-LIBS:rectifier-cache
+-EELAYER 26 0
+-EELAYER END
+-$Descr A4 11693 8268
+-encoding utf-8
+-Sheet 1 1
+-Title ""
+-Date ""
+-Rev ""
+-Comp ""
+-Comment1 ""
+-Comment2 ""
+-Comment3 ""
+-Comment4 ""
+-$EndDescr
+-$Comp
+-L rectifier_schlib:VSOURCE V1
+-U 1 1 57336052
+-P 4400 4050
+-F 0 "V1" H 4528 4096 50  0000 L CNN
+-F 1 "SINE(0 1.5 1k 0 0 0 0)" H 4528 4005 50  0000 L CNN
+-F 2 "" H 4400 4050 50  0000 C CNN
+-F 3 "" H 4400 4050 50  0000 C CNN
+-F 4 "Value" H 4400 4050 60  0001 C CNN "Fieldname"
+-F 5 "V" H 4400 4050 60  0001 C CNN "Spice_Primitive"
+-F 6 "1 2" H 4100 4250 60  0001 C CNN "Spice_Node_Sequence"
+-	1    4400 4050
+-	-1   0    0    1   
+-$EndComp
+-$Comp
+-L rectifier_schlib:GND #PWR01
+-U 1 1 573360D3
+-P 4400 4350
+-F 0 "#PWR01" H 4400 4100 50  0001 C CNN
+-F 1 "GND" H 4405 4177 50  0000 C CNN
+-F 2 "" H 4400 4350 50  0000 C CNN
+-F 3 "" H 4400 4350 50  0000 C CNN
+-	1    4400 4350
+-	1    0    0    -1  
+-$EndComp
+-$Comp
+-L rectifier_schlib:R R1
+-U 1 1 573360F5
+-P 4650 3700
+-F 0 "R1" V 4443 3700 50  0000 C CNN
+-F 1 "1k" V 4534 3700 50  0000 C CNN
+-F 2 "" V 4580 3700 50  0000 C CNN
+-F 3 "" H 4650 3700 50  0000 C CNN
+-F 4 "Value" H 4650 3700 60  0001 C CNN "Fieldname"
+-F 5 "1 2" H 4650 3700 60  0001 C CNN "SpiceMapping"
+-F 6 "R" V 4650 3700 60  0001 C CNN "Spice_Primitive"
+-	1    4650 3700
+-	0    1    1    0   
+-$EndComp
+-$Comp
+-L rectifier_schlib:D D1
+-U 1 1 573361B8
+-P 5100 3700
+-F 0 "D1" H 5100 3485 50  0000 C CNN
+-F 1 "1N4148" H 5100 3576 50  0000 C CNN
+-F 2 "" H 5100 3700 50  0000 C CNN
+-F 3 "" H 5100 3700 50  0000 C CNN
+-F 4 "Value" H 5100 3700 60  0001 C CNN "Fieldname"
+-F 5 "D" H 5100 3700 60  0001 C CNN "Spice_Primitive"
+-F 6 "2 1" H 5100 3700 60  0001 C CNN "Spice_Node_Sequence"
+-	1    5100 3700
+-	-1   0    0    1   
+-$EndComp
+-$Comp
+-L rectifier_schlib:C C1
+-U 1 1 5733628F
+-P 5400 4000
+-F 0 "C1" H 5515 4046 50  0000 L CNN
+-F 1 "100n" H 5515 3955 50  0000 L CNN
+-F 2 "" H 5438 3850 50  0000 C CNN
+-F 3 "" H 5400 4000 50  0000 C CNN
+-F 4 "Value" H 5400 4000 60  0001 C CNN "Fieldname"
+-F 5 "C" H 5400 4000 60  0001 C CNN "Spice_Primitive"
+-F 6 "1 2" H 5400 4000 60  0001 C CNN "SpiceMapping"
+-	1    5400 4000
+-	1    0    0    -1  
+-$EndComp
+-$Comp
+-L rectifier_schlib:R R2
+-U 1 1 573362F7
+-P 5750 4000
+-F 0 "R2" H 5680 3954 50  0000 R CNN
+-F 1 "100k" H 5680 4045 50  0000 R CNN
+-F 2 "" V 5680 4000 50  0000 C CNN
+-F 3 "" H 5750 4000 50  0000 C CNN
+-F 4 "Value" H 5750 4000 60  0001 C CNN "Fieldname"
+-F 5 "1 2" H 5750 4000 60  0001 C CNN "SpiceMapping"
+-F 6 "R" V 5750 4000 60  0001 C CNN "Spice_Primitive"
+-	1    5750 4000
+-	-1   0    0    1   
+-$EndComp
+-Text Notes 4300 4900 0    60   ~ 0
+-.tran 1u 10m\n
+-Wire Wire Line
+-	4400 4350 4400 4250
+-Wire Wire Line
+-	4400 4300 5750 4300
+-Connection ~ 4400 4300
+-Wire Wire Line
+-	5250 3700 5750 3700
+-Wire Wire Line
+-	5750 3700 5750 3850
+-Wire Wire Line
+-	5400 3850 5400 3700
+-Connection ~ 5400 3700
+-Wire Wire Line
+-	5400 4300 5400 4150
+-Wire Wire Line
+-	5750 4300 5750 4150
+-Connection ~ 5400 4300
+-Wire Wire Line
+-	4800 3700 4950 3700
+-Wire Wire Line
+-	4400 3850 4400 3700
+-Wire Wire Line
+-	4400 3700 4500 3700
+-Text Label 4400 3700 2    60   ~ 0
+-signal_in
+-Text Label 5750 3700 0    60   ~ 0
+-rect_out
+-Text Notes 4300 5000 0    60   ~ 0
+-*.ac dec 10 1 1Meg\n
+-$EndSCHEMATC
++EESchema Schematic File Version 4
++EELAYER 30 0
++EELAYER END
++$Descr A4 11693 8268
++encoding utf-8
++Sheet 1 1
++Title ""
++Date ""
++Rev ""
++Comp ""
++Comment1 ""
++Comment2 ""
++Comment3 ""
++Comment4 ""
++$EndDescr
++$Comp
++L rectifier_schlib:VSOURCE V1
++U 1 1 57336052
++P 4400 4050
++F 0 "V1" H 4528 4096 50  0000 L CNN
++F 1 "SINE(0 1.5 1k 0 0 0 0)" H 4528 4005 50  0000 L CNN
++F 2 "" H 4400 4050 50  0000 C CNN
++F 3 "" H 4400 4050 50  0000 C CNN
++F 4 "Value" H 4400 4050 60  0001 C CNN "Fieldname"
++F 5 "V" H 4400 4050 60  0001 C CNN "Spice_Primitive"
++F 6 "1 2" H 4100 4250 60  0001 C CNN "Spice_Node_Sequence"
++	1    4400 4050
++	-1   0    0    1   
++$EndComp
++$Comp
++L rectifier_schlib:GND #PWR01
++U 1 1 573360D3
++P 4400 4350
++F 0 "#PWR01" H 4400 4100 50  0001 C CNN
++F 1 "GND" H 4405 4177 50  0000 C CNN
++F 2 "" H 4400 4350 50  0000 C CNN
++F 3 "" H 4400 4350 50  0000 C CNN
++	1    4400 4350
++	1    0    0    -1  
++$EndComp
++$Comp
++L rectifier_schlib:R R1
++U 1 1 573360F5
++P 4650 3700
++F 0 "R1" V 4443 3700 50  0000 C CNN
++F 1 "1k" V 4534 3700 50  0000 C CNN
++F 2 "" V 4580 3700 50  0000 C CNN
++F 3 "" H 4650 3700 50  0000 C CNN
++F 4 "Value" H 4650 3700 60  0001 C CNN "Fieldname"
++F 5 "1 2" H 4650 3700 60  0001 C CNN "SpiceMapping"
++F 6 "R" V 4650 3700 60  0001 C CNN "Spice_Primitive"
++	1    4650 3700
++	0    1    1    0   
++$EndComp
++$Comp
++L rectifier_schlib:D D1
++U 1 1 573361B8
++P 5100 3700
++F 0 "D1" H 5100 3485 50  0000 C CNN
++F 1 "1N4148" H 5100 3576 50  0000 C CNN
++F 2 "" H 5100 3700 50  0000 C CNN
++F 3 "" H 5100 3700 50  0000 C CNN
++F 4 "Value" H 5100 3700 60  0001 C CNN "Fieldname"
++F 5 "D" H 5100 3700 60  0001 C CNN "Spice_Primitive"
++F 6 "2 1" H 5100 3700 60  0001 C CNN "Spice_Node_Sequence"
++F 7 "1N4148" H 5100 3700 50  0001 C CNN "Spice_Model"
++F 8 "Y" H 5100 3700 50  0001 C CNN "Spice_Netlist_Enabled"
++F 9 "diode.mod" H 5100 3700 50  0001 C CNN "Spice_Lib_File"
++	1    5100 3700
++	-1   0    0    1   
++$EndComp
++$Comp
++L rectifier_schlib:C C1
++U 1 1 5733628F
++P 5400 4000
++F 0 "C1" H 5515 4046 50  0000 L CNN
++F 1 "100n" H 5515 3955 50  0000 L CNN
++F 2 "" H 5438 3850 50  0000 C CNN
++F 3 "" H 5400 4000 50  0000 C CNN
++F 4 "Value" H 5400 4000 60  0001 C CNN "Fieldname"
++F 5 "C" H 5400 4000 60  0001 C CNN "Spice_Primitive"
++F 6 "1 2" H 5400 4000 60  0001 C CNN "SpiceMapping"
++	1    5400 4000
++	1    0    0    -1  
++$EndComp
++$Comp
++L rectifier_schlib:R R2
++U 1 1 573362F7
++P 5750 4000
++F 0 "R2" H 5680 3954 50  0000 R CNN
++F 1 "100k" H 5680 4045 50  0000 R CNN
++F 2 "" V 5680 4000 50  0000 C CNN
++F 3 "" H 5750 4000 50  0000 C CNN
++F 4 "Value" H 5750 4000 60  0001 C CNN "Fieldname"
++F 5 "1 2" H 5750 4000 60  0001 C CNN "SpiceMapping"
++F 6 "R" V 5750 4000 60  0001 C CNN "Spice_Primitive"
++	1    5750 4000
++	-1   0    0    1   
++$EndComp
++Text Notes 4300 4900 0    60   ~ 0
++.tran 1u 10m\n
++Wire Wire Line
++	4400 4350 4400 4300
++Wire Wire Line
++	4400 4300 5400 4300
++Connection ~ 4400 4300
++Wire Wire Line
++	5250 3700 5400 3700
++Wire Wire Line
++	5750 3700 5750 3850
++Wire Wire Line
++	5400 3850 5400 3700
++Connection ~ 5400 3700
++Wire Wire Line
++	5400 4300 5400 4150
++Wire Wire Line
++	5750 4300 5750 4150
++Connection ~ 5400 4300
++Wire Wire Line
++	4800 3700 4950 3700
++Wire Wire Line
++	4400 3850 4400 3700
++Wire Wire Line
++	4400 3700 4500 3700
++Text Label 4400 3700 2    60   ~ 0
++signal_in
++Text Label 5750 3700 0    60   ~ 0
++rect_out
++Text Notes 4300 5000 0    60   ~ 0
++*.ac dec 10 1 1Meg\n
++Wire Wire Line
++	4400 4300 4400 4250
++Wire Wire Line
++	5400 3700 5750 3700
++Wire Wire Line
++	5400 4300 5750 4300
++$EndSCHEMATC
+-- 
+GitLab
+

--- a/org.kicad.KiCad.yml
+++ b/org.kicad.KiCad.yml
@@ -1,0 +1,203 @@
+app-id: org.kicad.KiCad
+runtime: org.freedesktop.Platform
+runtime-version: '20.08'
+sdk: org.freedesktop.Sdk
+command: kicad
+rename-appdata-file: kicad.appdata.xml
+rename-desktop-file: kicad.desktop
+rename-icon: kicad
+finish-args:
+- --device=dri
+- --env=LD_LIBRARY_PATH=/app/lib
+- --env=KISYS3DMOD=/app/library-extensions/Packages3D/extra
+- --filesystem=home
+- --share=ipc
+- --share=network
+- --socket=x11
+
+add-extensions:
+  org.kicad.KiCad.Library:
+    version: '5.1'
+    directory: library-extensions
+    autodelete: true
+    no-autodownload: true
+    subdirectories: true
+    merge-dirs: extra/template
+
+cleanup:
+- /include
+- /lib/cmake
+- /lib/pkgconfig
+- /lib/wx
+- /lib64
+- /share/aclocal
+- /share/bakefile
+- '*.la'
+- '*.a'
+
+modules:
+- shared-modules/glu/glu-9.json
+- shared-modules/glew/glew.json
+
+- name: glm
+  buildsystem: simple
+  build-commands:
+  - cp -r glm /app/include
+  sources:
+  - type: archive
+    url: https://github.com/g-truc/glm/releases/download/0.9.9.8/glm-0.9.9.8.zip
+    sha256: 37e2a3d62ea3322e43593c34bae29f57e3e251ea89f4067506c94043769ade4c
+
+- name: boost
+  buildsystem: simple
+  build-commands:
+  - ./bootstrap.sh --prefix=/app --with-libraries=context,date_time,filesystem,iostreams,locale,program_options,regex,system,thread,test
+  - ./b2 -j $FLATPAK_BUILDER_N_JOBS install
+  sources:
+  - type: archive
+    url: http://sourceforge.net/projects/boost/files/boost/1.75.0/boost_1_75_0.tar.gz
+    sha256: aeb26f80e80945e82ee93e5939baebdca47b9dee80a07d3144be1e1a6a66dd6a
+
+- name: wxWidgets
+  rm-configure: true
+  cleanup:
+  - /bin
+  subdir: ext/wxWidgets
+  sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz
+    sha256: 5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e
+  - type: script
+    commands:
+    - cp -p /usr/share/automake-*/config.{sub,guess} .
+    - autoconf -f -B build/autoconf_prepend-include
+
+- python3-wxPython.yml
+
+- name: swig
+  buildsystem: autotools
+  cleanup:
+  - /bin
+  - /share
+  sources:
+  - type: archive
+    url: https://sourceforge.net/projects/swig/files/swig/swig-4.0.2/swig-4.0.2.tar.gz
+    sha256: d53be9730d8d58a16bf0cbd1f8ac0c0c3e1090573168bfa151b01eb47fa906fc
+
+- name: libXmu
+  cleanup:
+  - /share/doc
+  sources:
+  - type: archive
+    url: https://www.x.org/archive//individual/lib/libXmu-1.1.3.tar.gz
+    sha256: 5bd9d4ed1ceaac9ea023d86bf1c1632cd3b172dce4a193a72a94e1d9df87a62e
+
+- name: OCCT
+  buildsystem: cmake-ninja
+  cleanup:
+  - /bin
+  - /share/doc
+  config-opts:
+  - -DCMAKE_BUILD_TYPE=Release
+  - -DBUILD_LIBRARY_TYPE=Shared
+  - -DBUILD_Inspector=OFF
+  - -DBUILD_DOC_Overview=OFF
+  - -DBUILD_MODULE_ApplicationFramework=ON
+  - -DBUILD_MODULE_DataExchange=ON
+  - -DBUILD_MODULE_Draw=OFF
+  - -DBUILD_MODULE_FoundationClasses=ON
+  - -DBUILD_MODULE_ModelingAlgorithms=ON
+  - -DBUILD_MODULE_ModelingData=ON
+  - -DBUILD_MODULE_Visualization=ON
+  - -DUSE_VTK=OFF
+  - -DUSE_TBB=OFF
+  - -DINSTALL_FREETYPE=OFF
+  - -DINSTALL_SAMPLES=OFF
+  - -DINSTALL_TEST_CASES=OFF
+  sources:
+  - type: archive
+    url: https://github.com/tpaviot/oce/releases/download/official-upstream-packages/opencascade-7.5.0.tgz
+    sha256: d82d253aa6f43ce49111e84e04286dab4445eecba8efb5190973244b0c7fd211
+
+- name: ngspice
+  cleanup:
+  - /bin
+  - /share/man
+  config-opts:
+  - --disable-silent-rules
+  - --enable-xspice
+  - --enable-cider
+  - --enable-openmp
+  - --with-ngshared
+  rm-configure: true
+  sources:
+  - type: archive
+    url: https://downloads.sourceforge.net/project/ngspice/ng-spice-rework/33/ngspice-33.tar.gz
+    sha256: b99db66cc1c57c44e9af1ef6ccb1dcbc8ae1df3e35acf570af578f606f8541f1
+  - type: script
+    commands:
+    - cp -p /usr/share/automake-*/config.{sub,guess} .
+    - autoconf -f -B build/autoconf_prepend-include
+
+- name: kicad
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DGLEW_INCLUDE_DIR=/app/include/GL
+  - -DOCC_INCLUDE_DIR=/app/include/opencascade
+  - -DOPENGL_glu_LIBRARY=/app/lib/libGLU.so
+  - -DKICAD_BUILD_QA_TESTS=OFF
+  - -DKICAD_SCRIPTING_PYTHON3=ON
+  - -DKICAD_USE_OCC=ON
+  - -DKICAD_USE_OCE=OFF
+  - -DKICAD_SCRIPTING_WXPYTHON_PHOENIX=ON
+  post-install:
+  - install -d /app/library-extensions
+  sources:
+  - type: archive
+    url: https://gitlab.com/kicad/code/kicad/-/archive/5.1.9/kicad-5.1.9.tar.gz
+    sha256: 841be864b9dc5c761193c3ee9cbdbed6729952d7b38451aa8e1977bdfdb6081b
+  - type: patch
+    path: fix-rectifier-demo-for-ngspice-32.patch
+  - type: shell
+    commands:
+    - sed -i '5s/org\.kicad_pcb\.kicad/org.kicad.KiCad/;96i<kudos><kudo>UserDocs</kudo></kudos>' resources/linux/appdata/kicad.appdata.xml.in
+
+- name: kicad-i18n
+  builddir: true
+  buildsystem: cmake-ninja
+  config-opts:
+  - -DKICAD_I18N_UNIX_STRICT_PATH=ON
+  sources:
+  - type: archive
+    url: https://gitlab.com/kicad/code/kicad-i18n/-/archive/5.1.9/kicad-i18n-5.1.9.tar.gz
+    sha256: f2cadcae1400bf483668ceccd190dff3d9dfd098307c146d273ed0bb01f4882f
+
+- name: kicad-doc
+  build-commands:
+  - find . -type f -exec install -Dm644 "{}" "${FLATPAK_DEST}/{}" \;
+  buildsystem: simple
+  sources:
+  - type: archive
+    url: https://kicad-downloads.s3.cern.ch/docs/kicad-doc-5.1.9.tar.gz
+    sha256: 61571f260bba67e26b9f7456ad6eb5da7c3b406412f506e7857d0ca70ca66393
+
+- name: kicad-templates
+  buildsystem: cmake-ninja
+  sources:
+  - type: archive
+    url: https://gitlab.com/kicad/libraries/kicad-templates/-/archive/5.1.9/kicad-templates-5.1.9.tar.gz
+    sha256: 0c1bf3d2e6d8d1056a5da6c1f7a173551c154b4bdaddb86b6a34155b18e65da6
+
+- name: kicad-symbols
+  buildsystem: cmake-ninja
+  sources:
+  - type: archive
+    url: https://gitlab.com/kicad/libraries/kicad-symbols/-/archive/5.1.9/kicad-symbols-5.1.9.tar.gz
+    sha256: cdb033cc755cc66a087b44fff1d2b77bf2dd44311a02c81a516b8ca1fbd242a7
+
+- name: kicad-footprints
+  buildsystem: cmake-ninja
+  sources:
+  - type: archive
+    url: https://gitlab.com/kicad/libraries/kicad-footprints/-/archive/5.1.9/kicad-footprints-5.1.9.tar.gz
+    sha256: 415e014364d1c12584f115a4adfeec1b71e41e2cd7f4ae543237ee71b8ef41bd

--- a/python3-wxPython.yml
+++ b/python3-wxPython.yml
@@ -1,0 +1,23 @@
+name: python3-wxPython
+buildsystem: simple
+build-commands: []
+modules:
+- name: python3-wxPython
+  buildsystem: simple
+  build-commands:
+  - pip3 install --exists-action=i --no-index --no-build-isolation --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} "wxPython"
+  build-options:
+    env:
+      WXPYTHON_BUILD_ARGS: --use_syswx
+  cleanup:
+  - /bin
+  sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/c5/63/a48648ebc57711348420670bb074998f79828291f68aebfff1642be212ec/numpy-1.19.4.zip
+    sha256: 141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512
+  - type: file
+    url: https://files.pythonhosted.org/packages/2b/06/93bf1626ef36815010e971a5ce90f49919d84ab5d2fa310329f843a74bc1/Pillow-8.0.1.tar.gz
+    sha256: 11c5c6e9b02c9dac08af04f093eb5a2f84857df70a7d4a6a6ad461aca803fb9e
+  - type: file
+    url: https://files.pythonhosted.org/packages/b9/8b/31267dd6d026a082faed35ec8d97522c0236f2e083bf15aff64d982215e1/wxPython-4.0.7.post2.tar.gz
+    sha256: 5a229e695b64f9864d30a5315e0c1e4ff5e02effede0a07f16e8d856737a0c4e


### PR DESCRIPTION
This new flatpak is meant as a rename of https://github.com/flathub/org.kicad_pcb.KiCad (which I am maintaining), as the project is now owning kicad.org, and using it as the official URL, see https://kicad.org/blog/2020/10/kicad.org-the-permanent-internet-home-of-KiCad/

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am maintaining the flatpak together with other upstream developers: Please also add @sethhillbrand and @imciner2 to the maintainers list, when merging.
- [x] The KiCad project owns the domain used in the application ID.
- [x] Any additional patches or files have been submitted to the upstream projects concerned: `fix-rectifier-demo-for-ngspice-32.patch` is available in upstream's master, but has not yet been backported to the stable branch. I will remove it from the manifest as soon as it's available in a stable release.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
