### PR TITLE
Add com.clarahobbs.chessclock

### DIFF
--- a/com.clarahobbs.chessclock.json
+++ b/com.clarahobbs.chessclock.json
@@ -1,0 +1,43 @@
+{
+    "app-id" : "com.clarahobbs.chessclock",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "43",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "chess-clock",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "chess-clock",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/cghobbs/chess-clock.git",
+                    "tag" : "v0.1.0",
+                    "commit" : "86646ef459fed6d3045ccc87f11fb5811bbe2875"
+                }
+            ]
+        }
+    ],
+    "build-options" : {
+        "env" : {        }
+    }
+}

--- a/com.clarahobbs.chessclock.json
+++ b/com.clarahobbs.chessclock.json
@@ -5,7 +5,6 @@
     "sdk" : "org.gnome.Sdk",
     "command" : "chess-clock",
     "finish-args" : [
-        "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
         "--device=dri",


### PR DESCRIPTION
Chess Clock is a simple application to provide time control for over-the-board chess games.  Intended for mobile use, players select the time control settings desired for their game, then the black player taps their clock to start white's timer.  After each player's turn, they tap the clock to start their opponent's, until the game is finished or one of the clocks reaches zero.

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
