### PR TITLE
Added org.freedesktop.LinuxAudio.Plugins.Surge-XT

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.freedesktop.LinuxAudio.Plugins.Surge-XT.json
+++ b/org.freedesktop.LinuxAudio.Plugins.Surge-XT.json
@@ -1,0 +1,126 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Plugins.Surge-XT",
+    "branch": "21.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "21.08",
+    "sdk": "org.freedesktop.Sdk//21.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Plugins/Surge-XT",
+        "prepend-path": "/app/extensions/Plugins/Surge-XT/bin",
+        "cxxflags": "-I/app/extensions/Plugins/Surge-XT/include",
+        "env": {
+            "SURGE_VERSION": "1.0.0"
+        }
+    },
+    "cleanup": [
+        "/bin",
+        "/lib/lv2"
+    ],
+    "modules": [
+        {
+            "name": "surge-xt",
+            "buildsystem": "cmake-ninja",
+            "build-options": {
+                "arch": {
+                    "aarch64": {
+                        "config-opts": [
+                            "-DLINUX_ON_ARM=True"
+                        ]
+                    }
+                }
+            },
+            "config-opts": [
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Plugins/Surge-XT",
+                "-DSURGE_SKIP_STANDALONE=YES",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "no-make-install": true,
+            "make-args": [
+                "surge-xt_VST3",
+                "surge-fx_VST3"
+            ],
+            "cleanup": [
+                "/bin/python"
+            ],
+            "post-install": [
+                "install -d $FLATPAK_DEST/vst3/",
+                "cp -R src/surge-fx/surge-fx_artefacts/Release/VST3/*.vst3 $FLATPAK_DEST/vst3/",
+                "cp -R src/surge-xt/surge-xt_artefacts/Release/VST3/*.vst3 $FLATPAK_DEST/vst3/",
+                "install -d $FLATPAK_DEST/share/surge-xt",
+                "cp -a resources/data/* $FLATPAK_DEST/share/surge-xt",
+                "strip $FLATPAK_DEST/vst3/*.vst3/Contents/$(arch)-linux/*.so",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/surge-xt LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/surge-synthesizer/surge.git",
+                    "tag": "release_xt_1.0.0",
+                    "commit": "1edd725e51c236022d5f4cbc939e68453de15af4"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "install -d ${FLATPAK_DEST}/bin",
+                        "ln -sf /usr/bin/python3 ${FLATPAK_DEST}/bin/python"
+                    ]
+                }
+            ]
+        },
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "surge-xt-lv2",
+            "buildsystem": "cmake-ninja",
+            "build-options": {
+                "arch": {
+                    "aarch64": {
+                        "config-opts": [
+                            "-DLINUX_ON_ARM=True"
+                        ]
+                    }
+                }
+            },
+            "config-opts": [
+                "-DCMAKE_INSTALL_PREFIX=/app/extensions/Plugins/Surge-XT",
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DSURGE_SKIP_STANDALONE=YES",
+                "-DJUCE_SUPPORTS_LV2=True",
+                "-DSURGE_JUCE_PATH=/run/build/surge-xt-lv2/JUCE-lv2"
+            ],
+            "no-make-install": true,
+            "make-args": [
+                "surge-xt_LV2",
+                "surge-fx_LV2"
+            ],
+            "post-install": [
+                "install -d $FLATPAK_DEST/lv2/",
+                "cp -R src/surge-fx/surge-fx_artefacts/Release/LV2/*.lv2 $FLATPAK_DEST/lv2/",
+                "cp -R src/surge-xt/surge-xt_artefacts/Release/LV2/*.lv2 $FLATPAK_DEST/lv2/",
+                "strip $FLATPAK_DEST/lv2/*.lv2/*.so",
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml",
+                "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}",
+                "install -Dm644 -t $FLATPAK_DEST/share/licenses/surge LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/surge-synthesizer/surge.git",
+                    "tag": "release_xt_1.0.0",
+                    "commit": "1edd725e51c236022d5f4cbc939e68453de15af4"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/lv2-porting-project/JUCE",
+                    "commit": "000e15a1e108101a68aa068b5c621a0d5b58f4d6",
+                    "dest": "JUCE-lv2"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Plugins.Surge-XT.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Plugins.Surge-XT.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.Surge-XT.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Plugins.Surge-XT</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+  <name>Surge XT Synthesizer</name>
+  <summary>Surge XT Synthesizer LV2/VST3</summary>
+  <url type="homepage">https://surge-synthesizer.github.io/</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <releases>
+    <release date="2022-01-18" version="1.0.0" />
+  </releases>
+</component>


### PR DESCRIPTION
This is the successor of the Surge audio plugin, already on Flathub. As per discussions with upstream, it's meant to be installed in parallel with the previous. Version number are reset too.
This is based on `org.freedesktop.LinuxAudio.Plugins.Surge`.

It is currently in *Draft* as the development is still underway. This PR will be ready after there is an official release.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**  Upstream issue - https://github.com/surge-synthesizer/surge/issues/5429
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge). **This ID is for audio plugins.**
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)* **no patches at the moment**

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
