### PR TITLE
Add OceanPop

### DIFF
--- a/io.github.sharkwouter.oceanpop.yaml
+++ b/io.github.sharkwouter.oceanpop.yaml
@@ -1,0 +1,26 @@
+app-id: io.github.sharkwouter.OceanPop
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: oceanpop
+finish-args:
+  - --device=all
+  - --share=ipc
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=fallback-x11
+modules:
+  - name: jsoncpp
+    buildsystem: meson
+    config-opts:
+      - "--default-library=shared"
+    sources:
+      - type: archive
+        url: https://github.com/open-source-parsers/jsoncpp/archive/refs/tags/1.9.5.tar.gz
+        sha256: f409856e5920c18d0c2fb85276e24ee607d2a09b5e7d5f0a371368903c275da2
+  - name: oceanpop
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://github.com/sharkwouter/oceanpop/archive/refs/tags/1.1.tar.gz
+        sha256: 2f646b6d9e7978b228ffddddee710d2f551111063fbd9c0c12dc672475ba172e


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link: https://github.com/sharkwouter/oceanpop**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

I'd like to add an open source puzzle game called OceanPop to the Flathub. I developed this game over the course of about half a year and I think I managed to make quite a polished release out of it. It should build for all platforms the Flathub supports.

I had to use the `--device=all` permission to get gamepads to work unfortunately.