### PR TITLE
Add org.telegram.desktop.webview

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "automerge-flathubbot-prs": true
+}

--- a/org.telegram.desktop.webview.metainfo.xml
+++ b/org.telegram.desktop.webview.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.telegram.desktop.webview</id>
+  <extends>org.telegram.desktop</extends>
+  <name>WebKitGTK</name>
+  <summary>Webview addon that enables Telegram Desktop to show web content</summary>
+  <url type="homepage">https://www.webkitgtk.org</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.0</project_license>
+</component>

--- a/org.telegram.desktop.webview.yml
+++ b/org.telegram.desktop.webview.yml
@@ -1,7 +1,7 @@
 id: org.telegram.desktop.webview
 sdk: org.freedesktop.Sdk//21.08
 runtime: org.telegram.desktop
-runtime-version: stable
+runtime-version: beta
 build-extension: true
 appstream-compose: false
 build-options:

--- a/org.telegram.desktop.webview.yml
+++ b/org.telegram.desktop.webview.yml
@@ -15,10 +15,12 @@ modules:
   - name: webkitgtk
     buildsystem: cmake-ninja
     build-options:
+      cflags: ''
+      cflags-override: true
+      cxxflags: ''
+      cxxflags-override: true
       arch:
         x86_64:
-          cflags: -g1
-          cxxflags: -g1
           config-opts:
             - -DCMAKE_BUILD_TYPE=Release
         aarch64:

--- a/org.telegram.desktop.webview.yml
+++ b/org.telegram.desktop.webview.yml
@@ -1,0 +1,55 @@
+id: org.telegram.desktop.webview
+sdk: org.freedesktop.Sdk//21.08
+runtime: org.telegram.desktop
+runtime-version: stable
+build-extension: true
+appstream-compose: false
+build-options:
+  prefix: /app/lib/webview
+  strip: true
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/gir-1.0
+modules:
+  - name: webkitgtk
+    buildsystem: cmake-ninja
+    build-options:
+      arch:
+        x86_64:
+          cflags: -g1
+          cxxflags: -g1
+          config-opts:
+            - -DCMAKE_BUILD_TYPE=Release
+        aarch64:
+          config-opts:
+            - -DCMAKE_BUILD_TYPE=MinSizeRel
+    config-opts:
+      - -DPORT=GTK
+      - -DUSE_LIBNOTIFY=OFF
+      - -DUSE_LIBSECRET=OFF
+      - -DUSE_SOUP2=ON
+      - -DUSE_WOFF2=OFF
+      - -DUSE_WPE_RENDERER=OFF
+      - -DENABLE_GAMEPAD=OFF
+      - -DENABLE_SPELLCHECK=OFF
+    sources:
+      - type: archive
+        url: https://webkitgtk.org/releases/webkitgtk-2.34.1.tar.xz
+        sha256: 443c1316705de024741748e85fe32324d299d9ee68e6feb340b89e4a04073dee
+        x-checker-data:
+          type: html
+          url: https://webkitgtk.org/releases/
+          version-pattern: LATEST-STABLE-(\d[\.\d]+\d)
+          url-template: https://webkitgtk.org/releases/webkitgtk-$version.tar.xz
+
+  - name: metadata
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - >-
+        appstream-compose --origin=flatpak
+        --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} ${FLATPAK_ID}
+    sources:
+      - type: file
+        path: org.telegram.desktop.webview.metainfo.xml


### PR DESCRIPTION
Telegram Desktop flatpak is [moving](https://github.com/flathub/org.telegram.desktop/pull/342) WebKitGTK to an extension, because it's big and largely optional.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
