### PR TITLE
Add com.gitlab.JakobDev.jdMinecraftLauncher

### DIFF
--- a/com.gitlab.JakobDev.jdMinecraftLauncher.desktop
+++ b/com.gitlab.JakobDev.jdMinecraftLauncher.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=jdMinecraftLauncher
+Terminal=false
+Type=Application
+Icon=com.gitlab.JakobDev.jdMinecraftLauncher
+Exec=jdMinecraftLauncher
+Comment=A classic styled Minecraft Launcher
+Comment[de]=Ein Minecraft-Launcher im klassischen Stil
+Categories=Game;
+Keywords=Minecraft;NBT 

--- a/com.gitlab.JakobDev.jdMinecraftLauncher.metainfo.xml
+++ b/com.gitlab.JakobDev.jdMinecraftLauncher.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <!--Created with jdAppdataEdit 2.0-->
+  <id>com.gitlab.JakobDev.jdMinecraftLauncher</id>
+  <name>jdMinecraftLauncher</name>
+  <summary>A classic styled Minecraft Launcher</summary>
+  <summary xml:lang="de">Ein Minecraft Launcher im klassischen Stil</summary>
+  <developer_name>JakobDev</developer_name>
+  <launchable type="desktop-id">com.gitlab.JakobDev.jdMinecraftLauncher.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <description>
+    <p>jdMinecraftLauncher is a Minecraft launcher which Look and Feel is close the the good old offical Launcher</p>
+    <p xml:lang="de">jdMinecraftLauncher ist ein Minecraft Launcher der sich am klassischem Launcher orientiert</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The MainWIndow</caption>
+      <image type="source">https://gitlab.com/JakobDev/jdMinecraftLauncher/-/raw/3.0/Screenshots/MainWindow.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>The ProfileWindow</caption>
+      <image type="source">https://gitlab.com/JakobDev/jdMinecraftLauncher/-/raw/3.0/Screenshots/ProfileWindow.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="3.0" date="2022-01-15" type="stable"/>
+    <release version="2.5" date="2021-06-28" type="stable"/>
+    <release version="2.4" date="2020-05-23" type="stable"/>
+    <release version="2.3" date="2020-05-16" type="stable"/>
+    <release version="2.2" date="2020-05-14" type="stable"/>
+    <release version="2.1" date="2020-05-12" type="stable"/>
+    <release version="2.0" date="2020-04-27" type="stable"/>
+    <release version="1.5" date="2019-12-02" type="stable"/>
+    <release version="1.4" date="2019-11-26" type="stable"/>
+    <release version="1.3" date="2019-11-22" type="stable"/>
+    <release version="1.2" date="2019-11-20" type="stable"/>
+    <release version="1.1" date="2019-11-11" type="stable"/>
+    <release version="1.0" date="2019-11-11" type="stable"/>
+  </releases>
+  <url type="homepage">https://gitlab.com/JakobDev/jdMinecraftLauncher</url>
+  <url type="bugtracker">https://gitlab.com/JakobDev/jdMinecraftLauncher/-/issues</url>
+  <categories>
+    <category>Game</category>
+    <category>Qt</category>
+  </categories>
+  <requires>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </requires>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">moderate</content_attribute>
+  </content_rating>
+  <provides>
+    <binary>jdMinecraftLauncher</binary>
+    <python3>jdMinecraftLauncher</python3>
+  </provides>
+  <keywords>
+    <keyword>minecraft</keyword>
+    <keyword>sandbox</keyword>
+  </keywords>
+</component>

--- a/com.gitlab.JakobDev.jdMinecraftLauncher.yml
+++ b/com.gitlab.JakobDev.jdMinecraftLauncher.yml
@@ -1,0 +1,54 @@
+app-id: com.gitlab.JakobDev.jdMinecraftLauncher
+runtime: org.kde.Platform
+runtime-version: "6.2"
+sdk: org.kde.Sdk
+base: io.qt.qtwebengine.BaseApp
+base-version: "6.2"
+command: jdMinecraftLauncher
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --device=dri
+  - --socket=wayland
+  - --share=network
+  - --filesystem=host
+  - --socket=pulseaudio
+  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+
+modules:
+  - pyqt6.yml
+  - pyqt6-webengine.yml
+  - python3-modules.json
+
+  - name: gamemode
+    buildsystem: meson
+    config-opts: &gamemode_opts
+      - -Dwith-systemd=false
+      - -Dwith-daemon=false
+      - -Dwith-examples=false
+      - -Dwith-util=false
+      - -Dwith-sd-bus-provider=no-daemon
+    post-install:
+      - install -Dm755 ../data/gamemoderun -t /app/bin
+    sources: &gamemode_sources
+      - type: archive
+        url: https://github.com/FeralInteractive/gamemode/releases/download/1.6.1/gamemode-1.6.1.tar.xz
+        sha256: 10c2a3f142eae472f5a09e42616e38c666c05b25ca3e61e562a543bb3fda66c5
+
+  - name: jdMinecraftLauncher
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+      - install -Dm644 jdMinecraftLauncher/Icon.svg /app/share/icons/hicolor/scalable/apps/com.gitlab.JakobDev.jdMinecraftLauncher.svg
+      - install -Dm644 com.gitlab.JakobDev.jdMinecraftLauncher.metainfo.xml /app/share/appdata/com.gitlab.JakobDev.jdMinecraftLauncher.metainfo.xml
+      - install -Dm644 com.gitlab.JakobDev.jdMinecraftLauncher.desktop /app/share/applications/com.gitlab.JakobDev.jdMinecraftLauncher.desktop
+    sources:
+      - type: archive
+        url: https://gitlab.com/JakobDev/jdMinecraftLauncher/-/archive/3.0/jdMinecraftLauncher-3.0.tar.gz
+        sha256: b7e15059147d3480fa408789c850f252c38e7624fb8bb30f86b0784c4c1b76ae
+
+      - type: file
+        path: com.gitlab.JakobDev.jdMinecraftLauncher.desktop
+
+      - type: file
+        path: com.gitlab.JakobDev.jdMinecraftLauncher.metainfo.xml

--- a/pyqt6-webengine.yml
+++ b/pyqt6-webengine.yml
@@ -1,0 +1,21 @@
+name: pyqt6-webengine
+buildsystem: simple
+build-commands:
+  - sip-install
+    --debug
+    --verbose
+    --concatenate=1
+    --no-docstrings
+    --qmake=/usr/bin/qmake6
+    --target-dir=/app/lib/python3.9/site-packages/
+    --api-dir=/app/lib/python3.9/site-packages/
+    --qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngineCore
+    --qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngineQuick
+    --qmake-setting=QMAKE_INCDIR+=/app/include/QtWebEngineWidgets
+build-options:
+    env:
+      - QMAKEPATH=/app
+sources:
+  - type: archive
+    url: https://pypi.python.org/packages/source/P/PyQt6-WebEngine/PyQt6_WebEngine-6.2.1.tar.gz
+    sha256: 6f6d7cb612f20d1f1f8ea1bbe7ebb8bbaa3f7fcd56f0e9c41582851998be20c3

--- a/pyqt6.yml
+++ b/pyqt6.yml
@@ -1,0 +1,89 @@
+name: pyqt6
+modules:
+
+  - name: sip
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+    sources:
+      - type: archive
+        url: https://pypi.python.org/packages/source/s/sip/sip-6.4.0.tar.gz
+        sha256: 42ec368520b8da4a0987218510b1b520b4981e4405086c1be384733affc2bcb0
+    modules:
+
+      - name: python-toml
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://files.pythonhosted.org/packages/source/t/toml/toml-0.10.0.tar.gz
+            sha256: 229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c
+
+      - name: python-packaging
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://files.pythonhosted.org/packages/source/p/packaging/packaging-20.1.tar.gz
+            sha256: e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334
+        cleanup:
+          - "*"
+
+  - name: sip-pyqt6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+    sources:
+      - type: archive
+        url: https://pypi.python.org/packages/source/P/PyQt6-sip/PyQt6_sip-13.1.0.tar.gz
+        sha256: 7c31073fe8e6cb8a42e85d60d3a096700a9047c772b354d6227dfe965566ec8a
+
+  - name: python-pyparsing
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/source/p/pyparsing/pyparsing-2.4.6.tar.gz
+        sha256: 4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f
+    cleanup:
+      - "*"
+
+  - name: PyQt-builder
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/8b/5f/1bd49787262ddce37b826ef49dcccf5a9970facf0ed363dee5ee233e681d/PyQt-builder-1.12.2.tar.gz
+        sha256: f62bb688d70e0afd88c413a8d994bda824e6cebd12b612902d1945c5a67edcd7
+    cleanup:
+      - "*"
+
+buildsystem: simple
+build-commands:
+  - sip-install
+    --confirm-license
+    --no-designer-plugin
+    --no-qml-plugin
+    --no-tools
+    --concatenate=1
+    --debug
+    --no-docstrings
+    --verbose
+    --qt-shared
+    --target-dir=/app/lib/python3.9/site-packages/
+    --enable=QtCore
+    --enable=QtWidgets
+    --enable=QtGui
+    --enable=QtNetwork
+    --enable=QtWebChannel
+    --enable=QtQml
+    --enable=QtPrintSupport
+sources:
+  - type: archive
+    url: https://pypi.python.org/packages/source/P/PyQt6/PyQt6-6.2.1.tar.gz
+    sha256: d603a5c8effccc9174b3f43834256401a61ea40f2338306ca22fb6a1e870b89c
+

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -1,0 +1,94 @@
+{
+    "name": "python3-modules",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl",
+                    "sha256": "c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl",
+                    "sha256": "84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl",
+                    "sha256": "1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl",
+                    "sha256": "d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl",
+                    "sha256": "6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"
+                }
+            ]
+        },
+        {
+            "name": "python3-minecraft-launcher-lib",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"minecraft-launcher-lib\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/af/f4/524415c0744552cce7d8bf3669af78e8a069514405ea4fcbd0cc44733744/urllib3-1.26.7-py2.py3-none-any.whl",
+                    "sha256": "c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl",
+                    "sha256": "84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/47/84/b06f6729fac8108c5fa3e13cde19b0b3de66ba5538c325496dbe39f5ff8e/charset_normalizer-2.0.9-py3-none-any.whl",
+                    "sha256": "1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/37/45/946c02767aabb873146011e665728b680884cd8fe70dde973c640e45b775/certifi-2021.10.8-py2.py3-none-any.whl",
+                    "sha256": "d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/92/96/144f70b972a9c0eabbd4391ef93ccd49d0f2747f4f6a2a2738e99e5adc65/requests-2.26.0-py2.py3-none-any.whl",
+                    "sha256": "6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/6b/30/3355179120ced990cb6245389e5512d80dfd1ca760db66546c192f35ce39/minecraft_launcher_lib-4.1-py3-none-any.whl",
+                    "sha256": "bdfcae4b2a2a38720735732aef0071413831a14d58a81e30d7b46dda09501886"
+                }
+            ]
+        },
+        {
+            "name": "python3-jdTranslationHelper",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"jdTranslationHelper\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f0/f8/afdd938d8900a751acbf41931218327b6a11076a5fadd2882ab4acebe6b5/jdTranslationHelper-2.1-py3-none-any.whl",
+                    "sha256": "cd4a632cecbabebb23dacd4d47aa621d5ac2036314e168b696a0f70a6a07f187"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Network is needed to download Minecraft and play online.

Full Filesystem access is needed, because this Program tries to replicate the user experience from the classic Minecraft Launcher which uses text boxes for path input (custom game directory and custom java version) and not file dialogs, so portals will not work.

The desktop file and the metainfo file will be moved upstream in the next release.