### PR TITLE
Add org.kde.haruna

### DIFF
--- a/org.kde.haruna.yml
+++ b/org.kde.haruna.yml
@@ -20,8 +20,8 @@ modules:
     buildsystem: cmake-ninja
     sources:
       - type: archive
-        url: 'https://invent.kde.org/multimedia/haruna/-/archive/0.6.3/haruna-0.6.3.tar.gz'
-        sha256: 'c79ec1e351f47faf9a58a6ba7ec3cc05cfdc5423fde0584f2d4081f5058363e3'
+        url: 'https://invent.kde.org/multimedia/haruna/-/archive/0.6.3.1/haruna-0.6.3.1.tar.gz'
+        sha256: '0dbf156c4deb8a0db08bad182cf5f2bef964e9574933ca19c3f39a07963b6519'
     modules:
       - name: taglib
         buildsystem: cmake-ninja

--- a/org.kde.haruna.yml
+++ b/org.kde.haruna.yml
@@ -1,0 +1,181 @@
+---
+app-id: org.kde.haruna
+runtime: org.kde.Platform
+runtime-version: '5.15'
+sdk: org.kde.Sdk
+command: haruna
+finish-args:
+  - '--share=ipc'
+  - '--share=network'
+  - '--socket=fallback-x11'
+  - '--socket=wayland'
+  - '--socket=pulseaudio'
+  - '--device=dri'
+  - '--filesystem=host'
+  - '--talk-name=org.freedesktop.ScreenSaver'
+  - '--own-name=org.mpris.MediaPlayer2.haruna'
+  - '--env=LC_NUMERIC=C'
+modules:
+  - name: haruna
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: 'https://invent.kde.org/multimedia/haruna/-/archive/0.6.3/haruna-0.6.3.tar.gz'
+        sha256: 'c79ec1e351f47faf9a58a6ba7ec3cc05cfdc5423fde0584f2d4081f5058363e3'
+    modules:
+      - name: taglib
+        buildsystem: cmake-ninja
+        config-opts:
+        - '-DBUILD_SHARED_LIBS=ON'
+        sources:
+        - type: archive
+          url: 'https://github.com/taglib/taglib/releases/download/v1.12/taglib-1.12.tar.gz'
+          sha256: '7fccd07669a523b07a15bd24c8da1bbb92206cb19e9366c3692af3d79253b703'
+
+      - name: ffmpegthumbs
+        buildsystem: cmake-ninja
+        sources:
+        - type: archive
+          url: 'https://invent.kde.org/multimedia/ffmpegthumbs/-/archive/v21.04.1/ffmpegthumbs-v21.04.1.tar.gz'
+          sha256: '7509a2095e6d401afa614413fb7915736dd5e1bd43da2ffa9fd2cbe28a35edce'
+
+      - name: kio-extras
+        buildsystem: cmake-ninja
+        sources:
+        - type: archive
+          url: 'https://invent.kde.org/network/kio-extras/-/archive/v21.04.1/kio-extras-v21.04.1.tar.gz'
+          sha256: '32a04343396c55481861242c894eb84cedd1d4ef79a260e4dd0ec9aa654e8b24'
+
+      - name: libmpv
+        cleanup:
+          - /include
+          - /lib/pkgconfig
+          - /share/man
+        buildsystem: simple
+        build-commands:
+          - python3 waf configure --prefix=/app --enable-libmpv-shared --disable-cplayer --disable-build-date --disable-alsa
+          - python3 waf build
+          - python3 waf install
+        sources:
+          - type: archive
+            url: 'https://github.com/mpv-player/mpv/archive/v0.33.1.tar.gz'
+            sha256: '100a116b9f23bdcda3a596e9f26be3a69f166a4f1d00910d1789b6571c46f3a9'
+          - type: file
+            url: 'https://waf.io/waf-2.0.21'
+            sha256: '7cebf2c5efe53cbb9a4b5bdc4b49ae90ecd64a8fce7a3222d58e591b58215306'
+            dest-filename: waf
+        modules:
+          - name: luajit
+            no-autogen: true
+            cleanup:
+              - /bin
+              - /lib/*.a
+              - /include
+              - /lib/pkgconfig
+              - /share/man
+            sources:
+              - type: archive
+                url: 'https://luajit.org/download/LuaJIT-2.1.0-beta3.tar.gz'
+                sha256: '1ad2e34b111c802f9d0cdf019e986909123237a28c746b21295b63c9e785d9c3'
+              - type: shell
+                commands:
+                  - sed -i 's|/usr/local|/app|' ./Makefile
+
+          - name: libv4l2
+            cleanup:
+              - /sbin
+              - /bin
+              - /include
+              - /lib/*.la
+              - /lib/*/*.la
+              - /lib*/*/*/*.la
+              - /lib/pkgconfig
+              - /share/man
+            config-opts:
+              - '--disable-static'
+              - '--disable-bpf'
+              - '--with-udevdir=/app/lib/udev'
+            sources:
+              - type: archive
+                url: 'https://linuxtv.org/downloads/v4l-utils/v4l-utils-1.20.0.tar.bz2'
+                sha256: '956118713f7ccb405c55c7088a6a2490c32d54300dd9a30d8d5008c28d3726f7'
+
+          - name: nv-codec-headers
+            cleanup:
+              - '*'
+            no-autogen: true
+            make-install-args:
+              - PREFIX=/app
+            sources:
+              - type: archive
+                url: 'https://github.com/FFmpeg/nv-codec-headers/releases/download/n11.0.10.1/nv-codec-headers-11.0.10.1.tar.gz'
+                sha256: '97e37b85922f1167b2f0bf0bb804c3d7266cc679e78814fe820cf8912a0e1291'
+
+          - name: ffmpeg
+            cleanup:
+              - /include
+              - /lib/pkgconfig
+              - /share/ffmpeg/examples
+            config-opts:
+              - '--enable-shared'
+              - '--disable-static'
+              - '--enable-gnutls'
+              - '--enable-gpl'
+              - '--disable-doc'
+              - '--disable-programs'
+              - '--disable-encoders'
+              - '--disable-muxers'
+              - '--enable-encoder=png,libwebp'
+              - '--enable-libv4l2'
+              - '--enable-libdav1d'
+              - '--enable-libfontconfig'
+              - '--enable-libfreetype'
+              - '--enable-libopus'
+              - '--enable-librsvg'
+              - '--enable-libvpx'
+              - '--enable-libmp3lame'
+              - '--enable-libwebp'
+            sources:
+              - type: archive
+                url: 'https://ffmpeg.org/releases/ffmpeg-4.4.tar.gz'
+                sha256: 'a4abede145de22eaf233baa1726e38e137f5698d9edd61b5763cd02b883f3c7c'
+
+          - name: libass
+            cleanup:
+              - /include
+              - /lib/*.la
+              - /lib/pkgconfig
+            config-opts:
+              - '--disable-static'
+            sources:
+              - type: archive
+                url: 'https://github.com/libass/libass/releases/download/0.15.1/libass-0.15.1.tar.gz'
+                sha256: '101e2be1bf52e8fc265e7ca2225af8bd678839ba13720b969883eb9da43048a6'
+
+          - name: uchardet
+            buildsystem: cmake-ninja
+            config-opts:
+              - '-DCMAKE_BUILD_TYPE=Release'
+              - '-DBUILD_STATIC=0'
+            cleanup:
+              - /bin
+              - /include
+              - /lib/pkgconfig
+              - /share/man
+            sources:
+              - type: archive
+                url: 'https://gitlab.freedesktop.org/uchardet/uchardet/-/archive/v0.0.7/uchardet-v0.0.7.tar.gz'
+                sha256: 'f3635d1d10e1470452bc42c1bf509451a9926b399a11740a9949e86069d69f58'
+
+      - name: youtube-dl
+        no-autogen: true
+        no-make-install: true
+        make-args:
+          - youtube-dl
+          - PYTHON=/usr/bin/python3
+        post-install:
+          - install youtube-dl /app/bin
+        sources:
+          - type: archive
+            url: 'https://github.com/ytdl-org/youtube-dl/archive/2021.06.06.tar.gz'
+            sha256: '3d609df194db40f28fd4ef224cf732cd3ce7acd8596e3a0d19edba0fc5d047fa'


### PR DESCRIPTION
[com.georgefb.haruna](https://flathub.org/apps/details/com.georgefb.haruna) is now part of KDE, therefore it should be renamed.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions.
  - When a file is opened it adds files from the same folder to the playlist.
  - Users can define folders where for search for subtitles
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project.
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. 

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
