### PR TITLE
Add dev.serebit.Waycheck

### DIFF
--- a/dev.serebit.Waycheck.yml
+++ b/dev.serebit.Waycheck.yml
@@ -12,8 +12,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://gitlab.freedesktop.org/serebit/waycheck/-/archive/v0.1.2/waycheck-v0.1.2.tar.gz
-        sha256: 3bcf367ec9f89a98822f602171ec1e3ad2341b9a3c4144259b68c8ba629012bc
+        url: https://gitlab.freedesktop.org/serebit/waycheck/-/archive/v0.1.3/waycheck-v0.1.3.tar.gz
+        sha256: 5e7fa30ef7ff65f2bd8fe6036a6d035f564311c275461fc39c3480722252b674
         x-checker-data:
             type: anitya
             project-id: 369363

--- a/dev.serebit.Waycheck.yml
+++ b/dev.serebit.Waycheck.yml
@@ -1,0 +1,21 @@
+app-id: dev.serebit.Waycheck
+runtime: org.kde.Platform
+runtime-version: '6.5'
+sdk: org.kde.Sdk
+command: waycheck
+finish-args:
+  - --socket=fallback-x11 # only shows a message dialog on X11
+  - --socket=wayland
+  - --device=dri
+modules:
+  - name: waycheck
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/serebit/waycheck/-/archive/v0.1.2/waycheck-v0.1.2.tar.gz
+        sha256: 3bcf367ec9f89a98822f602171ec1e3ad2341b9a3c4144259b68c8ba629012bc
+        x-checker-data:
+            type: anitya
+            project-id: 369363
+            stable-only: true
+            url-template: https://gitlab.freedesktop.org/serebit/waycheck/-/archive/v$version/waycheck-v$version.tar.gz


### PR DESCRIPTION
Waycheck is a (very) simple GUI that displays the protocols that the current Wayland compositor implements. This is my first Flatpak and my first Flathub submission, so please go easy on me :)

### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
