### PR TITLE
Add app.xemu.Xemu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# Flatpak for Xemu
+
+## Installation
+
+1. [Set up Flatpak](https://www.flatpak.org/setup/)
+
+2. Install Xemu from [Flathub](https://flathub.org/apps/details/app.xemu.Xemu)
+
+`flatpak install -y app.xemu.Xemu`
+
+3. Run Xemu
+
+`flatpak run app.xemu.Xemu`
+
+To uninstall: `flatpak uninstall -y app.xemu.Xemu`
+
+## Usage
+
+Only `~/.var/app/app.xemu.Xemu/data/xemu/xemu` can be written by Xemu.
+The Hard Disk image has to be placed there, for example, at `~/.var/app/app.xemu.Xemu/data/xemu/xemu/xbox_hdd.qcow2`.
+
+## Build
+
+The `flatpak-builder` package is required.
+
+- Install the SDK
+
+`flatpak install org.freedesktop.Platform/x86_64/21.08`
+
+- Build Xemu
+
+`flatpak-builder --user --install --force-clean build-dir app.xemu.Xemu.yml`

--- a/app.xemu.Xemu.metainfo.xml
+++ b/app.xemu.Xemu.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>app.xemu.Xemu</id>
+  <launchable type="desktop-id">app.xemu.Xemu.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <name>Xemu</name>
+  <summary>Original Xbox Emulator.</summary>
+  <description>
+    <p>
+      A free and open-source application that emulates the original Microsoft Xbox game console, enabling people to play their original Xbox games on Windows, macOS, and Linux systems.
+    </p>
+    <p>
+     Only "~/.var/app/app.xemu.Xemu/data/xemu/xemu" can be written by Xemu.
+     The Hard Disk image has to be placed there, for example, at "~/.var/app/app.xemu.Xemu/data/xemu/xemu/xbox_hdd.qcow2".
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default"><image>https://raw.githubusercontent.com/mborgerson/xemu-website/master/resources/xbox_logo.png</image></screenshot>
+  </screenshots>
+  <categories>
+    <category>Games</category>
+    <category>Emulator</category>
+  </categories>
+  <url type="homepage">https://xemu.app</url>
+  <url type="bugtracker">https://github.com/mborgerson/xemu/issues</url>
+  <url type="help">https://xemu.app/docs</url>
+  <url type="faq">https://xemu.app/docs/faq</url>
+  <developer_name>Matt Borgerson</developer_name>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release date="2021-09-05" version="0.6.1" />
+  </releases>
+</component>

--- a/app.xemu.Xemu.yml
+++ b/app.xemu.Xemu.yml
@@ -1,0 +1,83 @@
+app-id: app.xemu.Xemu
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+command: xemu
+rename-desktop-file: xemu.desktop
+finish-args:
+  - --device=all
+  - --filesystem=host:ro
+  - --share=network
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+
+modules:
+  - name: libpcap
+    buildsystem: cmake-ninja
+    cleanup:
+      - /bin
+      - /include
+      - /lib/debug
+      - /lib/pkgconfig
+      - /lib/*.a
+      - /share
+    sources:
+      - type: archive
+        url: https://www.tcpdump.org/release/libpcap-1.10.1.tar.gz
+        sha256: ed285f4accaf05344f90975757b3dbfe772ba41d1c401c2648b7fa45b711bdd4
+        x-checker-data:
+          type: anitya
+          project-id: 1702
+          stable-only: true
+          url-template: https://www.tcpdump.org/release/libpcap-$version.tar.gz
+
+  - name: libglu
+    buildsystem: meson
+    cleanup:
+      - /include
+      - /lib/debug
+      - /lib/pkgconfig
+      - /lib/*.a
+    sources:
+      - type: archive
+        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
+        sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
+        x-checker-data:
+          type: anitya
+          project-id: 13518
+          stable-only: true
+          url-template: https://mesa.freedesktop.org/archive/glu/glu-$version.tar.xz
+
+  - name: xemu
+    buildsystem: autotools
+    builddir: true
+    no-make-install: true
+    build-options:
+      cflags: "-O3 -DXBOX=1 -Wno-error=redundant-decls"
+    config-opts:
+      - --audio-drv-list=sdl
+      - --disable-werror
+      - --target-list=i386-softmmu
+    make-args:
+      - qemu-system-i386
+    post-install:
+      - |-
+        for px in 16 32 48 64 128 256 512; do
+          install -Dm644 ../ui/icons/xemu_${px}x${px}.png /app/share/icons/hicolor/${px}x${px}/apps/app.xemu.Xemu.png
+        done
+      - install -Dm644 ../ui/icons/xemu.svg /app/share/icons/hicolor/scalable/apps/app.xemu.Xemu.svg
+      - desktop-file-install ../ui/xemu.desktop --dir /app/share/applications
+      - sed -i 's/^Icon=xemu/Icon=app.xemu.Xemu/' /app/share/applications/xemu.desktop
+      - mv qemu-system-i386 /app/bin/xemu
+      - mkdir -p /app/share/licenses/xemu
+      - cd .. && python3 scripts/gen-license.py > /app/share/licenses/xemu/LICENSE.txt
+      - install -Dm644 ../app.xemu.Xemu.metainfo.xml /app/share/metainfo/app.xemu.Xemu.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/mborgerson/xemu
+        tag: xemu-v0.6.1
+
+      - type: file
+        path: app.xemu.Xemu.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "automerge-flathubbot-prs": true,
+  "only-arches": ["x86_64"]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/mborgerson/xemu/issues/396#issuecomment-923440133
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

--- 

Permissions explanation:
- `device=all`: keyboard, mouse, controllers
- `filesystem=host:ro`:  ROMs
- `share=network`: multi-player/internet support
- `socket=pulseaudio`: sound
- `socket=wayland`, `socket=fallback-x11`, `share=ipc`: Wayland and X11

I don't expect Xemu working on aarch64, or if it does having abysmal performance, being quite demanding on "native" x86-64 platforms (even though it uses qemu i386).

~I have picked images generated by YouTube from the official channel for the screenshots for now, since I don't have any other "official" images.~ `flatpak run org.freedesktop.appstream-glib validate app.xemu.Xemu.metainfo.xml` cannot download this (webp) images, thus marking them as invalid files.