### PR TITLE
org.freedesktop.weston

### DIFF
--- a/org.freedesktop.weston.appdata.xml
+++ b/org.freedesktop.weston.appdata.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.freedesktop.weston</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Weston</name>
+  <summary>A lightweight and functional Wayland compositor</summary>
+
+  <description>
+    <p>
+      Weston is the reference implementation of a Wayland compositor, as well as a
+      useful environment in and of itself.
+    </p>
+    <p>
+      Out of the box, Weston provides a very basic desktop, or a full-featured
+      environment for non-desktop uses such as automotive, embedded, in-flight,
+      industrial, kiosks, set-top boxes and TVs. It also provides a library allowing
+      other projects to build their own full-featured environments on top of Weston's
+      core.
+    </p>
+    <p>
+      The core focus of Weston is correctness and reliability. Weston aims to be lean
+      and fast, but more importantly, to be predictable. Whilst Weston does have known
+      bugs and shortcomings, we avoid unknown or variable behaviour as much as
+      possible, including variable performance such as occasional spikes in frame
+      display time.
+    </p>
+    <p>
+      A small suite of example or demo clients are also provided: though they can be
+      useful in themselves, their main purpose is to be an example or test case for
+      others building compositors or clients.
+    </p>
+    <p>
+      If you are after a more mainline desktop experience, the
+      GNOME and KDE projects provide
+      full-featured desktop environments built on the Wayland protocol. Many other
+      projects also exist providing Wayland clients and desktop environments: you are
+      not limited to just what you can find in Weston.
+    </p>
+  </description>
+
+  <content_rating type="oars-1.1" />
+
+  <launchable type="desktop-id">org.freedesktop.weston.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Weston</caption>
+      <image>https://gitlab.freedesktop.org/wayland/weston/-/raw/main/doc/wayland-screenshot.jpg</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://gitlab.freedesktop.org/wayland/weston</url>
+
+  <releases>
+    <release version="10.0.0" date="2022-02-01">
+    </release>
+  </releases>
+</component>

--- a/org.freedesktop.weston.yaml
+++ b/org.freedesktop.weston.yaml
@@ -9,6 +9,26 @@ finish-args:
 - --socket=wayland
 - --device=dri
 - --filesystem=/run/user/
+cleanup:
+- /bin/checkmk
+- /bin/libevdev-tweak-device
+- /bin/libinput
+- /bin/mouse-dpi-tool
+- /bin/mtdev-test
+- /bin/touchpad-edge-detector
+- /etc
+- /include
+- /lib/*.a
+- /lib/*.la
+- /lib/cmake
+- /lib/debug
+- /lib/pkgconfig
+- /lib/udev
+- /libexec/libinput
+- /share/libweston-10
+- /share/man
+- /share/pkgconfig
+- /share/zsh
 
 modules:
 - name: mtdev

--- a/org.freedesktop.weston.yaml
+++ b/org.freedesktop.weston.yaml
@@ -3,6 +3,8 @@ runtime: org.freedesktop.Platform
 runtime-version: "21.08"
 sdk: org.freedesktop.Sdk
 command: weston
+rename-desktop-file: weston.desktop
+rename-icon: wayland
 finish-args:
 - --socket=wayland
 - --device=dri
@@ -79,3 +81,21 @@ modules:
   - -Dwcap-decode=false
   - -Dtest-junit-xml=false
   - -Dtest-gl-renderer=false
+  post-install:
+  # launcher
+  - install -Dm644 /app/share/wayland-sessions/weston.desktop /app/share/applications/weston.desktop
+  # SVG icon, "is not a valid icon: Format not recognized"
+  # - install -Dm644 /app/share/weston/wayland.svg /app/share/icons/hicolor/scalable/apps/wayland.svg
+  # PNG icon
+  - install -Dm644 /app/share/weston/wayland.png /app/share/icons/hicolor/128x128/apps/wayland.png
+  # set icon
+  - desktop-file-edit --set-icon=wayland /app/share/applications/weston.desktop
+
+- name: appstream
+  sources:
+  - type: file
+    path: org.freedesktop.weston.appdata.xml
+  buildsystem: simple
+  build-commands:
+  # AppStream meta data
+  - install -Dm644 org.freedesktop.weston.appdata.xml /app/share/metainfo/org.freedesktop.weston.appdata.xml

--- a/org.freedesktop.weston.yaml
+++ b/org.freedesktop.weston.yaml
@@ -99,3 +99,24 @@ modules:
   build-commands:
   # AppStream meta data
   - install -Dm644 org.freedesktop.weston.appdata.xml /app/share/metainfo/org.freedesktop.weston.appdata.xml
+
+- name: weston-seatd
+  sources:
+  - type: script
+    dest-filename: weston-seatd
+    commands:
+    - export SEATD_LOGLEVEL=debug
+    - seatd-launch -- weston
+  buildsystem: simple
+  build-commands:
+  - install -Dm755 weston-seatd /app/bin/weston-seatd
+
+- name: weston-logind
+  sources:
+  - type: script
+    dest-filename: weston-logind
+    commands:
+    - dbus-launch weston
+  buildsystem: simple
+  build-commands:
+  - install -Dm755 weston-logind /app/bin/weston-logind

--- a/org.freedesktop.weston.yaml
+++ b/org.freedesktop.weston.yaml
@@ -1,0 +1,81 @@
+app-id: org.freedesktop.weston
+runtime: org.freedesktop.Platform
+runtime-version: "21.08"
+sdk: org.freedesktop.Sdk
+command: weston
+finish-args:
+- --socket=wayland
+- --device=dri
+- --filesystem=/run/user/
+
+modules:
+- name: mtdev
+  sources:
+  - type: git
+    url: http://bitmath.org/git/mtdev.git
+    tag: "v1.1.6"
+    # fatal: dumb http transport does not support shallow capabilities
+    disable-shallow-clone: true
+  buildsystem: autotools
+
+- name: check
+  sources:
+  - type: git
+    url: https://github.com/libcheck/check.git
+    tag: "0.15.2"
+  buildsystem: cmake-ninja
+  builddir: true
+
+- name: libevdev
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/libevdev/libevdev.git
+    tag: "libevdev-1.12.0"
+  buildsystem: meson
+  builddir: true
+  config-opts:
+  - -Dtests=disabled
+  - -Ddocumentation=disabled
+
+- name: libinput
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/libinput/libinput.git
+    tag: "1.19.3"
+  buildsystem: meson
+  builddir: true
+  config-opts:
+  - -Dlibwacom=false
+  - -Ddebug-gui=false
+  - -Dtests=false
+
+- name: seat
+  sources:
+  - type: git
+    url: https://git.sr.ht/~kennylevinsen/seatd
+    tag: "0.6.3"
+  buildsystem: meson
+  builddir: true
+
+- name: weston
+  sources:
+  - type: git
+    url: https://gitlab.freedesktop.org/wayland/weston.git
+    tag: "10.0.0"
+  buildsystem: meson
+  builddir: true
+  config-opts:
+  - -Dbackend-rdp=false
+  - -Dxwayland=false
+  - -Dsystemd=false
+  - -Dpipewire=false
+  - -Dshell-fullscreen=false
+  - -Dshell-ivi=false
+  - -Dshell-kiosk=false
+  - -Dcolor-management-lcms=false
+  - -Dcolor-management-colord=false
+  - -Dlauncher-logind=true
+  - -Dlauncher-libseat=true
+  - -Dwcap-decode=false
+  - -Dtest-junit-xml=false
+  - -Dtest-gl-renderer=false

--- a/org.freedesktop.weston.yaml
+++ b/org.freedesktop.weston.yaml
@@ -9,6 +9,7 @@ finish-args:
 - --socket=wayland
 - --device=dri
 - --filesystem=/run/user/
+- --talk-name=org.freedesktop.Flatpak
 cleanup:
 - /bin/checkmk
 - /bin/libevdev-tweak-device
@@ -140,3 +141,27 @@ modules:
   buildsystem: simple
   build-commands:
   - install -Dm755 weston-logind /app/bin/weston-logind
+
+- name: shell-wrapper
+  sources:
+  - type: script
+    dest-filename: shell-wrapper
+    commands:
+    - flatpak-spawn --host "$SHELL" "$@"
+  buildsystem: simple
+  build-commands:
+  - install -Dm755 shell-wrapper /app/bin/shell-wrapper
+
+- name: terminal-wrapper
+  sources:
+  - type: script
+    dest-filename: weston-terminal
+    commands:
+    - export SHELL=bash
+    - weston-terminal-sandboxed --shell=/app/bin/shell-wrapper
+  buildsystem: simple
+  build-commands:
+  # rename original executable
+  - mv /app/bin/weston-terminal /app/bin/weston-terminal-sandboxed
+  # install wrapper script
+  - install -Dm755 weston-terminal /app/bin/weston-terminal


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission


This adds [Weston](https://gitlab.freedesktop.org/wayland/weston), the Wayland reference compositor, and its examples. At the moment, it can only be used as a nested compositor.

I would appreciate any help that would make it possible to run it from a VTE. This will require access to hardware and ttys and probably some launchd service, but I don't know which permissions have to be set for this.