### PR TITLE
Add Flatpak for wavbreaker

### DIFF
--- a/net.sourceforge.wavbreaker.json
+++ b/net.sourceforge.wavbreaker.json
@@ -4,6 +4,12 @@
     "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "wavbreaker",
+    "finish-args": [
+       "--socket=wayland",
+       "--socket=fallback-x11",
+       "--socket=pulseaudio",
+       "--filesystem=home"
+    ],
     "modules": [
         {
             "name": "libao",
@@ -11,7 +17,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/xiph/libao.git"
+                    "url": "https://github.com/xiph/libao.git",
+                    "tag": "1.2.2"
                 }
             ]
         },
@@ -26,11 +33,5 @@
                 }
             ]
         }
-    ],
-    "finish-args": [
-       "--socket=wayland",
-       "--socket=fallback-x11",
-       "--socket=pulseaudio",
-       "--filesystem=home"
     ]
 }

--- a/net.sourceforge.wavbreaker.json
+++ b/net.sourceforge.wavbreaker.json
@@ -1,0 +1,36 @@
+{
+    "app-id": "net.sourceforge.wavbreaker",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "20.08",
+    "sdk": "org.freedesktop.Sdk",
+    "command": "wavbreaker",
+    "modules": [
+        {
+            "name": "libao",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/xiph/libao.git"
+                }
+            ]
+        },
+        {
+            "name": "wavbreaker",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/thp/wavbreaker/archive/refs/tags/0.14.tar.gz",
+                    "sha256": "ad6ad4dda8c1e435e8dbe22d30176bc54130b1120fda335c1776493535ed3f43"
+                }
+            ]
+        }
+    ],
+    "finish-args": [
+       "--socket=wayland",
+       "--socket=fallback-x11",
+       "--socket=pulseaudio",
+       "--filesystem=home"
+    ]
+}

--- a/net.sourceforge.wavbreaker.json
+++ b/net.sourceforge.wavbreaker.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.sourceforge.wavbreaker",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "20.08",
+    "runtime-version": "21.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "wavbreaker",
     "modules": [

--- a/net.sourceforge.wavbreaker.json
+++ b/net.sourceforge.wavbreaker.json
@@ -28,8 +28,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/thp/wavbreaker/archive/refs/tags/0.14.tar.gz",
-                    "sha256": "ad6ad4dda8c1e435e8dbe22d30176bc54130b1120fda335c1776493535ed3f43"
+                    "url": "https://github.com/thp/wavbreaker/archive/refs/tags/0.15.tar.gz",
+                    "sha256": "dac911a309ba65d5fae880b42c683868ab9fa275a4dc308e4b7cefb4dbcab3c9"
                 }
             ]
         }


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions: Wayland + X11 for GUI, PulseAudio for libao output, filesystem home for file read/write access to audio files
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub.
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains http://wavbreaker.sourceforge.net
- [x] Any additional patches or files have been submitted to the upstream projects concerned: Yes, the packaging is based on [what we have in upstream](https://github.com/thp/wavbreaker/blob/master/scripts/flatpak/net.sourceforge.wavbreaker.json) 

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
