### PR TITLE
Add manifest for org.kde.kuiviewer

### DIFF
--- a/0001-Add-content-rating-tag.patch
+++ b/0001-Add-content-rating-tag.patch
@@ -1,0 +1,34 @@
+From b79eb0af2b7a496cb96a679c8a4ef496431ff1fc Mon Sep 17 00:00:00 2001
+From: Snehit Sah <snehitsah@protonmail.com>
+Date: Tue, 8 Feb 2022 09:57:43 +0530
+Subject: [PATCH] Add content rating tag
+
+Signed-off-by: Snehit Sah <snehitsah@protonmail.com>
+---
+ kuiviewer/org.kde.kuiviewer.metainfo.xml     | 1 +
+ kuiviewer/org.kde.kuiviewerpart.metainfo.xml | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/kuiviewer/org.kde.kuiviewer.metainfo.xml b/kuiviewer/org.kde.kuiviewer.metainfo.xml
+index 8d40707..95670f2 100644
+--- a/kuiviewer/org.kde.kuiviewer.metainfo.xml
++++ b/kuiviewer/org.kde.kuiviewer.metainfo.xml
+@@ -116,4 +116,5 @@
+     <release version="21.12.0" date="2021-12-09"/>
+     <release version="21.08.3" date="2021-11-04"/>
+   </releases>
++  <content_rating type="oars-1.1"/>
+ </component>
+diff --git a/kuiviewer/org.kde.kuiviewerpart.metainfo.xml b/kuiviewer/org.kde.kuiviewerpart.metainfo.xml
+index ccd0294..e4b811c 100644
+--- a/kuiviewer/org.kde.kuiviewerpart.metainfo.xml
++++ b/kuiviewer/org.kde.kuiviewerpart.metainfo.xml
+@@ -116,4 +116,5 @@
+     <release version="21.12.0" date="2021-12-09"/>
+     <release version="21.08.3" date="2021-11-04"/>
+   </releases>
++  <content_rating type="oars-1.1"/>
+ </component>
+-- 
+2.35.1
+

--- a/cmakelists.patch
+++ b/cmakelists.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt.old b/CMakeLists.txt
+index cebfdc6..c61a76b 100644
+--- a/CMakeLists.txt.old
++++ b/CMakeLists.txt
+@@ -34,7 +34,7 @@ add_definitions(
+     -DKF_DEPRECATED_WARNINGS_SINCE=0x060000
+ )
+ 
+-add_subdirectory(kpartloader)
++# add_subdirectory(kpartloader)
+ add_subdirectory(kuiviewer)
+ 
+ ki18n_install(po)

--- a/org.kde.kuiviewer.json
+++ b/org.kde.kuiviewer.json
@@ -1,0 +1,36 @@
+{
+    "id": "org.kde.kuiviewer",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15-21.08",
+    "sdk": "org.kde.Sdk",
+    "command": "kuiviewer",
+    "rename-icon": "kuiviewer",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
+    ],
+
+    "modules": [
+        {
+            "name": "kuiviewer",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/21.12.2/src/kde-dev-utils-21.12.2.tar.xz",
+                    "sha256": "0eabcb9b195f5edb1cc5bf1def07eb59a219ceade9dd2a9ead51144127609f3a"
+                },
+                {
+                    "type": "patch",
+                    "path": "cmakelists.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Add-content-rating-tag.patch"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project.
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned.   
   - `0001-Add-content-rating-tag.patch` : https://invent.kde.org/sdk/kde-dev-utils/-/merge_requests/4
   - **[NOT SUBMITTED]** `cmakelists.patch` : not required by upstream; only used during flatpak build process to not build other utility bundled in same tarball.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
