### PR TITLE
Add manifest for io.github.jacalz.rymdport

### DIFF
--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -44,5 +44,5 @@ modules:
         - install -Dm00644 internal/assets/unix/$FLATPAK_ID.appdata.xml $FLATPAK_DEST/share/appdata/$FLATPAK_ID.appdata.xml
       sources:
         - type: archive
-          url: "https://github.com/Jacalz/rymdport/releases/download/v3.0.1/rymdport-v3.0.1.tar.xz"
-          sha256: 7fcc0d7dce44a590796aa446bdb8a6c9365c453dde64e46477f041b6a48b37a7
+          url: "https://github.com/Jacalz/rymdport/releases/download/v3.0.1/rymdport-v3.0.1-vendored.tar.xz"
+          sha256: 0ad8938a4711639b32eb0fd4a51a7656eb8a9fb64add2612072325ed9bea7d76

--- a/io.github.jacalz.rymdport.yml
+++ b/io.github.jacalz.rymdport.yml
@@ -1,0 +1,48 @@
+app-id: io.github.jacalz.rymdport
+runtime: org.freedesktop.Platform
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+    - org.freedesktop.Sdk.Extension.golang
+command: rymdport
+
+finish-args:
+    - --share=ipc # Share IPC namespace with the host (necessary for X11).
+    - --share=network
+    - --socket=x11
+    - --device=dri # OpenGL rendering support.
+
+    # The below are commented out until there is out of the box support for wayland.
+    #- --socket=fallback-x11 # Only create the x11 socket if wayland isn't avaliable.
+    #- --socket=wayland
+
+    # Needed to support desktop notifications.
+    - --talk-name=org.freedesktop.Notifications
+
+    # Support only the most common directories.
+    - --filesystem=xdg-desktop
+    - --filesystem=xdg-documents
+    - --filesystem=xdg-download
+    - --filesystem=xdg-music
+    - --filesystem=xdg-pictures
+    - --filesystem=xdg-videos
+
+build-options:
+  env:
+    - GOBIN=/app/bin
+    - GOROOT=/usr/lib/sdk/golang
+
+modules:
+    - name: rymdport
+      buildsystem: simple
+      build-commands:
+        - $GOROOT/bin/go build -ldflags="-s -w" -o rymdport
+        - install -Dm00755 rymdport $FLATPAK_DEST/bin/rymdport
+        - install -Dm00644 internal/assets/icon/icon-512.png $FLATPAK_DEST/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png
+        - install -Dm00644 internal/assets/svg/icon.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/$FLATPAK_ID.png
+        - install -Dm00644 internal/assets/unix/$FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
+        - install -Dm00644 internal/assets/unix/$FLATPAK_ID.appdata.xml $FLATPAK_DEST/share/appdata/$FLATPAK_ID.appdata.xml
+      sources:
+        - type: archive
+          url: "https://github.com/Jacalz/rymdport/releases/download/v3.0.1/rymdport-v3.0.1.tar.xz"
+          sha256: 7fcc0d7dce44a590796aa446bdb8a6c9365c453dde64e46477f041b6a48b37a7


### PR DESCRIPTION
This solves https://github.com/Jacalz/rymdport/issues/23. I have tried to slim down the filesystem access as much as possible but it is hard given that the idea with the application is to send files. An option would be to make some paths read only, I guess. I'm happy for suggestions on how the permissions should be set to make the most sense.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
