### PR TITLE
Point to Matrix instead of the defunct IRC room.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ Please open bugs for packages on their respective repositories you can search fo
 
 Please do not open issues requesting packages. As long as a package meets the guidelines above and works it will be
 generally be accepted. If you want to create a Flatpak see the [documentation](https://flatpak.readthedocs.io/en/latest/)
-or join ircs://chat.freenode.net/flatpak for help.
+or join [#flatpak:matrix.org](https://matrix.to/#/#flatpak:matrix.org) for help.


### PR DESCRIPTION
Related commit https://github.com/flatpak/flatpak.github.io/commit/7650ec07b8a1990b2f5ab8418d6bf740615fc3c7
Fix https://github.com/flathub/flathub/issues/2366

The IRC reference in https://github.com/flathub/flathub/wiki/App-Submission#getting-help should be changed too but I can't modify it. 

Hope this is appropriate.