### PR TITLE
Add app.drey.Elastic

### DIFF
--- a/0001-graph-view-Don-t-use-gtk_widget_get_color.patch
+++ b/0001-graph-view-Don-t-use-gtk_widget_get_color.patch
@@ -1,0 +1,27 @@
+From 21b1996a90bd32e7c8d80c75c8e547bb9e6eeab9 Mon Sep 17 00:00:00 2001
+From: Alexander Mikhaylenko <alexm@gnome.org>
+Date: Tue, 21 Feb 2023 20:39:14 +0400
+Subject: [PATCH] graph-view: Don't use gtk_widget_get_color()
+
+That func was added in 4.9.x and since GTK doesn't ship its own vapi we'd
+have to bundle Vala as well. Instead, just use the deprecated one.
+---
+ src/graph-view.vala | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/graph-view.vala b/src/graph-view.vala
+index fbd209f..585e412 100644
+--- a/src/graph-view.vala
++++ b/src/graph-view.vala
+@@ -171,7 +171,7 @@ public class Elastic.GraphView : Adw.Bin {
+         Cairo.Context cr,
+         double alpha_multiplier
+     ) {
+-        Gdk.RGBA rgba = darea.get_color ();
++        Gdk.RGBA rgba = darea.get_style_context ().get_color ();
+ 
+         cr.set_source_rgba (
+             rgba.red, rgba.green, rgba.blue,
+-- 
+2.39.1
+

--- a/app.drey.Elastic.json
+++ b/app.drey.Elastic.json
@@ -1,0 +1,134 @@
+{
+    "app-id" : "app.drey.Elastic",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "43",
+    "sdk" : "org.gnome.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.vala"
+    ],
+    "command" : "app.drey.Elastic",
+    "finish-args" : [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "build-options" : {
+        "append-path" : "/usr/lib/sdk/vala/bin",
+        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
+    },
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/vala",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "libsass",
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "*"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/lazka/libsass.git",
+                    "branch" : "meson",
+                    "commit" : "aac79dccd3c8f7e8f22125f87a119f3b1ee9d487"
+                }
+            ]
+        },
+        {
+            "name" : "sassc",
+            "buildsystem" : "meson",
+            "cleanup" : [
+                "*"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/lazka/sassc.git",
+                    "branch" : "meson",
+                    "commit" : "a1950c2d95ea4c051feb90bb1f43559fbb54bf36"
+                }
+            ]
+        },
+        {
+            "name" : "gtk",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Ddemos=false",
+                "-Dbuild-testsuite=false",
+                "-Dbuild-examples=false",
+                "-Dbuild-tests=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/gtk.git",
+                    "tag" : "4.9.4",
+                    "commit" : "8967b2da0182b2496d858bddc8ae8c7a76aef9c9"
+                }
+            ]
+        },
+
+        {
+            "name" : "libadwaita",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Dtests=false",
+                "-Dexamples=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libadwaita.git",
+                    "tag" : "1.3.beta",
+                    "commit" : "dcf02bd2b6f4aa846d3d4c16fed0e7f384130e21"
+                }
+            ]
+        },
+        {
+            "name" : "template-glib",
+            "config-opts" : [
+                "--buildtype=debugoptimized",
+                "-Dintrospection=enabled",
+                "-Dvapi=true"
+            ],
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/template-glib.git",
+                    "tag" : "3.36.0",
+                    "commit" : "a79f0b3e8c09eed250f5fc0ed7b806daf6387c03"
+                }
+            ]
+        },
+        {
+            "name" : "elastic",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/exalm/elastic.git",
+                    "tag" : "0.1.0",
+                    "commit" : "61838de2d9b6de5fb246284d1cbbced215149874"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "0001-graph-view-Don-t-use-gtk_widget_get_color.patch"
+                }
+            ]
+        }
+    ]
+}

--- a/app.drey.Elastic.json
+++ b/app.drey.Elastic.json
@@ -8,7 +8,6 @@
     ],
     "command" : "app.drey.Elastic",
     "finish-args" : [
-        "--share=network",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",

--- a/app.drey.Elastic.json
+++ b/app.drey.Elastic.json
@@ -3,9 +3,6 @@
     "runtime" : "org.gnome.Platform",
     "runtime-version" : "43",
     "sdk" : "org.gnome.Sdk",
-    "sdk-extensions" : [
-        "org.freedesktop.Sdk.Extension.vala"
-    ],
     "command" : "app.drey.Elastic",
     "finish-args" : [
         "--share=ipc",
@@ -13,10 +10,6 @@
         "--socket=wayland",
         "--device=dri"
     ],
-    "build-options" : {
-        "append-path" : "/usr/lib/sdk/vala/bin",
-        "prepend-ld-library-path" : "/usr/lib/sdk/vala/lib"
-    },
     "cleanup" : [
         "/include",
         "/lib/pkgconfig",
@@ -40,7 +33,6 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/lazka/libsass.git",
-                    "branch" : "meson",
                     "commit" : "aac79dccd3c8f7e8f22125f87a119f3b1ee9d487"
                 }
             ]
@@ -55,7 +47,6 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/lazka/sassc.git",
-                    "branch" : "meson",
                     "commit" : "a1950c2d95ea4c051feb90bb1f43559fbb54bf36"
                 }
             ]

--- a/app.drey.Elastic.json
+++ b/app.drey.Elastic.json
@@ -88,12 +88,12 @@
         },
         {
             "name" : "template-glib",
+            "buildsystem" : "meson",
             "config-opts" : [
                 "--buildtype=debugoptimized",
                 "-Dintrospection=enabled",
                 "-Dvapi=true"
             ],
-            "buildsystem" : "meson",
             "sources" : [
                 {
                     "type" : "git",
@@ -105,7 +105,6 @@
         },
         {
             "name" : "elastic",
-            "builddir" : true,
             "buildsystem" : "meson",
             "sources" : [
                 {


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project.
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

The patch is temporary. The app was written against nightly GNOME SDK, and needs newer libadwaita (which is important here, otherwise there's no way to draw the animation graph), which in turn needs newer GTK.

Now, GTK deprecated `GtkStyleContext` this cycle and instead added `gtk_widget_get_color()`, and the app is using that. However, GTK also doesn't ship its own vapi and I would need to bundle Vala as well to get that func. So instead it's easier to bundle a patch reverting to the older func for now.

Once 44 SDK is available, both the patch and all of the deps except `template-glib` can go away, for comparison here's the upstream manifest: https://gitlab.gnome.org/exalm/elastic/-/blob/main/app.drey.Elastic.json