### PR TITLE
Add xyz.rescribe.rescribe

### DIFF
--- a/xyz.rescribe.rescribe.yml
+++ b/xyz.rescribe.rescribe.yml
@@ -55,7 +55,7 @@ modules:
   - name: getxbook
     buildsystem: simple
     build-commands:
-      - make DESTDIR=$FLATPAK_DEST PREFIX='' install
+      - make PREFIX=$FLATPAK_DEST install
     sources:
       - type: git
         url: https://git.njw.name/getxbook.git

--- a/xyz.rescribe.rescribe.yml
+++ b/xyz.rescribe.rescribe.yml
@@ -1,0 +1,47 @@
+app-id: xyz.rescribe.rescribe
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions: org.freedesktop.Sdk.Extension.golang
+build-options:
+  append-path: /usr/lib/sdk/golang/bin
+finish-args:
+  - --socket=x11
+  - --share=ipc # needed for X11
+  #- --socket=wayland # wayland is not stable on fyne yet, when it is add this and the wayland tag to 'go build'
+  - --device=dri # OpenGL
+  - --share=network # Used for google book downloading
+  - --filesystem=home
+command: rescribe
+modules:
+  - name: rescribe
+    buildsystem: simple
+    build-commands:
+      - cd cmd/rescribe && GOOS=linux GOARCH=amd64 go build -tags embed .
+      - install -Dm00755 cmd/rescribe/rescribe $FLATPAK_DEST/bin/rescribe-bin
+      - install -Dm00644 cmd/rescribe/icon.256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/xyz.rescribe.rescribe.png
+      - install -Dm00644 cmd/rescribe/xyz.rescribe.rescribe.desktop $FLATPAK_DEST/share/applications/xyz.rescribe.rescribe.desktop
+      - install -Dm00644 cmd/rescribe/xyz.rescribe.rescribe.appdata.xml $FLATPAK_DEST/share/appdata/xyz.rescribe.rescribe.appdata.xml
+      - printf '#!/bin/sh\nTMPDIR=$XDG_RUNTIME_DIR rescribe-bin\n' > $FLATPAK_DEST/bin/rescribe
+      - chmod 755 $FLATPAK_DEST/bin/rescribe
+    sources:
+      - type: git
+        url: https://github.com/rescribe/bookpipeline
+        tag: v1.0.1
+        commit: eac3d2a6c3302e78b34f4b680b7672d4bb44f9e3
+      - type: archive
+        url: https://rescribe.xyz/rescribe/modules-20221030-3a6024.tar.xz
+        sha256: 98fdbe455f7cb916cda570d0a30fca0de331809d4549e655e25b95e9be119856
+        strip-components: 0
+      - type: file
+        url: https://rescribe.xyz/rescribe/embeds/getgbook-linux-cac42fb.zip
+        sha256: c3b40a1c13da613d383f990bda5dd72425a7f26b89102d272a3388eb3d05ddb6
+        dest: cmd/rescribe
+      - type: file
+        url: https://rescribe.xyz/rescribe/embeds/tesseract-linux-v5.0.0-alpha.20210510.zip
+        sha256: 81cfba632b8aaf0a00180b1aa62d357d50f343b0e9bd51b941ee14c289ccd889
+        dest: cmd/rescribe
+      - type: file
+        url: https://rescribe.xyz/rescribe/embeds/tessdata.20220322.zip
+        sha256: 725fd570a3c3dc0eba9463248ce47a8646db8bafb198d428d6bb8f0be18540ee
+        dest: cmd/rescribe

--- a/xyz.rescribe.rescribe.yml
+++ b/xyz.rescribe.rescribe.yml
@@ -27,8 +27,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/rescribe/bookpipeline
-        tag: v1.0.1
-        commit: eac3d2a6c3302e78b34f4b680b7672d4bb44f9e3
+        tag: v1.0.2
+        commit: 3fb28b552eb1e945ff8ba48dd96271e641c295bc
       - type: archive
         url: https://rescribe.xyz/rescribe/modules-20221030-3a6024.tar.xz
         sha256: 98fdbe455f7cb916cda570d0a30fca0de331809d4549e655e25b95e9be119856

--- a/xyz.rescribe.rescribe.yml
+++ b/xyz.rescribe.rescribe.yml
@@ -17,13 +17,15 @@ modules:
   - name: rescribe
     buildsystem: simple
     build-commands:
-      - cd cmd/rescribe && GOOS=linux GOARCH=amd64 go build -tags embed .
+      - cd cmd/rescribe && go build .
       - install -Dm00755 cmd/rescribe/rescribe $FLATPAK_DEST/bin/rescribe-bin
       - install -Dm00644 cmd/rescribe/icon.256.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/xyz.rescribe.rescribe.png
       - install -Dm00644 cmd/rescribe/xyz.rescribe.rescribe.desktop $FLATPAK_DEST/share/applications/xyz.rescribe.rescribe.desktop
       - install -Dm00644 cmd/rescribe/xyz.rescribe.rescribe.appdata.xml $FLATPAK_DEST/share/appdata/xyz.rescribe.rescribe.appdata.xml
-      - printf '#!/bin/sh\nTMPDIR=$XDG_RUNTIME_DIR rescribe-bin\n' > $FLATPAK_DEST/bin/rescribe
+      - printf '#!/bin/sh\nTMPDIR=$XDG_RUNTIME_DIR rescribe-bin -gbookcmd "/app/bin/getgbook" -tesscmd "/app/bin/tesseract" -t "/app/share/tessdata/rescribev9_fast.traineddata"\n' > $FLATPAK_DEST/bin/rescribe
       - chmod 755 $FLATPAK_DEST/bin/rescribe
+      - mkdir -p $FLATPAK_DEST/share/tessdata
+      - cp -r tessdata/* $FLATPAK_DEST/share/tessdata/
     sources:
       - type: git
         url: https://github.com/rescribe/bookpipeline
@@ -33,15 +35,29 @@ modules:
         url: https://rescribe.xyz/rescribe/modules-20221030-3a6024.tar.xz
         sha256: 98fdbe455f7cb916cda570d0a30fca0de331809d4549e655e25b95e9be119856
         strip-components: 0
-      - type: file
-        url: https://rescribe.xyz/rescribe/embeds/getgbook-linux-cac42fb.zip
-        sha256: c3b40a1c13da613d383f990bda5dd72425a7f26b89102d272a3388eb3d05ddb6
-        dest: cmd/rescribe
-      - type: file
-        url: https://rescribe.xyz/rescribe/embeds/tesseract-linux-v5.0.0-alpha.20210510.zip
-        sha256: 81cfba632b8aaf0a00180b1aa62d357d50f343b0e9bd51b941ee14c289ccd889
-        dest: cmd/rescribe
-      - type: file
+      - type: archive
         url: https://rescribe.xyz/rescribe/embeds/tessdata.20220322.zip
         sha256: 725fd570a3c3dc0eba9463248ce47a8646db8bafb198d428d6bb8f0be18540ee
-        dest: cmd/rescribe
+        strip-components: 0
+        dest: tessdata
+  - name: leptonica
+    sources:
+      - type: git
+        url: https://github.com/DanBloomberg/leptonica
+        tag: 1.82.0
+        commit: f4138265b390f1921b9891d6669674d3157887d8
+  - name: tesseract-ocr
+    sources:
+      - type: git
+        url: https://github.com/tesseract-ocr/tesseract
+        tag: 5.2.0
+        commit: 5ad5325a0aa8effc47ca033625b6a51682f82767
+  - name: getxbook
+    buildsystem: simple
+    build-commands:
+      - make DESTDIR=$FLATPAK_DEST PREFIX='' install
+    sources:
+      - type: git
+        url: https://git.njw.name/getxbook.git
+        commit: c770a86cca74f3b6235000c77c2ab74487e2ac2a
+        disable-shallow-clone: true


### PR DESCRIPTION
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
Sadly this doesn't use a Portal for file opening / saving, as it uses the Fyne GUI toolkit which doesn't support that yet, hence the `--filesystem=home` usage.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- The modules archive contains the directories from "go mod vendor"; it'll need updating when modules are updated, but that's no problem for me.
- embeds/getgbook* is a precompiled version of another project of mine, ISC licensed.
- embeds/tesseract* is a precompiled version of tesseract-ocr, Apache licensed.
- embeds/tessdata* contains various tesseract trainings, both official ones and ones I created, all Apache licensed.
- [x] I am an upstream contributor to the project.
- [x] I own the domain used in the application ID.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission