### PR TITLE
Added io.github.muse_sequencer.Muse

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/io.github.muse_sequencer.Muse.json
+++ b/io.github.muse_sequencer.Muse.json
@@ -1,0 +1,121 @@
+{
+  "app-id": "io.github.muse_sequencer.Muse",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.15",
+  "sdk": "org.kde.Sdk",
+  "command": "muse4",
+  "rename-icon": "muse",
+  "rename-desktop-file": "org.musesequencer.Muse4.desktop",
+  "rename-appdata-file": "org.musesequencer.Muse4.appdata.xml",
+  "finish-args": [
+    /* X11 + XShm access */
+    "--share=ipc",
+    "--socket=x11",
+    /* Note playback */
+    "--socket=pulseaudio",
+    /* MIDI */
+    "--device=all",
+    /* JACK */
+    "--filesystem=xdg-run/pipewire-0",
+    "--system-talk-name=org.freedesktop.RealtimeKit1",
+    /* Allow loading, saving files from anywhere (portals don’t work yet) */
+    "--filesystem=home",
+    /* Allow other instances to see lockfiles */
+    "--env=TMPDIR=/var/tmp",
+    /* On SuSE it seems to be necessary for sound to work */
+    "--env=ALSA_CONFIG_PATH=",
+    "--env=LV2_PATH=/app/extensions/Plugins/lv2",
+    "--env=DSSI_PATH=/app/extensions/Plugins/dssi",
+    "--env=LADSPA_PATH=/app/extensions/Plugins/ladspa",
+    "--env=LXVST_PATH=/app/extensions/Plugins/lxvst",
+    "--env=QT_ENABLE_HIGHDPI_SCALING=1"
+  ],
+  "add-extensions": {
+    "org.freedesktop.LinuxAudio.Plugins": {
+      "directory": "extensions/Plugins",
+      "version": "20.08",
+      "add-ld-path": "lib",
+      "merge-dirs": "ladspa;dssi;lv2;lxvst",
+      "subdirectories": true,
+      "no-autodownload": true
+    }
+  },
+  "cleanup": [
+    "/include",
+    "/lib/cmake",
+    "/lib/pkgconfig",
+    "/share/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "*.la"
+  ],
+  "modules": [
+    "shared-modules/linux-audio/lrdf.json",
+    "shared-modules/linux-audio/jack2.json",
+    {
+      "name": "audiofile",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://audiofile.68k.org/audiofile-0.3.6.tar.gz",
+          "sha256": "cdc60df19ab08bfe55344395739bb08f50fc15c92da3962fac334d3bff116965"
+        },
+        {
+          "type": "patch",
+          "path": "patches/audiofile-gcc6.patch"
+        }
+      ]
+    },
+    "shared-modules/linux-audio/libinstpatch.json",
+    "shared-modules/linux-audio/fluidsynth2.json",
+    {
+      "name": "rtaudio",
+      "config-opts": [
+        "--disable-static",
+        "--enable-shared",
+        "--with-alsa",
+        "--with-pulse",
+        "--with-jack=no"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "http://www.music.mcgill.ca/~gary/rtaudio/release/rtaudio-5.0.0.tar.gz",
+          "sha256": "799deae1192da52cc2c15a078ed3b42449580be7d096fe9bc841c5bba0289c57"
+        }
+      ]
+    },
+    "shared-modules/linux-audio/liblo.json",
+    "shared-modules/linux-audio/dssi.json",
+    "shared-modules/linux-audio/lv2.json",
+    "shared-modules/linux-audio/lilv.json",
+    {
+      "name": "muse4",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=release"
+      ],
+      "build-options": {
+        "env": [
+          "LADSPA_PATH=/app/lib/ladspa"
+        ]
+      },
+      "post-install": [
+          "mv ${FLATPAK_DEST}/share/mime/packages/muse.xml ${FLATPAK_DEST}/share/mime/packages/${FLATPAK_ID}.xml",
+          "install -d /app/extensions/Plugins"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/muse-sequencer/muse/releases/download/4.0.0/muse-4.0.tar.gz",
+          "sha256": "4de670b8e4d7e14c09da26f4d085a7ed452332e030b106c8054685c580bb80dc"
+        },
+        {
+          "type": "patch",
+          "strip-components": 2,
+          "path": "patches/muse-appdata.patch"
+        }
+      ]
+    }
+  ]
+}

--- a/patches/audiofile-gcc6.patch
+++ b/patches/audiofile-gcc6.patch
@@ -1,0 +1,21 @@
+From b62c902dd258125cac86cd2df21fc898035a43d3 Mon Sep 17 00:00:00 2001
+From: Michael Pruett <michael@68k.org>
+Date: Mon, 29 Aug 2016 23:08:26 -0500
+Subject: [PATCH] Fix undefined behavior in sign conversion.
+Origin: https://github.com/mpruett/audiofile/commit/b62c902dd258125cac86cd2df21fc898035a43d3
+
+---
+diff --git a/libaudiofile/modules/SimpleModule.h b/libaudiofile/modules/SimpleModule.h
+index 03c6c69..bad85ad 100644
+--- a/libaudiofile/modules/SimpleModule.h
++++ b/libaudiofile/modules/SimpleModule.h
+@@ -123,7 +123,8 @@ struct signConverter
+ 	typedef typename IntTypes<Format>::UnsignedType UnsignedType;
+ 
+ 	static const int kScaleBits = (Format + 1) * CHAR_BIT - 1;
+-	static const int kMinSignedValue = -1 << kScaleBits;
++	static const int kMaxSignedValue = (((1 << (kScaleBits - 1)) - 1) << 1) + 1;
++	static const int kMinSignedValue = -kMaxSignedValue - 1;
+ 
+ 	struct signedToUnsigned : public std::unary_function<SignedType, UnsignedType>
+ 	{

--- a/patches/muse-appdata.patch
+++ b/patches/muse-appdata.patch
@@ -1,0 +1,20 @@
+diff --git a/muse3/packaging/org.musesequencer.Muse4.appdata.xml b/muse3/packaging/org.musesequencer.Muse4.appdata.xml
+index e6c9a09f..b3e45c3d 100644
+--- a/muse3/packaging/org.musesequencer.Muse4.appdata.xml
++++ b/muse3/packaging/org.musesequencer.Muse4.appdata.xml
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ <component type="desktop">
+-  <id>org.musesequencer.Muse4</id>
++  <id>io.github.muse_sequencer.Muse</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+   <name>MusE</name>
+@@ -49,6 +49,6 @@
+   </provides>
+ 
+   <releases>
+-    <release version="4.0.0-pre1" date="2020-11-15">
++    <release version="4.0.0" date="2021-04-24">
+       <description>
+         <p>Apart from the usual bunch of bug fixes and improvements 


### PR DESCRIPTION
This is Muse 4, the newer release of Muse3 already flathub. Upstream changed the app-id, and I changed it again as they no longer have the domain.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Just a new version of the old app with an ID change**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge). - _**the application ID is renamed to io.github.muse_sequencer.Muse**_ See details https://github.com/muse-sequencer/muse/issues/989
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
