### PR TITLE
Add RSS Guard

### DIFF
--- a/io.github.martinrotter.rssguard.yml
+++ b/io.github.martinrotter.rssguard.yml
@@ -1,0 +1,64 @@
+id: io.github.martinrotter.rssguard
+runtime: org.kde.Platform
+runtime-version: '6.3'
+base: io.qt.qtwebengine.BaseApp
+base-version: '6.3'
+sdk: org.kde.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node16
+command: rssguard
+finish-args:
+  - --device=dri
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --filesystem=xdg-download
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+modules:
+  # TODO: Remove the following module once we update to the 6.4 SDK.
+  # See also: https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/26
+  - name: qt6-core5compat
+    buildsystem: cmake-ninja
+    builddir: true
+    sources:
+      - type: archive
+        url: https://download.qt.io/official_releases/qt/6.3/6.3.2/submodules/qt5compat-everywhere-src-6.3.2.tar.xz
+        sha256: 91a3ac0f3f87e4103afa5834ccbecff9374daf716fab362d0c5e2d6ab98560cc
+    post-install:
+      - ln -sr /app/lib/${FLATPAK_ARCH}-linux-gnu/libQt6Core5Compat.so* -t /app/lib
+    cleanup:
+      - /include
+      - /mkspecs
+      - /modules
+
+  - name: rssguard
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_WITH_QT6=ON
+      - -DFORCE_BUNDLE_ICONS=ON
+      - -DIS_FLATPAK_BUILD=ON
+      - -DNO_UPDATE_CHECK=ON
+      - -DUSE_WEBENGINE=ON
+    sources:
+      - type: git
+        url: https://github.com/martinrotter/rssguard.git
+        tag: '4.2.7'
+        commit: 0bbf91affa297a4c11725867ae9b8fcac1b63483
+        x-checker-data:
+          type: git
+          tag-pattern: ^([\d.]+)$
+    cleanup:
+      - /include
+
+  - name: nodejs_and_npm
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/bin /app/lib
+      - cp -a /usr/lib/sdk/node16/bin/{node,npm} /app/bin
+      - cp -a /usr/lib/sdk/node16/lib/* /app/lib
+      - rm -r /app/lib/node_modules/npm/{docs,man}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/martinrotter/rssguard
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

---

Hello, I'm submitting this app on behalf of @martinrotter, which is the creator of RSS Guard, a RSS/ATOM feed reader.

RSS Guard is already on Flathub, but under a different and invalid (by today's standards) app id: [com.github.rssguard](https://github.com/flathub/com.github.rssguard).

So @martinrotter and I decided to have two separate builds of RSS Guard on Flathub:

- "Regular" (this one): Bundles a built-in web browser (QtWebEngine).
- "Lite" (submitted in #3737): No built-in web browser.

Because we couldn't simply re-use the old app id to create the Lite version, we thought it was best to just deprecate `com.github.rssguard` and create two new app ids:

- `io.github.martinrotter.rssguard` (this one)
- `io.github.martinrotter.rssguardlite` (submitted in #3737)

If this gets accepted, please add @martinrotter as a collaborator.

Thank you!