### PR TITLE
Add org.videolan.VLC.Plugin.pause_click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Created by https://www.toptal.com/developers/gitignore/api/flatpak
+# Edit at https://www.toptal.com/developers/gitignore?templates=flatpak
+
+### Flatpak ###
+.flatpak-builder
+build
+build-dir
+repo
+
+# End of https://www.toptal.com/developers/gitignore/api/flatpak

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-icons-check": true
+}

--- a/org.videolan.VLC.Plugin.pause_click.appdata.xml
+++ b/org.videolan.VLC.Plugin.pause_click.appdata.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.videolan.VLC.Plugin.pause_click</id>
+  <extends>org.videolan.VLC</extends>
+  <name>Pause Click plugin for VLC</name>
+  <summary>VLC plugin that allows to pause/play a video by clicking on the video image.</summary>
+  <description>
+    <p>
+    Once installed, the plugin needs to be enabled using following steps:
+    <ol>
+      <li>Restart VLC (so that it loads the newly installed plugin)</li>
+      <li>Tick "Pause/Play video on mouse click" checkbox in Tools -> Preferences -> Show settings -> All -> Interface -> Control Interfaces</li>
+      <li>Tick "Pause/Play video on mouse click" checkbox in Tools -> Preferences -> Show settings -> All -> Video -> Filters</li>
+      <li>Restart VLC (so that it enables the plugin)</li>
+    </ol>
+    </p>
+    <p>
+    Both checkboxes need to be ticked for the plugin to function!
+    </p>
+    <p>
+    Plugin settings are available under Tools -> Preferences -> Show settings -> All -> Video -> Filters -> Pause click. The settings changes apply right away, there is no need to restart VLC.
+    </p>
+  </description>
+  <categories>
+    <category>Video</category>
+    <category>AudioVideo</category>
+    <category>Player</category>
+  </categories>
+  <content_rating type="oars-1.1" />
+  <url type="homepage">https://github.com/nurupo/vlc-pause-click-plugin</url>
+  <url type="bugtracker">https://github.com/nurupo/vlc-pause-click-plugin/issues</url>
+  <url type="faq">https://github.com/nurupo/vlc-pause-click-plugin/blob/master/README.md</url>
+  <url type="donation">https://github.com/sponsors/nurupo</url>
+  <url type="donation">https://www.paypal.com/donate?hosted_button_id=9HJHAH5UDL3GL</url>
+  <url type="donation">https://blockstream.info/address/34qxFsZjs1ZWVBwer11gXiycpv7QHTA8q3</url>
+  <url type="vcs-browser">https://github.com/nurupo/vlc-pause-click-plugin</url>
+  <releases>
+    <release version="2.2.0" date="2020-05-19"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/2.2.0</url></release>
+    <release version="2.1.0" date="2019-07-30"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/2.1.0</url></release>
+    <release version="2.0.0" date="2019-04-21"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/2.0.0</url></release>
+    <release version="1.0.0" date="2018-02-09"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/1.0.0</url></release>
+    <release version="0.4.0" date="2017-11-22"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.4.0</url></release>
+    <release version="0.3.2" date="2017-06-24"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.3.2</url></release>
+    <release version="0.3.1" date="2017-02-22"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.3.1</url></release>
+    <release version="0.3.0" date="2016-03-06"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.3.0</url></release>
+    <release version="0.2.1" date="2015-09-24"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.2.1</url></release>
+    <release version="0.2.0" date="2014-11-09"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.2.0</url></release>
+    <release version="0.1.0" date="2014-09-30"><url>https://github.com/nurupo/vlc-pause-click-plugin/releases/tag/0.1.0</url></release>
+  </releases>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Plugin settings</caption>
+      <image type="source">https://i.imgur.com/Kdrekks.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Checkbox enabling the plugin under Interface menu</caption>
+      <image type="source">https://i.imgur.com/m9yF5Px.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Checkbox enabling the plugin under Video menu</caption>
+      <image type="source">https://i.imgur.com/OZLqmI6.png</image>
+    </screenshot>
+  </screenshots>
+  <metadata_license>CC-BY-SA-3.0</metadata_license>
+  <project_license>LGPL-2.1-or-later</project_license>
+  <developer_name>Maxim Biro (nurupo)</developer_name>
+</component>

--- a/org.videolan.VLC.Plugin.pause_click.json
+++ b/org.videolan.VLC.Plugin.pause_click.json
@@ -1,0 +1,74 @@
+{
+  "app-id": "org.videolan.VLC.Plugin.pause_click",
+  "build-extension": true,
+  "runtime": "org.videolan.VLC",
+  "runtime-version": "stable",
+  "sdk": "org.freedesktop.Sdk//22.08",
+  "branch": "3-22.08",
+  "separate-locales": false,
+  "appstream-compose": false,
+  "build-options": {
+    "env": {
+      "V": 1
+    }
+  },
+  "modules": [
+    {
+      "name": "vlc-sdk",
+      "buildsystem": "simple",
+      "build-options": {
+        "env": {
+          "MAKEFLAGS": "-j $FLATPAK_BUILDER_N_JOBS"
+        }
+      },
+      "build-commands": [
+        "./configure BUILDCC=/usr/bin/gcc --prefix=/var/tmp/vlc-sdk --disable-lua --disable-vlm --disable-addonmanagermodules --disable-archive --disable-live555 --disable-dc1394 --disable-dv1394 --disable-linsys --disable-dvdread --disable-dvdnav --disable-bluray --disable-opencv --disable-smbclient --disable-dsm --disable-sftp --disable-nfs --disable-v4l2 --disable-decklink --disable-vcd --disable-libcddb --disable-screen --disable-vnc --disable-freerdp --disable-realrtsp --disable-macosx-qtkit --disable-macosx-avfoundation --disable-asdcp --disable-dvbpsi --disable-gme --disable-sid --disable-ogg --disable-shout --disable-matroska --disable-mod --disable-mpc --disable-wma-fixed --disable-shine --disable-omxil --disable-omxil-vout --disable-rpi-omxil --disable-crystalhd --disable-mad --disable-mpg123 --disable-gst-decode --disable-merge-ffmpeg --disable-avcodec --disable-libva --disable-dxva2 --disable-d3d11va --disable-avformat --disable-swscale --disable-postproc --disable-faad --disable-aom --disable-vpx --disable-twolame --disable-fdkaac --disable-a52 --disable-dca --disable-flac --disable-libmpeg2 --disable-vorbis --disable-tremor --disable-speex --disable-opus --disable-spatialaudio --disable-theora --disable-oggspots --disable-daala --disable-schroedinger --disable-png --disable-jpeg --disable-bpg --disable-x262 --disable-x265 --disable-x26410b --disable-x264 --disable-mfx --disable-fluidsynth --disable-fluidlite --disable-zvbi --disable-telx --disable-libass --disable-aribsub --disable-aribb25 --disable-kate --disable-tiger --disable-css --disable-gles2 --disable-xcb --disable-xvideo --disable-vdpau --disable-wayland --disable-sdl-image --disable-freetype --disable-fribidi --disable-harfbuzz --disable-fontconfig --disable-svg --disable-svgdec --disable-directx --disable-aa --disable-caca --disable-kva --disable-mmal --disable-evas --disable-pulse --disable-alsa --disable-oss --disable-sndio --disable-wasapi --disable-jack --disable-opensles --disable-tizen-audio --disable-samplerate --disable-soxr --disable-kai --disable-chromaprint --disable-chromecast --disable-qt --disable-skins2 --disable-libtar --disable-macosx --disable-sparkle --disable-minimal-macosx --disable-ncurses --disable-lirc --disable-srt --disable-goom --disable-projectm --disable-vsxu --disable-avahi --disable-udev --disable-mtp --disable-upnp --disable-microdns --disable-libxml2 --disable-libgcrypt --disable-gnutls --disable-taglib --disable-secret --disable-kwallet --disable-update-check --disable-osx-notifications --disable-notify --disable-libplacebo --disable-vlc",
+        "make libcompat",
+        "make -C src all",
+        "make install -C src",
+        "make -C lib install-data"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.videolan.org/pub/videolan/vlc/3.0.0/vlc-3.0.0.tar.xz",
+          "sha256": "68d587999f50d58df5ca3d69998bba910bdb5a82e5a1a39247179932fae0c19c"
+        }
+      ]
+    },
+    {
+      "name": "vlc-pause-click-plugin",
+      "buildsystem": "simple",
+      "build-options": {
+        "append-pkg-config-path": "/var/tmp/vlc-sdk/lib/pkgconfig"
+      },
+      "build-commands": [
+        "make"
+      ],
+      "post-install": [
+        "install -Dp -m 644 libpause_click_plugin.so --target-directory=/app/share/vlc/extra/pause_click/plugins",
+        "install -Dp -m 644 org.videolan.VLC.Plugin.pause_click.appdata.xml --target-directory=${FLATPAK_DEST}/share/metainfo",
+        "appstream-compose --basename=org.videolan.VLC.Plugin.pause_click --prefix=${FLATPAK_DEST} --origin=flatpak org.videolan.VLC.Plugin.pause_click"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/nurupo/vlc-pause-click-plugin/archive/refs/tags/2.2.0.tar.gz",
+          "sha256": "2a2cd76bc0bc10cb5f7c2143ae8508008c5a100f9a9c19b4fbc2c517983ded4c",
+          "x-checker-data": {
+            "is-main-source": true,
+            "type": "json",
+            "url": "https://api.github.com/repos/nurupo/vlc-pause-click-plugin/releases/latest",
+            "version-query": ".tag_name",
+            "url-query": "\"https://github.com/nurupo/vlc-pause-click-plugin/archive/refs/tags/\" + $version + \".tar.gz\"",
+            "timestamp-query": ".published_at"
+          }
+        },
+        {
+          "type": "file",
+          "path": "org.videolan.VLC.Plugin.pause_click.appdata.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.videolan.VLC.Plugin.pause_click.json
+++ b/org.videolan.VLC.Plugin.pause_click.json
@@ -46,8 +46,9 @@
         "make"
       ],
       "post-install": [
-        "install -Dp -m 644 libpause_click_plugin.so --target-directory=/app/share/vlc/extra/pause_click/plugins",
+        "install -Dp -m 644 libpause_click_plugin.so --target-directory=${FLATPAK_DEST}/plugins",
         "install -Dp -m 644 org.videolan.VLC.Plugin.pause_click.appdata.xml --target-directory=${FLATPAK_DEST}/share/metainfo",
+        "install -Dp -m 755 usage.sh --target-directory=${FLATPAK_DEST}",
         "appstream-compose --basename=org.videolan.VLC.Plugin.pause_click --prefix=${FLATPAK_DEST} --origin=flatpak org.videolan.VLC.Plugin.pause_click"
       ],
       "sources": [
@@ -67,6 +68,10 @@
         {
           "type": "file",
           "path": "org.videolan.VLC.Plugin.pause_click.appdata.xml"
+        },
+        {
+          "type": "file",
+          "path": "usage.sh"
         }
       ]
     }

--- a/usage.sh
+++ b/usage.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+cat << EOF
+=== Begin org.videolan.VLC.Plugin.pause_click Usage Instructions ===
+You have installed org.videolan.VLC.Plugin.pause_click.
+This plugin must be enabled in order for it to work.
+
+(Recommended) You can enable it by using the following steps after the VLC launches:
+  1. Tick "Pause/Play video on mouse click" checkbox in Tools -> Preferences -> Show settings -> All -> Interface -> Control Interfaces. Screenshot: https://i.imgur.com/m9yF5Px.png
+  2. Tick "Pause/Play video on mouse click" checkbox in Tools -> Preferences -> Show settings -> All -> Video -> Filters. Screenshot: https://i.imgur.com/OZLqmI6.png
+  3. Restart VLC
+Note that both checkboxes need to be ticked for the plugin to function!
+
+(Alternative) You can pass:
+  --control=pause_click --video-filter=pause_click
+arguments when running VLC to enable the plugin.
+This method enables the plugin only for this specific VLC run, i.e. it's not persistent.
+
+Plugin settings are available under Tools -> Preferences -> Show settings -> All -> Video -> Filters -> Pause click. Screenshot: https://i.imgur.com/Kdrekks.png . The settings changes apply right away, there is no need to restart VLC.
+=== End org.videolan.VLC.Plugin.pause_click Usage Instructions ===
+EOF


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Hi, I'm the author of the [Pause Click VLC plugin](https://github.com/nurupo/vlc-pause-click-plugin). Some users expressed their desire to be able to use the plugin with the flatpak version of VLC, so I have put some effort into making a flatpak for the plugin and adding it to Flathub.

I have tested that the flatpak builds successfully locally and, upon installation, the plugin appears in the VLC, fully functioning. The appdata file was validated with `org.freedesktop.appstream-glib validate` and I have also added `x-checker-data` to the json, which hopefully works as I didn't test it.

I'm new to Flatpak so please tell me if I'm doing something wrong or missing something.

The addon uses id of `org.videolan.VLC.Plugin.pause_click`. I'm not a VLC developer, so I have no relation with the domain. I wanted to use the repository URL for the application id, i.e. `com.github.nurupo.vlc-pause-click-plugin`, but it seems like due to the way addons work in Flatpak this is not possible. The VLC flatpak exposes `org.videolan.VLC.Plugin` as the extension point, so it seems like the addon must use `org.videolan.VLC.Plugin.` for its id, using other ids didn't work for me.

The plugin requires `libvlccore.so` ABI-compatible with the version of VLC the plugin is going to be used, libvlc and libvlccore headers, and pkg-config file `vlc-plugin.pc` to be present in order for the plugin to get built. All of these are generated during the [`org.videolan.VLC`](https://github.com/flathub/org.videolan.VLC) build, but are not present in the resulting VLC flatpak. Ideally I want to build the plugin against the VLC version the user would be using it with, but since the VLC sdk is not provided by the `org.videolan.VLC` flatpak, I have to resort to building a very stripped-down but ABI-compatible version of VLC myself, in the addon manifest. It would be nice if  `org.videolan.VLC` was modified to provide `org.videolan.VLC.SDK` sdk extension, so that I could add it to my `sdk-extensions` and not have to build VLC in my addon manifest.

By the way, is there some guide on how to maintain the repository once it's created? From the looks of what [other VLC plugins](https://github.com/flathub/org.videolan.VLC.Plugin.makemkv) do, it looks like I need to create a new `branch/<version>` for each [version of `org.videolan.VLC.Plugin`](https://github.com/flathub/org.videolan.VLC/blob/0e6abb5a01a1fe331a2916b10d9798c08a6ce22c/org.videolan.VLC.json#L26) I want to support, and whenever I release a new version of `vlc-pause-click-plugin`, I need to update the json in all of these branches to use than new version?