### PR TITLE
add io.gitlab.caveman250.headlines

### DIFF
--- a/io.gitlab.caveman250.headlines.json
+++ b/io.gitlab.caveman250.headlines.json
@@ -177,7 +177,7 @@
         {
           "type": "git",
           "url": "https://code.videolan.org/videolan/x264.git",
-          "branch": "d198931a63049db1f2c92d96c34904c69fde8117"
+          "commit": "d198931a63049db1f2c92d96c34904c69fde8117"
         }
       ]
     },

--- a/io.gitlab.caveman250.headlines.json
+++ b/io.gitlab.caveman250.headlines.json
@@ -194,7 +194,7 @@
       "sources": [{
         "type": "git",
         "url": "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git",
-        "branch": "1.16.3"
+        "tag": "1.16.3"
       }
       ]
     },

--- a/io.gitlab.caveman250.headlines.json
+++ b/io.gitlab.caveman250.headlines.json
@@ -1,0 +1,283 @@
+{
+  "app-id": "io.gitlab.caveman250.headlines",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "41",
+  "sdk": "org.gnome.Sdk",
+  "command": "headlines",
+  "finish-args": [
+    "--share=network",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--socket=pulseaudio",
+    "--device=dri",
+    "--talk-name=org.freedesktop.secrets"],
+  "cleanup": ["/include", "/lib/*/include", "/lib/pkgconfig", "/share/pkgconfig", "/share/aclocal", "/man", "/share/man", "/share/info", "/share/gtk-doc", "*.la", "*.a" ],
+  "add-extensions": {
+    "org.freedesktop.Platform.ffmpeg-full": {
+      "directory": "lib/ffmpeg",
+      "version": "21.08",
+      "add-ld-path": "."
+    }
+  },
+  "cleanup-commands": [
+    "mkdir -p ${FLATPAK_DEST}/lib/ffmpeg"
+  ],
+  "modules": [
+    {
+      "name": "mm-common",
+      "cleanup": [ "*" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/mm-common/1.0/mm-common-1.0.3.tar.xz",
+          "sha256": "e81596625899aacf1d0bf27ccc2fcc7f373405ec48735ca1c7273c0fbcdc1ef5"
+        }
+      ]
+    },
+    {
+      "name": "sigc++",
+      "config-opts": [ "--disable-documentation" ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/libsigc++/3.0/libsigc++-3.0.7.tar.xz",
+          "sha256": "bfbe91c0d094ea6bbc6cbd3909b7d98c6561eea8b6d9c0c25add906a6e83d733"
+        }
+      ]
+    },
+    {
+      "name": "glibmm",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/glibmm/2.68/glibmm-2.68.1.tar.xz",
+          "sha256": "6664e27c9a9cca81c29e35687f49f2e0d173a2fc9e98c3428311f707db532f8c"
+        }
+      ]
+    },
+    {
+      "name": "cairomm",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://cairographics.org/releases/cairomm-1.16.1.tar.xz",
+          "sha256": "6f6060d8e98dd4b8acfee2295fddbdd38cf487c07c26aad8d1a83bb9bff4a2c6"
+        }
+      ]
+    },
+    {
+      "name": "pangomm",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/pangomm/2.49/pangomm-2.49.1.tar.xz",
+          "sha256": "a2272883152618fddea016a62f50eb23b9b056ab3c08f3b64422591e6a507bd5"
+        }
+      ]
+    },
+    {
+      "name": "atkmm",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/atkmm/2.36/atkmm-2.36.1.tar.xz",
+          "sha256": "e11324bfed1b6e330a02db25cecc145dca03fb0dff47f0710c85e317687da458"
+        }
+      ]
+    },
+    {
+      "name": "gtkmm",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnome.org/pub/GNOME/sources/gtkmm/4.2/gtkmm-4.2.0.tar.xz",
+          "sha256": "480c4c38f2e7ffcf58f56bb4b4d612f3f0cac9fd5908fd2cd8249fe10592a98b"
+        }
+      ]
+    },
+    {
+      "name": "jsoncpp",
+      "buildsystem": "meson",
+      "sources":
+      [
+        {
+          "type": "git",
+          "url": "https://github.com/open-source-parsers/jsoncpp",
+          "tag": "1.9.4"
+        }
+      ]
+    },
+    {
+      "name": "libmicrohttpd",
+      "sources":
+      [
+        {
+          "type": "archive",
+          "url": "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.73.tar.gz",
+          "sha256": "a37b2f1b88fd1bfe74109586be463a434d34e773530fc2a74364cfcf734c032e"
+        }
+      ]
+    },
+    {
+      "name": "boost",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cp -r ./boost /app/include/"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://downloads.sourceforge.net/project/boost/boost/1.74.0/boost_1_74_0.tar.bz2",
+          "sha256": "83bfc1507731a0906e387fc28b7ef5417d591429e51e788417fe9ff025e116b1"
+        }
+      ],
+      "cleanup": [
+        "/include"
+      ]
+    },
+    {
+      "name": "websocketpp",
+      "buildsystem": "cmake-ninja",
+      "sources":
+      [
+        {
+          "type": "git",
+          "url": "https://github.com/zaphoyd/websocketpp",
+          "tag": "0.8.2"
+        }
+      ]
+    },
+    {
+      "name": "youtube-dl",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=/app \"youtube-dl\" --no-build-isolation"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/94/a0/b8325b524700daae1c04a6156473ab7091d44071353f1d7c9e66b9c7f019/youtube_dl-2021.4.26.tar.gz",
+          "sha256": "6f311ffaf8b88cdcf27a2301a2272455e213bdb780aa447246933a3da4532879"
+        }
+      ]
+    },
+    {
+      "name": "x264",
+      "config-opts": [
+        "--enable-pic",
+        "--enable-shared"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://code.videolan.org/videolan/x264.git",
+          "branch": "d198931a63049db1f2c92d96c34904c69fde8117"
+        }
+      ]
+    },
+    {
+      "name": "gst-plugins-bad",
+      "buildsystem": "meson",
+      "builddir": true,
+      "config-opts": [
+        "-Dgtk_doc=disabled",
+        "--prefix=/app",
+        "--buildtype=release",
+        "-Dopenh264=disabled"
+      ],
+      "sources": [{
+        "type": "git",
+        "url": "https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git",
+        "branch": "1.16.3"
+      }
+      ]
+    },
+    {
+      "name": "gst-libav",
+      "buildsystem": "meson",
+      "builddir": true,
+      "config-opts": [
+        "-Dgtk_doc=disabled",
+        "--prefix=/app",
+        "--buildtype=release"
+      ],
+      "sources": [{
+        "type": "git",
+        "url": "https://gitlab.freedesktop.org/gstreamer/gst-libav.git",
+        "branch": "1.16.3"
+      }
+      ]
+    },
+    {
+      "name": "sassc",
+      "cleanup": [ "*" ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/sass/sassc.git",
+          "tag": "3.6.1"
+        },
+        {
+          "type": "script",
+          "dest-filename": "autogen.sh",
+          "commands": [ "autoreconf -si" ]
+        }
+      ],
+      "modules": [
+        {
+          "name": "libsass",
+          "cleanup": [ "*" ],
+          "sources": [
+            {
+              "type": "git",
+              "url": "https://github.com/sass/libsass.git",
+              "tag": "3.6.4"
+            },
+            {
+              "type": "script",
+              "dest-filename": "autogen.sh",
+              "commands": [ "autoreconf -si" ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name" : "libadwaita",
+      "buildsystem": "meson",
+      "config-opts" : [
+        "-Dexamples=false",
+        "-Dtests=false"
+      ],
+      "sources" : [
+        {
+          "type": "git",
+          "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
+          "commit": "facaa00ccba548b31608d6d746f25fda1ba48af4"
+        }
+      ]
+    },
+    {
+      "name": "headlines",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.com/caveman250/headlines",
+          "tag": "0.4.0"
+        }
+      ],
+      "buildsystem": "cmake-ninja",
+      "config-opts":
+      [
+        "-DFLATPAK_BUILD=ON",
+        "-DDIST_BUILD=ON",
+        "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+      ]
+    }
+  ]
+}

--- a/io.gitlab.caveman250.headlines.json
+++ b/io.gitlab.caveman250.headlines.json
@@ -210,7 +210,7 @@
       "sources": [{
         "type": "git",
         "url": "https://gitlab.freedesktop.org/gstreamer/gst-libav.git",
-        "branch": "1.16.3"
+        "tag": "1.16.3"
       }
       ]
     },

--- a/io.gitlab.caveman250.headlines.json
+++ b/io.gitlab.caveman250.headlines.json
@@ -6,6 +6,7 @@
   "command": "headlines",
   "finish-args": [
     "--share=network",
+    "--share=ipc",
     "--socket=wayland",
     "--socket=fallback-x11",
     "--socket=pulseaudio",


### PR DESCRIPTION
Adding io.gitlab.caveman250.headlines, this will replace io.gitlab.caveman250.gtkeddit due to a change of name. will deprecate gtkeddit afterwards as outlined [here.](https://github.com/flathub/org.x.Warpinator/pull/2#issuecomment-831965192) This manifest is the same as the one in the gtkeddit repository with all references to "gtkeddit" replaced with "headlines".

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages. 
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
