### PR TITLE
supersedes org.racket_lang.DrRacket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+build/
+rebuild/

--- a/org.racket_lang.Racket.appdata.xml
+++ b/org.racket_lang.Racket.appdata.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">org.racket_lang.Racket</id>
+  <name>Racket</name>
+  <summary>The Language-Oriented Programming Language</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      Racket is a multi-paradigm programming language with a rich set
+      of libraries included. 
+    </p>
+    <p>
+      The programming language is known for its powerful macro system which enables
+      the creation of embedded and domain-specific languages, language constructs
+      such as classes or modules, and separate dialects of Racket enable different
+      semantics.
+    </p>
+    <p>
+      DrRacket is a graphical environment for developing programs using the Racket programming languages.
+    </p>
+  </description>
+  <releases>
+    <release version="v8.7" date="2022-12-26">
+      <description>
+        <p>The latest stable release.</p>
+      </description>
+    </release>
+  </releases>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://user-images.githubusercontent.com/512906/209567825-dc6ef996-965f-4e9f-a25a-aa3773f7c98a.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">http://www.racket-lang.org/</url>
+  <content_rating type="oars-1.1"/>
+</application>

--- a/org.racket_lang.Racket.yml
+++ b/org.racket_lang.Racket.yml
@@ -1,0 +1,35 @@
+app-id: org.racket_lang.Racket
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: racket
+rename-desktop-file: drracket.desktop
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --filesystem=home
+  - --filesystem=/tmp
+modules:
+  - name: racket
+    no-autogen: true
+    subdir: src
+    build-options:
+      # by default, racket binaries are already stripped, so no debug info has to be extracted. 
+      no-debuginfo: true
+    config-opts:
+      - --enable-places
+    sources:
+      - type: archive
+        url : https://download.racket-lang.org/releases/8.7/installers/racket-8.7-src.tgz
+        sha256: 76a7e66d47e73eb0dc3fca27fc818e36e1d4bffe74da263c5efe3b8801a30a01
+      - type: file
+        path: org.racket_lang.Racket.appdata.xml
+      - type: file
+        path: racket-logo.svg
+    post-install:
+      - install -D -m644 ../racket-logo.svg /app/share/icons/hicolor/scalable/apps/org.racket_lang.Racket.svg
+      - install -D -m644 ../org.racket_lang.Racket.appdata.xml /app/share/appdata/org.racket_lang.Racket.appdata.xml
+      - desktop-file-edit --set-icon='org.racket_lang.Racket' /app/share/applications/drracket.desktop
+

--- a/racket-logo.svg
+++ b/racket-logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="circle_pieces" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="511.875px" height="511.824px" viewBox="0 0 511.875 511.824" enable-background="new 0 0 511.875 511.824" xml:space="preserve">
+<circle id="circle" fill="#FFFFFF" cx="256.252" cy="255.986" r="253.093"/>
+<path id="blue-piece" fill="#3E5BA9" d="M455.398,412.197c33.792-43.021,53.946-97.262,53.946-156.211  c0-139.779-113.313-253.093-253.093-253.093c-30.406,0-59.558,5.367-86.566,15.197C272.435,71.989,408.349,247.839,455.398,412.197z  "/>
+<path id="left-red-piece" fill="#9F1D20" d="M220.003,164.337c-39.481-42.533-83.695-76.312-130.523-98.715  C36.573,112.011,3.159,180.092,3.159,255.986c0,63.814,23.626,122.104,62.597,166.623  C100.111,319.392,164.697,219.907,220.003,164.337z"/>
+<path id="bottom-red-piece" fill="#9F1D20" d="M266.638,221.727c-54.792,59.051-109.392,162.422-129.152,257.794  c35.419,18.857,75.84,29.559,118.766,29.559c44.132,0,85.618-11.306,121.74-31.163C357.171,381.712,317.868,293.604,266.638,221.727  z"/>
+</svg>


### PR DESCRIPTION
Based on feedback from the Racket community, the entry point is preferred to be `racket`, which is consistent with other Racket distributions. However, using the new entry point with the old application id means that `flatpak run org.racket_lang.DrRacket` opens a repl, which is very likely to throw users off.

Therefore, the new application is created. The old application will later be declared EOL.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
