### PR TITLE
Add org.kicad.KiCad.Library.Packages3D

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.kicad.KiCad.Library.Packages3D.metainfo.xml
+++ b/org.kicad.KiCad.Library.Packages3D.metainfo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.kicad.KiCad.Library.Packages3D</id>
+  <extends>org.kicad.KiCad</extends>
+  <name>KiCad 3D Model Libraries</name>
+  <summary>Official KiCad 3D model libraries for rendering and MCAD integration</summary>
+  <url type="homepage">https://kicad.github.io/packages3d/</url>
+  <project_license>CC-BY-SA-4.0</project_license>
+  <metadata_license>CC-BY-SA-4.0</metadata_license>
+  <update_contact>jmaibaum_AT_gmail.com</update_contact>
+</component>

--- a/org.kicad.KiCad.Library.Packages3D.yml
+++ b/org.kicad.KiCad.Library.Packages3D.yml
@@ -1,0 +1,31 @@
+id: org.kicad.KiCad.Library.Packages3D
+branch: '5.1'
+runtime: org.kicad.KiCad
+runtime-version: stable
+sdk: org.freedesktop.Sdk//20.08
+build-extension: true
+separate-locales: false
+appstream-compose: false
+modules:
+- name: kicad-packages3D
+  buildsystem: simple
+  build-commands:
+  - install -D apply_extra $FLATPAK_DEST/bin/apply_extra
+  post-install:
+  - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.kicad.KiCad.Library.Packages3D.metainfo.xml
+  - appstream-compose --basename=org.kicad.KiCad.Library.Packages3D --prefix=${FLATPAK_DEST}
+    --origin=flatpak org.kicad.KiCad.Library.Packages3D
+  sources:
+  - type: script
+    commands:
+    - tar xzf kicad-packages3d.tar.gz --strip-components 1 --wildcards "*.step" "*.wrl"
+    - rm -rf kicad-packages3d.tar.gz
+    dest-filename: apply_extra
+  - type: extra-data
+    filename: kicad-packages3d.tar.gz
+    url: https://gitlab.com/kicad/libraries/kicad-packages3d/-/archive/5.1.9/kicad-packages3d-5.1.9.tar.gz
+    sha256: 6e3bd169eef2852b88a36f2a7a8156c7026830da2f6c319d8f35d60c87a0be48
+    size: 942968696
+    installed-size: 5551591622
+  - type: file
+    path: org.kicad.KiCad.Library.Packages3D.metainfo.xml


### PR DESCRIPTION
To be added after the renaming of the main app is done (see https://github.com/flathub/flathub/pull/2041).

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an maintaining the flatpak of KiCad together with other upstream developers: Please also add @sethhillbrand and @imciner2 to the list of maintainers when merging.
- [x] The KiCad project owns the domain used in the application ID.
- [x] Any additional patches or files have been submitted to the upstream projects concerned.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
