### PR TITLE
Add org.gnome.SimpleScan

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.gnome.SimpleScan.json
+++ b/org.gnome.SimpleScan.json
@@ -1,0 +1,164 @@
+{
+    "app-id": "org.gnome.SimpleScan",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "43",
+    "sdk": "org.gnome.Sdk",
+    "rename-desktop-file": "simple-scan.desktop",
+    "rename-appdata-file": "simple-scan.appdata.xml",
+    "command": "simple-scan",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=all",
+        "--share=network",
+        "--system-talk-name=org.freedesktop.Avahi"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/gir-1.0",
+        "/share/girepository-1",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+		"shared-modules/libusb/libusb.json",
+        {
+            "name": "libgusb",
+            "buildsystem": "meson",
+			"config-opts": [
+                "-Ddocs=false"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/hughsie/libgusb.git",
+                    "commit": "f79cb57e03a7111bde4c019ca3132160bbe97d3e",
+                    "tag": "0.4.3",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "sane-backends",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.com/sane-project/backends.git",
+                    "commit": "332edc8b7ce642bb06132cf204a8c2dd57720bce",
+                    "tag": "1.1.1",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libevent",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libevent/libevent.git",
+                    "commit": "5df3037d10556bfcb675bc73e516978b75fc7bc7",
+                    "tag": "release-2.1.12-stable",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^release-([\\d.]+)-stable$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "avahi",
+            "cleanup": [
+                "/bin",
+                "/lib/avahi",
+                "/share/applications/*.desktop",
+                "/share/avahi"
+            ],
+            "config-opts": [
+                "--with-distro=none",
+                "--disable-introspection",
+                "--disable-qt3",
+                "--disable-qt4",
+                "--disable-qt5",
+                "--disable-gtk",
+                "--disable-gtk3",
+                "--disable-core-docs",
+                "--disable-manpages",
+                "--disable-libdaemon",
+                "--disable-python",
+                "--disable-pygobject",
+                "--disable-mono",
+                "--disable-monodoc",
+                "--disable-autoipd",
+                "--disable-doxygen-doc",
+                "--disable-doxygen-dot",
+                "--disable-doxygen-xml",
+                "--disable-doxygen-html",
+                "--disable-manpages",
+                "--disable-xmltoman"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/lathiat/avahi.git",
+                    "commit": "f060abee2807c943821d88839c013ce15db17b58",
+                    "tag": "v0.8",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "sane-airscan",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/alexpevzner/sane-airscan.git",
+                    "commit": "053f5654cd4d16f077fe5cb40d32004aaa321462",
+                    "tag": "0.99.27",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "simple-scan",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/simple-scan.git",
+                    "commit": "a7add634a357caf31e08631d63c29f1d63340934",
+                    "tag": "42.5",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                },
+				{
+					"type": "patch",
+					"path": "patches/0001-data-update-appdata-name.patch"
+				}
+            ]
+        }
+    ]
+}

--- a/patches/0001-data-update-appdata-name.patch
+++ b/patches/0001-data-update-appdata-name.patch
@@ -1,0 +1,32 @@
+diff --git a/data/simple-scan.appdata.xml.in b/data/simple-scan.appdata.xml.in
+index ce92f9c4..9e3b40bf 100644
+--- a/data/simple-scan.appdata.xml.in
++++ b/data/simple-scan.appdata.xml.in
+@@ -88,27 +88,6 @@
+         </p>
+       </description>
+     </release>
+-    <release date="2021-02-25" version="40.beta" type="development">
+-      <description>
+-        <p>
+-          This is an unstable release in the 40 development series,
+-          with the following changes:
+-        </p>
+-        <ul>
+-          <li>Don't repeat vendor name in the device name</li>
+-          <li>GNOME 40 consistency updates</li>
+-          <li>Fix crop size after decreasing page size</li>
+-          <li>UI fixes: change crop icon, improve layout of buttons</li>
+-          <li>Add redetect button to device list</li>
+-          <li>Add new resolution 200 DPI</li>
+-          <li>Add zero second delay for Multiple Pages from FlatBed</li>
+-          <li>Display an error, when no documents found in the feeder</li>
+-          <li>Rename 'Start again' button to 'New document'</li>
+-          <li>Fix crash on lexmark backend</li>
+-        </ul>
+-        <p>This release also updates translations.</p>
+-      </description>
+-    </release>
+     <release date="2020-10-02" version="3.38.1">
+       <description>
+         <p>


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

Here Simple Scan flatpak package.

It only supports network scanners: https://gitlab.gnome.org/GNOME/simple-scan/-/issues/21

There is one appdata patch to reflect the network only behaviour. This may be an issue for translations, comments are welcome.


