### PR TITLE
xyz.safeworlds.midiconn

### DIFF
--- a/xyz.safeworlds.midiconn.yml
+++ b/xyz.safeworlds.midiconn.yml
@@ -1,0 +1,56 @@
+id: xyz.safeworlds.midiconn
+command: midiconn
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /lib/*.a
+  - /lib/*.la
+  - /share/aclocal
+  - /share/rtmidi
+finish-args:
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=ipc
+modules:
+  - name: fmt
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DFMT_DOC=OFF
+      - -DFMT_INSTALL=ON
+      - -DFMT_TEST=OFF 
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/fmtlib/fmt
+        tag: '8.1.1'
+  - name: spdlog
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/gabime/spdlog
+        tag: v1.10.0
+  - name: rtmidi
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DRTMIDI_API_JACK=OFF
+      - -DRTMIDI_BUILD_STATIC_LIBS=ON
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/thestk/rtmidi
+        commit: 806e18f575b68c23b26f9398e1b6866b335b5308
+  - name: midiconn
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://gitlab.com/mfep/midiconn.git
+        tag: 0.1.1


### PR DESCRIPTION
midiconn is a desktop application to channel [MIDI](https://en.wikipedia.org/wiki/MIDI) messages between MIDI devices connected to the computer.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
