### PR TITLE
Initial Kolibri Explore Plugin

### DIFF
--- a/org.learningequality.Kolibri.Plugin.Explore.json
+++ b/org.learningequality.Kolibri.Plugin.Explore.json
@@ -1,0 +1,27 @@
+{
+  "id": "org.learningequality.Kolibri.Plugin.Explore",
+  "branch": "1.0",
+  "build-extension": true,
+  "runtime": "org.learningequality.Kolibri",
+  "runtime-version": "master",
+  "sdk": "org.freedesktop.Sdk//19.08",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "kolibri-explore-plugin",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --target=${FLATPAK_DEST}/lib/python kolibri_explore_plugin"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/c5/aa/48fc3ada727334851ed762c84111f8a2372440cf4491089cf73292c96b81/kolibri_explore_plugin-0.0.2-py2.py3-none-any.whl",
+          "sha256": "b9230b8f5f14fa5971eecf97cb4a0bed5f0dccd4cf9bfc87e8e246142f89f680"
+        }
+      ]
+    }
+
+  ]
+}

--- a/org.learningequality.Kolibri.Plugin.Explore.json
+++ b/org.learningequality.Kolibri.Plugin.Explore.json
@@ -3,7 +3,7 @@
   "branch": "1.0",
   "build-extension": true,
   "runtime": "org.learningequality.Kolibri",
-  "runtime-version": "master",
+  "runtime-version": "stable",
   "sdk": "org.freedesktop.Sdk//19.08",
   "appstream-compose": false,
   "separate-locales": false,

--- a/org.learningequality.Kolibri.Plugin.Explore.json
+++ b/org.learningequality.Kolibri.Plugin.Explore.json
@@ -1,6 +1,5 @@
 {
   "id": "org.learningequality.Kolibri.Plugin.Explore",
-  "branch": "1.0",
   "build-extension": true,
   "runtime": "org.learningequality.Kolibri",
   "runtime-version": "stable",


### PR DESCRIPTION
This plugin will provide the [kolibri-explore-plugin python module](https://pypi.org/project/kolibri-explore-plugin/) inside the kolibri app sandbox.

This plugin depends on the [kolibri flatpak plugin support](https://github.com/flathub/org.learningequality.Kolibri/pull/21).

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [ x All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** This is a plugin for an existing app, and I'm working on this as part of my work on EndlessOS: https://github.com/flathub/org.learningequality.Kolibri/pull/21
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [ x Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
