### PR TITLE
[Test] Add org.freedesktop.Sdk.Extension.wxwidgets

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "automerge-flathubbot-prs": false,
+    "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.wxwidgets.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.wxwidgets.metainfo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.wxwidgets</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>wxWindows</project_license>
+  <name>WxWidgets Sdk extension</name>
+  <summary>Cross-Platform GUI Library</summary>
+  <url type="homepage">https://www.wxwidgets.org/</url>
+  <releases>
+    <release version="3.0.5" date="2020-04-25"/>
+  </releases>
+</component>

--- a/org.freedesktop.Sdk.Extension.wxwidgets.yaml
+++ b/org.freedesktop.Sdk.Extension.wxwidgets.yaml
@@ -1,0 +1,241 @@
+id: org.freedesktop.Sdk.Extension.wxwidgets
+branch: '21.08'
+runtime: org.freedesktop.Sdk
+runtime-version: '21.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.vala
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+  cflags: -I/usr/lib/sdk/wxwidgets/include
+  cxxflags: -I/usr/lib/sdk/wxwidgets/include
+  ldflags: -L/usr/lib/sdk/wxwidgets/lib
+  prefix: /usr/lib/sdk/wxwidgets
+  libdir: /usr/lib/sdk/wxwidgets/lib
+  prepend-path: /usr/lib/sdk/wxwidgets/bin
+  prepend-ld-library-path: /usr/lib/sdk/wxwidgets/lib
+  prepend-pkg-config-path: /usr/lib/sdk/wxwidgets/lib/pkgconfig
+  append-path: /usr/lib/sdk/vala/bin
+  append-ld-library-path: /usr/lib/sdk/vala/lib
+modules:
+  - name: wxwidgets
+    sources:
+      - type: archive
+        url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.tar.bz2
+        sha256: 8aacd56b462f42fb6e33b4d8f5d40be5abc3d3b41348ea968aa515cc8285d813
+        x-checker-data:
+          type: html
+          url: https://www.wxwidgets.org/downloads
+          version-pattern: 'Latest Stable Release: ([\d\.-]+)'
+          url-template: https://github.com/wxWidgets/wxWidgets/releases/download/v$version/wxWidgets-$version.tar.bz2
+    modules:
+      - name: glu
+        config-opts:
+          - --disable-static
+        sources:
+          - type: archive
+            url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
+            sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
+            x-checker-data:
+              type: anitya
+              project-id: 13518
+              url-template: https://mesa.freedesktop.org/archive/glu/glu-$version.tar.xz
+        cleanup:
+          - '*.la'
+      - name: webkit2gtk
+        # follow gnome sdk packaging https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/elements/sdk/webkitgtk.{-4.0.bst,inc}
+        # TODO: evaluate disabling (ENABLE_, USE_): gamepad, libnotify, libsecret, spellcheck/enchant, woff2, wpe
+        # TODO: check generated configure options, specifically: webrtc, gl
+        buildsystem: cmake-ninja
+        build-options:
+          # faster local compilation
+          cflags: -g0
+          cxxflags: -g0
+        config-opts:
+          - -DPORT=GTK
+          - -DCMAKE_BUILD_TYPE=Release
+         #- -DCMAKE_INSTALL_LIBDIR=lib
+         #- -DCMAKE_INSTALL_LIBEXECDIR=lib
+          - -DCMAKE_SKIP_RPATH=ON
+          - -DUSE_SOUP2=ON
+          - -DENABLE_WEBDRIVER=OFF
+         #- -DENABLE_MINIBROWSER=ON
+          - -DENABLE_BUBBLEWRAP_SANDBOX=OFF
+        sources:
+          - type: archive
+            url: https://webkitgtk.org/releases/webkitgtk-2.36.0.tar.xz
+            sha256: b877cca1f105235f5dd57c7ac2b2c2be3c6b691ff444f93925c7254cf156c64d
+        modules:
+          - name: enchant
+            config-opts:
+              - --disable-static
+              - --enable-relocatable
+            sources:
+              - type: archive
+                url: https://github.com/AbiWord/enchant/releases/download/v2.3.3/enchant-2.3.3.tar.gz
+                sha256: 3da12103f11cf49c3cf2fd2ce3017575c5321a489e5b9bfa81dd91ec413f3891
+            cleanup:
+              - /bin
+              - /share/man
+              - '*.la'
+          - name: libnotify
+            buildsystem: meson
+            config-opts:
+              - -Dtests=false
+              - -Dintrospection=enabled
+              - -Dman=false
+              - -Dgtk_doc=false
+              - -Ddocbook_docs=disabled
+            sources:
+              - type: archive
+                url: https://gitlab.gnome.org/GNOME/libnotify/-/archive/0.7.9/libnotify-0.7.9.tar.gz
+                sha256: 9bd4f5fa911d27567e7cc2d2d09d69356c16703c4e8d22c0b49a5c45651f3af0
+                x-checker-data:
+                  type: anitya
+                  project-id: 13149
+                  stable-only: true
+                  url-template: https://gitlab.gnome.org/GNOME/libnotify/-/archive/$version/libnotify-$version.tar.gz
+            cleanup:
+              - /bin
+          - name: libsecret
+            buildsystem: meson
+            config-opts:
+              - -Dmanpage=false
+              - -Ddebugging=false
+              - -Dvapi=false
+              - -Dgtk_doc=false
+              - -Dintrospection=true
+              - -Dbash_completion=disabled
+            sources:
+              - type: archive
+                url: https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz
+                sha256: 3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d
+                x-checker-data:
+                  type: gnome
+                  name: libsecret
+                  stable-only: true
+            cleanup:
+              - /bin
+          - name: libmanette
+            buildsystem: meson
+            build-options:
+              env:
+                - XDG_DATA_DIRS=/usr/lib/sdk/wxwidgets/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/share
+            config-opts:
+              - -Ddemos=false
+              - -Dbuild-tests=false
+              - -Ddoc=false
+              - -Dintrospection=true
+              - -Dvapi=false
+              - -Dgudev=enabled
+            sources:
+              - type: archive
+                url: https://download.gnome.org/sources/libmanette/0.2/libmanette-0.2.6.tar.xz
+                sha256: 63653259a821ec7d90d681e52e757e2219d462828c9d74b056a5f53267636bac
+                x-checker-data:
+                  type: gnome
+                  name: libmanette
+                  stable-only: true
+            modules:
+              - name: libevdev
+                buildsystem: meson
+                config-opts:
+                  - -Dtests=disabled
+                  - -Ddocumentation=disabled
+                sources:
+                  - type: archive
+                    url: https://freedesktop.org/software/libevdev/libevdev-1.12.1.tar.xz
+                    sha256: 1dbba41bc516d3ca7abc0da5b862efe3ea8a7018fa6e9b97ce9d39401b22426c
+                    x-checker-data:
+                      type: anitya
+                      project-id: 20540
+                      stable-only: true
+                      url-template: https://freedesktop.org/software/libevdev/libevdev-$version.tar.xz
+                cleanup:
+                  - /bin
+                  - /share/man
+              - name: libgudev
+                buildsystem: meson
+                config-opts:
+                  - -Dtests=disabled
+                  - -Dintrospection=enabled
+                  - -Dvapi=disabled
+                  - -Dgtk_doc=false
+                sources:
+                  - type: archive
+                    url: https://download.gnome.org/sources/libgudev/237/libgudev-237.tar.xz
+                    sha256: 0d06b21170d20c93e4f0534dbb9b0a8b4f1119ffb00b4031aaeb5b9148b686aa
+                    x-checker-data:
+                      type: gnome
+                      name: libgudev
+                      stable-only: true
+          - name: woff2
+            buildsystem: cmake
+            sources:
+              - type: git
+                url: https://github.com/google/woff2.git
+                branch: master
+                commit: 4721483ad780ee2b63cb787bfee4aa64b61a0446
+          - name: wpebackend-fdo
+            buildsystem: meson
+            sources:
+              - type: archive
+                url: https://wpewebkit.org/releases/wpebackend-fdo-1.12.0.tar.xz
+                sha256: 6239c9c15523410798d66315de6b491712ab30009ba180f3e0dd076d9b0074ac
+            modules:
+              - name: libwpe
+                buildsystem: meson
+                sources:
+                  - type: archive
+                    url: https://wpewebkit.org/releases/libwpe-1.12.0.tar.xz
+                    sha256: e8eeca228a6b4c36294cfb63f7d3ba9ada47a430904a5a973b3c99c96a44c18c
+  - name: packaging
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 {enable,install{,-wx,-webkitgtk}}.sh -t ${FLATPAK_DEST}/
+      - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/
+    sources:
+      - type: script
+        dest-filename: enable.sh
+        commands:
+          - SDK_PATH=/usr/lib/sdk/wxwidgets
+          - export PATH+=:${SDK_PATH}/bin
+          - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SDK_PATH}/lib/pkgconfig
+          - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}${SDK_PATH}/lib/pkgconfig
+      - type: script
+        dest-filename: install.sh
+        commands:
+          - SDK_PATH=/usr/lib/sdk/wxwidgets
+          - ${SDK_PATH}/install-wx.sh
+          - ${SDK_PATH}/install-webkitgtk.sh
+      - type: script
+        dest-filename: install-wx.sh
+        commands:
+          - SDK_PATH=/usr/lib/sdk/wxwidgets
+          - install -dm755 ${FLATPAK_DEST}/{lib,share}
+          - cp --no-dereference ${SDK_PATH}/lib/lib{GLU,notify,wx}*.so* ${FLATPAK_DEST}/lib/
+          # TODO: more fine grained locale deployment
+          - cp -r ${SDK_PATH}/share/locale ${FLATPAK_DEST}/share/
+          # gir
+          - install -dm755 ${FLATPAK_DEST}/{lib/girepository-1.0,share/gir-1.0}
+          - cp ${SDK_PATH}/lib/girepository-1.0/Notify-*.typelib ${FLATPAK_DEST}/lib/girepository-1.0/
+          - cp ${SDK_PATH}/share/gir-1.0/Notify-*.gir ${FLATPAK_DEST}/share/gir-1.0/
+      - type: script
+        dest-filename: install-webkitgtk.sh
+        commands:
+          - SDK_PATH=/usr/lib/sdk/wxwidgets
+          - install -dm755 ${FLATPAK_DEST}/{lib,libexec,share}
+          - cp --no-dereference ${SDK_PATH}/lib/lib{enchant,evdev,gudev,javascriptcoregtk,manette,secret,webkit2gtk,woff2,wpe,WPEBackend-fdo}*.so* ${FLATPAK_DEST}/lib/
+          - cp -r ${SDK_PATH}/lib/{enchant-2,webkit2gtk}* ${FLATPAK_DEST}/lib/
+          - install -dm755 ${FLATPAK_DEST}/lib/wx
+          - cp -r ${SDK_PATH}/lib/wx/3.0 ${FLATPAK_DEST}/lib/wx/
+          - cp -r ${SDK_PATH}/libexec/webkit2gtk* ${FLATPAK_DEST}/libexec/
+          - cp -r ${SDK_PATH}/share/enchant ${FLATPAK_DEST}/share/
+          # gir
+          - install -dm755 ${FLATPAK_DEST}/{lib/girepository-1.0,share/gir-1.0}
+          - cp ${SDK_PATH}/lib/girepository-1.0/{GUdev,JavaScriptCore,Manette,Secret,WebKit2{,WebExtension}}-*.typelib ${FLATPAK_DEST}/lib/girepository-1.0/
+          - cp ${SDK_PATH}/share/gir-1.0/{GUdev,JavaScriptCore,Manette,Secret,WebKit2{,WebExtension}}-*.gir ${FLATPAK_DEST}/share/gir-1.0/
+      - type: file
+        path: org.freedesktop.Sdk.Extension.wxwidgets.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

This is not ready, and not expected to be anytime soon, just testing the cost of building this on the CI due to WebKitGTK.  
The idea here is to decouple WxWidgets development from Codeblocks IDE, and make it easier to switch between different versions of the widget toolkit by not having headers and other files that might be picked up automatically.  
And this would be useful for WxWidgets development with other IDEs.