### PR TITLE
Add com.visualstudio.code.tool.podman

### DIFF
--- a/com.visualstudio.code.tool.podman.metainfo.xml
+++ b/com.visualstudio.code.tool.podman.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>com.visualstudio.code.tool.podman</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <name>Podman</name>
+  <summary>A tool for managing OCI containers and pods</summary>
+  <url type="homepage">https://podman.io/</url>
+</component>

--- a/com.visualstudio.code.tool.podman.metainfo.xml
+++ b/com.visualstudio.code.tool.podman.metainfo.xml
@@ -6,4 +6,7 @@
   <name>Podman</name>
   <summary>A tool for managing OCI containers and pods</summary>
   <url type="homepage">https://podman.io/</url>
+  <releases>
+    <release version="3.2.2" date="2021-06-25"/>
+  </releases>
 </component>

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -1,7 +1,7 @@
 id: com.visualstudio.code.tool.podman
-default-branch: stable
+branch: "20.08"
 build-extension: true
-sdk: org.freedesktop.Sdk//19.08
+sdk: org.freedesktop.Sdk//20.08
 runtime: com.visualstudio.code
 runtime-version: stable
 separate-locales: false

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -1,0 +1,26 @@
+id: com.visualstudio.code.tool.podman
+build-extension: true
+sdk: org.freedesktop.Sdk//19.08
+runtime: com.visualstudio.code-oss
+separate-locales: false
+appstream-compose: false
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
+build-options:
+  append-path: /usr/lib/sdk/golang/bin
+  prefix: /app/tools/podman
+  strip: true
+cleanup:
+  - "*.a"
+  - "*.la"
+  - /share/man
+modules:
+  - name: libpod
+    buildsystem: simple
+    build-commands:
+      - make PREFIX=${FLATPAK_DEST} podman
+      - install -Dm755 bin/podman -t ${FLATPAK_DEST}/bin/
+    sources:
+      - type: git
+        url: "https://github.com/containers/libpod.git"
+        tag: v2.0.0

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -1,7 +1,9 @@
 id: com.visualstudio.code.tool.podman
+default-branch: stable
 build-extension: true
 sdk: org.freedesktop.Sdk//19.08
-runtime: com.visualstudio.code-oss
+runtime: com.visualstudio.code
+runtime-version: stable
 separate-locales: false
 appstream-compose: false
 sdk-extensions:

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -25,4 +25,4 @@ modules:
     sources:
       - type: git
         url: "https://github.com/containers/libpod.git"
-        tag: v2.0.0
+        tag: v2.0.3

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -25,4 +25,4 @@ modules:
     sources:
       - type: git
         url: "https://github.com/containers/libpod.git"
-        tag: v2.0.3
+        tag: v2.1.0

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -20,8 +20,8 @@ modules:
   - name: libpod
     buildsystem: simple
     build-commands:
-      - make PREFIX=${FLATPAK_DEST} podman
-      - install -Dm755 bin/podman -t ${FLATPAK_DEST}/bin/
+      - make PREFIX=${FLATPAK_DEST} podman-remote
+      - install -Dm755 bin/podman-remote -t ${FLATPAK_DEST}/bin/
     sources:
       - type: git
         url: "https://github.com/containers/libpod.git"

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -1,5 +1,5 @@
 id: com.visualstudio.code.tool.podman
-branch: "20.08"
+branch: '20.08'
 build-extension: true
 sdk: org.freedesktop.Sdk//20.08
 runtime: com.visualstudio.code
@@ -13,8 +13,8 @@ build-options:
   prefix: /app/tools/podman
   strip: true
 cleanup:
-  - "*.a"
-  - "*.la"
+  - '*.a'
+  - '*.la'
   - /share/man
 modules:
   - name: podman
@@ -24,8 +24,9 @@ modules:
       - install -Dm755 bin/podman-remote -t ${FLATPAK_DEST}/bin/
     sources:
       - type: git
-        url: "https://github.com/containers/podman.git"
-        tag: v2.1.1
+        url: https://github.com/containers/podman.git
+        tag: v3.0.1
+        commit: c640670e85c4aaaff92741691d6a854a90229d8d
         x-checker-data:
           type: json
           url: https://api.github.com/repos/containers/podman/releases/latest

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -26,3 +26,9 @@ modules:
       - type: git
         url: "https://github.com/containers/podman.git"
         tag: v2.1.1
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/containers/podman/releases/latest
+          tag-query: .tag_name
+          timestamp-query: .published_at
+          version-query: $tag | sub("^v"; "")

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -33,3 +33,12 @@ modules:
           tag-query: .tag_name
           timestamp-query: .published_at
           version-query: $tag | sub("^v"; "")
+
+  - name: bundle-setup
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
+      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak $FLATPAK_ID
+    sources:
+      - type: file
+        path: com.visualstudio.code.tool.podman.metainfo.xml

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -17,12 +17,12 @@ cleanup:
   - "*.la"
   - /share/man
 modules:
-  - name: libpod
+  - name: podman
     buildsystem: simple
     build-commands:
       - make PREFIX=${FLATPAK_DEST} podman-remote
       - install -Dm755 bin/podman-remote -t ${FLATPAK_DEST}/bin/
     sources:
       - type: git
-        url: "https://github.com/containers/libpod.git"
-        tag: v2.1.0
+        url: "https://github.com/containers/podman.git"
+        tag: v2.1.1

--- a/com.visualstudio.code.tool.podman.yml
+++ b/com.visualstudio.code.tool.podman.yml
@@ -25,8 +25,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/containers/podman.git
-        tag: v3.0.1
-        commit: c640670e85c4aaaff92741691d6a854a90229d8d
+        tag: v3.2.2
+        commit: d577c44e359f9f8284b38cf984f939b3020badc3
         x-checker-data:
           type: json
           url: https://api.github.com/repos/containers/podman/releases/latest
@@ -38,7 +38,8 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
-      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak $FLATPAK_ID
+      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak
+        $FLATPAK_ID
     sources:
       - type: file
         path: com.visualstudio.code.tool.podman.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "skip-icons-check": true,
+    "automerge-flathubbot-prs": true,
+    "only-arches": ["x86_64"]
+}


### PR DESCRIPTION
This tool provides Podman remote client for VSCode flatpaks. It's useful with the [Docker extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker), and for CLI.
It requires the app to have `--filesystem=xdg-run/podman` (and/or `--filesystem=/run/podman`) permission and fairly recent Podman installed on host (≥ 2.0 if I recall; that has REST API).
Also VSCode needs to be configured to use `podman-remote` commands instead of `docker`:
```json
"docker.dockerPath": "podman-remote",
"//docker.host": "unix:///run/podman/podman.sock",
"docker.host": "unix:///run/user/1000/podman/podman.sock",
```

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub.
  _This is a very flatpak-specific thing, unlikely to be of any interest for the upstream._
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
