### PR TITLE
Add com.github.Matoking.protontricks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+/protontricks
+build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+Protontricks for Flatpak
+========================
+
+[Protontricks](https://github.com/Matoking/protontricks) compatible with the Flatpak version of Steam.
+
+# Installation
+
+You can install Protontricks for Flatpak from the Flathub repository. You need to have Flatpak installed with the Flathub repository configured. For installing Flatpak and configuring Flathub, see the [official installation instructions](https://flatpak.org/setup/).
+
+Install Protontricks for Flatpak using the following command:
+
+```sh
+flatpak install flathub com.github.Matoking.protontricks
+```
+
+Add an alias that allows you to call Protontricks using the `protontricks-flat` alias:
+
+```sh
+echo "alias protontricks-flat='flatpak run com.github.Matoking.protontricks'" >> ~/.bashrc
+```
+
+**You will need to restart any terminal emulators you have open for the alias to take effect.**
+
+# Usage
+
+## Command-line
+
+After you have installed Protontricks and added the alias, you can use Protontricks with the Flatpak version of Steam using the alias you configured:
+
+```sh
+# Note that you need to call `protontricks-flat` instead of `protontricks`
+
+# Find your game's App ID by searching for it
+protontricks-flat -s <GAME NAME>
+
+# Run winetricks for the game
+protontricks-flat <APPID> <ACTIONS>
+```
+
+For the rest of the usage options, [see the README](https://github.com/Matoking/protontricks/blob/master/README.md) on the main Protontricks repository.
+
+## Desktop
+
+You can launch the Protontricks GUI using the **Protontricks** app shortcut, and launch external EXEs using **Protontricks Launcher** when opening a Windows executable in a file manager.
+
+Due to the Flatpak security model, external EXE files have to be self-contained; if the EXE relies on other files in the same directory, Protontricks won't be able to access them.

--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -1,0 +1,266 @@
+---
+id: com.github.Matoking.protontricks
+runtime: org.freedesktop.Platform
+runtime-version: "20.08"
+sdk: org.freedesktop.Sdk
+appstream-compose: false
+command: protontricks
+finish-args:
+  # Copy some args from Steam Flatpak to make the environment similar
+  # to Proton apps running under Steam Flatpak. Arguments only related to
+  # native titles or the Steam client are omitted.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --socket=pulseaudio
+  - --share=network
+  # Steam in -steamos mode uses Network Manager for network settings, e.g.
+  # connecting to wifi and so on.
+  # In normal mode, it probably just gets info about current connection status.
+  - --system-talk-name=org.freedesktop.NetworkManager
+  # Wine uses UDisks2 to enumerate disk drives
+  - --system-talk-name=org.freedesktop.UDisks2
+  - --device=all
+  - --allow=multiarch
+  - --allow=devel
+  - --allow=bluetooth
+  - --env=ALSA_CONFIG_PATH=
+  - --unset-env=ALSA_CONFIG_PATH
+  - --env=MESA_GLSL_CACHE_DIR=
+  - --unset-env=MESA_GLSL_CACHE_DIR
+  - --env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES=
+  - --unset-env=STEAM_RUNTIME_PREFER_HOST_LIBRARIES
+  - --env=STEAM_RUNTIME=
+  - --unset-env=STEAM_RUNTIME
+  - --env=STEAM_EXTRA_COMPAT_TOOLS_PATHS=/app/share/steam/compatibilitytools.d
+  - --env=PROTON_DEBUG_DIR=/var/tmp
+  - --env=XDG_CONFIG_DIRS=/etc/xdg:/usr/lib/x86_64-linux-gnu/GL:/usr/lib/i386-linux-gnu/GL
+  - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
+  - --require-version=1.0.0
+
+  # Protontricks-specific permissions to grant access to Steam installation
+  - --filesystem=~/.var/app/com.valvesoftware.Steam
+  - --filesystem=xdg-data/Steam
+
+add-extensions:
+  org.freedesktop.Platform.Compat.i386:
+    directory: lib/i386-linux-gnu
+    version: '20.08'
+
+  org.freedesktop.Platform.Compat.i386.Debug:
+    directory: lib/debug/lib/i386-linux-gnu
+    version: '20.08'
+    no-autodownload: true
+
+  org.freedesktop.Platform.GL32:
+    directory: lib/i386-linux-gnu/GL
+    version: '1.4'
+    versions: 20.08;1.4
+    subdirectories: true
+    no-autodownload: true
+    autodelete: false
+    add-ld-path: lib
+    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
+    download-if: active-gl-driver
+    enable-if: active-gl-driver
+
+  com.valvesoftware.Steam.CompatibilityTool:
+    subdirectories: true
+    directory: share/steam/compatibilitytools.d
+    version: stable
+    versions: stable;beta;test
+    no-autodownload: true
+    autodelete: true
+
+cleanup:
+  - "*.a"
+  - "*.la"
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/man
+modules:
+
+  - "python3-setuptools-scm.json"
+  - "vdf.json"
+
+  - name: protontricks
+    buildsystem: simple
+    build-options:
+      env:
+        # Override setuptools-scm version detection logic.
+        # This is necessary because the patch to implement the required
+        # functionality for stand-alone Flatpak isn't part of a tagged release
+        # yet.
+        # TODO: Remove this for next version
+        SETUPTOOLS_SCM_PRETEND_VERSION: "1.6.0"
+    build-commands:
+      - pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} .
+      # This manifest ships '.desktop' files properly, so no need to install
+      # 'protontricks-desktop-install'
+      - rm ${FLATPAK_DEST}/bin/protontricks-desktop-install
+    post-install:
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo data/${FLATPAK_ID}.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - rename protontricks ${FLATPAK_ID} ${FLATPAK_DEST}/share/applications/protontricks*.desktop
+    sources:
+      - type: git
+        url: "https://github.com/Matoking/protontricks.git"
+        # Fetch specific commit consisting of 1.6.0 and additional changes
+        # to enable the standalone Flatpak.
+        # These will be included in the next upstream release.
+        #tag: "1.6.0"
+        commit: 3a57bc6bbfb039abd7fe623b25a29c277e064f9c
+
+    modules:
+
+      - name: yad
+        config-opts:
+          - "--enable-standalone"
+        sources:
+          - type: archive
+            url: "https://github.com/v1cont/yad/releases/download/v10.1/yad-10.1.tar.xz"
+            sha256: 742a5bd55de4b249eee6780bddeccb05c7ff4b158fd9743808f7d280219fd3ab
+        modules:
+
+          - name: intltool
+            cleanup:
+              - "*"
+            sources:
+              - type: archive
+                url: "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz"
+                sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+      - name: winetricks
+        no-autogen: true
+        make-install-args:
+          - PREFIX=$(FLATPAK_DEST)
+        sources:
+          - type: archive
+            url: "https://github.com/Winetricks/winetricks/archive/20210206.tar.gz"
+            sha256: 705421798b28696f577104ebdf03b068b9343ab096754150f47a6ec06fa8ae65
+        modules:
+
+          - name: p7zip
+            no-autogen: true
+            build-options:
+              strip: true
+            make-args:
+              - all2
+              - OPTFLAGS=-O2 -g
+              - DEST_HOME=$(FLATPAK_DEST)
+              - DEST_BIN=$(FLATPAK_DEST)/bin
+              - DEST_SHARE=$(FLATPAK_DEST)/lib/p7zip
+              - DEST_MAN=$(FLATPAK_DEST)/share/man
+            make-install-args:
+              - DEST_HOME=$(FLATPAK_DEST)
+              - DEST_BIN=$(FLATPAK_DEST)/bin
+              - DEST_SHARE=$(FLATPAK_DEST)/lib/p7zip
+              - DEST_MAN=$(FLATPAK_DEST)/share/man
+            sources:
+              - type: archive
+                url: "https://downloads.sourceforge.net/p7zip/p7zip_16.02_src_all.tar.bz2"
+                sha256: 5eb20ac0e2944f6cb9c2d51dd6c4518941c185347d4089ea89087ffdd6e2341f
+              - type: patch
+                paths:
+                  - patches/p7zip/gcc10-conversion.patch
+              - type: shell
+                only-arches:
+                  - "x86_64"
+                commands:
+                  - ln -sf makefile.linux_amd64_asm makefile.machine
+              - type: shell
+                only-arches:
+                  - "i386"
+                commands:
+                  - ln -sf makefile.linux_x86_asm_gcc_4.X makefile.machine
+            modules:
+
+              - name: yasm
+                buildsystem: cmake-ninja
+                sources:
+                  - type: archive
+                    url: "https://github.com/yasm/yasm/archive/v1.3.0.tar.gz"
+                    sha256: f708be0b7b8c59bc1dbe7134153cd2f31faeebaa8eec48676c10f972a1f13df3
+                cleanup:
+                  - "*"
+
+          - name: cabextract
+            build-options:
+              strip: true
+            sources:
+              - type: archive
+                url: "https://www.cabextract.org.uk/cabextract-1.9.1.tar.gz"
+                sha256: afc253673c8ef316b4d5c29cc4aa8445844bee14afffbe092ee9469405851ca7
+
+          - name: unrar
+            no-autogen: true
+            build-options:
+              strip: true
+            make-install-args:
+              - DESTDIR=$(FLATPAK_DEST)
+            sources:
+              - type: archive
+                url: "https://www.rarlab.com/rar/unrarsrc-5.8.3.tar.gz"
+                sha256: 3591685c8f5bbcb0be09de3d0a0544adb88966b9cccb80986f6cd2b534fd91a6
+
+          - name: binutils-ar
+            buildsystem: simple
+            build-options:
+              strip: true
+            build-commands:
+              - install -Dm755 /usr/bin/ar -t ${FLATPAK_DEST}/bin/
+              - install -Dm755 /usr/lib/$(gcc -print-multiarch)/libbfd-*.so -t ${FLATPAK_DEST}/lib/
+
+          - name: perl
+            no-autogen: true
+            config-opts:
+              - "-des"
+            cleanup:
+              - "*.pod"
+              - "/bin/perl5*"
+              - "/bin/c2ph"
+              - "/bin/corelist"
+              - "/bin/cpan"
+              - "/bin/enc2xs"
+              - "/bin/encguess"
+              - "/bin/h2*"
+              - "/bin/instmodsh"
+              - "/bin/json_pp"
+              - "/bin/libnetcfg"
+              - "/bin/perlbug"
+              - "/bin/perldoc"
+              - "/bin/perlthanks"
+              - "/bin/piconv"
+              - "/bin/pl2pm"
+              - "/bin/pod*"
+              - "/bin/prove"
+              - "/bin/pstruct"
+              - "/bin/ptar*"
+              - "/bin/shasum"
+              - "/bin/splain"
+              - "/bin/xsubpp"
+              - "/bin/zipdetails"
+            sources:
+              - type: archive
+                url: "https://www.cpan.org/src/5.0/perl-5.32.0.tar.gz"
+                sha256: efeb1ce1f10824190ad1cadbcccf6fdb8a5d37007d0100d2d9ae5f2b5900c0b4
+              - type: script
+                dest-filename: configure
+                commands:
+                  - "exec ./configure.gnu $@"
+            post-install:
+              - "find ${FLATPAK_DEST}/lib/perl5 -type f -exec chmod u+w {} \\;"
+
+  - name: bundle-setup
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/steam/compatibilitytools.d
+      - mkdir -p /app/lib/i386-linux-gnu
+      - mkdir -p /app/lib/debug/lib/i386-linux-gnu
+      - mkdir -p /app/lib/i386-linux-gnu/GL
+      - install -Dm644 ld.so.conf /app/etc/ld.so.conf
+    sources:
+      - type: file
+        dest-filename: ld.so.conf
+        url: data:/app/lib32%0A/app/lib/i386-linux-gnu%0A

--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -137,8 +137,8 @@ modules:
           - PREFIX=$(FLATPAK_DEST)
         sources:
           - type: archive
-            url: "https://github.com/Winetricks/winetricks/archive/20210206.tar.gz"
-            sha256: 705421798b28696f577104ebdf03b068b9343ab096754150f47a6ec06fa8ae65
+            url: "https://github.com/Winetricks/winetricks/archive/20210825.tar.gz"
+            sha256: bac77918ef4d58c6465a1043fd996d09c3ee2c5a07f56ed089c4c65a71881277
         modules:
 
           - name: p7zip

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,6 @@
+{
+    "only-arches": [
+        "x86_64"
+    ],
+    "skip-icons-check": true
+}

--- a/patches/p7zip/gcc10-conversion.patch
+++ b/patches/p7zip/gcc10-conversion.patch
@@ -1,0 +1,26 @@
+diff -Nrup a/CPP/Windows/ErrorMsg.cpp b/CPP/Windows/ErrorMsg.cpp
+--- a/CPP/Windows/ErrorMsg.cpp	2015-01-18 11:20:28.000000000 -0700
++++ b/CPP/Windows/ErrorMsg.cpp	2019-09-24 13:01:18.887289152 -0600
+@@ -14,14 +14,14 @@ UString MyFormatMessage(DWORD errorCode)
+   AString msg;
+ 
+   switch(errorCode) {
+-    case ERROR_NO_MORE_FILES   : txt = "No more files"; break ;
+-    case E_NOTIMPL             : txt = "E_NOTIMPL"; break ;
+-    case E_NOINTERFACE         : txt = "E_NOINTERFACE"; break ;
+-    case E_ABORT               : txt = "E_ABORT"; break ;
+-    case E_FAIL                : txt = "E_FAIL"; break ;
+-    case STG_E_INVALIDFUNCTION : txt = "STG_E_INVALIDFUNCTION"; break ;
+-    case E_OUTOFMEMORY         : txt = "E_OUTOFMEMORY"; break ;
+-    case E_INVALIDARG          : txt = "E_INVALIDARG"; break ;
++    case unsigned (ERROR_NO_MORE_FILES)   : txt = "No more files"; break ;
++    case unsigned (E_NOTIMPL)             : txt = "E_NOTIMPL"; break ;
++    case unsigned (E_NOINTERFACE)         : txt = "E_NOINTERFACE"; break ;
++    case unsigned (E_ABORT)               : txt = "E_ABORT"; break ;
++    case unsigned (E_FAIL)                : txt = "E_FAIL"; break ;
++    case unsigned (STG_E_INVALIDFUNCTION) : txt = "STG_E_INVALIDFUNCTION"; break ;
++    case unsigned (E_OUTOFMEMORY)         : txt = "E_OUTOFMEMORY"; break ;
++    case unsigned (E_INVALIDARG)          : txt = "E_INVALIDARG"; break ;
+     case ERROR_DIRECTORY          : txt = "Error Directory"; break ;
+     default:
+       txt = strerror(errorCode);

--- a/python3-setuptools-scm.json
+++ b/python3-setuptools-scm.json
@@ -1,0 +1,17 @@
+{
+    "name": "python3-setuptools_scm",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} setuptools_scm"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/8d/93/d380ad3ee3acdec01ef5fc1096214b57a8cbeab1e5e95eebf5e78b480d94/setuptools_scm-3.4.3-py2.py3-none-any.whl",
+            "sha256": "f7a5091d8de1b1491068623e9acbe7e881d62986e4c0af7f361424622902ff08"
+        }
+    ],
+    "cleanup": [
+        "*"
+    ]
+}

--- a/vdf.json
+++ b/vdf.json
@@ -1,0 +1,14 @@
+{
+    "name": "vdf",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} vdf"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1d/d3/b115bd86fdefa50cd035d5d7bb0a299088711218c8eca1dd163cf07508ed/vdf-3.3-py2.py3-none-any.whl",
+            "sha256": "f88db3a3e66e7264da7fdacf0ffa1d99be52dd30510b2c1a1340171b227472e4"
+        }
+    ]
+}


### PR DESCRIPTION
Convert Protontricks into a stand-alone Flatpak application. Most of the build manifest is based on the existing com.valvesoftware.Steam.Utility.protontricks.

---

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** N/A
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Until now, Protontricks has been maintained as a Flatpak extension on [com.valvesoftware.Steam.Utility.protontricks](github.com/flathub/com.valvesoftware.Steam.Utility.protontricks). However, Protontricks 1.6.0 now ships additional desktop entry files to launch  the GUI and add Protontricks specific actions for EXE files. Those desktop files can't be installed into the host system inside a Flatpak extension, making it necessary to convert Protontricks into a stand-alone application.

This comes with a set of changes into the build manifest:

* We copy most of the `finish-args` and `add-extensions` from the [Steam Flatpak](https://github.com/flathub/com.valvesoftware.Steam/blob/beta/com.valvesoftware.Steam.yml) instead of inheriting them automatically as a Flatpak extension. This is to ensure that Windows executables launched with Protontricks behave in a similar way to executables added inside the Steam client and launched there.
* ID is renamed from `com.valvesoftware.Steam.Utility.protontricks` to `com.github.Matoking.protontricks`
* Access is granted to Steam installation directory since we need to detect Steam apps and use Proton binaries.
* Desktop entry files are installed

The old com.valvesoftware.Steam.Utility.protontricks application will be EOL'd and updated to point toward this application. Flatpak can suggest the user to replace the application with the new one when this happens, although [it seems to be unclear](https://github.com/flathub/com.valvesoftware.Steam.Utility.protontricks/issues/30#issuecomment-899714721) whether this has been tested when the application type is also changed from an extension to an application.