### PR TITLE
Add org.freedesktop.Sdk.Extension.action-inject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.flatpak-builder

--- a/enable.sh
+++ b/enable.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+if [ "X$FLATPAK_ACTION_INJECT" != "X" ]; then
+    if [ -f ~/$FLATPAK_ACTION_INJECT ]; then
+        . ~/$FLATPAK_ACTION_INJECT
+    fi
+elif [ -f ~/.action-inject ]; then
+    . ~/.action-inject
+fi

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.action-inject.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.action-inject.appdata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.Sdk.Extension.action-inject</id>
+  <extends>org.freedesktop.Sdk</extends>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Action inject</name>
+  <summary>Inject actions from the outside of container</summary>
+  <description>Actions are defined in ~/$FLATPAK_ACTION_INJECT of ~/.action-inject if $FLATPAK_ACTION_INJECT is not set.</description>
+  <project_license>MIT</project_license>
+  <url type="homepage">https://github.com/wsgalaxy/flathub/tree/org.freedesktop.Sdk.Extension.action-inject</url>
+  <translation/>
+  <update_contact>wsgalaxy@qq.com</update_contact>
+</component>

--- a/org.freedesktop.Sdk.Extension.action-inject.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.action-inject.appdata.xml
@@ -5,7 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <name>Action inject</name>
   <summary>Inject actions from the outside of container</summary>
-  <description>Actions are defined in ~/$FLATPAK_ACTION_INJECT of ~/.action-inject if $FLATPAK_ACTION_INJECT is not set.</description>
+  <description>Actions are defined in ~/$FLATPAK_ACTION_INJECT or ~/.action-inject if $FLATPAK_ACTION_INJECT is not set.</description>
   <project_license>MIT</project_license>
   <url type="homepage">https://github.com/wsgalaxy/flathub/tree/org.freedesktop.Sdk.Extension.action-inject</url>
   <translation/>

--- a/org.freedesktop.Sdk.Extension.action-inject.json
+++ b/org.freedesktop.Sdk.Extension.action-inject.json
@@ -1,0 +1,43 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.action-inject",
+    "branch": "20.08",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "20.08",
+    "sdk-extensions": [],
+    "separate-locales": false,
+    "appstream-compose": false,
+
+    "modules": [
+        {
+            "name": "action-inject",
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "enable.sh"
+                }
+            ],
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /usr/lib/sdk/action-inject",
+                "cp enable.sh /usr/lib/sdk/action-inject"
+            ]
+        },
+        {
+            "name": "appdata",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/appdata",
+                "cp org.freedesktop.Sdk.Extension.action-inject.appdata.xml ${FLATPAK_DEST}/share/appdata",
+                "appstream-compose  --basename=org.freedesktop.Sdk.Extension.action-inject --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.action-inject"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.action-inject.appdata.xml"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission



This extension make it possible to inject addition actions from the outside of the container, it is mainly used with vscode as you can enable Sdk extensions with FLATPAK_ENABLE_SDK_EXT.

It is very useful  if you want to use external sdk(kotlin, groovy, etc) outside the container and hope the IDE(vscode) could detect it from PATH or any other environment variables

**Usage:**
1. Add actions to ~/.action-inject or any other file and set FLATPAK_ACTION_INJECT to that file(relative to ~);
2. Start vscode by: `FLATPAK_ENABLE_SDK_EXT=action-inject flatpak run com.visualstudio.code`
