### PR TITLE
Submit game AAAAXY (io.github.divverent.aaaaxy)

### DIFF
--- a/io.github.divverent.aaaaxy.yml
+++ b/io.github.divverent.aaaaxy.yml
@@ -49,12 +49,12 @@ modules:
         mkdir -p /app/share/applications
         sed -e 's,Icon=aaaaxy,Icon=io.github.divverent.aaaaxy,' < aaaaxy.desktop > /app/share/applications/io.github.divverent.aaaaxy.desktop
         mkdir -p /app/share/metainfo
-        sed -e 's,aaaaxy.png,io.github.divverent.aaaaxy.png,' < io.github.divverent.aaaaxy.metainfo.xml > /app/share/metainfo/io.github.divverent.aaaaxy.appdata.xml
+        sed -e 's,aaaaxy\.png,io.github.divverent.aaaaxy.png,; s,aaaaxy\.desktop,io.github.divverent.aaaaxy.desktop,g' < io.github.divverent.aaaaxy.metainfo.xml > /app/share/metainfo/io.github.divverent.aaaaxy.appdata.xml
     sources:
       - type: git
         url: https://github.com/divVerent/aaaaxy
-        tag: v1.0.79+flatpak-2
-        commit: dd1650f160cc0e693e46436ba17c5653cfb94ec7
+        tag: v1.0.79+flatpak-1
+        commit: b92d7dd0dae0cf678525227453993caaff6d48c4
         # Needed to allow querying the version during build.
         disable-shallow-clone: true
       - type: file

--- a/io.github.divverent.aaaaxy.yml
+++ b/io.github.divverent.aaaaxy.yml
@@ -9,10 +9,9 @@ command: aaaaxy
 cleanup:
   - /builddeps
 finish-args:
-  # Needed to access gamepads.
+  # Needed to access gamepads and for 3D graphics.
+  # If we ever get a gamepad-specific permission, switch to that + dri instead.
   - --device=all
-  # Needed for 3D graphics.
-  - --device=dri
   # Needed for XShm.
   - --share=ipc
   # Needed for X11.

--- a/io.github.divverent.aaaaxy.yml
+++ b/io.github.divverent.aaaaxy.yml
@@ -53,8 +53,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/divVerent/aaaaxy
-        tag: v1.0.79
-        commit: 0b3d06a8c8a68ce886f3f22ce307bda297077f1b
+        tag: v1.0.79+flatpak-1
+        commit: b92d7dd0dae0cf678525227453993caaff6d48c4
         # Needed to allow querying the version during build.
         disable-shallow-clone: true
       - type: file

--- a/io.github.divverent.aaaaxy.yml
+++ b/io.github.divverent.aaaaxy.yml
@@ -49,12 +49,12 @@ modules:
         mkdir -p /app/share/applications
         sed -e 's,Icon=aaaaxy,Icon=io.github.divverent.aaaaxy,' < aaaaxy.desktop > /app/share/applications/io.github.divverent.aaaaxy.desktop
         mkdir -p /app/share/metainfo
-        cp -v io.github.divverent.aaaaxy.metainfo.xml /app/share/metainfo/io.github.divverent.aaaaxy.appdata.xml
+        sed -e 's,aaaaxy.png,io.github.divverent.aaaaxy.png,' < io.github.divverent.aaaaxy.metainfo.xml > /app/share/metainfo/io.github.divverent.aaaaxy.appdata.xml
     sources:
       - type: git
         url: https://github.com/divVerent/aaaaxy
-        tag: v1.0.79+flatpak-1
-        commit: b92d7dd0dae0cf678525227453993caaff6d48c4
+        tag: v1.0.79+flatpak-2
+        commit: dd1650f160cc0e693e46436ba17c5653cfb94ec7
         # Needed to allow querying the version during build.
         disable-shallow-clone: true
       - type: file

--- a/io.github.divverent.aaaaxy.yml
+++ b/io.github.divverent.aaaaxy.yml
@@ -1,0 +1,263 @@
+app-id: io.github.divverent.aaaaxy
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+# Do we need to provide a GL extension somehow?
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
+command: aaaaxy
+cleanup:
+  - /builddeps
+finish-args:
+  # Needed to access gamepads.
+  - --device=all
+  # Needed for 3D graphics.
+  - --device=dri
+  # Needed for XShm.
+  - --share=ipc
+  # Needed for X11.
+  - --socket=x11
+  # Needed for audio playback.
+  - --socket=pulseaudio
+modules:
+  - name: graphviz
+    sources:
+      - type: archive
+        url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/2.50.0/graphviz-2.50.0.tar.gz
+        sha256: e17021a510bbd2770d4ca4b4eb841138122aaa5948f9e617e6bc12b4bac62e8d
+    config-opts:
+      # Graphviz is only used during the build process, so install it to a
+      # separate place we can keep out of the flatpak.
+      - --prefix=/app/builddeps
+  - name: imagemagick
+    sources:
+      - type: archive
+        url: https://github.com/ImageMagick/ImageMagick6/archive/6.9.12-32.tar.gz
+        sha256: 61943b71ae01bdace5a8d15bee4c3ee607001d026e94c0bfe2a4c3b2a312c91a
+    config-opts:
+      # ImageMagick is only used during the build process, so install it to a
+      # separate place we can keep out of the flatpak.
+      - --prefix=/app/builddeps
+  - name: aaaaxy
+    buildsystem: simple
+    build-commands:
+      - |
+        . /usr/lib/sdk/golang/enable.sh
+        export PATH=/app/builddeps/bin:$PATH
+        make BUILDTYPE=release BINARY=/app/bin/aaaaxy
+        mkdir -p /app/share/icons/hicolor/128x128/apps
+        cp aaaaxy.png /app/share/icons/hicolor/128x128/apps/io.github.divverent.aaaaxy.png
+        mkdir -p /app/share/applications
+        sed -e 's,Icon=aaaaxy,Icon=io.github.divverent.aaaaxy,' < aaaaxy.desktop > /app/share/applications/io.github.divverent.aaaaxy.desktop
+        mkdir -p /app/share/metainfo
+        cp -v io.github.divverent.aaaaxy.metainfo.xml /app/share/metainfo/io.github.divverent.aaaaxy.appdata.xml
+    sources:
+      - type: git
+        url: https://github.com/divVerent/aaaaxy
+        tag: v1.0.79
+        commit: 0b3d06a8c8a68ce886f3f22ce307bda297077f1b
+        # Needed to allow querying the version during build.
+        disable-shallow-clone: true
+      - type: file
+        path: modules.txt
+        dest: vendor
+      # --- GO MODULES START HERE, USE go-vendor-to-flatpak-yml.sh TO UPDATE ---
+      - type: git
+        url: https://github.com/adrg/xdg
+        tag: v0.4.0
+        commit: 4ec40e24f0cf1039f93c773f2984decdea9719b5
+        dest: vendor/github.com/adrg/xdg
+      - type: git
+        url: https://github.com/akavel/rsrc
+        tag: v0.10.2
+        commit: 936343600d578fb5da472acf6987ed76935a389b
+        dest: vendor/github.com/akavel/rsrc
+      - type: git
+        url: https://github.com/dchest/jsmin
+        commit: faeced8839472f349011f4c4c5441bbc28d02191
+        dest: vendor/github.com/dchest/jsmin
+      - type: git
+        url: https://github.com/emirpasic/gods
+        tag: v1.12.0
+        commit: 1615341f118ae12f353cc8a983f35b584342c9b3
+        dest: vendor/github.com/emirpasic/gods
+      - type: git
+        url: https://github.com/fardog/tmx
+        commit: 02c45f26167251c118de4f2b10f42fe43f1ad413
+        dest: vendor/github.com/fardog/tmx
+      - type: git
+        url: https://github.com/go-gl/glfw
+        commit: 40e447a793be3543d926449946f77f85505dbeed
+        dest: vendor/github.com/go-gl/glfw
+      - type: git
+        url: https://github.com/golang/freetype
+        commit: e2365dfdc4a05e4b8299a783240d4a7d5a65d4e4
+        dest: vendor/github.com/golang/freetype
+      - type: git
+        url: https://github.com/golang/glog
+        commit: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+        dest: vendor/github.com/golang/glog
+      - type: git
+        url: https://github.com/google/go-cmp
+        tag: v0.5.6
+        commit: d103655696d8ae43c4125ee61454dbf03d8e8324
+        dest: vendor/github.com/google/go-cmp
+      - type: git
+        url: https://github.com/google/go-licenses
+        commit: ceb292363ec84358c9a276ef23aa0de893e59b84
+        dest: vendor/github.com/google/go-licenses
+      - type: git
+        url: https://github.com/google/licenseclassifier
+        commit: 3043a050f148a588e7e0c84dce27579dfe17fd2d
+        dest: vendor/github.com/google/licenseclassifier
+      - type: git
+        url: https://github.com/hajimehoshi/ebiten
+        tag: v2.2.2
+        commit: 97af84c32a2fab6c151559e58379c7746c2cf2ab
+        dest: vendor/github.com/hajimehoshi/ebiten/v2
+      - type: git
+        url: https://github.com/hajimehoshi/oto
+        tag: v2.1.0-alpha.4
+        commit: c22435daf0950bfadae39090b29ee5e9911a6768
+        dest: vendor/github.com/hajimehoshi/oto/v2
+      - type: git
+        url: https://github.com/inconshreveable/mousetrap
+        tag: v1.0.0
+        commit: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+        dest: vendor/github.com/inconshreveable/mousetrap
+      - type: git
+        url: https://github.com/jbenet/go-context
+        commit: d14ea06fba99483203c19d92cfcd13ebe73135f4
+        dest: vendor/github.com/jbenet/go-context
+      - type: git
+        url: https://github.com/jezek/xgb
+        commit: 0e0f116e1240ae19099324c3b2632003082841b7
+        dest: vendor/github.com/jezek/xgb
+      - type: git
+        url: https://github.com/jfreymuth/oggvorbis
+        tag: v1.0.3
+        commit: 16dc03daa4122c3925b8b7f0d5118156e45aa6e9
+        dest: vendor/github.com/jfreymuth/oggvorbis
+      - type: git
+        url: https://github.com/jfreymuth/vorbis
+        tag: v1.0.2
+        commit: 55da9865afe7a8953bee35bef04c240163786ccc
+        dest: vendor/github.com/jfreymuth/vorbis
+      - type: git
+        url: https://github.com/josephspurrier/goversioninfo
+        tag: v1.3.0
+        commit: a8878317895b8e0313246346e1a7d79ef833208c
+        dest: vendor/github.com/josephspurrier/goversioninfo
+      - type: git
+        url: https://github.com/kevinburke/ssh_config
+        commit: 01f96b0aa0cdcaa93f9495f89bbc6cb5a992ce6e
+        dest: vendor/github.com/kevinburke/ssh_config
+      - type: git
+        url: https://github.com/mitchellh/go-homedir
+        tag: v1.1.0
+        commit: af06845cf3004701891bf4fdb884bfe4920b3727
+        dest: vendor/github.com/mitchellh/go-homedir
+      - type: git
+        url: https://github.com/mitchellh/hashstructure
+        tag: v2.0.2
+        commit: a045b665615f739329536a58c25ca6327abf1ec1
+        dest: vendor/github.com/mitchellh/hashstructure/v2
+      - type: git
+        url: https://github.com/ncruces/zenity
+        tag: v0.7.12
+        commit: fca9f5c3cebf4cffb03a16ff323538cc100a2a99
+        dest: vendor/github.com/ncruces/zenity
+      - type: git
+        url: https://github.com/otiai10/copy
+        tag: v1.6.0
+        commit: edeb9f37d4d0c28725014fcab6635120197932a1
+        dest: vendor/github.com/otiai10/copy
+      - type: git
+        url: https://github.com/pkg/errors
+        tag: v0.9.1
+        commit: 614d223910a179a466c1767a985424175c39b465
+        dest: vendor/github.com/pkg/errors
+      - type: git
+        url: https://github.com/randall77/makefat
+        commit: 7ddd0e42c8442593c87c1705a5545099604008e5
+        dest: vendor/github.com/randall77/makefat
+      - type: git
+        url: https://github.com/sergi/go-diff
+        tag: v1.2.0
+        commit: b292a3123758b064eeaa3a5aa86df1adca0f4401
+        dest: vendor/github.com/sergi/go-diff
+      - type: git
+        url: https://github.com/spf13/cobra
+        tag: v0.0.5
+        commit: f2b07da1e2c38d5f12845a4f607e2e1018cbb1f5
+        dest: vendor/github.com/spf13/cobra
+      - type: git
+        url: https://github.com/spf13/pflag
+        tag: v1.0.5
+        commit: 2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab
+        dest: vendor/github.com/spf13/pflag
+      - type: git
+        url: https://github.com/src-d/gcfg
+        tag: v1.4.0
+        commit: 1ac3a1ac202429a54835fe8408a92880156b489d
+        dest: vendor/github.com/src-d/gcfg
+      - type: git
+        url: https://github.com/xanzy/ssh-agent
+        tag: v0.2.1
+        commit: 6a3e2ff9e7c564f36873c2e36413f634534f1c44
+        dest: vendor/github.com/xanzy/ssh-agent
+      - type: git
+        url: https://go.googlesource.com/crypto
+        commit: 089bfa5675191fd96a44247682f76ebca03d7916
+        dest: vendor/golang.org/x/crypto
+      - type: git
+        url: https://go.googlesource.com/exp
+        commit: 8a230f1f7d7a4905d4551b473275e86e2aadfe86
+        dest: vendor/golang.org/x/exp
+      - type: git
+        url: https://go.googlesource.com/image
+        commit: 6944b10bf41077a939a283aba62be2c1a676d8ef
+        dest: vendor/golang.org/x/image
+      - type: git
+        url: https://go.googlesource.com/mobile
+        commit: d61a72f26a1aa0e53cd846e90f115dbbd20cd067
+        dest: vendor/golang.org/x/mobile
+      - type: git
+        url: https://go.googlesource.com/mod
+        commit: c96bc1413d570acfb16c7db96b4380cb508ae205
+        dest: vendor/golang.org/x/mod
+      - type: git
+        url: https://go.googlesource.com/net
+        commit: 4f30a5c0130f199e0dfd54e9de49f9367cabf1ad
+        dest: vendor/golang.org/x/net
+      - type: git
+        url: https://go.googlesource.com/sync
+        commit: 036812b2e83c0ddf193dd5a34e034151da389d09
+        dest: vendor/golang.org/x/sync
+      - type: git
+        url: https://go.googlesource.com/sys
+        commit: fe61309f888157de161a48facf03d9412635cffe
+        dest: vendor/golang.org/x/sys
+      - type: git
+        url: https://go.googlesource.com/tools
+        commit: d6a9af8af0233f67fad56942665eb392464c2321
+        dest: vendor/golang.org/x/tools
+      - type: git
+        url: https://go.googlesource.com/xerrors
+        commit: 5ec99f83aff198f5fbd629d6c8d8eb38a04218ca
+        dest: vendor/golang.org/x/xerrors
+      - type: git
+        url: https://gopkg.in/src-d/go-billy.v4
+        tag: v4.3.2
+        commit: 780403cfc1bc95ff4d07e7b26db40a6186c5326e
+        dest: vendor/gopkg.in/src-d/go-billy.v4
+      - type: git
+        url: https://gopkg.in/src-d/go-git.v4
+        tag: v4.13.1
+        commit: 0d1a009cbb604db18be960db5f1525b99a55d727
+        dest: vendor/gopkg.in/src-d/go-git.v4
+      - type: git
+        url: https://gopkg.in/warnings.v0
+        tag: v0.1.2
+        commit: ec4a0fea49c7b46c2aeb0b51aac55779c607e52b
+        dest: vendor/gopkg.in/warnings.v0

--- a/modules.txt
+++ b/modules.txt
@@ -1,0 +1,310 @@
+# github.com/adrg/xdg v0.4.0
+## explicit; go 1.14
+github.com/adrg/xdg
+github.com/adrg/xdg/internal/pathutil
+# github.com/akavel/rsrc v0.10.2
+## explicit; go 1.12
+github.com/akavel/rsrc/binutil
+github.com/akavel/rsrc/coff
+github.com/akavel/rsrc/ico
+github.com/akavel/rsrc/internal
+github.com/akavel/rsrc/rsrc
+# github.com/dchest/jsmin v0.0.0-20160823214000-faeced883947
+## explicit
+github.com/dchest/jsmin
+# github.com/emirpasic/gods v1.12.0
+## explicit
+github.com/emirpasic/gods/containers
+github.com/emirpasic/gods/lists
+github.com/emirpasic/gods/lists/arraylist
+github.com/emirpasic/gods/trees
+github.com/emirpasic/gods/trees/binaryheap
+github.com/emirpasic/gods/utils
+# github.com/fardog/tmx v0.0.0-20210504210836-02c45f261672
+## explicit
+github.com/fardog/tmx
+# github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211024062804-40e447a793be
+## explicit; go 1.10
+github.com/go-gl/glfw/v3.3/glfw
+github.com/go-gl/glfw/v3.3/glfw/glfw/deps
+github.com/go-gl/glfw/v3.3/glfw/glfw/deps/glad
+github.com/go-gl/glfw/v3.3/glfw/glfw/deps/mingw
+github.com/go-gl/glfw/v3.3/glfw/glfw/deps/vs2008
+github.com/go-gl/glfw/v3.3/glfw/glfw/include/GLFW
+github.com/go-gl/glfw/v3.3/glfw/glfw/src
+# github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
+## explicit
+github.com/golang/freetype/raster
+github.com/golang/freetype/truetype
+# github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+## explicit
+github.com/golang/glog
+# github.com/google/go-cmp v0.5.6
+## explicit; go 1.8
+github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/internal/diff
+github.com/google/go-cmp/cmp/internal/flags
+github.com/google/go-cmp/cmp/internal/function
+github.com/google/go-cmp/cmp/internal/value
+# github.com/google/go-licenses v0.0.0-20211006200916-ceb292363ec8
+## explicit; go 1.16
+github.com/google/go-licenses/licenses
+# github.com/google/licenseclassifier v0.0.0-20210722185704-3043a050f148
+## explicit; go 1.16
+github.com/google/licenseclassifier
+github.com/google/licenseclassifier/internal/sets
+github.com/google/licenseclassifier/licenses
+github.com/google/licenseclassifier/stringclassifier
+github.com/google/licenseclassifier/stringclassifier/internal/pq
+github.com/google/licenseclassifier/stringclassifier/searchset
+github.com/google/licenseclassifier/stringclassifier/searchset/tokenizer
+# github.com/hajimehoshi/ebiten/v2 v2.2.2
+## explicit; go 1.15
+github.com/hajimehoshi/ebiten/v2
+github.com/hajimehoshi/ebiten/v2/audio
+github.com/hajimehoshi/ebiten/v2/audio/internal/convert
+github.com/hajimehoshi/ebiten/v2/audio/internal/go2cpp
+github.com/hajimehoshi/ebiten/v2/audio/vorbis
+github.com/hajimehoshi/ebiten/v2/ebitenutil
+github.com/hajimehoshi/ebiten/v2/ebitenutil/internal/assets
+github.com/hajimehoshi/ebiten/v2/internal/affine
+github.com/hajimehoshi/ebiten/v2/internal/atlas
+github.com/hajimehoshi/ebiten/v2/internal/buffered
+github.com/hajimehoshi/ebiten/v2/internal/clock
+github.com/hajimehoshi/ebiten/v2/internal/debug
+github.com/hajimehoshi/ebiten/v2/internal/devicescale
+github.com/hajimehoshi/ebiten/v2/internal/driver
+github.com/hajimehoshi/ebiten/v2/internal/gamepaddb
+github.com/hajimehoshi/ebiten/v2/internal/glfw
+github.com/hajimehoshi/ebiten/v2/internal/graphics
+github.com/hajimehoshi/ebiten/v2/internal/graphicscommand
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/metal
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/metal/ca
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/metal/mtl
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/metal/ns
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl/gl
+github.com/hajimehoshi/ebiten/v2/internal/graphicsdriver/opengl/gles
+github.com/hajimehoshi/ebiten/v2/internal/hooks
+github.com/hajimehoshi/ebiten/v2/internal/jsutil
+github.com/hajimehoshi/ebiten/v2/internal/mipmap
+github.com/hajimehoshi/ebiten/v2/internal/packing
+github.com/hajimehoshi/ebiten/v2/internal/png
+github.com/hajimehoshi/ebiten/v2/internal/restorable
+github.com/hajimehoshi/ebiten/v2/internal/shader
+github.com/hajimehoshi/ebiten/v2/internal/shaderir
+github.com/hajimehoshi/ebiten/v2/internal/shaderir/glsl
+github.com/hajimehoshi/ebiten/v2/internal/shaderir/metal
+github.com/hajimehoshi/ebiten/v2/internal/thread
+github.com/hajimehoshi/ebiten/v2/internal/uidriver/glfw
+github.com/hajimehoshi/ebiten/v2/internal/uidriver/js
+github.com/hajimehoshi/ebiten/v2/internal/uidriver/mobile
+github.com/hajimehoshi/ebiten/v2/text
+# github.com/hajimehoshi/oto/v2 v2.1.0-alpha.4
+## explicit; go 1.14
+github.com/hajimehoshi/oto/v2
+github.com/hajimehoshi/oto/v2/internal/oboe
+# github.com/inconshreveable/mousetrap v1.0.0
+## explicit
+github.com/inconshreveable/mousetrap
+# github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
+## explicit
+github.com/jbenet/go-context/io
+# github.com/jezek/xgb v0.0.0-20210312150743-0e0f116e1240
+## explicit
+github.com/jezek/xgb
+github.com/jezek/xgb/randr
+github.com/jezek/xgb/render
+github.com/jezek/xgb/xproto
+# github.com/jfreymuth/oggvorbis v1.0.3
+## explicit; go 1.15
+github.com/jfreymuth/oggvorbis
+# github.com/jfreymuth/vorbis v1.0.2
+## explicit; go 1.15
+github.com/jfreymuth/vorbis
+# github.com/josephspurrier/goversioninfo v1.3.0
+## explicit; go 1.12
+github.com/josephspurrier/goversioninfo
+# github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
+## explicit
+github.com/kevinburke/ssh_config
+# github.com/mitchellh/go-homedir v1.1.0
+## explicit
+github.com/mitchellh/go-homedir
+# github.com/mitchellh/hashstructure/v2 v2.0.2
+## explicit; go 1.14
+github.com/mitchellh/hashstructure/v2
+# github.com/ncruces/zenity v0.7.12
+## explicit; go 1.16
+github.com/ncruces/zenity
+github.com/ncruces/zenity/internal/zenutil
+# github.com/otiai10/copy v1.6.0
+## explicit; go 1.14
+github.com/otiai10/copy
+# github.com/pkg/errors v0.9.1
+## explicit
+# github.com/randall77/makefat v0.0.0-20210315173500-7ddd0e42c844
+## explicit; go 1.13
+github.com/randall77/makefat
+# github.com/sergi/go-diff v1.2.0
+## explicit; go 1.12
+github.com/sergi/go-diff/diffmatchpatch
+# github.com/spf13/cobra v0.0.5
+## explicit; go 1.12
+github.com/spf13/cobra
+# github.com/spf13/pflag v1.0.5
+## explicit; go 1.12
+github.com/spf13/pflag
+# github.com/src-d/gcfg v1.4.0
+## explicit
+github.com/src-d/gcfg
+github.com/src-d/gcfg/scanner
+github.com/src-d/gcfg/token
+github.com/src-d/gcfg/types
+# github.com/xanzy/ssh-agent v0.2.1
+## explicit
+github.com/xanzy/ssh-agent
+# golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
+## explicit; go 1.17
+golang.org/x/crypto/blowfish
+golang.org/x/crypto/cast5
+golang.org/x/crypto/chacha20
+golang.org/x/crypto/curve25519
+golang.org/x/crypto/curve25519/internal/field
+golang.org/x/crypto/ed25519
+golang.org/x/crypto/ed25519/internal/edwards25519
+golang.org/x/crypto/internal/poly1305
+golang.org/x/crypto/internal/subtle
+golang.org/x/crypto/openpgp
+golang.org/x/crypto/openpgp/armor
+golang.org/x/crypto/openpgp/elgamal
+golang.org/x/crypto/openpgp/errors
+golang.org/x/crypto/openpgp/packet
+golang.org/x/crypto/openpgp/s2k
+golang.org/x/crypto/ssh
+golang.org/x/crypto/ssh/agent
+golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
+golang.org/x/crypto/ssh/knownhosts
+# golang.org/x/exp v0.0.0-20211129234152-8a230f1f7d7a
+## explicit; go 1.18
+golang.org/x/exp/shiny/driver/gldriver
+golang.org/x/exp/shiny/driver/internal/drawer
+golang.org/x/exp/shiny/driver/internal/errscreen
+golang.org/x/exp/shiny/driver/internal/event
+golang.org/x/exp/shiny/driver/internal/lifecycler
+golang.org/x/exp/shiny/driver/internal/win32
+golang.org/x/exp/shiny/driver/internal/x11key
+golang.org/x/exp/shiny/screen
+# golang.org/x/image v0.0.0-20211028202545-6944b10bf410
+## explicit; go 1.12
+golang.org/x/image/colornames
+golang.org/x/image/font
+golang.org/x/image/font/gofont/gobold
+golang.org/x/image/font/gofont/goitalic
+golang.org/x/image/font/gofont/gomono
+golang.org/x/image/font/gofont/goregular
+golang.org/x/image/font/gofont/gosmallcaps
+golang.org/x/image/math/f64
+golang.org/x/image/math/fixed
+# golang.org/x/mobile v0.0.0-20211109191125-d61a72f26a1a
+## explicit; go 1.16
+golang.org/x/mobile/app
+golang.org/x/mobile/app/internal/callfn
+golang.org/x/mobile/event/key
+golang.org/x/mobile/event/lifecycle
+golang.org/x/mobile/event/mouse
+golang.org/x/mobile/event/paint
+golang.org/x/mobile/event/size
+golang.org/x/mobile/event/touch
+golang.org/x/mobile/geom
+golang.org/x/mobile/gl
+golang.org/x/mobile/internal/mobileinit
+# golang.org/x/mod v0.6.0-dev.0.20211013180041-c96bc1413d57
+## explicit; go 1.17
+golang.org/x/mod/semver
+# golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
+## explicit; go 1.17
+golang.org/x/net/context
+golang.org/x/net/internal/socks
+golang.org/x/net/proxy
+# golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+## explicit
+golang.org/x/sync/errgroup
+# golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
+## explicit; go 1.17
+golang.org/x/sys/cpu
+golang.org/x/sys/execabs
+golang.org/x/sys/internal/unsafeheader
+golang.org/x/sys/unix
+golang.org/x/sys/windows
+# golang.org/x/tools v0.1.8-0.20211029000441-d6a9af8af023
+## explicit; go 1.17
+golang.org/x/tools/go/gcexportdata
+golang.org/x/tools/go/internal/gcimporter
+golang.org/x/tools/go/internal/packagesdriver
+golang.org/x/tools/go/packages
+golang.org/x/tools/internal/event
+golang.org/x/tools/internal/event/core
+golang.org/x/tools/internal/event/keys
+golang.org/x/tools/internal/event/label
+golang.org/x/tools/internal/gocommand
+golang.org/x/tools/internal/packagesinternal
+golang.org/x/tools/internal/typeparams
+golang.org/x/tools/internal/typesinternal
+# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+## explicit; go 1.11
+golang.org/x/xerrors
+golang.org/x/xerrors/internal
+# gopkg.in/src-d/go-billy.v4 v4.3.2
+## explicit
+gopkg.in/src-d/go-billy.v4
+gopkg.in/src-d/go-billy.v4/helper/chroot
+gopkg.in/src-d/go-billy.v4/helper/polyfill
+gopkg.in/src-d/go-billy.v4/osfs
+gopkg.in/src-d/go-billy.v4/util
+# gopkg.in/src-d/go-git.v4 v4.13.1
+## explicit
+gopkg.in/src-d/go-git.v4
+gopkg.in/src-d/go-git.v4/config
+gopkg.in/src-d/go-git.v4/internal/revision
+gopkg.in/src-d/go-git.v4/internal/url
+gopkg.in/src-d/go-git.v4/plumbing
+gopkg.in/src-d/go-git.v4/plumbing/cache
+gopkg.in/src-d/go-git.v4/plumbing/filemode
+gopkg.in/src-d/go-git.v4/plumbing/format/config
+gopkg.in/src-d/go-git.v4/plumbing/format/diff
+gopkg.in/src-d/go-git.v4/plumbing/format/gitignore
+gopkg.in/src-d/go-git.v4/plumbing/format/idxfile
+gopkg.in/src-d/go-git.v4/plumbing/format/index
+gopkg.in/src-d/go-git.v4/plumbing/format/objfile
+gopkg.in/src-d/go-git.v4/plumbing/format/packfile
+gopkg.in/src-d/go-git.v4/plumbing/format/pktline
+gopkg.in/src-d/go-git.v4/plumbing/object
+gopkg.in/src-d/go-git.v4/plumbing/protocol/packp
+gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/capability
+gopkg.in/src-d/go-git.v4/plumbing/protocol/packp/sideband
+gopkg.in/src-d/go-git.v4/plumbing/revlist
+gopkg.in/src-d/go-git.v4/plumbing/storer
+gopkg.in/src-d/go-git.v4/plumbing/transport
+gopkg.in/src-d/go-git.v4/plumbing/transport/client
+gopkg.in/src-d/go-git.v4/plumbing/transport/file
+gopkg.in/src-d/go-git.v4/plumbing/transport/git
+gopkg.in/src-d/go-git.v4/plumbing/transport/http
+gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common
+gopkg.in/src-d/go-git.v4/plumbing/transport/server
+gopkg.in/src-d/go-git.v4/plumbing/transport/ssh
+gopkg.in/src-d/go-git.v4/storage
+gopkg.in/src-d/go-git.v4/storage/filesystem
+gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit
+gopkg.in/src-d/go-git.v4/storage/memory
+gopkg.in/src-d/go-git.v4/utils/binary
+gopkg.in/src-d/go-git.v4/utils/diff
+gopkg.in/src-d/go-git.v4/utils/ioutil
+gopkg.in/src-d/go-git.v4/utils/merkletrie
+gopkg.in/src-d/go-git.v4/utils/merkletrie/filesystem
+gopkg.in/src-d/go-git.v4/utils/merkletrie/index
+gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame
+gopkg.in/src-d/go-git.v4/utils/merkletrie/noder
+# gopkg.in/warnings.v0 v0.1.2
+## explicit
+gopkg.in/warnings.v0


### PR DESCRIPTION
Note that the AppStream data is in the upstream repo itself:

https://github.com/divVerent/aaaaxy/blob/main/io.github.divverent.aaaaxy.metainfo.xml

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - IPC, X11, DRI: used for using OpenGL access of the game
  - Pulseaudio: used for sound playback of the game
  - --device=all: used to access gamepads
- [ ] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/divVerent/aaaaxy (i.e. I _am_ upstream)
- [X] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
  - modules.txt is output of "go mod vendor" in the upstream repo, and is necessary to be able to build the project without internet access. In theory it can be derived from the go.mod file, but I am not aware of any tools to do that. I had tried using https://github.com/flatpak/flatpak-builder-tools/tree/master/go-get instead, but my project does not build in GO111MODULES=off mode and I see no avenue to make it so, so I am using this "go vendor" based approach instead.


[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
