### PR TITLE
Add com.obsproject.Studio.Plugin.InputOverlay

### DIFF
--- a/com.obsproject.Studio.Plugin.InputOverlay.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.InputOverlay.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.InputOverlay</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>Input Overlay Plugin</name>
+  <summary>Show keyboard, gamepad and mouse input on stream</summary>
+  <url type="homepage">https://github.com/univrsal/input-overlay</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+</component>

--- a/com.obsproject.Studio.Plugin.InputOverlay.yaml
+++ b/com.obsproject.Studio.Plugin.InputOverlay.yaml
@@ -5,6 +5,7 @@ runtime-version: stable
 sdk: org.kde.Sdk//5.15
 build-extension: true
 separate-locales: false
+appstream-compose: false
 build-options:
   prefix: /app/plugins/InputOverlay
 modules:
@@ -19,7 +20,12 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DLIBOBS_INCLUDE_DIR=/app/include/obs
+    post-install:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
     sources:
       - type: git
         url: https://github.com/univrsal/input-overlay.git
         commit: 94019421573978924d247e7b4a4a98c04441cd25
+      - type: file
+        path: com.obsproject.Studio.Plugin.InputOverlay.metainfo.xml

--- a/com.obsproject.Studio.Plugin.InputOverlay.yaml
+++ b/com.obsproject.Studio.Plugin.InputOverlay.yaml
@@ -1,0 +1,25 @@
+id: com.obsproject.Studio.Plugin.InputOverlay
+branch: stable
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.kde.Sdk//5.15
+build-extension: true
+separate-locales: false
+build-options:
+  prefix: /app/plugins/InputOverlay
+modules:
+  - name: libuiohook
+    buildsystem: autotools
+    sources:
+      - type: git
+        url: https://github.com/kwhat/libuiohook.git
+        commit: 57630b7036becb8fa8ed65903ae994eda50a72f6
+  - name: input-overlay
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLIBOBS_INCLUDE_DIR=/app/include/obs
+    sources:
+      - type: git
+        url: https://github.com/univrsal/input-overlay.git
+        commit: 94019421573978924d247e7b4a4a98c04441cd25

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "skip-icons-check": true,
+  "only-arches": ["x86_64", "i386"]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/univrsal/input-overlay/issues/158
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

I should have submitted this a long time ago, but I guess I wanted to make sure people weren't discontent with WebSocket before I gave this another go. This plugin adds a customizable input overlay that can use keyboard, mouse, and gamepad.

I took what I learned from submitting WebSocket; hopefully I hit this one in one shot this time! Thanks very much for your time. 🙂