### PR TITLE
Add net.launchpad.Gnuclad (second try)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/gnuclad-compile-fix.patch
+++ b/gnuclad-compile-fix.patch
@@ -1,0 +1,11 @@
+--- gnuclad-0.2.4/src/gnuclad.cpp	2011-01-07 13:28:37.000000000 -0500
++++ gnuclad-0.2.4/src/gnuclad-fixed.cpp	2023-02-24 12:05:06.706818738 -0500
+@@ -142,7 +142,7 @@
+     cout << "\nError: " << err;
+   } catch(string err) {
+     cout << "\nError: " << err;
+-  } catch(exception e) {
++  } catch(exception &e) {
+     cout << "\nError: " << e.what();
+   } catch(...) {
+     cout << "\nError: unknown reason";

--- a/net.launchpad.Gnuclad.appdata.xml
+++ b/net.launchpad.Gnuclad.appdata.xml
@@ -25,4 +25,5 @@
     <category>VectorGraphics</category>
   </categories>
   
+  <content_rating type=\"oars-1.1\" />
 </component>

--- a/net.launchpad.Gnuclad.appdata.xml
+++ b/net.launchpad.Gnuclad.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>net.launchpad.Gnuclad</id>
+  
+  <name>Gnuclad</name>
+  <summary>Cladogram tree generator</summary>
+  <metadata_license>FSFAP</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  
+  <description>
+    <p>
+      gnuclad tries to help the environment by creating trees. It's primary use will be generating cladogram trees for the GNU/Linux distro timeline and similar projects.
+    </p>
+  </description>
+  
+  <url type="homepage">https://launchpad.net/gnuclad</url>
+  <url type="bugtracker">https://bugs.launchpad.net/gnuclad</url>
+  
+  <releases>
+    <release version="0.2.4" date="2010-07-23"/>
+  </releases>
+    
+  <categories>
+    <category>Graphics</category>
+    <category>VectorGraphics</category>
+  </categories>
+  
+</component>

--- a/net.launchpad.Gnuclad.appdata.xml
+++ b/net.launchpad.Gnuclad.appdata.xml
@@ -25,5 +25,5 @@
     <category>VectorGraphics</category>
   </categories>
   
-  <content_rating type=\"oars-1.1\" />
+  <content_rating type="oars-1.1" />
 </component>

--- a/net.launchpad.Gnuclad.yml
+++ b/net.launchpad.Gnuclad.yml
@@ -1,0 +1,20 @@
+app-id: net.launchpad.Gnuclad
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: gnuclad
+finish-args:
+  - --filesystem=home
+modules:
+  - name: gnuclad
+    buildsystem: autotools
+    post-install:
+      - install -Dm644 net.launchpad.Gnuclad.appdata.xml /app/share/appdata/net.launchpad.Gnuclad.appdata.xml
+    sources:
+      - type: archive
+        url: https://launchpad.net/gnuclad/trunk/0.2/+download/gnuclad-0.2.4.tar.gz
+        sha512: 881b1feab8cb7458223987c5a36359e31e7e00e94d60cd0002c289930b99236947aadbea40f96aaa6aa4b5d7953278bf581edbd6df3cb660bca1505950e66b67 
+      - type: patch
+        path: gnuclad-compile-fix.patch
+      - type: file
+        path: net.launchpad.Gnuclad.appdata.xml


### PR DESCRIPTION
Gnuclad is a small CLI-only application that creates cladograms from CSV data. No desktop-file or app icon as this is CLI-only.

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://launchpad.net/gnuclad _I did not contact upstream for this Flatpak, as the last commit was in 2010 (app is "finished") and no reponse to bug reports_
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge). _Hope I did it right, I converted the URL launchpad.net/gnuclad to app ID net.launchpad.Gnuclad_
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)* _A small patch is needed for compilation. This has been reported as a bug in 2021 but no reponse from the developers._ Bug report: https://bugs.launchpad.net/gnuclad/+bug/1949632 

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
