### PR TITLE
Add manifest for KDE KStars

### DIFF
--- a/appstream-metadata-fix.patch
+++ b/appstream-metadata-fix.patch
@@ -1,0 +1,15 @@
+diff --git a/org.kde.kstars.appdata.xml b/org.kde.kstars.appdata.xml
+index 18a4fa000..608c0d39c 100644
+--- a/org.kde.kstars.appdata.xml
++++ b/org.kde.kstars.appdata.xml
+@@ -501,4 +501,10 @@
+     <value key="KDE::google_play">https://play.google.com/store/apps/details?id=org.kde.kstars.lite</value>
+   </custom>
+   <content_rating type="oars-1.1"/>
++  <releases>
++    <release version="3.5.7" date="2022-01-16"/>
++    <release version="3.5.6" date="2021-11-10"/>
++    <release version="3.5.5" date="2021-09-14"/>
++    <release version="3.5.4" date="2021-07-03"/>
++  </releases>
+ </component>

--- a/make-default-color-scheme-default.patch
+++ b/make-default-color-scheme-default.patch
@@ -1,0 +1,12 @@
+diff --git a/kstars/kstars.kcfg a/kstars/kstars.kcfg
+index 7dd5ab063..35d189191 100644
+--- a/kstars/kstars.kcfg
++++ b/kstars/kstars.kcfg
+@@ -115,7 +115,7 @@
+       </entry>
+       <entry name="CurrentTheme" type="String">
+          <label>Current application theme</label>
+-         <default>Black Body</default>
++         <default>Default</default>
+       </entry>
+    </group>

--- a/org.kde.kstars.json
+++ b/org.kde.kstars.json
@@ -54,6 +54,10 @@
                 {
                     "type": "patch",
                     "path": "make-default-color-scheme-default.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "appstream-metadata-fix.patch"
                 }
             ]
         }

--- a/org.kde.kstars.json
+++ b/org.kde.kstars.json
@@ -1,0 +1,62 @@
+{
+    "id": "org.kde.kstars",
+    "branch": "3.5.7",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "5.15-21.08",
+    "sdk": "org.kde.Sdk",
+    "command": "kstars",
+    "rename-icon": "kstars",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--share=network"
+    ],
+
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.a",
+        "/lib/*.la",
+        "/share/man"
+     ],
+
+    "modules": [
+    {
+        "name": "eigen3",
+        "buildsystem": "cmake-ninja",
+        "builddir": true,
+        "config-opts": [
+            "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+            "-DBUILD_TESTING=OFF"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.bz2",
+                "sha256": "b4c198460eba6f28d34894e3a5710998818515104d6e74e5cc331ce31e46e626"
+            }
+        ]
+
+    },
+        {
+            "name": "kstars",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kstars/kstars-3.5.7.tar.xz",
+                    "sha256": "aa8f122ee9b8e81334433191eab276c361112b9dcb9bcf8dfa0851e87a100d06"
+                },
+                {
+                    "type": "patch",
+                    "path": "make-default-color-scheme-default.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.kstars.json
+++ b/org.kde.kstars.json
@@ -1,6 +1,5 @@
 {
     "id": "org.kde.kstars",
-    "branch": "3.5.7",
     "runtime": "org.kde.Platform",
     "runtime-version": "5.15-21.08",
     "sdk": "org.kde.Sdk",
@@ -8,7 +7,7 @@
     "rename-icon": "kstars",
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--device=dri",
         "--share=network"


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions.
  - `--device=dri` is for direct rendering access on Wayland
  - `--share=network` is to make the network download features work
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub.
  - https://invent.kde.org/ngraham
  - https://invent.kde.org/education/kstars/-/commits/master?author=Nate%20Graham
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned.
  - One patch to fix the initial color scheme has been submitted upstream at https://invent.kde.org/education/kstars/-/merge_requests/550

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
