### PR TITLE
Add org.kde.kdevelop (KDevelop)

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,16 @@
+commit 866973199f
+Author: Timothée Ravier <tim@siosm.fr>
+Date:   Thu Jan 14 09:38:56 2021 +0100
+
+    appdata: Add OARS rating
+
+diff --git a/org.kde.kdevelop.appdata.xml b/org.kde.kdevelop.appdata.xml
+index 3b8648dda0..4375dabf84 100644
+--- a/org.kde.kdevelop.appdata.xml
++++ b/org.kde.kdevelop.appdata.xml
+@@ -187,4 +187,5 @@
+     <value key="KDE::forum">218</value>
+   </custom>
+   <update_contact>kdevelop-devel@kde.org</update_contact>
++  <content_rating type="oars-1.1" />
+ </component>

--- a/libksysguard_helper.patch
+++ b/libksysguard_helper.patch
@@ -1,0 +1,64 @@
+commit 425d7ed
+Author: Timothée Ravier <tim@siosm.fr>
+Date:   Wed Jan 13 19:32:22 2021 +0100
+
+    Add option to not build/install KAuth helper
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0b167ad..55db5ad 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -91,6 +91,8 @@ configure_file(config-ksysguard.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-ksysg
+ option(BUILD_DESIGNERPLUGIN "Build plugin for Qt Designer" ON)
+ add_feature_info(DESIGNERPLUGIN ${BUILD_DESIGNERPLUGIN} "Build plugin for Qt Designer")
+ 
++option(ENABLE_KAUTH_HELPER "Build and install ksysguardprocesslist_helper KAuth helper" ON)
++add_feature_info(DESIGNERPLUGIN ${ENABLE_KAUTH_HELPER} "Build and install ksysguardprocesslist_helper KAuth helper")
+ 
+ add_definitions(-DQT_NO_URL_CAST_FROM_STRING)
+ add_definitions(-DQT_USE_QSTRINGBUILDER)
+diff --git a/processcore/CMakeLists.txt b/processcore/CMakeLists.txt
+index 4f7b097..23962a9 100644
+--- a/processcore/CMakeLists.txt
++++ b/processcore/CMakeLists.txt
+@@ -74,21 +74,22 @@ install( FILES
+ 
+ #------ KAuth stuff
+ 
+-# Auth example helper
+-set(ksysguardprocesslist_helper_srcs
+-    helper.cpp
+-    process.cpp
+-    processes_local_p.cpp
+-    processes_base_p.cpp
+-    read_procsmaps_runnable.cpp
+-)
+-
+-add_executable(ksysguardprocesslist_helper ${ksysguardprocesslist_helper_srcs})
+-target_link_libraries(ksysguardprocesslist_helper Qt5::Core KF5::AuthCore KF5::I18n)
+-install(TARGETS ksysguardprocesslist_helper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
+-
+-kauth_install_helper_files(ksysguardprocesslist_helper org.kde.ksysguard.processlisthelper root)
+-kauth_install_actions(org.kde.ksysguard.processlisthelper actions.actions)
+-
+-set_target_properties(ksysguardprocesslist_helper PROPERTIES COMPILE_FLAGS "-Wall -ggdb")
+-
++if(ENABLE_KAUTH_HELPER)
++    # Auth example helper
++    set(ksysguardprocesslist_helper_srcs
++        helper.cpp
++        process.cpp
++        processes_local_p.cpp
++        processes_base_p.cpp
++        read_procsmaps_runnable.cpp
++    )
++
++    add_executable(ksysguardprocesslist_helper ${ksysguardprocesslist_helper_srcs})
++    target_link_libraries(ksysguardprocesslist_helper Qt5::Core KF5::AuthCore KF5::I18n)
++    install(TARGETS ksysguardprocesslist_helper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
++
++    kauth_install_helper_files(ksysguardprocesslist_helper org.kde.ksysguard.processlisthelper root)
++    kauth_install_actions(org.kde.ksysguard.processlisthelper actions.actions)
++
++    set_target_properties(ksysguardprocesslist_helper PROPERTIES COMPILE_FLAGS "-Wall -ggdb")
++endif()

--- a/org.kde.kdevelop.json
+++ b/org.kde.kdevelop.json
@@ -1,0 +1,205 @@
+{
+    "id": "org.kde.kdevelop",
+    "runtime": "org.kde.Sdk",
+    "runtime-version": "5.15",
+    "base": "io.qt.qtwebengine.BaseApp",
+    "base-version": "5.15",
+    "sdk": "org.kde.Sdk",
+    "command": "kdevelop",
+    "finish-args": [
+        "--allow=devel",
+        "--device=dri",
+        "--filesystem=host",
+        "--own-name=org.kdevelop.*",
+        "--share=ipc",
+        "--share=network",
+        "--socket=cups",
+        "--socket=wayland",
+        "--socket=x11"
+    ],
+    "modules": [
+        {
+            "name": "boost",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/include/boost",
+                "cp -r boost/* ${FLATPAK_DEST}/include/boost"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2",
+                    "sha256": "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
+                }
+            ]
+        },
+        {
+            "name": "grantlee",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://downloads.grantlee.org/grantlee-5.2.0.tar.gz",
+                    "sha256": "d6cd04de39a073a787c9ab8e72a0888e40779d21b83fbc788a1b36d31ac659d5"
+                }
+            ]
+        },
+        {
+            "name": "qca",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTS=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/qca/2.3.1/qca-2.3.1.tar.xz",
+                    "sha256": "c13851109abefc4623370989fae3a745bf6b1acb3c2a13a8958539823e974e4b"
+                }
+            ]
+        },
+        {
+            "name": "libkomparediff2",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org//stable/release-service/20.12.0/src/libkomparediff2-20.12.0.tar.xz",
+                    "sha256": "8b92b729d2d1c7998b22ffd6a7ae95f46954785d4855ce6cfa7a1fb401cf66ec"
+                }
+            ]
+        },
+        {
+            "name": "okteta",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/okteta/0.26.4/src/okteta-0.26.4.tar.xz",
+                    "sha256": "ef22b096c4d8a682b5467ee7d8e9e05ede44cde116daef804312745c4bfd0f03"
+                }
+            ]
+        },
+        {
+            "name": "krunner",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/frameworks/5.76/krunner-5.76.0.tar.xz",
+                    "sha256": "08c8addcdd3dac87472e84bd14c6d02b99f98c5efbbda7802de92286105dcdda"
+                }
+            ]
+        },
+        {
+            "name": "libksysguard",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF",
+                "-DENABLE_KAUTH_HELPER=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org//stable/plasma/5.20.4/libksysguard-5.20.4.tar.xz",
+                    "sha256": "a89968476cb8a888550e1a5138ab8e86eeb49788187192cba71f79abd4aad422"
+                },
+                {
+                    "type": "patch",
+                    "path": "libksysguard_helper.patch"
+                }
+            ]
+        },
+        {
+            "name": "konsole",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/20.12.1/src/konsole-20.12.1.tar.xz",
+                    "sha256": "b690be392462cab5abac74d1e1010c3f991c3d00968b51ed5525040640d769ec"
+                }
+            ]
+        },
+        {
+            "name": "kdevelop-pg-qt",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kdevelop-pg-qt/2.2.1/src/kdevelop-pg-qt-2.2.1.tar.xz",
+                    "sha256": "c13931788ac9dc02188cdd9c6e71e164ae81b4568b048748652bbf6fa4a9c62b"
+                }
+            ]
+        },
+        {
+            "name": "kdevelop",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kdevelop/5.6.1/src/kdevelop-5.6.1.tar.xz",
+                    "sha256": "9e4488522275ebef9d68eebb68523a99e1c58d35e8d75127f7d749784c2e370a"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
+                }
+            ]
+        },
+        {
+            "name": "kdev-python",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kdevelop/5.6.1/src/kdev-python-5.6.1.tar.xz",
+                    "sha256": "00d5db9596b7db9a6dd109fd3605dc155ac849b1b88328e038d4cf7b7fd575f3"
+                }
+            ]
+        },
+        {
+            "name": "kdev-php",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kdevelop/5.6.1/src/kdev-php-5.6.1.tar.xz",
+                    "sha256": "702f12a1ad0caadd020ac30294b70ec6426e7961ac439d270f3010748b3f7a5a"
+                }
+            ]
+        },
+        {
+            "name": "cmake",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://cmake.org/files/v3.19/cmake-3.19.3.tar.gz",
+                    "sha256": "3faca7c131494a1e34d66e9f8972ff5369e48d419ea8ceaa3dc15b4c11367732"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions.
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub:
  -  I am a member of KDE Team on Flathub
- [X] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge):
  - KDE project owns the domain
- [X] Any additional patches or files have been submitted to the upstream projects concerned:
  - https://invent.kde.org/plasma/libksysguard/-/merge_requests/105
  - https://invent.kde.org/kdevelop/kdevelop/-/merge_requests/221

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Currently missing features:

```
-- The following RUNTIME packages have not been found:

 * ClangTidy, A clang-based C++ “linter” tool, <https://clang.llvm.org/extra/clang-tidy/>
 * ClazyStandalone, Qt oriented code checker based on clang framework. Krazy's little brother, <https://commits.kde.org/clazy>
   Recommended: required by the non-essential Clazy plugin
 * Cppcheck, A tool for static C/C++ code analysis, <http://cppcheck.sourceforge.net/>
   Recommended: required by the non-essential Cppcheck plugin
 * heaptrack, A heap memory profiler for Linux, <https://phabricator.kde.org/dashboard/view/28>
   Recommended: required by the non-essential heaptrack plugin
 * heaptrack_gui, Analyzer gui for heaptrack, a heap memory profiler for Linux, <https://phabricator.kde.org/dashboard/view/28>
   Recommended: required by the non-essential heaptrack plugin

-- The following OPTIONAL packages have not been found:

 * SubversionLibrary, <https://subversion.apache.org/>
   Support for Subversion integration

-- The following RECOMMENDED packages have not been found:

 * LibAStyle (required version >= 3.1), Artistic Style library, <http://astyle.sourceforge.net/>
   External library for the astyle plugin
```