### PR TITLE
Add org.gnome.design.Emblem

### DIFF
--- a/org.gnome.design.Emblem.json
+++ b/org.gnome.design.Emblem.json
@@ -1,0 +1,88 @@
+{
+    "app-id": "org.gnome.design.Emblem",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "40",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
+    "command": "emblem",
+    "finish-args" : [
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--talk-name=org.a11y.Bus"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/rust-stable/bin"
+    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name" : "libadwaita",
+            "buildsystem" : "meson",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "config-opts": [
+                "-Dgtk_doc=false",
+                "-Dtests=false",
+                "-Dexamples=false",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "commit": "03f159488ec3b8e3ea4c3c2daa9c408b071d512d"
+                }
+            ],
+            "modules" : [
+                {
+                    "name" : "libsass",
+                    "buildsystem" : "meson",
+                    "cleanup": ["*"],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/lazka/libsass.git",
+                            "commit": "302397c0c8ae2d7ab02f45ea461c2c3d768f248e"
+                        }
+                    ]
+                },
+                {
+                    "name" : "sassc",
+                    "buildsystem" : "meson",
+                    "cleanup": ["*"],
+                    "sources" : [
+                        {
+                            "type" : "git",
+                            "url" : "https://github.com/lazka/sassc.git",
+                            "commit": "82803377c33247265d779af034eceb5949e78354"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "emblem",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://gitlab.gnome.org/msandova/emblem/uploads/3e68f2326b601bc468d4c8a63ea7fae2/emblem-0.1.0.tar.xz",
+                    "sha256": "7208e71333e5c2335e2159ca49d0c5fe25970300c0ea2a3ae9356ecfd197d664"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Add org.gnome.design.Emblem

I am the maintainer of the app.

Repository: https://gitlab.gnome.org/msandova/emblem

- Repository is going to be moved to World/design soon (https://gitlab.gnome.org/Infrastructure/GitLab/-/issues/530)
- libadwaita is using the latest commit, the reason the latest tag has fixes for flat headerbars.

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. 
- [x] All assets referenced in the manifest are redistributable by any party. 
- [x] I am an upstream contributor to the project.
- [x] I own the domain used in the application ID.
- [x] Any additional patches or files have been submitted to the upstream projects concerned.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
