### PR TITLE
Add org.gnome.design.Lorem

### DIFF
--- a/org.gnome.design.Lorem.json
+++ b/org.gnome.design.Lorem.json
@@ -1,0 +1,90 @@
+{
+    "app-id": "org.gnome.design.Lorem",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "40",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+    "command": "lorem",
+    "finish-args": [
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--talk-name=org.a11y.Bus"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "libadwaita",
+            "buildsystem": "meson",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "config-opts": [
+                "-Dgtk_doc=false",
+                "-Dtests=false",
+                "-Dexamples=false",
+                "-Dvapi=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "commit": "3e9ae3fc25c46f221e4636eb46221ccd60fae5d0"
+                }
+            ],
+            "modules": [
+                {
+                    "name": "libsass",
+                    "buildsystem": "meson",
+                    "cleanup": ["*"],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/lazka/libsass.git",
+                            "branch": "meson",
+                            "commit": "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
+                        }
+                    ]
+                },
+                {
+                    "name": "sassc",
+                    "buildsystem": "meson",
+                    "cleanup": ["*"],
+                    "sources": [
+                        {
+                            "type": "git",
+                            "url": "https://github.com/lazka/sassc.git",
+                            "branch": "meson",
+                            "commit": "82803377c33247265d779af034eceb5949e78354"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "lorem",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.gnome.org/World/design/lorem/uploads/87a206a2bf0ffb22847efd91c7c3f642/lorem-0.1.0.tar.xz",
+                    "sha256": "3e7bc3ed1a21660659243799f36a9dd6d932058fdf3e047fc42a3ffe99287aec"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Add Lorem to Flathub

I am the maintaner of the app.

Repository: https://gitlab.gnome.org/World/design/lorem

libadwaita is using the latest commit, the reason the latest tag is not used instead is because a patch that affects the app was merged since then.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
