### PR TITLE
Extension to io.neovim.nvim to enable tmux in Neovim flatpak (io.neovim.nvim.tool.tmux)

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,1 @@
+{    "skip-icons-check": true }

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,0 @@
-{
-    "skip-icons-check": true,
-    "automerge-flathubbot-prs": true
-}

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
     "skip-icons-check": true,
-    "automerge-flathubbot-prs": true,
-    "only-arches": ["x86_64"]
+    "automerge-flathubbot-prs": true
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+    "skip-icons-check": true,
+    "automerge-flathubbot-prs": true,
+    "only-arches": ["x86_64"]
+}

--- a/io.neovim.nvim.tool.tmux.metainfo.xml
+++ b/io.neovim.nvim.tool.tmux.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="runtime">
+<component type="addon">
   <id>io.neovim.nvim.tool.tmux</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>ISC</project_license>
@@ -9,4 +9,5 @@
   <releases>
     <release version="3.3a" date="2022-06-09"/>
   </releases>
+  <extends>io.neovim.nvim</extends>
 </component>

--- a/io.neovim.nvim.tool.tmux.metainfo.xml
+++ b/io.neovim.nvim.tool.tmux.metainfo.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>io.neovim.nvim.tool.tmux</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>ISC</project_license>
+  <name>Tmux</name>
+  <summary>A tool for Neovim for run tmux inside of flatpak</summary>
+  <url type="homepage">https://github.com/tmux/tmux</url>
+  <releases>
+    <release version="3.3a" date="2022-06-09"/>
+  </releases>
+</component>

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -14,7 +14,7 @@ modules:
         sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
     buildsystem: simple
     build-commands:
-      - ./configure --prefix=${FLATPAK_DEST}
+      - ./configure --prefix=${FLATPAK_DEST} --enable-shared
       - make
       - make install
   - name: libutempter
@@ -24,24 +24,27 @@ modules:
         sha256: 258d8bc4a42d2cbe4df6415912ab842574899adddbfc89d14ab56b57bb81158b 
     buildsystem: simple
     build-commands:
-      - make -C libutempter DESTDIR=${FLATPAK_DEST}
-      - make -C libutempter DESTDIR=${FLATPAK_DEST} install
+      - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include
+      - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include install
   - name: tmux
     sources:
       - type: archive
         url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
         sha256: e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
-      - type: file
-        path: tmux-wrapper.sh
     buildsystem: simple
     build-commands:
-      - ./configure --prefix=${FLATPAK_DEST} PKG_CONFIG_PATH=${FLATPAK_DEST}/lib/pkgconfig LDFLAGS=-L${FLATPAK_DEST}/lib
-      # - ./configure --prefix=${FLATPAK_DEST} --enable-utempter 
+      - ./configure LIBRARY_PATH=${FLATPAK_DEST}/lib:$LIBRARY_PATH PKG_CONFIG_PATH=${FLATPAK_DEST}/lib/pkgconfig LDFLAGS=-L${FLATPAK_DEST}/lib CFLAGS=-I${FLATPAK_DEST}/include --prefix=${FLATPAK_DEST} --enable-utempter
       - make
       - make install
+  - name: tmux-wrapper
+    buildsystem: simple
+    sources:
+      - type: file
+        path: tmux-wrapper.sh
+    build-commands:
+      - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
+      - chmod +x /app/tools/tmux/bin/tmux-wrapper.sh
 post-install:
   - install -Dm644 -t /app/share/metainfo io.neovim.nvim.tool.tmux.metadata.xml
-  - install -Dm755 /app/bin/tmux tmux-wrapper.sh
-  - chmod +x /app/bin/tmux
 metadata:
   - io.neovim.nvim.tool.tmux.metadata.xml

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -9,11 +9,10 @@ appstream-compose: false
 
 modules:
   - name: libevent
-    buildsystem: simple
-    build-commands:
-      - ./configure --prefix=${FLATPAK_DEST} --enable-shared
-      - make
-      - make install
+    buildsystem: autotools 
+    config-opts:
+      - --prefix=${FLATPAK_DEST}
+      - --enable-shared
     sources:
       - type: archive
         url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -22,9 +22,10 @@ modules:
         sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
   - name: libutempter
     buildsystem: simple
+    subdir: libutempter
     build-commands:
-      - make -C libutempter libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man
-      - make -C libutempter libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man install
+      - make libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man
+      - make libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man install
     sources:
       - type: archive
         url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -9,41 +9,41 @@ appstream-compose: false
 
 modules:
   - name: libevent
-    sources:
-      - type: archive
-        url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
-        sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
     buildsystem: simple
     build-commands:
       - ./configure --prefix=${FLATPAK_DEST} --enable-shared
       - make
       - make install
-  - name: libutempter
     sources:
       - type: archive
-        url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 
-        sha256: 258d8bc4a42d2cbe4df6415912ab842574899adddbfc89d14ab56b57bb81158b 
+        url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+        sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+  - name: libutempter
     buildsystem: simple
     build-commands:
       - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include
       - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include install
-  - name: tmux
     sources:
       - type: archive
-        url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
-        sha256: e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
+        url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 
+        sha256: 258d8bc4a42d2cbe4df6415912ab842574899adddbfc89d14ab56b57bb81158b 
+  - name: tmux
     buildsystem: simple
     build-commands:
       - ./configure LIBRARY_PATH=${FLATPAK_DEST}/lib:$LIBRARY_PATH PKG_CONFIG_PATH=${FLATPAK_DEST}/lib/pkgconfig LDFLAGS=-L${FLATPAK_DEST}/lib CFLAGS=-I${FLATPAK_DEST}/include --prefix=${FLATPAK_DEST} --enable-utempter
       - make
       - make install
+    sources:
+      - type: archive
+        url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
+        sha256: e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
   - name: tmux-wrapper
     buildsystem: simple
+    build-commands:
+      - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
     sources:
       - type: file
         path: tmux-wrapper.sh
-    build-commands:
-      - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
   - name: bundle-setup
     buildsystem: simple
     build-commands:

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -1,0 +1,47 @@
+app-id: io.neovim.nvim.tool.tmux
+branch: stable
+runtime: io.neovim.nvim
+runtime-version: stable
+sdk: org.freedesktop.Sdk//22.08
+build-extension: true
+separate-locales: false
+
+modules:
+  - name: libevent
+    sources:
+      - type: archive
+        url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+        sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=${FLATPAK_DEST}
+      - make
+      - make install
+  - name: libutempter
+    sources:
+      - type: archive
+        url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 
+        sha256: 258d8bc4a42d2cbe4df6415912ab842574899adddbfc89d14ab56b57bb81158b 
+    buildsystem: simple
+    build-commands:
+      - make -C libutempter DESTDIR=${FLATPAK_DEST}
+      - make -C libutempter DESTDIR=${FLATPAK_DEST} install
+  - name: tmux
+    sources:
+      - type: archive
+        url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
+        sha256: e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
+      - type: file
+        path: tmux-wrapper.sh
+    buildsystem: simple
+    build-commands:
+      - ./configure --prefix=${FLATPAK_DEST} PKG_CONFIG_PATH=${FLATPAK_DEST}/lib/pkgconfig LDFLAGS=-L${FLATPAK_DEST}/lib
+      # - ./configure --prefix=${FLATPAK_DEST} --enable-utempter 
+      - make
+      - make install
+post-install:
+  - install -Dm644 -t /app/share/metainfo io.neovim.nvim.tool.tmux.metadata.xml
+  - install -Dm755 /app/bin/tmux tmux-wrapper.sh
+  - chmod +x /app/bin/tmux
+metadata:
+  - io.neovim.nvim.tool.tmux.metadata.xml

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -45,7 +45,12 @@ modules:
     build-commands:
       - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
       - chmod +x /app/tools/tmux/bin/tmux-wrapper.sh
-post-install:
-  - install -Dm644 -t /app/share/metainfo io.neovim.nvim.tool.tmux.metadata.xml
-metadata:
-  - io.neovim.nvim.tool.tmux.metadata.xml
+  - name: bundle-setup
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
+      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak
+        $FLATPAK_ID
+    sources:
+      - type: file
+        path: io.neovim.nvim.tool.tmux.metainfo.xml

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -5,6 +5,7 @@ runtime-version: stable
 sdk: org.freedesktop.Sdk//22.08
 build-extension: true
 separate-locales: false
+appstream-compose: false
 
 modules:
   - name: libevent

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -6,12 +6,12 @@ runtime-version: stable
 branch: stable
 separate-locales: false
 appstream-compose: false
-
+build-options:
+  prefix: ${FLATPAK_DEST}
 modules:
   - name: libevent
     buildsystem: autotools 
     config-opts:
-      - --prefix=${FLATPAK_DEST}
       - --enable-shared
     sources:
       - type: archive

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -44,7 +44,6 @@ modules:
         path: tmux-wrapper.sh
     build-commands:
       - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
-      - chmod +x /app/tools/tmux/bin/tmux-wrapper.sh
   - name: bundle-setup
     buildsystem: simple
     build-commands:

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -7,7 +7,10 @@ branch: stable
 separate-locales: false
 appstream-compose: false
 build-options:
-  prefix: ${FLATPAK_DEST}
+  prefix: /app/tools/tmux
+  prepend-pkg-config-path: /app/tools/tmux/lib/pkgconfig
+  ldflags: -L/app/tools/tmux/lib
+  cflags: -I/app/tools/tmux/include
 modules:
   - name: libevent
     buildsystem: autotools 
@@ -27,11 +30,9 @@ modules:
         url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 
         sha256: 258d8bc4a42d2cbe4df6415912ab842574899adddbfc89d14ab56b57bb81158b 
   - name: tmux
-    buildsystem: simple
-    build-commands:
-      - ./configure LIBRARY_PATH=${FLATPAK_DEST}/lib:$LIBRARY_PATH PKG_CONFIG_PATH=${FLATPAK_DEST}/lib/pkgconfig LDFLAGS=-L${FLATPAK_DEST}/lib CFLAGS=-I${FLATPAK_DEST}/include --prefix=${FLATPAK_DEST} --enable-utempter
-      - make
-      - make install
+    buildsystem: autotools 
+    config-opts:
+      - --enable-utempter
     sources:
       - type: archive
         url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -1,9 +1,9 @@
-app-id: io.neovim.nvim.tool.tmux
-branch: stable
+id: io.neovim.nvim.tool.tmux
+build-extension: true
+sdk: org.freedesktop.Sdk//22.08
 runtime: io.neovim.nvim
 runtime-version: stable
-sdk: org.freedesktop.Sdk//22.08
-build-extension: true
+branch: stable
 separate-locales: false
 appstream-compose: false
 
@@ -21,8 +21,8 @@ modules:
   - name: libutempter
     buildsystem: simple
     build-commands:
-      - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include
-      - make -C libutempter DESTDIR=${FLATPAK_DEST} libdir=/lib libexecdir=/lib includedir=/include install
+      - make -C libutempter libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man
+      - make -C libutempter libdir=${FLATPAK_DEST}/lib libexecdir=${FLATPAK_DEST}/lib includedir=${FLATPAK_DEST}/include mandir=${FLATPAK_DEST}/share/man install
     sources:
       - type: archive
         url: https://github.com/altlinux/libutempter/archive/refs/tags/1.2.1-alt1.tar.gz 

--- a/io.neovim.nvim.tool.tmux.yml
+++ b/io.neovim.nvim.tool.tmux.yml
@@ -34,23 +34,16 @@ modules:
     buildsystem: autotools 
     config-opts:
       - --enable-utempter
+    post-install:
+      - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
+      - install -Dm644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
+      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak
+        $FLATPAK_ID    
     sources:
       - type: archive
         url: https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
         sha256: e4fd347843bd0772c4f48d6dde625b0b109b7a380ff15db21e97c11a4dcdf93f
-  - name: tmux-wrapper
-    buildsystem: simple
-    build-commands:
-      - install -Dm755 tmux-wrapper.sh /app/tools/tmux/bin/tmux-wrapper.sh
-    sources:
       - type: file
         path: tmux-wrapper.sh
-  - name: bundle-setup
-    buildsystem: simple
-    build-commands:
-      - install -Dm644 -t $FLATPAK_DEST/share/metainfo $FLATPAK_ID.metainfo.xml
-      - appstream-compose --basename=$FLATPAK_ID --prefix=$FLATPAK_DEST --origin=flatpak
-        $FLATPAK_ID
-    sources:
       - type: file
         path: io.neovim.nvim.tool.tmux.metainfo.xml

--- a/tmux-wrapper.sh
+++ b/tmux-wrapper.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 export PATH=$PATH:/app/tools/tmux/bin
 exec /app/tools/tmux/bin/tmux "$@"
 

--- a/tmux-wrapper.sh
+++ b/tmux-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export PATH=$PATH:/app/tools/tmux/bin
+exec /app/tools/tmux/bin/tmux "$@"
+


### PR DESCRIPTION
# Usage

For best results, use the `tmux-wrapper.sh` to start tmux. For example, the following works:

```
alias vim-tmux='flatpak --user run --command=/app/tools/tmux/bin/tmux-wrapper.sh io.neovim.nvim'
```

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
