### PR TITLE
Add manifest for org.kde.kcolorchooser

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,0 +1,23 @@
+From 72e154a57939f4beeb5b0e88ce3eab45470d07e7 Mon Sep 17 00:00:00 2001
+From: Snehit Sah <snehitsah@protonmail.com>
+Date: Thu, 13 Jan 2022 17:12:42 +0530
+Subject: [PATCH] Add content tag in appdata
+
+Signed-off-by: Snehit Sah <snehitsah@protonmail.com>
+---
+ org.kde.kcolorchooser.appdata.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/org.kde.kcolorchooser.appdata.xml b/org.kde.kcolorchooser.appdata.xml
+index 98cbcf5..03fc844 100644
+--- a/org.kde.kcolorchooser.appdata.xml
++++ b/org.kde.kcolorchooser.appdata.xml
+@@ -136,4 +136,5 @@
+     <release version="21.08.3" date="2021-11-04"/>
+     <release version="21.08.2" date="2021-10-07"/>
+   </releases>
++  <content_rating type="oars-1.1"/>
+ </component>
+-- 
+2.34.1
+

--- a/org.kde.kcolorchooser.json
+++ b/org.kde.kcolorchooser.json
@@ -25,7 +25,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/20.12.1/src/kcolorchooser-21.12.1.tar.xz",
+                    "url": "https://download.kde.org/stable/release-service/21.12.1/src/kcolorchooser-21.12.1.tar.xz",
                     "sha256": "a3b34c3fe699435664f99a5fad7960f7b38147ecd17010faafd3d03e49cabeb2"
                 },
                 {

--- a/org.kde.kcolorchooser.json
+++ b/org.kde.kcolorchooser.json
@@ -1,0 +1,38 @@
+{
+    "id": "org.kde.kcolorchooser",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15-21.08",
+    "sdk": "org.kde.Sdk",
+    "command": "kcolorchooser",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
+    ],
+
+    "modules": [
+        {
+            "name": "icon",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/share/icons/hicolor/32x32/apps/",
+                "install -D /usr/share/icons/breeze/apps/48/kcolorchooser.svg /app/share/icons/hicolor/32x32/apps/"
+            ]
+        },
+        {
+            "name": "kcolorchooser",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/20.12.1/src/kcolorchooser-21.12.1.tar.xz",
+                    "sha256": "a3b34c3fe699435664f99a5fad7960f7b38147ecd17010faafd3d03e49cabeb2"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.kcolorchooser.json
+++ b/org.kde.kcolorchooser.json
@@ -12,14 +12,6 @@
 
     "modules": [
         {
-            "name": "icon",
-            "buildsystem": "simple",
-            "build-commands": [
-                "mkdir -p /app/share/icons/hicolor/32x32/apps/",
-                "install -D /usr/share/icons/breeze/apps/48/kcolorchooser.svg /app/share/icons/hicolor/32x32/apps/"
-            ]
-        },
-        {
             "name": "kcolorchooser",
             "buildsystem": "cmake-ninja",
             "sources": [
@@ -32,6 +24,10 @@
                     "type": "patch",
                     "path": "appdata.patch"
                 }
+            ],
+            "post-install": [
+                "mkdir -p /app/share/icons/hicolor/scalable/apps",
+                "install -D /usr/share/icons/breeze/apps/48/kcolorchooser.svg /app/share/icons/hicolor/scalable/apps/"
             ]
         }
     ]

--- a/org.kde.kcolorchooser.json
+++ b/org.kde.kcolorchooser.json
@@ -26,8 +26,7 @@
                 }
             ],
             "post-install": [
-                "mkdir -p /app/share/icons/hicolor/scalable/apps",
-                "install -D /usr/share/icons/breeze/apps/48/kcolorchooser.svg /app/share/icons/hicolor/scalable/apps/"
+                "install -D /usr/share/icons/breeze/apps/48/kcolorchooser.svg /app/share/icons/hicolor/scalable/apps/kcolorchooser.svg"
             ]
         }
     ]

--- a/org.kde.kcolorchooser.json
+++ b/org.kde.kcolorchooser.json
@@ -5,6 +5,7 @@
     "sdk": "org.kde.Sdk",
     "command": "kcolorchooser",
     "finish-args": [
+        "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland"


### PR DESCRIPTION

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. 
  - coordinated via KDE Matrix Webchat
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned.
  - https://invent.kde.org/graphics/kcolorchooser/-/merge_requests/2

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
