### PR TITLE
drumgizmo manifest

### DIFF
--- a/org.freedesktop.LinuxAudio.Plugins.drumgizmo.json
+++ b/org.freedesktop.LinuxAudio.Plugins.drumgizmo.json
@@ -1,0 +1,52 @@
+{
+    "id": "org.freedesktop.LinuxAudio.Plugins.drumgizmo",
+    "branch": "22.08",
+    "runtime": "org.freedesktop.LinuxAudio.BaseExtension",
+    "runtime-version": "stable",
+    "sdk": "org.freedesktop.Sdk//22.08",
+    "build-extension": true,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/extensions/Plugins/drumgizmo",
+        "prepend-pkg-config-path": "/app/extensions/Plugins/drumgizmo/lib/pkgconfig"
+    },
+    "modules": [
+        "shared-modules/linux-audio/lv2.json",
+        {
+            "name": "drumgizmo",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://www.drumgizmo.org/releases/drumgizmo-0.9.20/drumgizmo-0.9.20.tar.gz",
+                    "sha256": "005f2040b881dbd8fdeb7b88f384f2347202d2ac0458e0aa999214586abc576a"
+                },
+                {
+                    "type": "file",
+                    "path": "org.freedesktop.LinuxAudio.Plugins.drumgizmo.metainfo.xml"
+                }
+            ],
+            "build-options": {
+                "env": {
+                    "CPPFLAGS": "-I/app/extensions/Plugins/drumgizmo/include"
+                }
+            },
+            "config-opts": [
+                "--prefix=/app/extensions/Plugins/drumgizmo",
+                "--enable-lv2",
+                "--disable-cli",
+                "--with-lv2dir=/app/extensions/Plugins/drumgizmo/lv2"
+            ],
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib",
+                "/share"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.freedesktop.LinuxAudio.Plugins.drumgizmo.metainfo.xml",
+                "appstream-compose --basename=org.freedesktop.LinuxAudio.Plugins.drumgizmo --prefix=${FLATPAK_DEST} --origin=flatpak org.freedesktop.LinuxAudio.Plugins.drumgizmo",
+                "install -Dm644 -t ${FLATPAK_DEST}/share/licenses/drumgizmo COPYING"
+            ]
+        }
+    ]
+}

--- a/org.freedesktop.LinuxAudio.Plugins.drumgizmo.metainfo.xml
+++ b/org.freedesktop.LinuxAudio.Plugins.drumgizmo.metainfo.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.juanelas.LinuxAudio.Plugins.drumgizmo</id>
+  <extends>org.freedesktop.LinuxAudio.BaseExtension</extends>
+  <name>drumgizmo.lv2</name>
+  <summary>Drumgizmo LV2 plugin</summary>
+  <description>
+    <p>
+      Flatpack version of drumgizmo using org.freedesktop.LinuxAudio.BaseExtension available in flathub. It can be used to make drumgizmo LV2 plugin available for the flathub's versions of Ardour and/or Bitwig
+    </p>
+    <p>
+      DrumGizmo is an open source, multichannel, multilayered, cross-platform drum plugin and stand-alone application. It enables you to compose drums in midi and mix them with a multichannel approach. It is comparable to that of mixing a real drumkit that has been recorded with a multimic setup.
+    </p>
+    <p>
+    Features include:
+    </p>
+    <ul>
+      <li>Stand-alone, Lv2 and VSTi versions available</li>
+      <li>Open drumkit file format, allowing the community to create their own drumkits</li>
+      <li>Drum velocity, allowing for several different hit velocities for each drum</li>
+      <li>Multichannel output, making it possible to mix it just the way you would a real drumkit</li>
+      <li>Optional built-in humanizer, analyzing the midi notes, adjusting velocities on-the-fly</li>
+      <li>Stand-alone midi renderer, generating .wav files, 1 for each channel</li>
+      <li>Stand-alone midi input, making it possible to use DrumGizmo as a software sampler for an electronic drumkit</li>
+    </ul>
+    <p>Add a midi track to Ardour/BitWig and add the DrumGizmo plugin to this track. Open the GUI and select the drumkit and midimap to use (download them at <a href="https://www.drumgizmo.org/wiki/doku.php?id=kits">https://www.drumgizmo.org/wiki/doku.php?id=kits</a>). The drumkit is loaded in the background so it might take a while before it is fully ready to use.</p>
+    <p>Add 16 mono audio tracks or mono audio busses and connect the 16 output from the midi channel to each of these.</p>
+    <p>Important: The midi track has a 16 channel panner that is useless in the DrumGizmo context. Disable it by right clicking it in the channel strip and select “Bypass”. If you fail to do this DrumGizmo will seemingly only output to channel 5.</p>
+    <p>Add some midi notes to the DrumGizmo tracks and play away.</p>
+    <p>It is also possible to play the drums using the piano roll</p>
+  </description>
+  <url type="homepage">https://www.drumgizmo.org</url>
+  <project_license>GPL-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <releases>
+    <release date="2022-08-09" version="0.9.20" />
+  </releases>
+</component>


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** <https://www.drumgizmo.org/>
  - I'm not the main developer but I've contacted the founder, developer and lead programmer Bent Bisballe Nyeng (<deva@aasimon.org>) and agrees to publish the drumgizmo LV2 plugin as a flatpak in flathub. See conversation at <https://www.drumgizmo.org/irc-logs/drumgizmo.log.2023_08_15>
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge)..
  - Not sure about this one. We are just using the same kind of IDs other linuxaudio plugins are using (`org.freedesktop.LinuxAudio.Plugins.<plugin-name>`). It seems to be the way. However, we could switch to other domain by drumgizmo.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
