### PR TITLE
Add io.github.davidoc26.wallpaper_selector

### DIFF
--- a/io.github.davidoc26.wallpaper_selector.json
+++ b/io.github.davidoc26.wallpaper_selector.json
@@ -12,8 +12,7 @@
     "--share=ipc",
     "--socket=fallback-x11",
     "--device=dri",
-    "--socket=wayland",
-    "--talk-name=org.freedesktop.Flatpak"
+    "--socket=wayland"
   ],
   "build-options": {
     "append-path": "/usr/lib/sdk/rust-stable/bin"
@@ -40,8 +39,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/Davidoc26/wallpaper-selector/releases/download/v0.1.0/wallpaper-selector-0.1.0.tar.xz",
-          "sha256": "67047735b64316a9f7d57755e31689107cc4bd14531c2bb30693a0e6149e3893"
+          "url": "https://github.com/Davidoc26/wallpaper-selector/releases/download/v0.2.0/wallpaper-selector-0.2.0.tar.xz",
+          "sha256": "d11311147614b382f81b483e58f2086855a17ab96bbb096c500bdfb973be07f0"
         }
       ]
     }

--- a/io.github.davidoc26.wallpaper_selector.json
+++ b/io.github.davidoc26.wallpaper_selector.json
@@ -1,0 +1,49 @@
+{
+  "app-id": "io.github.davidoc26.wallpaper_selector",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "42",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "command": "wallpaper-selector",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--socket=wayland",
+    "--talk-name=org.freedesktop.Flatpak"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/rust-stable/bin"
+  },
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "wallpaper-selector",
+      "builddir": true,
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dprofile=default"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/Davidoc26/wallpaper-selector/releases/download/v0.1.0/wallpaper-selector-0.1.0.tar.xz",
+          "sha256": "67047735b64316a9f7d57755e31689107cc4bd14531c2bb30693a0e6149e3893"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
--talk-name=org.freedesktop.Flatpak - Used to set desktop wallpaper via cli. For example to use gsettings
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
