### PR TITLE
Add io.sourceforge.atanks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build-dir/
+.flatpak-builder/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/encoding.patch
+++ b/encoding.patch
@@ -1,0 +1,10 @@
+--- allegro-4.4.3/docs/src/allegro._tx.orig     2019-02-02 20:28:46.000000000 +0100
++++ allegro-4.4.3/docs/src/allegro._tx  2019-11-04 11:12:39.352699777 +0100
+@@ -23,6 +23,7 @@
+ @man_shortdesc_force1=allegro
+ @man_shortdesc_force2=Allegro game programming library.
+ @$\input texinfo
++@$@documentencoding ISO-8859-1
+ @$@setfilename allegro.inf
+ @$@settitle Allegro Manual
+ @$@setchapternewpage odd

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/io.sourceforge.atanks.json
+++ b/io.sourceforge.atanks.json
@@ -1,0 +1,62 @@
+{
+    "app-id": "io.sourceforge.atanks",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "21.08",
+    "sdk": "org.freedesktop.Sdk",
+    "finish-args": [
+        "--device=dri",
+        "--persist=.atanks",
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=pulseaudio"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/aclocal",
+        "/share/man",
+        "*.la", "*.a"
+    ],
+    "rename-desktop-file": "atanks.desktop",
+    "rename-icon": "atanks",
+    "modules": [
+        "shared-modules/glu/glu-9.json",
+        {
+            "name": "allegro",
+            "buildsystem": "cmake",
+            "cleanup": [
+                "/bin",
+                "/doc",
+                "/info"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/liballeg/allegro5/releases/download/4.4.3.1/allegro-4.4.3.1.tar.gz",
+                    "sha256": "ec19dbc9a021244582b4819b3583ee594b50141f9fcf6944a4ed8069cbf8d4d4"
+                },
+                {
+                    "type": "patch",
+                    "path": "encoding.patch"
+                }
+            ]
+        },
+        {
+            "name": "atanks",
+            "no-autogen": true,
+            "make-args": [
+                "PREFIX=/app"
+            ],
+            "make-install-args": [
+                "PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/atanks/atanks/atanks-6.6/atanks-6.6.tar.gz",
+                    "sha256": "bc6b1efc9fc7e7624fad1d8352d72e927be0fba2160bb25bb6b8bd6c6370bf43"
+                }
+            ]
+        }
+    ]
+}

--- a/io.sourceforge.atanks.json
+++ b/io.sourceforge.atanks.json
@@ -1,7 +1,7 @@
 {
     "app-id": "io.sourceforge.atanks",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "finish-args": [
         "--device=dri",


### PR DESCRIPTION
Deprecate https://github.com/flathub/net.sourceforge.atanks/pull/8 as upstream changed the application ID as SourceForge changed their URLs.