### PR TITLE
Write comment when not targeting the `new-pr` branch

### DIFF
--- a/.github/workflows/wrong-branch-comment.yaml
+++ b/.github/workflows/wrong-branch-comment.yaml
@@ -1,0 +1,25 @@
+name: Check PR branch
+
+on: 
+  pull_request:
+    types:
+      - opened
+    branches-ignore:
+      - new-pr
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check_pr_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.FLATHUBBOT_TOKEN }}
+          message: |
+            It looks like you made your PR not against the `new-pr` branch. If you want to submit a App, you must target the `new-pr` branch.


### PR DESCRIPTION
As there a lot of of PR's accidental targeting the wrong branch. I think it's a good idea to 
automatically add a comment, if that happens.