### PR TITLE
re.sonny.Commit

### DIFF
--- a/re.sonny.Commit.json
+++ b/re.sonny.Commit.json
@@ -1,0 +1,54 @@
+{
+  "app-id": "re.sonny.Commit",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "40",
+  "sdk": "org.gnome.Sdk",
+  "command": "re.sonny.Commit",
+  "finish-args": [
+    "--filesystem=host",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "gspell",
+      "config-opts": [
+        "--disable-vala",
+        "--disable-static",
+        "--disable-gtk-doc"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download-fallback.gnome.org/sources/gspell/1.9/gspell-1.9.1.tar.xz",
+          "sha256": "dcbb769dfdde8e3c0a8ed3102ce7e661abbf7ddf85df08b29915e92cd723abdd"
+        }
+      ],
+      "cleanup": ["/bin"]
+    },
+    {
+      "name": "Commit",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/sonnyp/Commit.git",
+          "tag": "v1.0.0",
+          "commit": "4bacb6ba1402975392d574507e80c6ff749fef66"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
https://github.com/sonnyp/Commit

`"--filesystem=host",` is required and there is no way around it. Git will invoke the editor with the path to a file as argument.

Commit is a fork of Gnomit - also present on flathub. Multiple attempts to contact the maintainer failed. All my improvements were submitted a while ago upstream.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
