### PR TITLE
Add com.riverbankcomputing.PyQt.BaseApp

### DIFF
--- a/com.riverbankcomputing.PyQt.BaseApp.yaml
+++ b/com.riverbankcomputing.PyQt.BaseApp.yaml
@@ -1,0 +1,96 @@
+app-id: com.riverbankcomputing.PyQt.BaseApp
+runtime: org.kde.Platform
+runtime-version: "6.2"
+sdk: org.kde.Sdk
+command: /usr/bin/python
+finish-args:
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --share=ipc
+
+modules:
+  - name: pyqt6
+    modules:
+
+      - name: sip
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://pypi.python.org/packages/source/s/sip/sip-6.4.0.tar.gz
+            sha256: 42ec368520b8da4a0987218510b1b520b4981e4405086c1be384733affc2bcb0
+        modules:
+
+          - name: python-toml
+            buildsystem: simple
+            build-commands:
+              - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+            sources:
+              - type: archive
+                url: https://files.pythonhosted.org/packages/source/t/toml/toml-0.10.0.tar.gz
+                sha256: 229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c
+
+          - name: python-packaging
+            buildsystem: simple
+            build-commands:
+              - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+            sources:
+              - type: archive
+                url: https://files.pythonhosted.org/packages/source/p/packaging/packaging-20.1.tar.gz
+                sha256: e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334
+            cleanup:
+              - "*"
+
+      - name: sip-pyqt6
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://pypi.python.org/packages/source/P/PyQt6-sip/PyQt6_sip-13.1.0.tar.gz
+            sha256: 7c31073fe8e6cb8a42e85d60d3a096700a9047c772b354d6227dfe965566ec8a
+
+      - name: python-pyparsing
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://files.pythonhosted.org/packages/source/p/pyparsing/pyparsing-2.4.6.tar.gz
+            sha256: 4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f
+        cleanup:
+          - "*"
+
+      - name: PyQt-builder
+        buildsystem: simple
+        build-commands:
+          - pip3 install --no-deps --no-use-pep517 --prefix=$FLATPAK_DEST .
+        sources:
+          - type: archive
+            url: https://files.pythonhosted.org/packages/8b/5f/1bd49787262ddce37b826ef49dcccf5a9970facf0ed363dee5ee233e681d/PyQt-builder-1.12.2.tar.gz
+            sha256: f62bb688d70e0afd88c413a8d994bda824e6cebd12b612902d1945c5a67edcd7
+        cleanup:
+          - "*"
+
+    buildsystem: simple
+    build-commands:
+      - sip-install
+        --confirm-license
+        --no-designer-plugin
+        --no-tools
+        --concatenate=1
+        --debug
+        --no-docstrings
+        --verbose
+        --qt-shared
+        --target-dir=/app/lib/python3.9/site-packages/
+        --enable=QtCore
+        --enable=QtWidgets
+        --enable=QtGui
+        --enable=QtPrintSupport
+    sources:
+      - type: archive
+        url: https://pypi.python.org/packages/source/P/PyQt6/PyQt6-6.2.1.tar.gz
+        sha256: d603a5c8effccc9174b3f43834256401a61ea40f2338306ca22fb6a1e870b89c

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-appstream-check": true
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

This is a BaseApp which contains PyQt. It used by many Python Programs. It is not easy to build and take some time to build (around 10 Minutes).  This BaseApp currently has PyQt6. PyQt5 may be added in the future. I'm also planing to make a second BaseApp which is based on [io.qt.qtwebengine.BaseApp](https://github.com/flathub/io.qt.qtwebengine.BaseApp) and contains Qt Web Engine.