### PR TITLE
add io.github.beamerpresenter.beamerpresenter manifest

### DIFF
--- a/io.github.beamerpresenter.beamerpresenter.yml
+++ b/io.github.beamerpresenter.beamerpresenter.yml
@@ -1,0 +1,65 @@
+app-id: io.github.beamerpresenter.beamerpresenter
+branch: master
+runtime: org.kde.Platform
+runtime-version: 5.15-21.08
+sdk: org.kde.Sdk
+command: beamerpresenter
+build-options:
+  strip: true
+  no-debuginfo: true
+finish-args:
+  - "--socket=x11"
+  - "--socket=wayland"
+  - "--socket=pulseaudio"
+  - "--filesystem=xdg-documents"
+  - "--filesystem=xdg-download"
+  - "--filesystem=xdg-public-share"
+  - "--filesystem=xdg-desktop"
+  - "--filesystem=xdg-config/beamerpresenter"
+  - "--own-name=io.github.beamerpresenter.beamerpresenter"
+modules:
+  - name: poppler
+    buildsystem: cmake-ninja
+    config-opts:
+    - "-DCMAKE_INSTALL_PREFIX=/app"
+    - "-DCMAKE_INSTALL_LIBDIR=/app/lib"
+    - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
+    - "-DENABLE_LIBOPENJPEG=none"
+    - "-DENABLE_BOOST=OFF"
+    - "-DENABLE_UTILS=OFF"
+    - "-DENABLE_LIBCURL=OFF"
+    - "-DENABLE_QT5=ON"
+    - "-DENABLE_QT6=OFF"
+    - "-DENABLE_GLIB=OFF"
+    - "-DENABLE_GOBJECT_INTROSPECTION=OFF"
+    - "-DENABLE_GTK_DOC=OFF"
+    - "-DENABLE_CPP=OFF"
+    cleanup:
+    - "/bin"
+    sources:
+    - type: archive
+      url: https://poppler.freedesktop.org/poppler-22.09.0.tar.xz
+      sha256: d7a8f748211359cadb774ba3e18ecda6464b34027045c0648eb30d5852a41e2e
+  - name: beamerpresenter
+    buildsystem: cmake-ninja
+    config-opts:
+    - "-DQT_VERSION_MAJOR=5"
+    - "-DQT_VERSION_MINOR=15"
+    - "-DUSE_POPPLER=ON"
+    - "-DUSE_MUPDF=OFF"
+    - "-DUSE_QTPDF=OFF"
+    - "-DUSE_EXTERNAL_RENDERER=OFF"
+    - "-DUSE_TRANSLATIONS=ON"
+    - "-DGIT_VERSION=OFF"
+    - "-DAPPID_NAME=io.github.beamerpresenter.beamerpresenter"
+    - "-DINSTALL_METAINFO=ON"
+    - "-DCMAKE_BUILD_TYPE=Release"
+    - "-DCMAKE_INSTALL_PREFIX=/app"
+    - "-DCMAKE_INSTALL_SYSCONFDIR=/app/etc"
+    - "-DCMAKE_INSTALL_DATAROOTDIR=/app/share"
+    - "-DCMAKE_INSTALL_LIBDIR=/app/usr/lib"
+    - "-DCMAKE_INSTALL_INCLUDEDIR=/app/usr/include"
+    sources:
+    - type: git
+      url: https://github.com/stiglers-eponym/BeamerPresenter.git
+      commit: 57c23d04fe41cc4eca9d4ea6198555e3ebe95b34

--- a/io.github.beamerpresenter.beamerpresenter.yml
+++ b/io.github.beamerpresenter.beamerpresenter.yml
@@ -15,7 +15,6 @@ finish-args:
   - "--filesystem=xdg-public-share"
   - "--filesystem=xdg-desktop"
   - "--filesystem=xdg-config/beamerpresenter"
-  - "--own-name=io.github.beamerpresenter.beamerpresenter"
 modules:
   - name: poppler
     buildsystem: cmake-ninja

--- a/io.github.beamerpresenter.beamerpresenter.yml
+++ b/io.github.beamerpresenter.beamerpresenter.yml
@@ -7,7 +7,7 @@ build-options:
   strip: true
   no-debuginfo: true
 finish-args:
-  - "--socket=x11"
+  - "--socket=fallback-x11"
   - "--socket=wayland"
   - "--socket=pulseaudio"
   - "--filesystem=xdg-documents"

--- a/io.github.beamerpresenter.beamerpresenter.yml
+++ b/io.github.beamerpresenter.beamerpresenter.yml
@@ -3,9 +3,6 @@ runtime: org.kde.Platform
 runtime-version: 5.15-21.08
 sdk: org.kde.Sdk
 command: beamerpresenter
-build-options:
-  strip: true
-  no-debuginfo: true
 finish-args:
   - "--socket=fallback-x11"
   - "--socket=wayland"
@@ -19,9 +16,6 @@ modules:
   - name: poppler
     buildsystem: cmake-ninja
     config-opts:
-    - "-DCMAKE_INSTALL_PREFIX=/app"
-    - "-DCMAKE_INSTALL_LIBDIR=/app/lib"
-    - "-DCMAKE_INSTALL_INCLUDEDIR=/app/include"
     - "-DENABLE_LIBOPENJPEG=none"
     - "-DENABLE_BOOST=OFF"
     - "-DENABLE_UTILS=OFF"
@@ -52,9 +46,6 @@ modules:
     - "-DAPPID_NAME=io.github.beamerpresenter.beamerpresenter"
     - "-DINSTALL_METAINFO=ON"
     - "-DCMAKE_BUILD_TYPE=Release"
-    - "-DCMAKE_INSTALL_PREFIX=/app"
-    - "-DCMAKE_INSTALL_SYSCONFDIR=/app/etc"
-    - "-DCMAKE_INSTALL_DATAROOTDIR=/app/share"
     - "-DCMAKE_INSTALL_LIBDIR=/app/usr/lib"
     - "-DCMAKE_INSTALL_INCLUDEDIR=/app/usr/include"
     sources:

--- a/io.github.beamerpresenter.beamerpresenter.yml
+++ b/io.github.beamerpresenter.beamerpresenter.yml
@@ -1,5 +1,4 @@
 app-id: io.github.beamerpresenter.beamerpresenter
-branch: master
 runtime: org.kde.Platform
 runtime-version: 5.15-21.08
 sdk: org.kde.Sdk


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions.
- [X] All assets referenced in the manifest are redistributable by any party.
- [X] I am an upstream contributor to the project.
- [X] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [X] Any additional patches or files have been submitted to the upstream projects concerned.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

### Extra information
The source points to a commit shortly after version 0.2.3 of beamerpresenter. The difference to v0.2.3 lies only in small adaptions required for flatpak/flathub.

This manifest defines building for Qt 5.15. It is also possible to build for Qt 6.3 with minor changes (adapt version numbers, enable Qt 6 in poppler and disable Qt 5 in poppler).

This manifest defines one possible configuration of BeamerPresenter. Other configurations with other PDF engines have not been tested with flatpak but might become available in the future.
