### PR TITLE
Draft: Add org.kde.nota

### DIFF
--- a/appstream.patch
+++ b/appstream.patch
@@ -1,0 +1,18 @@
+commit 955217261abc3e018cce25da569f79c375c90e32
+Author: Camilo Higuita <chiguitar@unal.edu.co>
+Date:   Fri May 14 12:13:37 2021 -0500
+
+    install appstream metadata
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0f3011f..83eeab9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -84,6 +84,7 @@ add_subdirectory(src)
+ 
+ if(UNIX AND NOT APPLE AND NOT ANDROID)
+     install(FILES org.kde.nota.desktop DESTINATION ${XDG_APPS_INSTALL_DIR})
++    install(FILES org.kde.nota.metainfo.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
+ endif()
+ 
+ feature_summary(WHAT ALL   FATAL_ON_MISSING_REQUIRED_PACKAGES)

--- a/org.kde.nota.json
+++ b/org.kde.nota.json
@@ -1,0 +1,94 @@
+{
+    "id": "org.kde.nota",
+    "rename-icon": "nota",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15",
+    "sdk": "org.kde.Sdk",
+    "command": "nota",
+    "finish-args": [
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host"
+    ],
+    "modules": [
+        {
+            "name": "mauikit",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "3af24f8f8ac85a3215092d6014e60e324f400bbd96d8135ee273cf1d86dedef6",
+                    "url": "https://download.kde.org/stable/maui/mauikit/1.2.2/mauikit-1.2.2.tar.xz"
+                }
+            ]
+        },
+        {
+            "name": "mauikit-filebrowsing",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/maui/mauikit-filebrowsing/1.2.2/mauikit-filebrowsing-1.2.2.tar.xz",
+                    "sha256": "22301e96514f5dd83e0b6dc0aefe15dc11ad05edb7bfdf5a891de55fd2414da0"
+                }
+            ]
+        },
+        {
+            "name": "mauikit-texteditor",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/maui/mauikit-texteditor/1.2.2/mauikit-texteditor-1.2.2.tar.xz",
+                    "sha256": "b5d292e865ebd3e61e25c54b06e38723ad04ba0b60e0a77f887d8e6df2e1c698"
+                }
+            ]
+        },
+        {
+            "name": "kdecoration",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "sha256": "bc550b7bfde5b5762e76b33ac53f8268b6178ae389c953d729b864b22787d54c",
+                    "url": "https://download.kde.org/stable/plasma/5.21.5/kdecoration-5.21.5.tar.xz"
+                }
+            ]
+        },
+        {
+            "name": "applet-window-buttons",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/psifidotos/applet-window-buttons/archive/refs/tags/0.9.0.tar.gz",
+                    "sha256": "053201441e2cc7c0589c920028b985752ad9a87dc0f7fb35070cf44c9fcfbab7"
+                }
+            ]
+        },
+        {
+            "name": "nota",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/maui/nota/1.2.2/nota-1.2.2.tar.xz",
+                    "sha256": "e2b06f94eb30151028e5a42b96fd3eafeb7063fb332845e98618a844d2ebed1f"
+                },
+                {
+                    "type": "file",
+                    "path": "org.kde.nota.metainfo.xml",
+                    "dest-filename": "org.kde.nota.metainfo.xml",
+                    "sha256": "2e1e43206bdb720ecc2523db3e5f3fb4c3b51acc3ca81473a56b96eb8d870335"
+                },
+                {
+                    "type": "patch",
+                    "path": "appstream.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.nota.metainfo.xml
+++ b/org.kde.nota.metainfo.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: 2021 Carl Schwan <carlschwan@kde.org>
+SPDX-License-Identifier: CC0-1.0
+-->
+<component type="desktop">
+  <id>org.kde.nota</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-3.0</project_license>
+  <name>Nota</name>
+  <name xml:lang="ca">Nota</name>
+  <name xml:lang="ca-valencia">Nota</name>
+  <name xml:lang="de">Nota</name>
+  <name xml:lang="es">Nota</name>
+  <name xml:lang="nl">Nota</name>
+  <name xml:lang="pl">Nota</name>
+  <name xml:lang="pt">Nota</name>
+  <name xml:lang="pt-BR">Nota</name>
+  <name xml:lang="sk">Nota</name>
+  <name xml:lang="sv">Nota</name>
+  <name xml:lang="uk">Nota</name>
+  <name xml:lang="x-test">xxNotaxx</name>
+  <summary>Browse, create and edit text files</summary>
+  <summary xml:lang="ca">Navegueu, creeu, i editeu fitxers de text</summary>
+  <summary xml:lang="ca-valencia">Navegueu, creeu, i editeu fitxers de text</summary>
+  <summary xml:lang="de">Textdaten durchsehen, erstellen und bearbeiten</summary>
+  <summary xml:lang="es">Navegue, cree y edite archivos de texto</summary>
+  <summary xml:lang="nl">Tekstbestanden, er in bladeren, aanmaken en bewerken</summary>
+  <summary xml:lang="pl">Przeglądaj, twórz i zmieniaj swoje pliki tekstowe</summary>
+  <summary xml:lang="pt">Navegue, crie e edite ficheiros de texto</summary>
+  <summary xml:lang="pt-BR">Navegar, criar e editar arquivos de texto</summary>
+  <summary xml:lang="sk">Prehliadanie, vytváranie a editovanie textových súborov</summary>
+  <summary xml:lang="sv">Bläddra bland, skapa och redigera textfiler</summary>
+  <summary xml:lang="uk">Перегляд, створення та редагування текстових файлів</summary>
+  <summary xml:lang="x-test">xxBrowse, create and edit text filesxx</summary>
+  <description>
+    <p>Nota is a simple text editor for desktop and mobile computers.</p>
+    <p xml:lang="ca">El Nota és un editor senzill de text per a ordinadors d'escriptori i mòbils.</p>
+    <p xml:lang="ca-valencia">El Nota és un editor senzill de text per a ordinadors d'escriptori i mòbils.</p>
+    <p xml:lang="de">Nota ist ein einfacher Texteditor für die Arbeitsfläche und Mobilgeräte.</p>
+    <p xml:lang="es">Nota es un editor simple de texto para móviles y el escritorio.</p>
+    <p xml:lang="nl">Nota is een eenvoudige tekstverwerker voor bureaublad en mobiele computers.</p>
+    <p xml:lang="pl">Nota jest prostym edytorem tekstu dla urządzeń na biurko i przenośnych.</p>
+    <p xml:lang="pt">O Nota é um editor de texto simples para computadores e dispositivos móveis.</p>
+    <p xml:lang="pt-BR">O Nota é um editor de texto simples para a área de trabalho e celulares.</p>
+    <p xml:lang="sk">Nota je jednoduchý editor pre desktopové a mobilné počítače.</p>
+    <p xml:lang="sv">Nota är en enkel texteditor för skrivbords- och bärbara datorer.</p>
+    <p xml:lang="uk">Nota — простий текстовий редактор для робочих станцій та мобільних комп'ютерів.</p>
+    <p xml:lang="x-test">xxNota is a simple text editor for desktop and mobile computers.xx</p>
+  </description>
+  <url type="homepage">https://mauikit.org/</url>
+  <url type="bugtracker">https://invent.kde.org/maui/nota/-/issues</url>
+  <url type="donation">https://kde.org/community/donations</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Nota</caption>
+      <caption xml:lang="ca">Nota</caption>
+      <caption xml:lang="ca-valencia">Nota</caption>
+      <caption xml:lang="de">Nota</caption>
+      <caption xml:lang="es">Nota</caption>
+      <caption xml:lang="nl">Nota</caption>
+      <caption xml:lang="pl">Nota</caption>
+      <caption xml:lang="pt">Nota</caption>
+      <caption xml:lang="pt-BR">Nota</caption>
+      <caption xml:lang="sk">Nota</caption>
+      <caption xml:lang="sv">Nota</caption>
+      <caption xml:lang="uk">Nota</caption>
+      <caption xml:lang="x-test">xxNotaxx</caption>
+      <image type="source" width="2464" height="1929">
+        https://cdn.kde.org/screenshots/nota/nota.png
+      </image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Nota, find dialog</caption>
+      <image type="source" width="3285" height="2052">
+        https://cdn.kde.org/screenshots/nota/nota-tabs-find-dialog.png
+      </image>
+    </screenshot>
+    <screenshot type="default">
+      <image type="source" width="1947" height="1375">
+        https://cdn.kde.org/screenshots/nota/nota-stable.png
+      </image>
+    </screenshot>
+  </screenshots>
+  <provides>
+    <binary>nota</binary>
+  </provides>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </recommends>
+  <content_rating type="oars-1.0"/>
+  <project_group>KDE</project_group>
+  <releases>
+    <release version="1.2.2" date="2021-05-11">
+      <url>https://nxos.org/maui/maui-1-2-2-release/</url>
+    </release>
+  </releases>
+</component>


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions.
    -  It use filesystem:home because Nota is using a embedded file dialog instead of a normal FileDialog. I will try to submit a patch upstream and this is why this MR is a draft
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub.
- [x] I sort of maintaining kde.org, does it count? :)  
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
