### PR TITLE
Added com.chowdsp.BYOD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules/

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ Filesystem:
 
 `--filesystem=~/.config/ChowdhuryDSP`: To persist and share with the
 plugin. Doesn't honour XDG
+`--persist=.config` because of `./.config/BYOD.settings`.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
 BYOD
 ====
 
-
-Flatpaking notes
-
-Checking out the repository with submodules doesn't work because one
-of the submodule has an orphan commit and it not fetched.
-See https://github.com/Chowdhury-DSP/chowdsp_juce_dsp/issues/1
-
-So `byod.json` has been auto generated to have all the submodule but
-the one that is a problem, that is downloaded as a tarball.
-
 Permissions
 -----------
 
@@ -20,6 +10,4 @@ Filesystem:
 
 `--filesystem=xdg-run/pipewire-0`: needed for Pipewire
 
-`--filesystem=~/.config/ChowdhuryDSP`: To persist and share with the
-plugin. Doesn't honour XDG
-`--persist=.config` because of `./.config/BYOD.settings`.
+JUCE has been patched to respect XDG.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+BYOD
+====
+
+
+Flatpaking notes
+
+Checking out the repository with submodules doesn't work because one
+of the submodule has an orphan commit and it not fetched.
+See https://github.com/Chowdhury-DSP/chowdsp_juce_dsp/issues/1
+
+So `byod.json` has been auto generated to have all the submodule but
+the one that is a problem, that is downloaded as a tarball.
+
+Permissions
+-----------
+
+DRI: The app use GL to render.
+
+Filesystem:
+
+`--filesystem=xdg-run/pipewire-0`: needed for Pipewire
+
+`--filesystem=~/.config/ChowdhuryDSP`: To persist and share with the
+plugin. Doesn't honour XDG

--- a/com.chowdsp.BYOD.desktop
+++ b/com.chowdsp.BYOD.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=BYOD
+GenericName=Guitar Distortion
+Comment=Guitar Distortion effect
+Type=Application
+Exec=BYOD
+Terminal=false
+Categories=Audio;
+Icon=com.chowdsp.BYOD
+StartupWMClass=BYOD

--- a/com.chowdsp.BYOD.json
+++ b/com.chowdsp.BYOD.json
@@ -9,9 +9,7 @@
         "--share=ipc",
         "--device=dri",
         "--socket=pulseaudio",
-        "--filesystem=xdg-run/pipewire-0",
-        "--persist=.config",
-        "--filesystem=~/.config/ChowdhuryDSP"
+        "--filesystem=xdg-run/pipewire-0"
     ],
     "build-options": {
         "env": {

--- a/com.chowdsp.BYOD.json
+++ b/com.chowdsp.BYOD.json
@@ -1,0 +1,92 @@
+{
+    "id": "com.chowdsp.BYOD",
+    "runtime": "org.freedesktop.Platform",
+    "sdk": "org.freedesktop.Sdk//22.08",
+    "runtime-version": "22.08",
+    "command": "BYOD",
+    "finish-args": [
+        "--socket=x11",
+        "--share=ipc",
+        "--device=dri",
+        "--socket=pulseaudio",
+        "--filesystem=xdg-run/pipewire-0",
+        "--filesystem=~/.config/ChowdhuryDSP"
+    ],
+    "build-options": {
+        "env": {
+            "PLUGINS_DIR": "/app/extensions/Plugins/BYOD",
+            "PLUGINS_ID": "org.freedesktop.LinuxAudio.Plugins.BYOD"
+        }
+    },
+    "add-extensions": {
+        "org.freedesktop.LinuxAudio.Plugins.BYOD": {
+            "directory": "extensions/Plugins/BYOD",
+            "version": "22.08",
+            "add-ld-path": "lib",
+            "bundle": true,
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": false
+        }
+    },
+    "cleanup": [
+        "/bin/JUCE-*",
+        "/include",
+        "/share/doc/lv2",
+        "/share/lv2*",
+        "/lib/cmake",
+        "/lib/lv2",
+        "/lib/pkgconfig"
+    ],
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "byod",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_AR=/usr/bin/gcc-ar",
+                "-DCMAKE_NM=/usr/bin/gcc-nm",
+                "-DCMAKE_RANLIB=/usr/bin/gcc-ranlib",
+                "-DBYOD_BUILD_CLAP=ON",
+                "-DBUILD_RELEASE=ON",
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "post-install": [
+                "install -d ${PLUGINS_DIR}/vst3",
+                "cp -R BYOD_artefacts/Release/VST3/BYOD.vst3 ${PLUGINS_DIR}/vst3",
+                "install -d ${PLUGINS_DIR}/lv2",
+                "cp -R BYOD_artefacts/Release/LV2/BYOD.lv2 ${PLUGINS_DIR}/lv2",
+                "install -Dm755 BYOD_artefacts/Release/CLAP/BYOD.clap -t ${PLUGINS_DIR}/clap",
+                "install -Dm755 BYOD_artefacts/Release/Standalone/BYOD -t ${FLATPAK_DEST}/bin",
+                "install -Dm644 res/logo.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg",
+                "install -Dm644 com.chowdsp.BYOD.desktop -t ${FLATPAK_DEST}/share/applications",
+                "install -Dm644 com.chowdsp.BYOD.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo",
+                "install -Dm644 org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml -t ${PLUGINS_DIR}/share/metainfo/",
+                "appstream-compose --basename=${PLUGINS_ID} --prefix=${PLUGINS_DIR} --origin=flatpak ${PLUGINS_ID}"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Chowdhury-DSP/BYOD.git",
+                    "tag": "v1.0.1"
+                },
+                {
+                    "type": "patch",
+                    "path": "patches/juce-616-header.patch"
+                },
+                {
+                    "type": "file",
+                    "path": "com.chowdsp.BYOD.desktop"
+                },
+                {
+                    "type": "file",
+                    "path": "com.chowdsp.BYOD.metainfo.xml"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/com.chowdsp.BYOD.json
+++ b/com.chowdsp.BYOD.json
@@ -81,6 +81,14 @@
                     "path": "patches/juce-616-header.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "patches/juce-xdg-path.patch",
+                    "options": [
+                        "-d",
+                        "modules/JUCE"
+                    ]
+                },
+                {
                     "type": "file",
                     "path": "com.chowdsp.BYOD.desktop"
                 },

--- a/com.chowdsp.BYOD.json
+++ b/com.chowdsp.BYOD.json
@@ -1,7 +1,7 @@
 {
     "id": "com.chowdsp.BYOD",
     "runtime": "org.freedesktop.Platform",
-    "sdk": "org.freedesktop.Sdk//22.08",
+    "sdk": "org.freedesktop.Sdk",
     "runtime-version": "22.08",
     "command": "BYOD",
     "finish-args": [

--- a/com.chowdsp.BYOD.json
+++ b/com.chowdsp.BYOD.json
@@ -10,6 +10,7 @@
         "--device=dri",
         "--socket=pulseaudio",
         "--filesystem=xdg-run/pipewire-0",
+        "--persist=.config",
         "--filesystem=~/.config/ChowdhuryDSP"
     ],
     "build-options": {
@@ -68,7 +69,12 @@
                 {
                     "type": "git",
                     "url": "https://github.com/Chowdhury-DSP/BYOD.git",
-                    "tag": "v1.0.1"
+                    "tag": "v1.1.3",
+                    "commit": "a90c2abde910e09b140ef2adbdd60411e3e98050",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "patch",

--- a/com.chowdsp.BYOD.metainfo.xml
+++ b/com.chowdsp.BYOD.metainfo.xml
@@ -15,7 +15,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.0.1/manual/screenshots/full_gui.png</image>
+      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.1.3/manual/screenshots/full_gui.png</image>
       <caption>Main window</caption>
     </screenshot>
   </screenshots>
@@ -26,6 +26,7 @@
   <update_contact>hub_AT_figuiere.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2023-01-13" version="1.1.3" />
     <release date="2022-11-21" version="1.1.0" />
     <release date="2022-03-15" version="1.0.1" />
   </releases>

--- a/com.chowdsp.BYOD.metainfo.xml
+++ b/com.chowdsp.BYOD.metainfo.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.chowdsp.BYOD</id>
+  <name>BYOD</name>
+  <summary>BYOD: Bring Your Own Distortion, Standalone</summary>
+  <description>
+    <p>
+      BYOD (Bring Your Own Distortion) is a guitar distortion plugin
+      with a customisable signal chain that allows users to create
+      their own guitar distortion effects. The plugin contains a wide
+      variety of distortion effects from analog modelled circuits to
+      purely digital creations, along with some musical tone-shaping
+      filters, and a handful of other useful processing blocks.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.0.1/manual/screenshots/full_gui.png</image>
+      <caption>Main window</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://chowdsp.com/</url>
+  <url type="vcs-browser">https://github.com/Chowdhury-DSP/BYOD</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release date="2022-03-15" version="1.0.1" />
+  </releases>
+</component>

--- a/com.chowdsp.BYOD.metainfo.xml
+++ b/com.chowdsp.BYOD.metainfo.xml
@@ -26,6 +26,7 @@
   <update_contact>hub_AT_figuiere.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2022-11-21" version="1.1.0" />
     <release date="2022-03-15" version="1.0.1" />
   </releases>
 </component>

--- a/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
@@ -30,6 +30,7 @@
   <update_contact>hub_AT_figuiere.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2022-11-21" version="1.1.0" />
     <release date="2022-03-15" version="1.0.1" />
   </releases>
 </component>

--- a/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.freedesktop.LinuxAudio.Plugins.BYOD</id>
+  <extends>com.chowdsp.BYOD</extends>
+  <name>BYOD</name>
+  <summary>BYOD: Bring Your Own Distortion, LV2/VST3/CLAP plugins</summary>
+  <description>
+    <p>
+      BYOD (Bring Your Own Distortion) is a guitar distortion plugin
+      with a customisable signal chain that allows users to create
+      their own guitar distortion effects. The plugin contains a wide
+      variety of distortion effects from analog modelled circuits to
+      purely digital creations, along with some musical tone-shaping
+      filters, and a handful of other useful processing blocks.
+    </p>
+    <p>
+      This is the plugins package in LV2/VST3/CLAP.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.0.1/manual/screenshots/full_gui.png</image>
+      <caption>Main window</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://chowdsp.com/</url>
+  <url type="vcs-browser">https://github.com/Chowdhury-DSP/BYOD</url>
+  <project_license>GPL-3.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <update_contact>hub_AT_figuiere.net</update_contact>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release date="2022-03-15" version="1.0.1" />
+  </releases>
+</component>

--- a/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.BYOD.metainfo.xml
@@ -19,7 +19,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.0.1/manual/screenshots/full_gui.png</image>
+      <image>https://github.com/Chowdhury-DSP/BYOD/raw/v1.1.3/manual/screenshots/full_gui.png</image>
       <caption>Main window</caption>
     </screenshot>
   </screenshots>
@@ -30,6 +30,7 @@
   <update_contact>hub_AT_figuiere.net</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
+    <release date="2023-01-13" version="1.1.3" />
     <release date="2022-11-21" version="1.1.0" />
     <release date="2022-03-15" version="1.0.1" />
   </releases>

--- a/patches/juce-616-header.patch
+++ b/patches/juce-616-header.patch
@@ -1,0 +1,13 @@
+diff --git a/modules/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h b/modules/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+index 06c0a72..119f146 100644
+--- a/modules/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
++++ b/modules/JUCE/modules/juce_gui_basics/windows/juce_ComponentPeer.h
+@@ -23,6 +23,8 @@
+   ==============================================================================
+ */
+ 
++#include <utility>
++
+ namespace juce
+ {
+ 

--- a/patches/juce-xdg-path.patch
+++ b/patches/juce-xdg-path.patch
@@ -1,0 +1,35 @@
+diff --git a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+index 1f13a1d8a..cfc779795 100644
+--- a/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
++++ b/modules/juce_audio_plugin_client/Standalone/juce_StandaloneFilterApp.cpp
+@@ -56,7 +56,7 @@ public:
+         options.filenameSuffix      = ".settings";
+         options.osxLibrarySubFolder = "Application Support";
+        #if JUCE_LINUX || JUCE_BSD
+-        options.folderName          = "~/.config";
++        options.folderName          = File::getSpecialLocation(File::userApplicationDataDirectory).getFullPathName();
+        #else
+         options.folderName          = "";
+        #endif
+diff --git a/modules/juce_core/native/juce_linux_Files.cpp b/modules/juce_core/native/juce_linux_Files.cpp
+index 38429ba69..5c7bf66fc 100644
+--- a/modules/juce_core/native/juce_linux_Files.cpp
++++ b/modules/juce_core/native/juce_linux_Files.cpp
+@@ -124,7 +124,16 @@ File File::getSpecialLocation (const SpecialLocationType type)
+         case userMoviesDirectory:             return resolveXDGFolder ("XDG_VIDEOS_DIR",    "~/Videos");
+         case userPicturesDirectory:           return resolveXDGFolder ("XDG_PICTURES_DIR",  "~/Pictures");
+         case userDesktopDirectory:            return resolveXDGFolder ("XDG_DESKTOP_DIR",   "~/Desktop");
+-        case userApplicationDataDirectory:    return resolveXDGFolder ("XDG_CONFIG_HOME",   "~/.config");
++        case userApplicationDataDirectory:
++        {
++            // XDG spec https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
++            const char* configDir = getenv ("XDG_CONFIG_HOME");
++            if (configDir && *configDir)
++                return File (CharPointer_UTF8 (configDir));
++
++            return File (CharPointer_UTF8 ("~/.config"));
++        }
++
+         case commonDocumentsDirectory:
+         case commonApplicationDataDirectory:  return File ("/opt");
+         case globalApplicationsDirectory:     return File ("/usr");


### PR DESCRIPTION
This is the standalone app version + the plugins. The standalone app version allow playback of your guitar without launching the DAW.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** TBD
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge). - app-id is based on upstream domain, and the id for the separated plugin pacakge as what it is.
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
Some patches are for the JUCE framework that is used as a submodule. TBD for the desktop files.

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
