### PR TITLE
Add TypeScript SDK Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+repo/
+.flatpak-builder/
+.flatpak/
+.fenv/

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.typescript.json
+++ b/org.freedesktop.Sdk.Extension.typescript.json
@@ -1,0 +1,65 @@
+{
+    "id": "org.freedesktop.Sdk.Extension.typescript",
+    "branch": "22.08",
+    "runtime": "org.freedesktop.Sdk",
+    "build-extension": true,
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "22.08",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.node18"
+    ],
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/usr/lib/sdk/typescript",
+        "append-path": "/usr/lib/sdk/node18/bin"
+    },
+    "cleanup": [
+        "/share/info",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name": "typescript",
+            "buildsystem": "simple",
+            "build-options": {
+                "env" : {
+                    "XDG_CACHE_HOME": "/run/build/typescript/flatpak-node/cache",
+                    "npm_config_cache": "/run/build/typescript/flatpak-node/npm-cache"
+                }
+            },
+            "build-commands": [
+                "npm install -g --offline --prefix=$FLATPAK_DEST --install-links"
+            ],
+            "sources": [
+                "sources/typescript.json",
+                {
+                    "type": "archive",
+                    "url": "https://github.com/microsoft/TypeScript/releases/download/v5.1.3/typescript-5.1.3.tgz",
+                    "sha256": "e23048b17a796af96db4ea0c1a5e4e6928673fb1d42a3c0af6d48a7da861e6bd",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 13733,
+                        "stable-only": true,
+                        "url-template": "https://github.com/microsoft/TypeScript/releases/download/$version/typescript-$version.tgz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "metainfo",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p ${FLATPAK_DEST}/share/metainfo",
+                "cp org.freedesktop.Sdk.Extension.typescript.metainfo.xml ${FLATPAK_DEST}/share/metainfo",
+                "appstream-compose  --basename=org.freedesktop.Sdk.Extension.typescript --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.Sdk.Extension.typescript"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.Sdk.Extension.typescript.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.Sdk.Extension.typescript.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.typescript.metainfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Christopher Davis <christopherdavis@gnome.org> -->
+<component type="addon">
+  <id>org.freedesktop.Sdk.Extension.typescript</id>
+  <extends>org.freedesktop.Sdk</extends>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>TypeScript</name>
+  <summary>TypeScript stable compiler and tools</summary>
+  <description>TypeScript compiler and tools extension for the flatpak Freedesktop SDK</description>
+  <project_license>Apache-2.0 AND MIT</project_license>
+  <url type="homepage">https://github.com/flathub/org.freedesktop.Sdk.Extension.typescript/</url>
+  <translation/>
+  <update_contact>christopherdavis@gnome.org</update_contact>
+  <releases>
+    <release version="5.1.3" date="2023-06-01"/>
+  </releases>
+</component>

--- a/sources/typescript.json
+++ b/sources/typescript.json
@@ -1,0 +1,321 @@
+[
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+        "sha512": "ac829d773aa199abfb3129a814298321be9ed96e7b81e46c33de20576977f1fce15ccc2aee16680a5ba0f54488da915118bd3a7f820e3c71e914d3a45a2791f0",
+        "dest-filename": "9d773aa199abfb3129a814298321be9ed96e7b81e46c33de20576977f1fce15ccc2aee16680a5ba0f54488da915118bd3a7f820e3c71e914d3a45a2791f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/82"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+        "sha512": "281316bc4668a11efe93363406d6d3427d0e01863b0ac8b2753eb7a5511a3ed5581748576d468ec99a20dfb0cac4aecd1775da70124ea584f869d20987e6afc4",
+        "dest-filename": "16bc4668a11efe93363406d6d3427d0e01863b0ac8b2753eb7a5511a3ed5581748576d468ec99a20dfb0cac4aecd1775da70124ea584f869d20987e6afc4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/13"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+        "sha512": "b944d3738c463434fb61202ba7fcdbb666e13b4b8410af7f1135b6f56935b61614241cf72159ef804884c046bd21e2f2be7a4aad62bae14b70d9b814983bdec3",
+        "dest-filename": "d3738c463434fb61202ba7fcdbb666e13b4b8410af7f1135b6f56935b61614241cf72159ef804884c046bd21e2f2be7a4aad62bae14b70d9b814983bdec3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/44"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+        "sha512": "f34c04a027c5fe114a33a584d45c811dcf527d46e5968016c7a1499055935a20a886df4c734011184338edeebb5bdac8d3d62853124bebc5877c3458100bce86",
+        "dest-filename": "04a027c5fe114a33a584d45c811dcf527d46e5968016c7a1499055935a20a886df4c734011184338edeebb5bdac8d3d62853124bebc5877c3458100bce86",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/4c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+        "sha512": "209338249b0b85162bf7176d2f2b4f2d21fd93fa314776e86942188879006b0b7034e5ca13c2a853cb4cbebca881d713f0053e05f96687cd579fa434bd365b43",
+        "dest-filename": "38249b0b85162bf7176d2f2b4f2d21fd93fa314776e86942188879006b0b7034e5ca13c2a853cb4cbebca881d713f0053e05f96687cd579fa434bd365b43",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/93"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+        "sha512": "a41c1b73b0ee7e5b94786763494e528be3f74a8305e4343f17f5264d26fc1d73bcd19100266af290fcb3a3521f35b0286aac38f18469bfcb21c1dd4da08d2371",
+        "dest-filename": "1b73b0ee7e5b94786763494e528be3f74a8305e4343f17f5264d26fc1d73bcd19100266af290fcb3a3521f35b0286aac38f18469bfcb21c1dd4da08d2371",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+        "sha512": "e25bbe9fc5a4d1795a8c485b11f7ddcb6c72e77769474e92973be1181cb2837eaa270e8aa5f93b729e390d1ffad9a3c7f66b49466232ad7012e54581ac94fa4d",
+        "dest-filename": "be9fc5a4d1795a8c485b11f7ddcb6c72e77769474e92973be1181cb2837eaa270e8aa5f93b729e390d1ffad9a3c7f66b49466232ad7012e54581ac94fa4d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/5b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+        "sha512": "71d993dcac6394e43f819d9c8dfad03ad9a11b81c9b3a861be6de65924433ed67f94fe687bc15671e4b5d09692242d77181778787fe16879ea7fb86118d2deac",
+        "dest-filename": "93dcac6394e43f819d9c8dfad03ad9a11b81c9b3a861be6de65924433ed67f94fe687bc15671e4b5d09692242d77181778787fe16879ea7fb86118d2deac",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/d9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+        "sha512": "72dd53837586c1ddcffa8658aa273e619178b27365d9bb2730a4646f7a331e69ccd1d196bb170f4d39ed005e9b38fd12a78c743e3485fb8b87435c6fc5f44aaa",
+        "dest-filename": "53837586c1ddcffa8658aa273e619178b27365d9bb2730a4646f7a331e69ccd1d196bb170f4d39ed005e9b38fd12a78c743e3485fb8b87435c6fc5f44aaa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+        "sha512": "c38211852cb555bb0dc47450a5e1821c49a26ea753531eb555cdfc00f72c45bb9580ad0e3c49d0d180f7f41af29a7f7a98ec78f18da5681406aa06748fdc3a49",
+        "dest-filename": "11852cb555bb0dc47450a5e1821c49a26ea753531eb555cdfc00f72c45bb9580ad0e3c49d0d180f7f41af29a7f7a98ec78f18da5681406aa06748fdc3a49",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c3/82"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+        "sha512": "da20278146c13ccab8dfd6becfffe013ef56065768329d6ce465ac51282a1cbccb27d5a864b661a705aeca6d2ed2eff85e66778291e6cd5f383e89c4fbd20875",
+        "dest-filename": "278146c13ccab8dfd6becfffe013ef56065768329d6ce465ac51282a1cbccb27d5a864b661a705aeca6d2ed2eff85e66778291e6cd5f383e89c4fbd20875",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/20"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+        "sha512": "2ca265b5ce0b55d30a1ecac57b830634fa7486a0c50355a9b778c4d601323379ca52f3a23bfffd3e17996477d845f625e80c1d4c7e1a4dc5d2a817ab5f49a5e0",
+        "dest-filename": "65b5ce0b55d30a1ecac57b830634fa7486a0c50355a9b778c4d601323379ca52f3a23bfffd3e17996477d845f625e80c1d4c7e1a4dc5d2a817ab5f49a5e0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+        "sha512": "fdcfc31b26ecf79597352f32dd38bfcada844e25bb114e383042ae0807293eda3762341bc8adc841529f17a9db8210fb11c2d41a5d0d6e22f946de433219f9b6",
+        "dest-filename": "c31b26ecf79597352f32dd38bfcada844e25bb114e383042ae0807293eda3762341bc8adc841529f17a9db8210fb11c2d41a5d0d6e22f946de433219f9b6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/cf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+        "sha512": "142de75005a1bc5a2eb658409201dff1fe47c055942fa6d876f2dcfd34eec4a96f2e2dfea4fcdd66214a496cff3c5df44c1d4ad7d4ae0b10d323929ca80489a8",
+        "dest-filename": "e75005a1bc5a2eb658409201dff1fe47c055942fa6d876f2dcfd34eec4a96f2e2dfea4fcdd66214a496cff3c5df44c1d4ad7d4ae0b10d323929ca80489a8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/2d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+        "sha512": "21b16c15bc4c58bb8a11b1feeec4e42b32fa349986daf472cba2bb249a39e70fbcc4393b4449589fac6f5ed0d6f0709fa0a0452baf5fde980125251240fafee1",
+        "dest-filename": "6c15bc4c58bb8a11b1feeec4e42b32fa349986daf472cba2bb249a39e70fbcc4393b4449589fac6f5ed0d6f0709fa0a0452baf5fde980125251240fafee1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/b1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+        "sha512": "0b016ae36ad7091f136088c87e95c26d15f4ae9d63a3a70f2143d2696c336d523868e7d7f7a39763c33a28d9ad3dc83b42361e0e637e0c3d16a772da04e2dfe1",
+        "dest-filename": "6ae36ad7091f136088c87e95c26d15f4ae9d63a3a70f2143d2696c336d523868e7d7f7a39763c33a28d9ad3dc83b42361e0e637e0c3d16a772da04e2dfe1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/01"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+        "sha512": "727ab96eb258ad2676085e9cdf97829af88837793745cce61f3f1e61a56535ab15aac358f892a885953930a99a388f8a92594277338a29d3ecefad9508f0b6d2",
+        "dest-filename": "b96eb258ad2676085e9cdf97829af88837793745cce61f3f1e61a56535ab15aac358f892a885953930a99a388f8a92594277338a29d3ecefad9508f0b6d2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/7a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+        "sha512": "bc2453ef23f7cd7f9b29615e3ffcdd4ba4aa75607c388a5a46afe66d74314c61e7231b2946d8a0a6451c0cc95208e7a3947a302ea208ecad8929ebf0c913f6ae",
+        "dest-filename": "53ef23f7cd7f9b29615e3ffcdd4ba4aa75607c388a5a46afe66d74314c61e7231b2946d8a0a6451c0cc95208e7a3947a302ea208ecad8929ebf0c913f6ae",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/24"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+        "sha512": "c98c7ef23c28c14b2d55da2b70c74d9739252d884fc639e21d614a811a87ec81655046b4526bb72ae62995fd47519678db67b7354f45e0b19bfb83b429d71a6a",
+        "dest-filename": "7ef23c28c14b2d55da2b70c74d9739252d884fc639e21d614a811a87ec81655046b4526bb72ae62995fd47519678db67b7354f45e0b19bfb83b429d71a6a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/8c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+        "sha512": "7a080329a9c9b3352d09d955b34441fa1df9c0d95be6fe1358492ae2f65c995b79bbf1e20d9ad35ded9b5854147b3dd180d1f0c7fc78b24e7efb83524a270a93",
+        "dest-filename": "0329a9c9b3352d09d955b34441fa1df9c0d95be6fe1358492ae2f65c995b79bbf1e20d9ad35ded9b5854147b3dd180d1f0c7fc78b24e7efb83524a270a93",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+        "sha512": "9408727262a754eb9160db51b5ab504752cf41fda86029111a44859ec78300a3e5f25bb948eb0afded6c5dee5ad0f7399072077ba3f623f8a59ed36fdb17f770",
+        "dest-filename": "727262a754eb9160db51b5ab504752cf41fda86029111a44859ec78300a3e5f25bb948eb0afded6c5dee5ad0f7399072077ba3f623f8a59ed36fdb17f770",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+        "sha512": "c62a8c411e3101e1d3b81f6e5a6f9f1517083a02813223813fe7978b24fb8ec8150aad5b915ca0b74d28012a3007b11db6938769a3e02adf35d8ff5a6fe0c328",
+        "dest-filename": "8c411e3101e1d3b81f6e5a6f9f1517083a02813223813fe7978b24fb8ec8150aad5b915ca0b74d28012a3007b11db6938769a3e02adf35d8ff5a6fe0c328",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/2a"
+    },
+    {
+        "type": "inline",
+        "contents": "0d176da104ef4b1a2283ee79e8648bdfa37e6b2e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz\", \"integrity\": \"sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==\", \"time\": 0, \"size\": 3889601, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba9324c3d9055b6a2eaa4cef7f7f8737fa25f87553078c06cd0554491d5c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/29"
+    },
+    {
+        "type": "inline",
+        "contents": "17490cd63f93e9f77f8fa81d25a1c08f130572b0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz\", \"integrity\": \"sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==\", \"time\": 0, \"size\": 3662652, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7d06f9bf30c33964acb5d6c85ee822b65cdd41a3114ec446413f17570fec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/c5"
+    },
+    {
+        "type": "inline",
+        "contents": "23c32b5a2091f5dbe6163aa5e4eb93736d36de2d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz\", \"integrity\": \"sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==\", \"time\": 0, \"size\": 3575680, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1f79fdf11992ae6e62eca93507da293eeff8d9dc128ef5a742db4e66b93c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/11"
+    },
+    {
+        "type": "inline",
+        "contents": "3ee27f1dd07cb672bd4e413b8d5d0ce239b34a2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz\", \"integrity\": \"sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==\", \"time\": 0, \"size\": 3753063, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "81170d643251830cd99f3e5d3fceff3c208ef57ad884b885e7e0b1ecd9a2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/0e"
+    },
+    {
+        "type": "inline",
+        "contents": "46d21cfc8fbd15fb1113b26e070b40abdedd13d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz\", \"integrity\": \"sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==\", \"time\": 0, \"size\": 3256720, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "238fa74eaa0b17e1f9eb3eb1083d2dd6f92fff7468631fcd4bf918f40ac7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "5f5a1bd25c87724a8423d9849ca14dc2279921df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz\", \"integrity\": \"sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==\", \"time\": 0, \"size\": 3820905, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e4a76aa854423ce0acc1ba080425d6f46699c011b54c5740dec1c8509424",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/c3"
+    },
+    {
+        "type": "inline",
+        "contents": "6a864c9aa6f7e309085c2a370b0b027f17417889\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz\", \"integrity\": \"sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==\", \"time\": 0, \"size\": 3821303, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "72e4aeb9b23e611a491025f1ba7f7b54c2f9e7680dd6c909f84610e43ae6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/c3"
+    },
+    {
+        "type": "inline",
+        "contents": "86aad81330d29bf188597439731190d95aa2884b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz\", \"integrity\": \"sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==\", \"time\": 0, \"size\": 3811572, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "56830701c6108076a11607a3045de3f38cc96177be3268a41674f8622c76",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "96976d7a8748c3fa75e01095c309beaf513fe94a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz\", \"integrity\": \"sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==\", \"time\": 0, \"size\": 3579674, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d9a1d8fd02024dd9d76902cac350a5b098c3be75ffe8a0fe051a904cc007",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/94"
+    },
+    {
+        "type": "inline",
+        "contents": "ad6ba2906dfb06fb000296c94179b367ab14f5f0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz\", \"integrity\": \"sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==\", \"time\": 0, \"size\": 3516374, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "103ec2094eb664f07077059b144b07b662933607fc85b2bcafa96811fc77",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/6a"
+    },
+    {
+        "type": "inline",
+        "contents": "afc3bdd5f7742b61ca40d12891555bf0abd5df36\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz\", \"integrity\": \"sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==\", \"time\": 0, \"size\": 3940951, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0131ce5480d07196f54557f6a80fcaf67538930657e8bee6739c7cfbd22c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/44"
+    },
+    {
+        "type": "inline",
+        "contents": "b352cb3586103212e6c975c445736c2af45500cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz\", \"integrity\": \"sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==\", \"time\": 0, \"size\": 22066, \"metadata\": {\"url\": \"https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0a5d928eccd3d26024823f03c4c2dec41e70a31fa5def48d65dc75dd2cb6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/75"
+    },
+    {
+        "type": "inline",
+        "contents": "ce3f44eb86014b923e78a10889735c2641ffad4f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz\", \"integrity\": \"sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==\", \"time\": 0, \"size\": 3810886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "782787592a901ce06d5b7869a4f8ec22c842d862db4867d4185dc37ec6d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/73"
+    },
+    {
+        "type": "inline",
+        "contents": "d1629472a2a5b050cb78dcb14df1b49e07e6b794\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz\", \"integrity\": \"sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==\", \"time\": 0, \"size\": 3729962, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b1bee5755ea547606ca8b2c1062fb94921f88d0f91107fc45b49691a320a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/94/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "d4943fddd8d30e31a5b8d10ca719fcb908cce4fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz\", \"integrity\": \"sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==\", \"time\": 0, \"size\": 2908706, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5ef4594d9f101977ad1bfed5e06f6eb9eea8dbdae808c1100a640bfdfde0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/35"
+    },
+    {
+        "type": "inline",
+        "contents": "dc7830fbefb97276ccb51ba1df632841df7a5f42\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz\", \"integrity\": \"sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==\", \"time\": 0, \"size\": 3541878, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "649687b34632daa9ed3819e3b0cd4c052a818752bbac348edac76a8feaff",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/a7"
+    },
+    {
+        "type": "inline",
+        "contents": "e10217881ba9eeb828fe67dbbfc804d3cd1f30c2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz\", \"integrity\": \"sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==\", \"time\": 0, \"size\": 3559010, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bbcb84b76562584783fd3dfef002972e2ce40c2ab13e3a976516d23c462b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/84"
+    },
+    {
+        "type": "inline",
+        "contents": "ecc2dff3afb056a92116273379d9926d457f5c1b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz\", \"integrity\": \"sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==\", \"time\": 0, \"size\": 3457641, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1ac2c23770f76218882ba44354915bf17189ffbadda43173bc2dbaa3b8aa",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/27"
+    },
+    {
+        "type": "inline",
+        "contents": "eedd0d687b263046a7e7f183833e8fcbaf7bc349\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz\", \"integrity\": \"sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==\", \"time\": 0, \"size\": 2908692, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9477aa70c360252d1dfe44ad20b4c4d977fa829febab9e1984fd318099b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/be"
+    },
+    {
+        "type": "inline",
+        "contents": "f7338677059702030b611c3713de2cfa5510c029\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz\", \"integrity\": \"sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==\", \"time\": 0, \"size\": 3716495, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "22bb0a7e7be8f480c40c5ff04349612541673fc59e4a6f203c9cfee7d09e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/45"
+    },
+    {
+        "type": "inline",
+        "contents": "f74986c20d2bac99a377832fb877aaa028961c5a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz\", \"integrity\": \"sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==\", \"time\": 0, \"size\": 3455260, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9485a3f679f77dec109927f92acef22a55c53fc5cbdc7012cdbb2351b501",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "f9b933f316e2fcf212dc9adebbda2409a32b274d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz\", \"integrity\": \"sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==\", \"time\": 0, \"size\": 3411527, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2daef502ff4f001eb5b6cd420a56ded17b45d29203d36ae21e645ce2eaec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/a4"
+    },
+    {
+        "type": "script",
+        "commands": [],
+        "dest-filename": "patch.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "$FLATPAK_BUILDER_BUILDDIR/flatpak-node/patch.sh"
+        ],
+        "dest-filename": "patch-all.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "version=$(node --version | sed \"s/^v//\")",
+            "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+            "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+            "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+            "echo 9 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+        ],
+        "dest-filename": "setup_sdk_node_headers.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "FLATPAK_BUILDER_BUILDDIR=$PWD flatpak-node/patch-all.sh",
+            "bash flatpak-node/setup_sdk_node_headers.sh"
+        ]
+    }
+]


### PR DESCRIPTION
Creates a new SDK extension for the TypeScript programming language. Installs the binaries for `tsc` and `tsserver`.

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.

Unsure how the following apply to SDK extensions:

- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub.
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x]  Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
