### PR TITLE
Move jdEolConverter to Codeberg

### DIFF
--- a/page.codeberg.JakobDev.jdEolConverter.yaml
+++ b/page.codeberg.JakobDev.jdEolConverter.yaml
@@ -1,0 +1,31 @@
+id: page.codeberg.JakobDev.jdEolConverter
+runtime: org.kde.Platform
+runtime-version: '6.4'
+sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '6.4'
+command: jdeolconverter
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+build-options:
+  env:
+    - BASEAPP_REMOVE_PYWEBENGINE=1
+finish-args:
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --share=ipc
+
+modules:
+  - name: jdEolConverter
+    buildsystem: simple
+    build-commands:
+      - pip install --no-deps --no-build-isolation --prefix=$FLATPAK_DEST .
+      - python ./install-unix-datafiles.py --prefix=$FLATPAK_DEST
+    sources:
+      - type: git
+        url: https://codeberg.org/JakobDev/jdEolConverter.git
+        tag: '1.2'
+        commit: dbf4868f8ea87bec4cc651b919e55c0203366c93
+        x-checker-data:
+          type: git


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

This replaces com.gitlab.JakobDev.jdEolConverter