### PR TITLE
Add the mouse-tracker extension for pro.vpup.vpuppr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "only-arches": ["x86_64"],
+    "skip-icons-check": true
+}

--- a/pro.vpup.vpuppr.Extension.mouse-tracker.metainfo.xml
+++ b/pro.vpup.vpuppr.Extension.mouse-tracker.metainfo.xml
@@ -2,6 +2,7 @@
 <component type="addon">
   <!--Created with jdAppdataEdit 5.1-->
   <id>pro.vpup.vpuppr.Extension.mouse-tracker</id>
+  <extends>pro.vpup.vpuppr</extends>
   <name>Virtual Puppet Project mouse tracker</name>
   <summary>A Virtual Puppet Project mouse tracker extension</summary>
   <developer_name>Timothy Yuen</developer_name>

--- a/pro.vpup.vpuppr.Extension.mouse-tracker.metainfo.xml
+++ b/pro.vpup.vpuppr.Extension.mouse-tracker.metainfo.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="addon">
+  <!--Created with jdAppdataEdit 5.1-->
+  <id>pro.vpup.vpuppr.Extension.mouse-tracker</id>
+  <name>Virtual Puppet Project mouse tracker</name>
+  <summary>A Virtual Puppet Project mouse tracker extension</summary>
+  <developer_name>Timothy Yuen</developer_name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+  <project_group>Virtual Puppet Project</project_group>
+  <description>
+    <p>A mouse tracker for the Virtual Puppet Project.</p>
+  </description>
+  <url type="homepage">https://github.com/virtual-puppet-project/mouse-tracker</url>
+  <url type="bugtracker">https://github.com/virtual-puppet-project/mouse-tracker/issues</url>
+  <url type="vcs-browser">https://github.com/virtual-puppet-project/mouse-tracker</url>
+  <url type="contribute">https://github.com/virtual-puppet-project/mouse-tracker</url>
+  <recommends>
+    <control>pointing</control>
+  </recommends>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/pro.vpup.vpuppr.Extension.mouse-tracker.yml
+++ b/pro.vpup.vpuppr.Extension.mouse-tracker.yml
@@ -10,6 +10,8 @@ modules:
     buildsystem: simple
     build-commands:
       - ls -a
+
+      - mv * /app/share/pro.vpup.vpuppr/extensions/mouse-tracker/
         #post-install:
         #- install -Dm644 -t ${FLATPAK_DEST}/share/metainfo data/${FLATPAK_ID}.metainfo.xml
         #- appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}

--- a/pro.vpup.vpuppr.Extension.mouse-tracker.yml
+++ b/pro.vpup.vpuppr.Extension.mouse-tracker.yml
@@ -5,17 +5,21 @@ runtime-version: stable
 sdk: org.freedesktop.Sdk//22.08
 build-extension: true
 appstream-compose: false
+build-options:
+  prefix: /app/extensions/mouse-tracker
 modules:
   - name: mouse-tracker
     buildsystem: simple
     build-commands:
-      - ls -a
-
-      - mv * /app/share/pro.vpup.vpuppr/extensions/mouse-tracker/
-        #post-install:
-        #- install -Dm644 -t ${FLATPAK_DEST}/share/metainfo data/${FLATPAK_ID}.metainfo.xml
-        #- appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+      - install -Dm644 -t ${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - mkdir -p /app/extensions/mouse-tracker
+      - mv * /app/extensions/mouse-tracker/
+      - mv /app/extensions/mouse-tracker/mouse-poller/libmouse_poller.so /app/extensions/mouse-tracker/mouse-poller/mouse_poller.so 
+    post-install:
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
     sources:
       - type: archive
         url: https://github.com/virtual-puppet-project/mouse-tracker/releases/download/0.1.1/mouse-tracker_linux.tar.gz
         sha256: 08ff0c6fd12a6bc7e45778b691b40235033ca715baa897315534f993e869a25e
+      - type: file
+        path: pro.vpup.vpuppr.Extension.mouse-tracker.metainfo.xml

--- a/pro.vpup.vpuppr.Extension.mouse-tracker.yml
+++ b/pro.vpup.vpuppr.Extension.mouse-tracker.yml
@@ -1,0 +1,19 @@
+id: pro.vpup.vpuppr.Extension.mouse-tracker
+branch: stable
+runtime: pro.vpup.vpuppr
+runtime-version: stable
+sdk: org.freedesktop.Sdk//22.08
+build-extension: true
+appstream-compose: false
+modules:
+  - name: mouse-tracker
+    buildsystem: simple
+    build-commands:
+      - ls -a
+        #post-install:
+        #- install -Dm644 -t ${FLATPAK_DEST}/share/metainfo data/${FLATPAK_ID}.metainfo.xml
+        #- appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    sources:
+      - type: archive
+        url: https://github.com/virtual-puppet-project/mouse-tracker/releases/download/0.1.1/mouse-tracker_linux.tar.gz
+        sha256: 08ff0c6fd12a6bc7e45778b691b40235033ca715baa897315534f993e869a25e


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link**: https://github.com/virtual-puppet-project/mouse-tracker/issues/2
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned.

Relies on https://github.com/flathub/pro.vpup.vpuppr/pull/2

Feedback very much appreciated.
