### PR TITLE
Add com.github.sqlitebrowser.sqlitebrowser

### DIFF
--- a/com.github.sqlitebrowser.sqlitebrowser.desktop.appdata.xml
+++ b/com.github.sqlitebrowser.sqlitebrowser.desktop.appdata.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>sqlitebrowser.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0 and GPL-3.0+</project_license>
+  <name>DB Browser for SQLite</name>
+  <summary>DB Browser for SQLite is a light GUI editor for SQLite databases</summary>
+  <description>
+    <p>DB Browser for SQLite is a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.</p>
+    <p>It is for users and developers wanting to create databases, search, and edit data. It uses a familiar spreadsheet-like interface, and you don't need to learn complicated SQL commands.</p>
+    <p>Controls and wizards are available for users to:</p>
+    <ul>
+      <li>Create and compact database files</li>
+      <li>Create, define, modify and delete tables</li>
+      <li>Create, define and delete indexes</li>
+      <li>Browse, edit, add and delete records</li>
+      <li>Search records</li>
+      <li>Import and export records as text</li>
+      <li>Import and export tables from/to CSV files</li>
+      <li>Import and export databases from/to SQL dump files</li>
+      <li>Issue SQL queries and inspect the results</li>
+      <li>Examine a log of all SQL commands issued by the application</li>
+    </ul>
+  </description>
+  <content_rating type="oars-1.1" />
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/sqlitebrowser/db4s-screenshots/master/v3.3/gnome3_2-execute.png</image>
+      <caption>DB Browser for SQLite, executing query</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/sqlitebrowser/db4s-screenshots/master/v3.3/gnome3_1-plot.png</image>
+      <caption>DB Browser for SQLite, browsing data with plot</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/sqlitebrowser/db4s-screenshots/master/v3.3/kde413_2-blob.png</image>
+      <caption>DB Browser for SQLite, browsing a blob field</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/sqlitebrowser/db4s-screenshots/master/v3.3/kde413_1-create_table.png</image>
+      <caption>DB Browser for SQLite, creating a table</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://sqlitebrowser.org/</url>
+  <url type="bugtracker">https://github.com/sqlitebrowser/sqlitebrowser/issues</url>
+  <releases>
+    <release version="3.12.1" date="2020-11-09" />
+  </releases>
+</component>
+

--- a/com.github.sqlitebrowser.sqlitebrowser.desktop.appdata.xml
+++ b/com.github.sqlitebrowser.sqlitebrowser.desktop.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>sqlitebrowser.desktop</id>
+  <id>com.github.sqlitebrowser.sqlitebrowser</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0 and GPL-3.0+</project_license>
   <name>DB Browser for SQLite</name>

--- a/com.github.sqlitebrowser.sqlitebrowser.yaml
+++ b/com.github.sqlitebrowser.sqlitebrowser.yaml
@@ -4,7 +4,7 @@ runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: sqlitebrowser
 rename-icon: sqlitebrowser
-rename-appdata-file: sqlitebrowser.appdata.xml  
+rename-appdata-file: sqlitebrowser.desktop.appdata.xml
 rename-desktop-file: sqlitebrowser.desktop
 copy-icon: true
 finish-args:

--- a/com.github.sqlitebrowser.sqlitebrowser.yaml
+++ b/com.github.sqlitebrowser.sqlitebrowser.yaml
@@ -4,10 +4,10 @@ runtime-version: '5.15'
 sdk: org.kde.Sdk
 command: sqlitebrowser
 rename-icon: sqlitebrowser
-rename-appdata-file: sqlitebrowser.desktop.appdata.xml
 rename-desktop-file: sqlitebrowser.desktop
 copy-icon: true
 finish-args:
+  - --device=dri
   - --filesystem=home
   - --share=ipc
   - --share=network

--- a/com.github.sqlitebrowser.sqlitebrowser.yaml
+++ b/com.github.sqlitebrowser.sqlitebrowser.yaml
@@ -1,0 +1,22 @@
+app-id: com.github.sqlitebrowser.sqlitebrowser
+runtime: org.kde.Platform
+runtime-version: '5.15'
+sdk: org.kde.Sdk
+command: sqlitebrowser
+rename-icon: sqlitebrowser
+rename-appdata-file: sqlitebrowser.appdata.xml  
+rename-desktop-file: sqlitebrowser.desktop
+copy-icon: true
+finish-args:
+  - --filesystem=home
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+modules:
+  - name: sqlitebrowser
+    buildsystem: cmake
+    sources:
+      - type: archive
+        url: https://github.com/sqlitebrowser/sqlitebrowser/archive/v3.12.1.tar.gz
+        sha256: c1f13a7caeab9c36908d7fd6e46718d5f2bb5d116882c5c6392e7c4b0f8dba0f


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
  - `<content_rating>` and `<release>` are missing from appdata in the tagged release. Its in master but not tagged yet. Is this a problem?
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - `--filesystem=home` The app does sort of support portals but there are errors after opening files. FS access makes sense until that can be resolved
  - `--share=network` The only place I can see this used is for printing. Removing network access only allows the "Print to file" option. I guess if people want to lock this down more they can use flatseal but better to have the default config with everything working.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link: https://github.com/sqlitebrowser/sqlitebrowser/issues/2103**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
  - Its a github repo I do not control
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
  - No patches used

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
