### PR TITLE
Import new puzzle set for GNOME Crosswords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+_flatpak

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.gnome.Crosswords.PuzzleSets.gnome.json
+++ b/org.gnome.Crosswords.PuzzleSets.gnome.json
@@ -18,7 +18,7 @@
             "sources": [
                 {
                     "type" : "git",
-                    "url" : "https://gitlab.gnome.org/jrb/puzzle-sets-gnome",
+                    "url" : "https://gitlab.gnome.org/jrb/puzzle-sets-gnome.git",
                     "commit": "0bef3d252c097610cd34b65f8704abe87d823d97"
                 }
             ]

--- a/org.gnome.Crosswords.PuzzleSets.gnome.json
+++ b/org.gnome.Crosswords.PuzzleSets.gnome.json
@@ -21,6 +21,10 @@
                     "url" : "https://gitlab.gnome.org/jrb/puzzle-sets-gnome.git",
                     "commit": "0bef3d252c097610cd34b65f8704abe87d823d97"
                 }
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ../org.gnome.Crosswords.PuzzleSets.gnome.metainfo.xml",
+                "appstream-compose --basename=org.gnome.Crosswords.PuzzleSets.gnome --prefix=${FLATPAK_DEST} --origin=flatpak org.gnome.Crosswords.PuzzleSets.gnome"
             ]
         }
     ]

--- a/org.gnome.Crosswords.PuzzleSets.gnome.json
+++ b/org.gnome.Crosswords.PuzzleSets.gnome.json
@@ -1,0 +1,27 @@
+{
+    "app-id": "org.gnome.Crosswords.PuzzleSets.gnome",
+    "runtime": "org.gnome.Crosswords",
+    "runtime-version": "stable",
+    "branch": "1",
+    "sdk" : "org.gnome.Sdk//43",
+    "build-extension": true,
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions"
+    },
+    "modules": [
+        {
+            "name": "puzzle-sets-gnome",
+            "buildsystem": "meson",
+            "config-opts" : [ "-Dflatpak=true" ],
+            "sources": [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/jrb/puzzle-sets-gnome",
+                    "commit": "0bef3d252c097610cd34b65f8704abe87d823d97"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://gitlab.gnome.org/jrb/puzzle-sets-gnome
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

This is a set of standalone crossword puzzles. They're either written by me, or permission has gotten from each author to ship them. Puzzles are all available under CC-BY-SA-4.0

