### PR TITLE
Add Flatpak recipe for AppStream

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-appstream-check": true
+}

--- a/org.freedesktop.appstream.cli.yaml
+++ b/org.freedesktop.appstream.cli.yaml
@@ -1,0 +1,76 @@
+---
+app-id: org.freedesktop.appstream.cli
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+command: appstreamcli
+separate-locales: false
+
+finish-args:
+ - --filesystem=host
+ - --filesystem=~/.local/share/flatpak:ro
+ - --filesystem=/var/lib/flatpak:ro
+ - --share=network
+
+cleanup:
+ - /include
+ - /lib/pkgconfig
+ - /lib/*.a
+ - /lib/*.la
+
+modules:
+- name: libyaml
+  sources:
+  - type: git
+    url: https://github.com/yaml/libyaml.git
+    tag: '0.2.5'
+
+- name: snowball
+  buildsystem: simple
+  build-commands:
+   - make libstemmer.so -j$FLATPAK_BUILDER_N_JOBS
+   - install -Dm644 include/libstemmer.h /app/include/libstemmer.h
+   - cp -d libstemmer.so.* -t /app/lib/
+   - install -Dm644 libstemmer.so /app/lib/libstemmer.so
+  sources:
+   - type: git
+     url: https://github.com/snowballstem/snowball.git
+     tag: v2.2.0
+   - type: patch
+     path: patches/snowball_build-options.diff
+   - type: patch
+     path: patches/snowball_shared-library.diff
+
+- name: libxmlb
+  buildsystem: meson
+  config-opts:
+   - -Dstemmer=true
+   - -Dintrospection=false
+   - -Dgtkdoc=false
+  sources:
+  - type: git
+    url: https://github.com/hughsie/libxmlb.git
+    tag: '0.3.6'
+
+- name: appstream
+  buildsystem: meson
+  config-opts:
+   - -Dcompose=true
+   - -Dgir=false
+   - -Dapidocs=false
+  sources:
+  - type: git
+    url: https://github.com/ximion/appstream.git
+    tag: v0.15.2
+
+# TODO: remove this module once Flatpak has updated to appstreamcli
+# or its appstream-glib copy understands modern AppStream XML and
+# doesn't fail parsing it.
+- name: metainfo-downgrade
+  buildsystem: simple
+  build-options:
+    env:
+      ASCLI_METAINFO_FNAME: '/app/share/metainfo/org.freedesktop.appstream.cli.metainfo.xml'
+  build-commands:
+   - sed -i 's/<em>//g' $ASCLI_METAINFO_FNAME
+   - sed -i 's/<\/em>//g' $ASCLI_METAINFO_FNAME

--- a/patches/snowball_build-options.diff
+++ b/patches/snowball_build-options.diff
@@ -1,0 +1,24 @@
+From: Stefano Rivera <stefanor@debian.org>
+Date: Sun, 24 Jan 2021 19:07:24 -0700
+Subject: Honor build flags passed as command line arguments
+
+Forwarded: not-needed
+---
+ GNUmakefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index 98eb1fa..d5e29cd 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -170,8 +170,8 @@ C_OTHER_OBJECTS = $(C_OTHER_SOURCES:.c=.o)
+ JAVA_CLASSES = $(JAVA_SOURCES:.java=.class)
+ JAVA_RUNTIME_CLASSES=$(JAVARUNTIME_SOURCES:.java=.class)
+ 
+-CFLAGS=-O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
+-CPPFLAGS=
++override CFLAGS += -O2 -W -Wall -Wmissing-prototypes -Wmissing-declarations
++CPPFLAGS?=
+ 
+ INCLUDES=-Iinclude
+ 

--- a/patches/snowball_shared-library.diff
+++ b/patches/snowball_shared-library.diff
@@ -1,0 +1,141 @@
+From: Stefano Rivera <stefanor@debian.org>
+Date: Sun, 24 Jan 2021 19:07:24 -0700
+Subject: Build libstemmer as a shared library.
+
+Forwarded: https://github.com/snowballstem/snowball/pull/42
+---
+ GNUmakefile | 41 +++++++++++++++++++++++++++--------------
+ 1 file changed, 27 insertions(+), 14 deletions(-)
+
+diff --git a/GNUmakefile b/GNUmakefile
+index d5e29cd..60c950e 100644
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -175,7 +175,7 @@ CPPFLAGS?=
+ 
+ INCLUDES=-Iinclude
+ 
+-all: snowball$(EXEEXT) libstemmer.a stemwords$(EXEEXT) $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
++all: snowball$(EXEEXT) libstemmer.a libstemmer.so stemwords$(EXEEXT) $(C_OTHER_SOURCES) $(C_OTHER_HEADERS) $(C_OTHER_OBJECTS)
+ 
+ algorithms.mk: libstemmer/mkalgorithms.pl libstemmer/modules.txt
+ 	libstemmer/mkalgorithms.pl algorithms.mk libstemmer/modules.txt
+@@ -183,7 +183,7 @@ algorithms.mk: libstemmer/mkalgorithms.pl libstemmer/modules.txt
+ clean:
+ 	rm -f $(COMPILER_OBJECTS) $(RUNTIME_OBJECTS) \
+ 	      $(LIBSTEMMER_OBJECTS) $(LIBSTEMMER_UTF8_OBJECTS) $(STEMWORDS_OBJECTS) snowball$(EXEEXT) \
+-	      libstemmer.a stemwords$(EXEEXT) \
++	      libstemmer.a libstemmer.so stemwords$(EXEEXT) \
+               libstemmer/modules.h \
+               libstemmer/modules_utf8.h \
+ 	      $(C_LIB_SOURCES) $(C_LIB_HEADERS) $(C_LIB_OBJECTS) \
+@@ -198,7 +198,7 @@ clean:
+               libstemmer/mkinc.mak libstemmer/mkinc_utf8.mak \
+               libstemmer/libstemmer.c libstemmer/libstemmer_utf8.c \
+ 	      algorithms.mk
+-	rm -rf dist
++	rm -rf dist .shared
+ 	-rmdir $(c_src_dir)
+ 	-rmdir $(python_output_dir)
+ 	-rmdir $(js_output_dir)
+@@ -225,17 +225,25 @@ libstemmer/libstemmer.o: libstemmer/modules.h $(C_LIB_HEADERS)
+ libstemmer.a: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
+ 	$(AR) -cru $@ $^
+ 
++libstemmer.so: libstemmer/libstemmer.o $(RUNTIME_OBJECTS) $(C_LIB_OBJECTS)
++	$(CC) $(CFLAGS) -shared $(LDFLAGS) \
++	      -Wl,-soname,libstemmer.so.0d \
++	      -o $@.0d.0.0 ${^:%=.shared/%}
++	ln -s $@.0d.0.0 $@.0d
++	ln -s $@.0d.0.0 $@
++	$(AR) -crs ${@:.so=.a} $^
++
+ examples/%.o: examples/%.c
+ 	$(CC) $(CFLAGS) $(INCLUDES) $(CPPFLAGS) -c -o $@ $<
+ 
+-stemwords$(EXEEXT): $(STEMWORDS_OBJECTS) libstemmer.a
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
++stemwords$(EXEEXT): $(STEMWORDS_OBJECTS) libstemmer.so
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(STEMWORDS_OBJECTS) -L. -lstemmer
+ 
+ tests/%.o: tests/%.c
+ 	$(CC) $(CFLAGS) $(INCLUDES) $(CPPFLAGS) -c -o $@ $<
+ 
+-stemtest$(EXEEXT): $(STEMTEST_OBJECTS) libstemmer.a
+-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
++stemtest$(EXEEXT): $(STEMTEST_OBJECTS) libstemmer.so
++	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(STEMTEST_OBJECTS) -L. -lstemmer
+ 
+ csharp_stemwords$(EXEEXT): $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
+ 	$(MCS) -unsafe -target:exe -out:$@ $(CSHARP_STEMWORDS_SOURCES) $(CSHARP_RUNTIME_SOURCES) $(CSHARP_SOURCES)
+@@ -275,7 +283,6 @@ $(c_src_dir)/stem_ISO_8859_2_%.c $(c_src_dir)/stem_ISO_8859_2_%.h: algorithms/%.
+ 	./snowball charsets/ISO-8859-2.sbl $< -o $${o} -eprefix $${l}_ISO_8859_2_ -r ../runtime
+ 
+ $(c_src_dir)/stem_%.o: $(c_src_dir)/stem_%.c $(c_src_dir)/stem_%.h
+-	$(CC) $(CFLAGS) $(INCLUDES) $(CPPFLAGS) -c -o $@ $<
+ 
+ $(java_src_dir)/%Stemmer.java: algorithms/%.sbl snowball$(EXEEXT)
+ 	@mkdir -p $(java_src_dir)
+@@ -506,7 +513,7 @@ dist_libstemmer_js: $(JS_SOURCES)
+ check: check_stemtest check_utf8 check_iso_8859_1 check_iso_8859_2 check_koi8r
+ 
+ check_stemtest: stemtest$(EXEEXT)
+-	./stemtest
++	LD_LIBRARY_PATH=.:$(LD_LIBRARY_PATH) ./stemtest
+ 
+ check_utf8: $(libstemmer_algorithms:%=check_utf8_%)
+ 
+@@ -520,13 +527,14 @@ check_koi8r: $(KOI8_R_algorithms:%=check_koi8r_%)
+ # a sibling to this one.
+ STEMMING_DATA ?= ../snowball-data
+ STEMMING_DATA_ABS := $(abspath $(STEMMING_DATA))
++STEMWORDS=LD_LIBRARY_PATH=.:$(LD_LIBRARY_PATH) ./stemwords$(EXEEXT)
+ 
+ check_utf8_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with UTF-8"
+ 	@if test -f '$</voc.txt.gz' ; then \
+-	  gzip -dc '$</voc.txt.gz'|./stemwords$(EXEEXT) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -o tmp.txt; \
++	  gzip -dc '$</voc.txt.gz'|$(STEMWORDS) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -o tmp.txt; \
+ 	else \
+-	  ./stemwords$(EXEEXT) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
++	  $(STEMWORDS) -c UTF_8 -l `echo $<|sed 's!.*/!!'` -i $</voc.txt -o tmp.txt; \
+ 	fi
+ 	@if test -f '$</output.txt.gz' ; then \
+ 	  gzip -dc '$</output.txt.gz'|$(DIFF) -u - tmp.txt; \
+@@ -538,7 +546,7 @@ check_utf8_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ check_iso_8859_1_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with ISO_8859_1"
+ 	@$(ICONV) -f UTF-8 -t ISO-8859-1 '$</voc.txt' |\
+-	    ./stemwords -c ISO_8859_1 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
++	    $(STEMWORDS) -c ISO_8859_1 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
+ 	@$(ICONV) -f UTF-8 -t ISO-8859-1 '$</output.txt' |\
+ 	    $(DIFF) -u - tmp.txt
+ 	@rm tmp.txt
+@@ -546,7 +554,7 @@ check_iso_8859_1_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ check_iso_8859_2_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with ISO_8859_2"
+ 	@$(ICONV) -f UTF-8 -t ISO-8859-2 '$</voc.txt' |\
+-	    ./stemwords -c ISO_8859_2 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
++	    $(STEMWORDS) -c ISO_8859_2 -l `echo $<|sed 's!.*/!!'` -o tmp.txt
+ 	@$(ICONV) -f UTF-8 -t ISO-8859-2 '$</output.txt' |\
+ 	    $(DIFF) -u - tmp.txt
+ 	@rm tmp.txt
+@@ -554,7 +562,7 @@ check_iso_8859_2_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ check_koi8r_%: $(STEMMING_DATA)/% stemwords$(EXEEXT)
+ 	@echo "Checking output of `echo $<|sed 's!.*/!!'` stemmer with KOI8R"
+ 	@$(ICONV) -f UTF-8 -t KOI8-R '$</voc.txt' |\
+-	    ./stemwords -c KOI8_R -l `echo $<|sed 's!.*/!!'` -o tmp.txt
++	    $(STEMWORDS) -c KOI8_R -l `echo $<|sed 's!.*/!!'` -o tmp.txt
+ 	@$(ICONV) -f UTF-8 -t KOI8-R '$</output.txt' |\
+ 	    $(DIFF) -u - tmp.txt
+ 	@rm tmp.txt
+@@ -739,4 +747,9 @@ ada/bin/generate:
+ ada/bin/stemwords: $(ADA_SOURCES)
+ 	cd ada && $(gprbuild) -Pstemwords -p
+ 
++%.o: %.c
++	@mkdir -p $(shell dirname ${@:%=.shared/%})
++	$(CC) $(CFLAGS) $(CPPFLAGS) -c -fPIC -o ${@:%=.shared/%} $<
++	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
++
+ .SUFFIXES: .class .java


### PR DESCRIPTION
Hi!

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project.
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains.

This adds a bundle for the `appstreamcli` utility, to make validating things or composing metadata easier for users on older distros which do not ship with an up-to-date AppStream out of the box.

One thing I am not sure about is that AppStream ships two metainfo files: `org.freedesktop.appstream.cli.metainfo.xml` for the main `appstreamcli` app, and `org.freedesktop.appstream.compose.metainfo.xml`, which is an `addon` component to the CLI utility. I haven't found a way to explicitly tell Flatpak which one of the files should be used though (besides simply removing one of the files, which feels wrong) - so, some advice on this would be appreciated!
The other question is, due to this basically exposing the `appstreamcli` utility, but not really the library and documentation and other stuff, whether the bundle's ID should rather be `org.freedesktop.appstream.cli`, and not just `org.freedesktop.appstream` - is there any preference on that?

Cheers,
    Matthias
