### PR TITLE
Add org.gnome.design.Typography

### DIFF
--- a/org.gnome.design.Typography.json
+++ b/org.gnome.design.Typography.json
@@ -1,0 +1,99 @@
+{
+    "app-id" : "org.gnome.design.Typography",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.38",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "org.gnome.design.Typography",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a",
+        "/lib/girepository-1.0",
+        "/share/gir-1.0",
+        "/bin/gtk4*",
+        "/bin/pango*",
+        "/bin/sassc"
+    ],
+    "modules" : [
+        {
+            "name" : "pango",
+            "buildsystem" : "meson",
+            "sources" :  [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/pango/1.48/pango-1.48.0.tar.xz",
+                    "sha256" : "391f26f3341c2d7053e0fb26a956bd42360dadd825efe7088b1e9340a65e74e6"
+                }
+            ]
+        },
+        {
+            "name": "libsass",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/sass/libsass/archive/3.6.4.tar.gz",
+                    "sha256": "f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889"
+                },
+                {
+                    "type" : "script",
+                    "dest-filename" : "autogen.sh",
+                    "commands" : [ "autoreconf -si" ]
+                }
+            ]
+        },
+        {
+            "name": "sassc",
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/sass/sassc/archive/3.6.1.tar.gz",
+                    "sha256": "8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60"
+                },
+                {
+                    "type" : "script",
+                    "dest-filename" : "autogen.sh",
+                    "commands" : [ "autoreconf -si" ]
+                }
+            ]
+        },
+        {
+            "name" : "gtk4",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Ddemos=false",
+                "-Dbuild-examples=false",
+                "-Dbuild-tests=false"
+            ],
+            "sources" :  [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "commit" : "edcd4c6207616ea97822b9a480ee2e07d6ce114c"
+                }
+            ]
+        },
+        {
+            "name" : "typography",
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://gitlab.gnome.org/World/design/typography/-/archive/0.1.0/typography-0.1.0.tar.gz",
+                    "sha256" : "7990df024495c6018f066273b91ab8f6bf27e4ea2dc2f506bc18420b4ed769b0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Typography is an app from the GNOME Design Tooling team
to showcase the style classes and characters we suggest
using for text in applications.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://gitlab.gnome.org/World/design/typography
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
