### PR TITLE
Add org.fcitx.Fcitx5.Addon.McBopomofo

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
+++ b/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
@@ -1,0 +1,39 @@
+app-id: org.fcitx.Fcitx5.Addon.McBopomofo
+branch: stable
+runtime: org.fcitx.Fcitx5
+runtime-version: stable
+sdk: org.kde.Sdk//5.15-21.08
+build-extension: true
+appstream-compose: false
+separate-locales: false
+build-options:
+  prefix: /app/addons/McBopomofo
+  prepend-pkg-config-path: "/app/addons/McBopomofo/lib/pkgconfig:/app/addons/McBopomofo/share/pkgconfig"
+cleanup:
+  - /bin
+  - /include
+  - /lib/pkgconfig
+  - /share/pkgconfig
+  - "*.la"
+  - /lib/cmake
+modules:
+  - name: fmt
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DFMT_TEST=Off
+      - -DBUILD_SHARED_LIBS=ON
+    sources:
+      - type: git
+        url: https://github.com/fmtlib/fmt
+        tag: 9.1.0
+  - name: fcitx5-mcbopomofo
+    buildsystem: cmake
+    sources:
+      - type: git
+        url: https://github.com/openvanilla/fcitx5-mcbopomofo
+        tag: 2.5.2
+        commit: cd0db9ff0626ee603aa5cdf484da995729e0ba42
+    config-opts:
+      - -DENABLE_TEST=Off
+    post-install:
+      - appstream-compose --basename=org.fcitx.Fcitx5.Addon.McBopomofo --prefix=${FLATPAK_DEST} --origin=flatpak org.fcitx.Fcitx5.Addon.McBopomofo

--- a/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
+++ b/org.fcitx.Fcitx5.Addon.McBopomofo.yaml
@@ -27,7 +27,7 @@ modules:
         url: https://github.com/fmtlib/fmt
         tag: 9.1.0
   - name: fcitx5-mcbopomofo
-    buildsystem: cmake
+    buildsystem: cmake-ninja
     sources:
       - type: git
         url: https://github.com/openvanilla/fcitx5-mcbopomofo


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission

Note: fcitx5-mcbopomofo is a third-party add-on to fcitx5, an input method editor (IME) framework. I'm the maintainer of fcitx5-mcbopomofo. The PR is modelled after https://github.com/flathub/flathub/pull/3311. Our project is also distributed on other *NIX, for example: https://www.freshports.org/chinese/fcitx5-mcbopomofo/                                                                                                                                       
                                                                                                                                                         
Thank you!
