### PR TITLE
Add com.github.dail8859.NotepadNext

### DIFF
--- a/com.github.dail8859.NotepadNext.yml
+++ b/com.github.dail8859.NotepadNext.yml
@@ -1,0 +1,33 @@
+app-id: com.github.dail8859.NotepadNext
+runtime: org.kde.Platform
+runtime-version: "5.15-21.08"
+sdk: org.kde.Sdk
+
+rename-icon: NotepadNext
+rename-desktop-file: NotepadNext.desktop
+command: NotepadNext
+
+finish-args:
+    - --share=ipc
+    - --socket=x11
+    - --device=dri
+    - --filesystem=home
+    - --env=QT_QPA_PLATFORM=xcb
+
+modules:
+    - name: NotepadNext
+      buildsystem: simple
+      build-commands:
+        # fix install prefix
+        - sed -i -e 's|/usr/bin|/bin|g' src/NotepadNext/NotepadNext.pro
+        - sed -i -e 's|/usr/share/|/share/|g' src/NotepadNext/NotepadNext.pro
+        - qmake src/NotepadNext.pro
+        - make -j $FLATPAK_BUILDER_N_JOBS
+        - make install INSTALL_ROOT=/app
+      post-install:
+        - install -D -m644 deploy/linux/com.github.dail8859.NotepadNext.metainfo.xml -t /app/share/metainfo
+      sources:
+        - type: git
+          url: https://github.com/dail8859/NotepadNext.git
+          tag: v0.5
+          commit: bd6ca110d8219bde7467866e0d67da53353c69c8


### PR DESCRIPTION
I would like to submit Notepad Next which is an open source, cross-platform reimplementation of Notepad++.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/dail8859/NotepadNext/issues/84
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

#### additional notes

- The `--filesystem=home` permission is needed, so users can open files in the editor.
- The upstream developer @dail8859 is not only aware of me submitting NotepadNext, but he is supporting the effort and it would be great if he had write access to the new repo if this submission gets accepted. I was just helping him to get started with Flatpak.
