### PR TITLE
Fix repeated word

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,6 @@ Please open bugs for packages on their respective repositories you can search fo
 
 ### Requesting a new package
 
-Please do not open issues requesting packages. As long as a package meets the guidelines above and works it will be
+Please do not open issues requesting packages. As long as a package meets the guidelines above and works it will
 generally be accepted. If you want to create a Flatpak see the [documentation](https://flatpak.readthedocs.io/en/latest/)
 or join [#flatpak:matrix.org](https://matrix.to/#/#flatpak:matrix.org) for help.


### PR DESCRIPTION
This error typically happens when changing the sentence structure mid writing.

