### PR TITLE
Add manifest for org.kde.cantor

### DIFF
--- a/analitza.json
+++ b/analitza.json
@@ -1,0 +1,11 @@
+{
+    "name": "analitza",
+    "buildsystem": "cmake-ninja",
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.kde.org/stable/release-service/21.12.1/src/analitza-21.12.1.tar.xz",
+            "sha256": "75fbd9f310a37e5ad245277ac58193b87e7e4a1f747590a4233092f03ee18d36"
+        }
+    ]
+}

--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,23 @@
+From 6eb2da853f683a1fee0ba9f9260f07c2b2eb9361 Mon Sep 17 00:00:00 2001
+From: Snehit Sah <snehitsah@protonmail.com>
+Date: Mon, 10 Jan 2022 21:00:22 +0530
+Subject: [PATCH] Add content rating tag
+
+Signed-off-by: Snehit Sah <snehitsah@protonmail.com>
+---
+ org.kde.cantor.appdata.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/org.kde.cantor.appdata.xml b/org.kde.cantor.appdata.xml
+index 47736b10..fc739e06 100644
+--- a/org.kde.cantor.appdata.xml
++++ b/org.kde.cantor.appdata.xml
+@@ -145,4 +145,5 @@
+     <release version="21.08.3" date="2021-11-04"/>
+     <release version="21.08.2" date="2021-10-07"/>
+   </releases>
++  <content_rating type="oars-1.1"/>
+ </component>
+-- 
+2.34.1
+

--- a/boost.json
+++ b/boost.json
@@ -8,8 +8,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2",
-            "sha256": "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
+            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2",
+            "sha256": "8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc"
         }
     ]
 }

--- a/boost.json
+++ b/boost.json
@@ -1,0 +1,15 @@
+{
+    "name": "boost",
+    "buildsystem": "simple",
+    "build-commands": [
+        "./bootstrap.sh --prefix=/app --with-libraries=system",
+        "./b2 -j $FLATPAK_BUILDER_N_JOBS install"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2",
+            "sha256": "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
+        }
+    ]
+}

--- a/org.kde.cantor.json
+++ b/org.kde.cantor.json
@@ -12,7 +12,8 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--filesystem=host"
+        "--filesystem=host",
+        "--device=dri"
     ],
 
     "modules": [

--- a/org.kde.cantor.json
+++ b/org.kde.cantor.json
@@ -12,7 +12,7 @@
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--filesystem=host",
+        "--filesystem=xdg-documents",
         "--device=dri"
     ],
 

--- a/org.kde.cantor.json
+++ b/org.kde.cantor.json
@@ -1,0 +1,37 @@
+{
+    "id": "org.kde.cantor",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15-21.08",
+    "base": "io.qt.qtwebengine.BaseApp",
+    "base-version": "5.15-21.08",
+    "sdk": "org.kde.Sdk",
+    "command": "cantor",
+    "rename-icon": "cantor",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--filesystem=host"
+    ],
+
+    "modules": [
+        "poppler.json",
+        "analitza.json",
+        {
+            "name": "cantor",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/21.12.1/src/cantor-21.12.1.tar.xz",
+                    "sha256": "e1ed91e0488ea8483ed9ddc6ab88a8e486fddfe4cb8176831c652fc445a79b50"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/poppler.json
+++ b/poppler.json
@@ -1,0 +1,45 @@
+{
+    "name": "poppler",
+    "config-opts": [
+        "-DENABLE_TESTING=OFF",
+        "-DENABLE_UNSTABLE_API_ABI_HEADERS=ON",
+        "-DENABLE_CPP=OFF",
+        "-DENABLE_GLIB=OFF",
+        "-DENABLE_GOBJECT_INTROSPECTION=OFF",
+        "-DENABLE_UTILS=OFF"
+    ],
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://poppler.freedesktop.org/poppler-22.01.0.tar.xz",
+            "sha256": "7d3493056b5b86413e5c693c2cae02c5c06cd8e618d14c2c31e2c84b67b2313e"
+        }
+    ],
+    "modules": [
+        "boost.json",
+        {
+            "name": "openjpeg2",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/uclouvain/openjpeg/archive/refs/tags/v2.4.0.tar.gz",
+                    "sha256": "8702ba68b442657f11aaeb2b338443ca8d5fb95b0d845757968a7be31ef7f16d"
+                }
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/openjpeg-*",
+                "/lib/pkgconfig"
+            ]
+        }
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - `--share=network` for cantor to connect to internet
  - `--filesystem=host` for load/save/export functionality
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
  - https://invent.kde.org/education/cantor/-/merge_requests/37

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

<hr>

Notes

Cantor supports multiple backends. This manifest only bundles cantor with defaults, providing KAlgebra.