### PR TITLE
Add io.raphamorim.Rio

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,0 +1,4987 @@
+[
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.17.crate",
+        "sha256": "04a9283dace1c41c265496614998d5b9c4a97b3eb770e804f007c5144bf03f2b",
+        "dest": "cargo/vendor/ab_glyph-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04a9283dace1c41c265496614998d5b9c4a97b3eb770e804f007c5144bf03f2b\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ab_glyph_rasterizer/ab_glyph_rasterizer-0.1.7.crate",
+        "sha256": "330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6",
+        "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6\", \"files\": {}}",
+        "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/addr2line/addr2line-0.19.0.crate",
+        "sha256": "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97",
+        "dest": "cargo/vendor/addr2line-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97\", \"files\": {}}",
+        "dest": "cargo/vendor/addr2line-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler/adler-1.0.2.crate",
+        "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
+        "dest": "cargo/vendor/adler-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe\", \"files\": {}}",
+        "dest": "cargo/vendor/adler-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler32/adler32-1.2.0.crate",
+        "sha256": "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234",
+        "dest": "cargo/vendor/adler32-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234\", \"files\": {}}",
+        "dest": "cargo/vendor/adler32-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ahash/ahash-0.7.6.crate",
+        "sha256": "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47",
+        "dest": "cargo/vendor/ahash-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ahash/ahash-0.8.3.crate",
+        "sha256": "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f",
+        "dest": "cargo/vendor/ahash-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-0.7.20.crate",
+        "sha256": "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac",
+        "dest": "cargo/vendor/aho-corasick-0.7.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac\", \"files\": {}}",
+        "dest": "cargo/vendor/aho-corasick-0.7.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android-activity/android-activity-0.5.0-beta.1.crate",
+        "sha256": "934936a9ad4dc79563cd6644fcef68dc328f105d927679454de39ad03ca1cfe8",
+        "dest": "cargo/vendor/android-activity-0.5.0-beta.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"934936a9ad4dc79563cd6644fcef68dc328f105d927679454de39ad03ca1cfe8\", \"files\": {}}",
+        "dest": "cargo/vendor/android-activity-0.5.0-beta.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android-properties/android-properties-0.2.2.crate",
+        "sha256": "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04",
+        "dest": "cargo/vendor/android-properties-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04\", \"files\": {}}",
+        "dest": "cargo/vendor/android-properties-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
+        "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+        "dest": "cargo/vendor/android_system_properties-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311\", \"files\": {}}",
+        "dest": "cargo/vendor/android_system_properties-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anes/anes-0.1.6.crate",
+        "sha256": "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299",
+        "dest": "cargo/vendor/anes-0.1.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299\", \"files\": {}}",
+        "dest": "cargo/vendor/anes-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstream/anstream-0.3.2.crate",
+        "sha256": "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163",
+        "dest": "cargo/vendor/anstream-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163\", \"files\": {}}",
+        "dest": "cargo/vendor/anstream-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle/anstyle-1.0.0.crate",
+        "sha256": "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d",
+        "dest": "cargo/vendor/anstyle-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-parse/anstyle-parse-0.2.0.crate",
+        "sha256": "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee",
+        "dest": "cargo/vendor/anstyle-parse-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-parse-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-query/anstyle-query-1.0.0.crate",
+        "sha256": "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b",
+        "dest": "cargo/vendor/anstyle-query-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-query-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anstyle-wincon/anstyle-wincon-1.0.1.crate",
+        "sha256": "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188",
+        "dest": "cargo/vendor/anstyle-wincon-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188\", \"files\": {}}",
+        "dest": "cargo/vendor/anstyle-wincon-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/approx/approx-0.5.1.crate",
+        "sha256": "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6",
+        "dest": "cargo/vendor/approx-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6\", \"files\": {}}",
+        "dest": "cargo/vendor/approx-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.4.crate",
+        "sha256": "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711",
+        "dest": "cargo/vendor/arrayvec-0.7.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711\", \"files\": {}}",
+        "dest": "cargo/vendor/arrayvec-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/as-raw-xcb-connection/as-raw-xcb-connection-1.0.0.crate",
+        "sha256": "2d5f312b0a56c5cdf967c0aeb67f6289603354951683bc97ddc595ab974ba9aa",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d5f312b0a56c5cdf967c0aeb67f6289603354951683bc97ddc595ab974ba9aa\", \"files\": {}}",
+        "dest": "cargo/vendor/as-raw-xcb-connection-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ash/ash-0.37.3+1.3.251.crate",
+        "sha256": "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a",
+        "dest": "cargo/vendor/ash-0.37.3+1.3.251"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a\", \"files\": {}}",
+        "dest": "cargo/vendor/ash-0.37.3+1.3.251",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.1.crate",
+        "sha256": "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3",
+        "dest": "cargo/vendor/atomic-waker-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic-waker-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
+        "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+        "dest": "cargo/vendor/autocfg-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.67.crate",
+        "sha256": "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca",
+        "dest": "cargo/vendor/backtrace-0.3.67"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca\", \"files\": {}}",
+        "dest": "cargo/vendor/backtrace-0.3.67",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.21.0.crate",
+        "sha256": "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a",
+        "dest": "cargo/vendor/base64-0.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-set/bit-set-0.5.3.crate",
+        "sha256": "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1",
+        "dest": "cargo/vendor/bit-set-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-set-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-vec/bit-vec-0.6.3.crate",
+        "sha256": "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb",
+        "dest": "cargo/vendor/bit-vec-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-vec-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit_field/bit_field-0.10.2.crate",
+        "sha256": "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61",
+        "dest": "cargo/vendor/bit_field-0.10.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61\", \"files\": {}}",
+        "dest": "cargo/vendor/bit_field-0.10.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+        "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "dest": "cargo/vendor/bitflags-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.3.3.crate",
+        "sha256": "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42",
+        "dest": "cargo/vendor/bitflags-2.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block/block-0.1.6.crate",
+        "sha256": "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a",
+        "dest": "cargo/vendor/block-0.1.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a\", \"files\": {}}",
+        "dest": "cargo/vendor/block-0.1.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block-sys/block-sys-0.0.4.crate",
+        "sha256": "078aa3a3535876bebff823280f99839535c406a34438b2a877106db45ae53575",
+        "dest": "cargo/vendor/block-sys-0.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"078aa3a3535876bebff823280f99839535c406a34438b2a877106db45ae53575\", \"files\": {}}",
+        "dest": "cargo/vendor/block-sys-0.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block-sys/block-sys-0.2.0.crate",
+        "sha256": "2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92",
+        "dest": "cargo/vendor/block-sys-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2dd7cf50912cddc06dc5ea7c08c5e81c1b2c842a70d19def1848d54c586fed92\", \"files\": {}}",
+        "dest": "cargo/vendor/block-sys-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block2/block2-0.2.0-alpha.4.crate",
+        "sha256": "602e30baab86355a0ec4c99e65fa350cc4b92d8d3d404f8ecf4683e59e462325",
+        "dest": "cargo/vendor/block2-0.2.0-alpha.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"602e30baab86355a0ec4c99e65fa350cc4b92d8d3d404f8ecf4683e59e462325\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.2.0-alpha.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block2/block2-0.3.0.crate",
+        "sha256": "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68",
+        "dest": "cargo/vendor/block2-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.11.1.crate",
+        "sha256": "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba",
+        "dest": "cargo/vendor/bumpalo-3.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.14.0.crate",
+        "sha256": "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6",
+        "dest": "cargo/vendor/bytemuck-1.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.4.1.crate",
+        "sha256": "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192",
+        "dest": "cargo/vendor/bytemuck_derive-1.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck_derive-1.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder/byteorder-1.4.3.crate",
+        "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
+        "dest": "cargo/vendor/byteorder-1.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-1.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-0.3.0.crate",
+        "sha256": "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27",
+        "dest": "cargo/vendor/bytes-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-1.4.0.crate",
+        "sha256": "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be",
+        "dest": "cargo/vendor/bytes-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/calloop/calloop-0.10.6.crate",
+        "sha256": "52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8",
+        "dest": "cargo/vendor/calloop-0.10.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52e0d00eb1ea24371a97d2da6201c6747a633dc6dc1988ef503403b4c59504a8\", \"files\": {}}",
+        "dest": "cargo/vendor/calloop-0.10.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cast/cast-0.3.0.crate",
+        "sha256": "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5",
+        "dest": "cargo/vendor/cast-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5\", \"files\": {}}",
+        "dest": "cargo/vendor/cast-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cc/cc-1.0.73.crate",
+        "sha256": "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11",
+        "dest": "cargo/vendor/cc-1.0.73"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.0.73",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate",
+        "sha256": "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c",
+        "dest": "cargo/vendor/cesu8-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
+        "dest": "cargo/vendor/cesu8-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-0.1.10.crate",
+        "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
+        "dest": "cargo/vendor/cfg-if-0.1.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate",
+        "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "dest": "cargo/vendor/cfg-if-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.1.1.crate",
+        "sha256": "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ciborium/ciborium-0.2.1.crate",
+        "sha256": "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926",
+        "dest": "cargo/vendor/ciborium-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926\", \"files\": {}}",
+        "dest": "cargo/vendor/ciborium-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ciborium-io/ciborium-io-0.2.1.crate",
+        "sha256": "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656",
+        "dest": "cargo/vendor/ciborium-io-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656\", \"files\": {}}",
+        "dest": "cargo/vendor/ciborium-io-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ciborium-ll/ciborium-ll-0.2.1.crate",
+        "sha256": "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b",
+        "dest": "cargo/vendor/ciborium-ll-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b\", \"files\": {}}",
+        "dest": "cargo/vendor/ciborium-ll-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap/clap-4.3.4.crate",
+        "sha256": "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed",
+        "dest": "cargo/vendor/clap-4.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed\", \"files\": {}}",
+        "dest": "cargo/vendor/clap-4.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_builder/clap_builder-4.3.4.crate",
+        "sha256": "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636",
+        "dest": "cargo/vendor/clap_builder-4.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_builder-4.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_derive/clap_derive-4.3.2.crate",
+        "sha256": "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f",
+        "dest": "cargo/vendor/clap_derive-4.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_derive-4.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.5.0.crate",
+        "sha256": "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b",
+        "dest": "cargo/vendor/clap_lex-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b\", \"files\": {}}",
+        "dest": "cargo/vendor/clap_lex-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clipboard-win/clipboard-win-3.1.1.crate",
+        "sha256": "9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342",
+        "dest": "cargo/vendor/clipboard-win-3.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9fdf5e01086b6be750428ba4a40619f847eb2e95756eee84b18e06e5f0b50342\", \"files\": {}}",
+        "dest": "cargo/vendor/clipboard-win-3.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/codespan-reporting/codespan-reporting-0.11.1.crate",
+        "sha256": "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e",
+        "dest": "cargo/vendor/codespan-reporting-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e\", \"files\": {}}",
+        "dest": "cargo/vendor/codespan-reporting-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/color_quant/color_quant-1.1.0.crate",
+        "sha256": "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b",
+        "dest": "cargo/vendor/color_quant-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b\", \"files\": {}}",
+        "dest": "cargo/vendor/color_quant-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/colorchoice/colorchoice-1.0.0.crate",
+        "sha256": "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7",
+        "dest": "cargo/vendor/colorchoice-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7\", \"files\": {}}",
+        "dest": "cargo/vendor/colorchoice-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/com-rs/com-rs-0.2.1.crate",
+        "sha256": "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642",
+        "dest": "cargo/vendor/com-rs-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642\", \"files\": {}}",
+        "dest": "cargo/vendor/com-rs-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/combine/combine-4.6.6.crate",
+        "sha256": "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4",
+        "dest": "cargo/vendor/combine-4.6.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4\", \"files\": {}}",
+        "dest": "cargo/vendor/combine-4.6.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/console_error_panic_hook/console_error_panic_hook-0.1.7.crate",
+        "sha256": "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc",
+        "dest": "cargo/vendor/console_error_panic_hook-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc\", \"files\": {}}",
+        "dest": "cargo/vendor/console_error_panic_hook-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/console_log/console_log-0.2.2.crate",
+        "sha256": "e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f",
+        "dest": "cargo/vendor/console_log-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e89f72f65e8501878b8a004d5a1afb780987e2ce2b4532c562e367a72c57499f\", \"files\": {}}",
+        "dest": "cargo/vendor/console_log-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/copypasta/copypasta-0.8.2.crate",
+        "sha256": "133fc8675ee3a4ec9aa513584deda9aa0faeda3586b87f7f0f2ba082c66fb172",
+        "dest": "cargo/vendor/copypasta-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"133fc8675ee3a4ec9aa513584deda9aa0faeda3586b87f7f0f2ba082c66fb172\", \"files\": {}}",
+        "dest": "cargo/vendor/copypasta-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.3.crate",
+        "sha256": "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146",
+        "dest": "cargo/vendor/core-foundation-0.9.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.9.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.3.crate",
+        "sha256": "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.22.3.crate",
+        "sha256": "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb",
+        "dest": "cargo/vendor/core-graphics-0.22.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.22.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.1.1.crate",
+        "sha256": "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b",
+        "dest": "cargo/vendor/core-graphics-types-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.3.2.crate",
+        "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
+        "dest": "cargo/vendor/crc32fast-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/criterion/criterion-0.5.1.crate",
+        "sha256": "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f",
+        "dest": "cargo/vendor/criterion-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f\", \"files\": {}}",
+        "dest": "cargo/vendor/criterion-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/criterion-plot/criterion-plot-0.5.0.crate",
+        "sha256": "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1",
+        "dest": "cargo/vendor/criterion-plot-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1\", \"files\": {}}",
+        "dest": "cargo/vendor/criterion-plot-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.8.crate",
+        "sha256": "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.2.crate",
+        "sha256": "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.11.crate",
+        "sha256": "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.12.crate",
+        "sha256": "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crunchy/crunchy-0.2.2.crate",
+        "sha256": "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7",
+        "dest": "cargo/vendor/crunchy-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7\", \"files\": {}}",
+        "dest": "cargo/vendor/crunchy-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cursor-icon/cursor-icon-1.0.0.crate",
+        "sha256": "740bb192a8e2d1350119916954f4409ee7f62f149b536911eeb78ba5a20526bf",
+        "dest": "cargo/vendor/cursor-icon-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"740bb192a8e2d1350119916954f4409ee7f62f149b536911eeb78ba5a20526bf\", \"files\": {}}",
+        "dest": "cargo/vendor/cursor-icon-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/d3d12/d3d12-0.7.0.crate",
+        "sha256": "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20",
+        "dest": "cargo/vendor/d3d12-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20\", \"files\": {}}",
+        "dest": "cargo/vendor/d3d12-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/deflate/deflate-1.0.0.crate",
+        "sha256": "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f",
+        "dest": "cargo/vendor/deflate-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f\", \"files\": {}}",
+        "dest": "cargo/vendor/deflate-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs/dirs-5.0.0.crate",
+        "sha256": "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd",
+        "dest": "cargo/vendor/dirs-5.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-5.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.4.0.crate",
+        "sha256": "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b",
+        "dest": "cargo/vendor/dirs-sys-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-sys-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dispatch/dispatch-0.2.0.crate",
+        "sha256": "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b",
+        "dest": "cargo/vendor/dispatch-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b\", \"files\": {}}",
+        "dest": "cargo/vendor/dispatch-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlib/dlib-0.5.2.crate",
+        "sha256": "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412",
+        "dest": "cargo/vendor/dlib-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412\", \"files\": {}}",
+        "dest": "cargo/vendor/dlib-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.0.crate",
+        "sha256": "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650",
+        "dest": "cargo/vendor/downcast-rs-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650\", \"files\": {}}",
+        "dest": "cargo/vendor/downcast-rs-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/either/either-1.8.0.crate",
+        "sha256": "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797",
+        "dest": "cargo/vendor/either-1.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/env_logger/env_logger-0.4.3.crate",
+        "sha256": "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b",
+        "dest": "cargo/vendor/env_logger-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b\", \"files\": {}}",
+        "dest": "cargo/vendor/env_logger-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/env_logger/env_logger-0.10.0.crate",
+        "sha256": "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0",
+        "dest": "cargo/vendor/env_logger-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0\", \"files\": {}}",
+        "dest": "cargo/vendor/env_logger-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno/errno-0.3.1.crate",
+        "sha256": "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a",
+        "dest": "cargo/vendor/errno-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno-dragonfly/errno-dragonfly-0.1.2.crate",
+        "sha256": "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf",
+        "dest": "cargo/vendor/errno-dragonfly-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-dragonfly-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/euclid/euclid-0.22.9.crate",
+        "sha256": "87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787",
+        "dest": "cargo/vendor/euclid-0.22.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87f253bc5c813ca05792837a0ff4b3a580336b224512d48f7eda1d7dd9210787\", \"files\": {}}",
+        "dest": "cargo/vendor/euclid-0.22.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/exr/exr-1.6.3.crate",
+        "sha256": "bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4",
+        "dest": "cargo/vendor/exr-1.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bdd2162b720141a91a054640662d3edce3d50a944a50ffca5313cd951abb35b4\", \"files\": {}}",
+        "dest": "cargo/vendor/exr-1.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.0.crate",
+        "sha256": "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10",
+        "dest": "cargo/vendor/fdeflate-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.21.crate",
+        "sha256": "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153",
+        "dest": "cargo/vendor/filetime-0.2.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flate2/flate2-1.0.24.crate",
+        "sha256": "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6",
+        "dest": "cargo/vendor/flate2-1.0.24"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.0.24",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flume/flume-0.10.14.crate",
+        "sha256": "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577",
+        "dest": "cargo/vendor/flume-0.10.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577\", \"files\": {}}",
+        "dest": "cargo/vendor/flume-0.10.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
+        "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+        "dest": "cargo/vendor/fnv-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
+        "dest": "cargo/vendor/fnv-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fontconfig-parser/fontconfig-parser-0.5.3.crate",
+        "sha256": "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4\", \"files\": {}}",
+        "dest": "cargo/vendor/fontconfig-parser-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.3.2.crate",
+        "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
+        "dest": "cargo/vendor/foreign-types-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
+        "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
+        "dest": "cargo/vendor/foreign-types-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
+        "sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
+        "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
+        "sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fsevent-sys/fsevent-sys-4.1.0.crate",
+        "sha256": "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2",
+        "dest": "cargo/vendor/fsevent-sys-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2\", \"files\": {}}",
+        "dest": "cargo/vendor/fsevent-sys-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fuchsia-cprng/fuchsia-cprng-0.1.1.crate",
+        "sha256": "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba",
+        "dest": "cargo/vendor/fuchsia-cprng-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba\", \"files\": {}}",
+        "dest": "cargo/vendor/fuchsia-cprng-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fuchsia-zircon/fuchsia-zircon-0.3.3.crate",
+        "sha256": "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82",
+        "dest": "cargo/vendor/fuchsia-zircon-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82\", \"files\": {}}",
+        "dest": "cargo/vendor/fuchsia-zircon-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fuchsia-zircon-sys/fuchsia-zircon-sys-0.3.3.crate",
+        "sha256": "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7",
+        "dest": "cargo/vendor/fuchsia-zircon-sys-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7\", \"files\": {}}",
+        "dest": "cargo/vendor/fuchsia-zircon-sys-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures/futures-0.3.28.crate",
+        "sha256": "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40",
+        "dest": "cargo/vendor/futures-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.28.crate",
+        "sha256": "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2",
+        "dest": "cargo/vendor/futures-channel-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.28.crate",
+        "sha256": "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c",
+        "dest": "cargo/vendor/futures-core-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.28.crate",
+        "sha256": "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0",
+        "dest": "cargo/vendor/futures-executor-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.28.crate",
+        "sha256": "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964",
+        "dest": "cargo/vendor/futures-io-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.28.crate",
+        "sha256": "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72",
+        "dest": "cargo/vendor/futures-macro-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.28.crate",
+        "sha256": "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e",
+        "dest": "cargo/vendor/futures-sink-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.28.crate",
+        "sha256": "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65",
+        "dest": "cargo/vendor/futures-task-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.28.crate",
+        "sha256": "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533",
+        "dest": "cargo/vendor/futures-util-0.3.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gethostname/gethostname-0.2.3.crate",
+        "sha256": "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e",
+        "dest": "cargo/vendor/gethostname-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gethostname/gethostname-0.3.0.crate",
+        "sha256": "bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177",
+        "dest": "cargo/vendor/gethostname-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bb65d4ba3173c56a500b555b532f72c42e8d1fe64962b518897f8959fae2c177\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.8.crate",
+        "sha256": "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31",
+        "dest": "cargo/vendor/getrandom-0.2.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gif/gif-0.12.0.crate",
+        "sha256": "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045",
+        "dest": "cargo/vendor/gif-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045\", \"files\": {}}",
+        "dest": "cargo/vendor/gif-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gimli/gimli-0.27.2.crate",
+        "sha256": "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4",
+        "dest": "cargo/vendor/gimli-0.27.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4\", \"files\": {}}",
+        "dest": "cargo/vendor/gimli-0.27.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glow/glow-0.12.3.crate",
+        "sha256": "ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728",
+        "dest": "cargo/vendor/glow-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca0fe580e4b60a8ab24a868bc08e2f03cbcb20d3d676601fa909386713333728\", \"files\": {}}",
+        "dest": "cargo/vendor/glow-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glyph_brush/glyph_brush-0.7.7.crate",
+        "sha256": "4edefd123f28a0b1d41ec4a489c2b43020b369180800977801611084f342978d",
+        "dest": "cargo/vendor/glyph_brush-0.7.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4edefd123f28a0b1d41ec4a489c2b43020b369180800977801611084f342978d\", \"files\": {}}",
+        "dest": "cargo/vendor/glyph_brush-0.7.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glyph_brush_draw_cache/glyph_brush_draw_cache-0.1.5.crate",
+        "sha256": "6010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610",
+        "dest": "cargo/vendor/glyph_brush_draw_cache-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610\", \"files\": {}}",
+        "dest": "cargo/vendor/glyph_brush_draw_cache-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glyph_brush_layout/glyph_brush_layout-0.2.3.crate",
+        "sha256": "cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38",
+        "dest": "cargo/vendor/glyph_brush_layout-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38\", \"files\": {}}",
+        "dest": "cargo/vendor/glyph_brush_layout-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gpu-alloc/gpu-alloc-0.6.0.crate",
+        "sha256": "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171",
+        "dest": "cargo/vendor/gpu-alloc-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171\", \"files\": {}}",
+        "dest": "cargo/vendor/gpu-alloc-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gpu-alloc-types/gpu-alloc-types-0.3.0.crate",
+        "sha256": "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4",
+        "dest": "cargo/vendor/gpu-alloc-types-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4\", \"files\": {}}",
+        "dest": "cargo/vendor/gpu-alloc-types-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gpu-allocator/gpu-allocator-0.22.0.crate",
+        "sha256": "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8",
+        "dest": "cargo/vendor/gpu-allocator-0.22.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8\", \"files\": {}}",
+        "dest": "cargo/vendor/gpu-allocator-0.22.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gpu-descriptor/gpu-descriptor-0.2.3.crate",
+        "sha256": "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a",
+        "dest": "cargo/vendor/gpu-descriptor-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a\", \"files\": {}}",
+        "dest": "cargo/vendor/gpu-descriptor-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gpu-descriptor-types/gpu-descriptor-types-0.1.1.crate",
+        "sha256": "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126",
+        "dest": "cargo/vendor/gpu-descriptor-types-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126\", \"files\": {}}",
+        "dest": "cargo/vendor/gpu-descriptor-types-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/guillotiere/guillotiere-0.6.2.crate",
+        "sha256": "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782",
+        "dest": "cargo/vendor/guillotiere-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782\", \"files\": {}}",
+        "dest": "cargo/vendor/guillotiere-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/half/half-1.8.2.crate",
+        "sha256": "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7",
+        "dest": "cargo/vendor/half-1.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7\", \"files\": {}}",
+        "dest": "cargo/vendor/half-1.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/half/half-2.2.1.crate",
+        "sha256": "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0",
+        "dest": "cargo/vendor/half-2.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0\", \"files\": {}}",
+        "dest": "cargo/vendor/half-2.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate",
+        "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+        "dest": "cargo/vendor/hashbrown-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hassle-rs/hassle-rs-0.10.0.crate",
+        "sha256": "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0",
+        "dest": "cargo/vendor/hassle-rs-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0\", \"files\": {}}",
+        "dest": "cargo/vendor/hassle-rs-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.4.1.crate",
+        "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+        "dest": "cargo/vendor/heck-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.19.crate",
+        "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+        "dest": "cargo/vendor/hermit-abi-0.1.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.1.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.3.2.crate",
+        "sha256": "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b",
+        "dest": "cargo/vendor/hermit-abi-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hexf-parse/hexf-parse-0.2.1.crate",
+        "sha256": "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df",
+        "dest": "cargo/vendor/hexf-parse-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df\", \"files\": {}}",
+        "dest": "cargo/vendor/hexf-parse-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/humantime/humantime-2.1.0.crate",
+        "sha256": "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4",
+        "dest": "cargo/vendor/humantime-2.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4\", \"files\": {}}",
+        "dest": "cargo/vendor/humantime-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icrate/icrate-0.0.4.crate",
+        "sha256": "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319",
+        "dest": "cargo/vendor/icrate-0.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319\", \"files\": {}}",
+        "dest": "cargo/vendor/icrate-0.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image/image-0.24.7.crate",
+        "sha256": "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711",
+        "dest": "cargo/vendor/image-0.24.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.24.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-1.9.3.crate",
+        "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+        "dest": "cargo/vendor/indexmap-1.9.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-1.9.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inotify/inotify-0.9.6.crate",
+        "sha256": "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff",
+        "dest": "cargo/vendor/inotify-0.9.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff\", \"files\": {}}",
+        "dest": "cargo/vendor/inotify-0.9.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inotify-sys/inotify-sys-0.1.5.crate",
+        "sha256": "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb",
+        "dest": "cargo/vendor/inotify-sys-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb\", \"files\": {}}",
+        "dest": "cargo/vendor/inotify-sys-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/io-lifetimes/io-lifetimes-1.0.11.crate",
+        "sha256": "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2",
+        "dest": "cargo/vendor/io-lifetimes-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2\", \"files\": {}}",
+        "dest": "cargo/vendor/io-lifetimes-1.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iovec/iovec-0.1.4.crate",
+        "sha256": "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e",
+        "dest": "cargo/vendor/iovec-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e\", \"files\": {}}",
+        "dest": "cargo/vendor/iovec-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-terminal/is-terminal-0.4.7.crate",
+        "sha256": "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f",
+        "dest": "cargo/vendor/is-terminal-0.4.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f\", \"files\": {}}",
+        "dest": "cargo/vendor/is-terminal-0.4.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.10.5.crate",
+        "sha256": "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473",
+        "dest": "cargo/vendor/itertools-0.10.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.10.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.6.crate",
+        "sha256": "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6",
+        "dest": "cargo/vendor/itoa-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni/jni-0.21.1.crate",
+        "sha256": "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97",
+        "dest": "cargo/vendor/jni-0.21.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.0.crate",
+        "sha256": "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130",
+        "dest": "cargo/vendor/jni-sys-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jobserver/jobserver-0.1.26.crate",
+        "sha256": "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2",
+        "dest": "cargo/vendor/jobserver-0.1.26"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2\", \"files\": {}}",
+        "dest": "cargo/vendor/jobserver-0.1.26",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jpeg-decoder/jpeg-decoder-0.3.0.crate",
+        "sha256": "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e",
+        "dest": "cargo/vendor/jpeg-decoder-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e\", \"files\": {}}",
+        "dest": "cargo/vendor/jpeg-decoder-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.64.crate",
+        "sha256": "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a",
+        "dest": "cargo/vendor/js-sys-0.3.64"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.64",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/khronos-egl/khronos-egl-4.1.0.crate",
+        "sha256": "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3",
+        "dest": "cargo/vendor/khronos-egl-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3\", \"files\": {}}",
+        "dest": "cargo/vendor/khronos-egl-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kqueue/kqueue-1.0.7.crate",
+        "sha256": "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98",
+        "dest": "cargo/vendor/kqueue-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98\", \"files\": {}}",
+        "dest": "cargo/vendor/kqueue-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kqueue-sys/kqueue-sys-1.0.3.crate",
+        "sha256": "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587",
+        "dest": "cargo/vendor/kqueue-sys-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587\", \"files\": {}}",
+        "dest": "cargo/vendor/kqueue-sys-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy-bytes-cast/lazy-bytes-cast-5.0.1.crate",
+        "sha256": "10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b",
+        "dest": "cargo/vendor/lazy-bytes-cast-5.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"10257499f089cd156ad82d0a9cd57d9501fa2c989068992a97eb3c27836f206b\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy-bytes-cast-5.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
+        "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        "dest": "cargo/vendor/lazy_static-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy_static-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazycell/lazycell-1.3.0.crate",
+        "sha256": "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55",
+        "dest": "cargo/vendor/lazycell-1.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55\", \"files\": {}}",
+        "dest": "cargo/vendor/lazycell-1.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lebe/lebe-0.5.2.crate",
+        "sha256": "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8",
+        "dest": "cargo/vendor/lebe-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8\", \"files\": {}}",
+        "dest": "cargo/vendor/lebe-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.148.crate",
+        "sha256": "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b",
+        "dest": "cargo/vendor/libc-0.2.148"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.148",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.7.3.crate",
+        "sha256": "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd",
+        "dest": "cargo/vendor/libloading-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.8.0.crate",
+        "sha256": "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb",
+        "dest": "cargo/vendor/libloading-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linked-hash-map/linked-hash-map-0.5.6.crate",
+        "sha256": "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f",
+        "dest": "cargo/vendor/linked-hash-map-0.5.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f\", \"files\": {}}",
+        "dest": "cargo/vendor/linked-hash-map-0.5.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.3.8.crate",
+        "sha256": "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.3.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.4.5.crate",
+        "sha256": "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.4.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.9.crate",
+        "sha256": "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df",
+        "dest": "cargo/vendor/lock_api-0.4.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.3.9.crate",
+        "sha256": "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b",
+        "dest": "cargo/vendor/log-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.4.20.crate",
+        "sha256": "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f",
+        "dest": "cargo/vendor/log-0.4.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
+        "sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
+        "dest": "cargo/vendor/malloc_buf-0.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb\", \"files\": {}}",
+        "dest": "cargo/vendor/malloc_buf-0.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memchr/memchr-2.5.0.crate",
+        "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
+        "dest": "cargo/vendor/memchr-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.5.8.crate",
+        "sha256": "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc",
+        "dest": "cargo/vendor/memmap2-0.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memmap2/memmap2-0.7.1.crate",
+        "sha256": "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6",
+        "dest": "cargo/vendor/memmap2-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6\", \"files\": {}}",
+        "dest": "cargo/vendor/memmap2-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.6.5.crate",
+        "sha256": "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce",
+        "dest": "cargo/vendor/memoffset-0.6.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.6.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.7.1.crate",
+        "sha256": "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4",
+        "dest": "cargo/vendor/memoffset-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/metal/metal-0.26.0.crate",
+        "sha256": "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318",
+        "dest": "cargo/vendor/metal-0.26.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318\", \"files\": {}}",
+        "dest": "cargo/vendor/metal-0.26.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
+        "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.5.4.crate",
+        "sha256": "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34",
+        "dest": "cargo/vendor/miniz_oxide-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.6.2.crate",
+        "sha256": "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa",
+        "dest": "cargo/vendor/miniz_oxide-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.7.1.crate",
+        "sha256": "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7",
+        "dest": "cargo/vendor/miniz_oxide-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mio/mio-0.8.6.crate",
+        "sha256": "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9",
+        "dest": "cargo/vendor/mio-0.8.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-0.8.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miow/miow-0.5.0.crate",
+        "sha256": "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123",
+        "dest": "cargo/vendor/miow-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123\", \"files\": {}}",
+        "dest": "cargo/vendor/miow-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/naga/naga-0.13.0.crate",
+        "sha256": "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e",
+        "dest": "cargo/vendor/naga-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e\", \"files\": {}}",
+        "dest": "cargo/vendor/naga-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nanorand/nanorand-0.7.0.crate",
+        "sha256": "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3",
+        "dest": "cargo/vendor/nanorand-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3\", \"files\": {}}",
+        "dest": "cargo/vendor/nanorand-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk/ndk-0.8.0-beta.0.crate",
+        "sha256": "49f58741784b0f6ac12311c3f6fbdb3c766a992f8914d035c77a07b5fd2940dc",
+        "dest": "cargo/vendor/ndk-0.8.0-beta.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49f58741784b0f6ac12311c3f6fbdb3c766a992f8914d035c77a07b5fd2940dc\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-0.8.0-beta.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate",
+        "sha256": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b",
+        "dest": "cargo/vendor/ndk-context-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-context-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.5.0-beta.0+25.2.9519653.crate",
+        "sha256": "ff38603775cba10d0f1141fab1b167df73662a0636a4b631c187fe11fb624042",
+        "dest": "cargo/vendor/ndk-sys-0.5.0-beta.0+25.2.9519653"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff38603775cba10d0f1141fab1b167df73662a0636a4b631c187fe11fb624042\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-sys-0.5.0-beta.0+25.2.9519653",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/net2/net2-0.2.39.crate",
+        "sha256": "b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac",
+        "dest": "cargo/vendor/net2-0.2.39"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b13b648036a2339d06de780866fbdfda0dde886de7b3af2ddeba8b14f4ee34ac\", \"files\": {}}",
+        "dest": "cargo/vendor/net2-0.2.39",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.24.2.crate",
+        "sha256": "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc",
+        "dest": "cargo/vendor/nix-0.24.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.24.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.25.1.crate",
+        "sha256": "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4",
+        "dest": "cargo/vendor/nix-0.25.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.25.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nix/nix-0.26.2.crate",
+        "sha256": "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a",
+        "dest": "cargo/vendor/nix-0.26.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a\", \"files\": {}}",
+        "dest": "cargo/vendor/nix-0.26.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-7.1.1.crate",
+        "sha256": "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36",
+        "dest": "cargo/vendor/nom-7.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-7.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/notify/notify-6.0.0.crate",
+        "sha256": "4d9ba6c734de18ca27c8cef5cd7058aa4ac9f63596131e4c7e41e579319032a2",
+        "dest": "cargo/vendor/notify-6.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d9ba6c734de18ca27c8cef5cd7058aa4ac9f63596131e4c7e41e579319032a2\", \"files\": {}}",
+        "dest": "cargo/vendor/notify-6.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.45.crate",
+        "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
+        "dest": "cargo/vendor/num-integer-0.1.45"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.45",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-rational/num-rational-0.4.1.crate",
+        "sha256": "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0",
+        "dest": "cargo/vendor/num-rational-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0\", \"files\": {}}",
+        "dest": "cargo/vendor/num-rational-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.15.crate",
+        "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
+        "dest": "cargo/vendor/num-traits-0.2.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_cpus/num_cpus-1.13.1.crate",
+        "sha256": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1",
+        "dest": "cargo/vendor/num_cpus-1.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1\", \"files\": {}}",
+        "dest": "cargo/vendor/num_cpus-1.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.0.crate",
+        "sha256": "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb",
+        "dest": "cargo/vendor/num_enum-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.0.crate",
+        "sha256": "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597",
+        "dest": "cargo/vendor/num_enum_derive-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum_derive-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc/objc-0.2.7.crate",
+        "sha256": "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1",
+        "dest": "cargo/vendor/objc-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc-foundation/objc-foundation-0.1.1.crate",
+        "sha256": "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9",
+        "dest": "cargo/vendor/objc-foundation-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-foundation-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.2.0-beta.0.crate",
+        "sha256": "d7cb23a031fed7d6cb8f2d03b04b981d1b7cfe56dc3d0ad5fb1d8daab67d0e26",
+        "dest": "cargo/vendor/objc-sys-0.2.0-beta.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d7cb23a031fed7d6cb8f2d03b04b981d1b7cfe56dc3d0ad5fb1d8daab67d0e26\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-sys-0.2.0-beta.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc-sys/objc-sys-0.3.1.crate",
+        "sha256": "99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845",
+        "dest": "cargo/vendor/objc-sys-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"99e1d07c6eab1ce8b6382b8e3c7246fe117ff3f8b34be065f5ebace6749fe845\", \"files\": {}}",
+        "dest": "cargo/vendor/objc-sys-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2/objc2-0.3.0-beta.0.crate",
+        "sha256": "f325aba6a304899c08c8db71e40d86e58b54d70febfe22212c23ab8a732e6267",
+        "dest": "cargo/vendor/objc2-0.3.0-beta.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f325aba6a304899c08c8db71e40d86e58b54d70febfe22212c23ab8a732e6267\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.3.0-beta.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2/objc2-0.4.1.crate",
+        "sha256": "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d",
+        "dest": "cargo/vendor/objc2-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-2.0.0-pre.0.crate",
+        "sha256": "f345f5981fb5b9f68c5f3ec79efd8a9fb01385d199fa0eff9ed739d854e321ea",
+        "dest": "cargo/vendor/objc2-encode-2.0.0-pre.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f345f5981fb5b9f68c5f3ec79efd8a9fb01385d199fa0eff9ed739d854e321ea\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-2.0.0-pre.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-3.0.0.crate",
+        "sha256": "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666",
+        "dest": "cargo/vendor/objc2-encode-3.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-3.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.2.0-alpha.5.crate",
+        "sha256": "eeca4b9f5cb162b14fd3da3f8efe8424b7550dc8bb255515ec8441d65a1738d0",
+        "dest": "cargo/vendor/objc2-foundation-0.2.0-alpha.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eeca4b9f5cb162b14fd3da3f8efe8424b7550dc8bb255515ec8441d65a1738d0\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-foundation-0.2.0-alpha.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc_exception/objc_exception-0.1.2.crate",
+        "sha256": "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4",
+        "dest": "cargo/vendor/objc_exception-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4\", \"files\": {}}",
+        "dest": "cargo/vendor/objc_exception-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc_id/objc_id-0.1.1.crate",
+        "sha256": "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b",
+        "dest": "cargo/vendor/objc_id-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b\", \"files\": {}}",
+        "dest": "cargo/vendor/objc_id-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/object/object-0.30.3.crate",
+        "sha256": "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439",
+        "dest": "cargo/vendor/object-0.30.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439\", \"files\": {}}",
+        "dest": "cargo/vendor/object-0.30.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.18.0.crate",
+        "sha256": "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d",
+        "dest": "cargo/vendor/once_cell-1.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/oorandom/oorandom-11.1.3.crate",
+        "sha256": "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575",
+        "dest": "cargo/vendor/oorandom-11.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575\", \"files\": {}}",
+        "dest": "cargo/vendor/oorandom-11.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/orbclient/orbclient-0.3.43.crate",
+        "sha256": "974465c5e83cf9df05c1e4137b271d29035c902e39e5ad4c1939837e22160af8",
+        "dest": "cargo/vendor/orbclient-0.3.43"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"974465c5e83cf9df05c1e4137b271d29035c902e39e5ad4c1939837e22160af8\", \"files\": {}}",
+        "dest": "cargo/vendor/orbclient-0.3.43",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-float/ordered-float-3.3.0.crate",
+        "sha256": "1f74e330193f90ec45e2b257fa3ef6df087784157ac1ad2c1e71c62837b03aa7",
+        "dest": "cargo/vendor/ordered-float-3.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1f74e330193f90ec45e2b257fa3ef6df087784157ac1ad2c1e71c62837b03aa7\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-float-3.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-float/ordered-float-4.1.0.crate",
+        "sha256": "e3a540f3e3b3d7929c884e46d093d344e4e5bdeed54d08bf007df50c93cc85d5",
+        "dest": "cargo/vendor/ordered-float-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3a540f3e3b3d7929c884e46d093d344e4e5bdeed54d08bf007df50c93cc85d5\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-float-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.15.2.crate",
+        "sha256": "05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb",
+        "dest": "cargo/vendor/owned_ttf_parser-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb\", \"files\": {}}",
+        "dest": "cargo/vendor/owned_ttf_parser-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.1.crate",
+        "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
+        "dest": "cargo/vendor/parking_lot-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.4.crate",
+        "sha256": "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0",
+        "dest": "cargo/vendor/parking_lot_core-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste/paste-1.0.14.crate",
+        "sha256": "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c",
+        "dest": "cargo/vendor/paste-1.0.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-1.0.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.2.0.crate",
+        "sha256": "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e",
+        "dest": "cargo/vendor/percent-encoding-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e\", \"files\": {}}",
+        "dest": "cargo/vendor/percent-encoding-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project/pin-project-1.1.0.crate",
+        "sha256": "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead",
+        "dest": "cargo/vendor/pin-project-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.1.0.crate",
+        "sha256": "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07",
+        "dest": "cargo/vendor/pin-project-internal-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-internal-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.13.crate",
+        "sha256": "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58",
+        "dest": "cargo/vendor/pin-project-lite-0.2.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-lite-0.2.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-utils/pin-utils-0.1.0.crate",
+        "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
+        "dest": "cargo/vendor/pin-utils-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-utils-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.25.crate",
+        "sha256": "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae",
+        "dest": "cargo/vendor/pkg-config-0.3.25"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/plotters/plotters-0.3.5.crate",
+        "sha256": "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45",
+        "dest": "cargo/vendor/plotters-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45\", \"files\": {}}",
+        "dest": "cargo/vendor/plotters-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/plotters-backend/plotters-backend-0.3.5.crate",
+        "sha256": "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609",
+        "dest": "cargo/vendor/plotters-backend-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609\", \"files\": {}}",
+        "dest": "cargo/vendor/plotters-backend-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/plotters-svg/plotters-svg-0.3.5.crate",
+        "sha256": "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab",
+        "dest": "cargo/vendor/plotters-svg-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab\", \"files\": {}}",
+        "dest": "cargo/vendor/plotters-svg-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.17.8.crate",
+        "sha256": "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa",
+        "dest": "cargo/vendor/png-0.17.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.16.crate",
+        "sha256": "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872",
+        "dest": "cargo/vendor/ppv-lite86-0.2.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872\", \"files\": {}}",
+        "dest": "cargo/vendor/ppv-lite86-0.2.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.2.1.crate",
+        "sha256": "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9",
+        "dest": "cargo/vendor/proc-macro-crate-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.66.crate",
+        "sha256": "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9",
+        "dest": "cargo/vendor/proc-macro2-1.0.66"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.66",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/profiling/profiling-1.0.7.crate",
+        "sha256": "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df",
+        "dest": "cargo/vendor/profiling-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df\", \"files\": {}}",
+        "dest": "cargo/vendor/profiling-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/qoi/qoi-0.4.1.crate",
+        "sha256": "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001",
+        "dest": "cargo/vendor/qoi-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001\", \"files\": {}}",
+        "dest": "cargo/vendor/qoi-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.28.2.crate",
+        "sha256": "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1",
+        "dest": "cargo/vendor/quick-xml-0.28.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.28.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.28.crate",
+        "sha256": "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488",
+        "dest": "cargo/vendor/quote-1.0.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.4.6.crate",
+        "sha256": "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293",
+        "dest": "cargo/vendor/rand-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.8.5.crate",
+        "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
+        "dest": "cargo/vendor/rand-0.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.8.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate",
+        "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+        "dest": "cargo/vendor/rand_chacha-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.3.1.crate",
+        "sha256": "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b",
+        "dest": "cargo/vendor/rand_core-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.4.2.crate",
+        "sha256": "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc",
+        "dest": "cargo/vendor/rand_core-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.6.4.crate",
+        "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+        "dest": "cargo/vendor/rand_core-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/range-alloc/range-alloc-0.1.2.crate",
+        "sha256": "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6",
+        "dest": "cargo/vendor/range-alloc-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6\", \"files\": {}}",
+        "dest": "cargo/vendor/range-alloc-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.5.2.crate",
+        "sha256": "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon/rayon-1.5.3.crate",
+        "sha256": "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d",
+        "dest": "cargo/vendor/rayon-1.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-1.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.11.0.crate",
+        "sha256": "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d",
+        "dest": "cargo/vendor/rayon-core-1.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-core-1.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rdrand/rdrand-0.4.0.crate",
+        "sha256": "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2",
+        "dest": "cargo/vendor/rdrand-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2\", \"files\": {}}",
+        "dest": "cargo/vendor/rdrand-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.16.crate",
+        "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
+        "dest": "cargo/vendor/redox_syscall-0.2.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.2.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.3.5.crate",
+        "sha256": "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29",
+        "dest": "cargo/vendor/redox_syscall-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate",
+        "sha256": "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b",
+        "dest": "cargo/vendor/redox_users-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex/regex-1.7.2.crate",
+        "sha256": "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c",
+        "dest": "cargo/vendor/regex-1.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.29.crate",
+        "sha256": "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1",
+        "dest": "cargo/vendor/regex-syntax-0.6.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.6.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/remove_dir_all/remove_dir_all-0.5.3.crate",
+        "sha256": "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7",
+        "dest": "cargo/vendor/remove_dir_all-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7\", \"files\": {}}",
+        "dest": "cargo/vendor/remove_dir_all-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/renderdoc-sys/renderdoc-sys-1.0.0.crate",
+        "sha256": "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b",
+        "dest": "cargo/vendor/renderdoc-sys-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b\", \"files\": {}}",
+        "dest": "cargo/vendor/renderdoc-sys-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/roxmltree/roxmltree-0.18.0.crate",
+        "sha256": "d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8",
+        "dest": "cargo/vendor/roxmltree-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8f595a457b6b8c6cda66a48503e92ee8d19342f905948f29c383200ec9eb1d8\", \"files\": {}}",
+        "dest": "cargo/vendor/roxmltree-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc-demangle/rustc-demangle-0.1.21.crate",
+        "sha256": "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342",
+        "dest": "cargo/vendor/rustc-demangle-0.1.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc-demangle-0.1.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-1.1.0.crate",
+        "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
+        "dest": "cargo/vendor/rustc-hash-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc-hash-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustix/rustix-0.37.13.crate",
+        "sha256": "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0",
+        "dest": "cargo/vendor/rustix-0.37.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.37.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustix/rustix-0.38.8.crate",
+        "sha256": "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f",
+        "dest": "cargo/vendor/rustix-0.38.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-0.38.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.13.crate",
+        "sha256": "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041",
+        "dest": "cargo/vendor/ryu-1.0.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/same-file/same-file-1.0.6.crate",
+        "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        "dest": "cargo/vendor/same-file-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
+        "dest": "cargo/vendor/same-file-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.0.crate",
+        "sha256": "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2",
+        "dest": "cargo/vendor/scoped-tls-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2\", \"files\": {}}",
+        "dest": "cargo/vendor/scoped-tls-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.1.0.crate",
+        "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+        "dest": "cargo/vendor/scopeguard-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd\", \"files\": {}}",
+        "dest": "cargo/vendor/scopeguard-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde/serde-1.0.188.crate",
+        "sha256": "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e",
+        "dest": "cargo/vendor/serde-1.0.188"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.188",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.188.crate",
+        "sha256": "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2",
+        "dest": "cargo/vendor/serde_derive-1.0.188"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.188",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.97.crate",
+        "sha256": "bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a",
+        "dest": "cargo/vendor/serde_json-1.0.97"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.97",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.1.crate",
+        "sha256": "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4",
+        "dest": "cargo/vendor/serde_spanned-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook/signal-hook-0.3.15.crate",
+        "sha256": "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9",
+        "dest": "cargo/vendor/signal-hook-0.3.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-0.3.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.0.crate",
+        "sha256": "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.5.crate",
+        "sha256": "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f",
+        "dest": "cargo/vendor/simd-adler32-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f\", \"files\": {}}",
+        "dest": "cargo/vendor/simd-adler32-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slab/slab-0.4.9.crate",
+        "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
+        "dest": "cargo/vendor/slab-0.4.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67\", \"files\": {}}",
+        "dest": "cargo/vendor/slab-0.4.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slotmap/slotmap-1.0.6.crate",
+        "sha256": "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342",
+        "dest": "cargo/vendor/slotmap-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342\", \"files\": {}}",
+        "dest": "cargo/vendor/slotmap-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.10.0.crate",
+        "sha256": "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0",
+        "dest": "cargo/vendor/smallvec-1.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.16.0.crate",
+        "sha256": "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.16.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.16.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.17.0.crate",
+        "sha256": "e1476c3d89bb67079264b88aaf4f14358353318397e083b7c4e8c14517f55de7",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e1476c3d89bb67079264b88aaf4f14358353318397e083b7c4e8c14517f55de7\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-client-toolkit-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smithay-clipboard/smithay-clipboard-0.6.6.crate",
+        "sha256": "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8",
+        "dest": "cargo/vendor/smithay-clipboard-0.6.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8\", \"files\": {}}",
+        "dest": "cargo/vendor/smithay-clipboard-0.6.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smol_str/smol_str-0.2.0.crate",
+        "sha256": "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c",
+        "dest": "cargo/vendor/smol_str-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c\", \"files\": {}}",
+        "dest": "cargo/vendor/smol_str-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spin/spin-0.9.8.crate",
+        "sha256": "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67",
+        "dest": "cargo/vendor/spin-0.9.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67\", \"files\": {}}",
+        "dest": "cargo/vendor/spin-0.9.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spirv/spirv-0.2.0+1.5.4.crate",
+        "sha256": "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830",
+        "dest": "cargo/vendor/spirv-0.2.0+1.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830\", \"files\": {}}",
+        "dest": "cargo/vendor/spirv-0.2.0+1.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
+        "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+        "dest": "cargo/vendor/static_assertions-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
+        "dest": "cargo/vendor/static_assertions-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strsim/strsim-0.10.0.crate",
+        "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
+        "dest": "cargo/vendor/strsim-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623\", \"files\": {}}",
+        "dest": "cargo/vendor/strsim-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/svg_fmt/svg_fmt-0.4.1.crate",
+        "sha256": "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2",
+        "dest": "cargo/vendor/svg_fmt-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2\", \"files\": {}}",
+        "dest": "cargo/vendor/svg_fmt-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-1.0.109.crate",
+        "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+        "dest": "cargo/vendor/syn-1.0.109"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-1.0.109",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-2.0.32.crate",
+        "sha256": "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2",
+        "dest": "cargo/vendor/syn-2.0.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tempdir/tempdir-0.3.7.crate",
+        "sha256": "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8",
+        "dest": "cargo/vendor/tempdir-0.3.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8\", \"files\": {}}",
+        "dest": "cargo/vendor/tempdir-0.3.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/termcolor/termcolor-1.1.3.crate",
+        "sha256": "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755",
+        "dest": "cargo/vendor/termcolor-1.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755\", \"files\": {}}",
+        "dest": "cargo/vendor/termcolor-1.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.37.crate",
+        "sha256": "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e",
+        "dest": "cargo/vendor/thiserror-1.0.37"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.37",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.37.crate",
+        "sha256": "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb",
+        "dest": "cargo/vendor/thiserror-impl-1.0.37"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.37",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiff/tiff-0.9.0.crate",
+        "sha256": "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211",
+        "dest": "cargo/vendor/tiff-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211\", \"files\": {}}",
+        "dest": "cargo/vendor/tiff-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinytemplate/tinytemplate-1.2.1.crate",
+        "sha256": "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc",
+        "dest": "cargo/vendor/tinytemplate-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc\", \"files\": {}}",
+        "dest": "cargo/vendor/tinytemplate-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.6.0.crate",
+        "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
+        "dest": "cargo/vendor/tinyvec-1.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec-1.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
+        "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio/tokio-1.32.0.crate",
+        "sha256": "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9",
+        "dest": "cargo/vendor/tokio-1.32.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-1.32.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.1.0.crate",
+        "sha256": "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e",
+        "dest": "cargo/vendor/tokio-macros-2.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-macros-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.5.9.crate",
+        "sha256": "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7",
+        "dest": "cargo/vendor/toml-0.5.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.5.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.7.3.crate",
+        "sha256": "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21",
+        "dest": "cargo/vendor/toml-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.1.crate",
+        "sha256": "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622",
+        "dest": "cargo/vendor/toml_datetime-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.7.crate",
+        "sha256": "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274",
+        "dest": "cargo/vendor/toml_edit-0.19.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.19.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.15.2.crate",
+        "sha256": "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd",
+        "dest": "cargo/vendor/ttf-parser-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.19.2.crate",
+        "sha256": "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1",
+        "dest": "cargo/vendor/ttf-parser-0.19.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1\", \"files\": {}}",
+        "dest": "cargo/vendor/ttf-parser-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/twox-hash/twox-hash-1.6.3.crate",
+        "sha256": "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675",
+        "dest": "cargo/vendor/twox-hash-1.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675\", \"files\": {}}",
+        "dest": "cargo/vendor/twox-hash-1.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.5.crate",
+        "sha256": "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3",
+        "dest": "cargo/vendor/unicode-ident-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.22.crate",
+        "sha256": "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921",
+        "dest": "cargo/vendor/unicode-normalization-0.1.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-normalization-0.1.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.10.1.crate",
+        "sha256": "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36",
+        "dest": "cargo/vendor/unicode-segmentation-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.10.crate",
+        "sha256": "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b",
+        "dest": "cargo/vendor/unicode-width-0.1.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-width-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.4.crate",
+        "sha256": "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c",
+        "dest": "cargo/vendor/unicode-xid-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-xid-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8parse/utf8parse-0.2.1.crate",
+        "sha256": "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
+        "dest": "cargo/vendor/utf8parse-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8parse-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vec_map/vec_map-0.8.2.crate",
+        "sha256": "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191",
+        "dest": "cargo/vendor/vec_map-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191\", \"files\": {}}",
+        "dest": "cargo/vendor/vec_map-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.4.crate",
+        "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+        "dest": "cargo/vendor/version_check-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f\", \"files\": {}}",
+        "dest": "cargo/vendor/version_check-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.3.3.crate",
+        "sha256": "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698",
+        "dest": "cargo/vendor/walkdir-2.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasi/wasi-0.11.0+wasi-snapshot-preview1.crate",
+        "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
+        "dest": "cargo/vendor/wasi-0.11.0+wasi-snapshot-preview1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.11.0+wasi-snapshot-preview1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.87.crate",
+        "sha256": "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.87"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.87.crate",
+        "sha256": "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.34.crate",
+        "sha256": "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.34"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.34",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.87.crate",
+        "sha256": "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.87.crate",
+        "sha256": "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.87.crate",
+        "sha256": "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.87",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-test/wasm-bindgen-test-0.3.34.crate",
+        "sha256": "6db36fc0f9fb209e88fb3642590ae0205bb5a56216dabd963ba15879fe53a30b",
+        "dest": "cargo/vendor/wasm-bindgen-test-0.3.34"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6db36fc0f9fb209e88fb3642590ae0205bb5a56216dabd963ba15879fe53a30b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-test-0.3.34",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-test-macro/wasm-bindgen-test-macro-0.3.34.crate",
+        "sha256": "0734759ae6b3b1717d661fe4f016efcfb9828f5edb4520c18eaee05af3b43be9",
+        "dest": "cargo/vendor/wasm-bindgen-test-macro-0.3.34"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0734759ae6b3b1717d661fe4f016efcfb9828f5edb4520c18eaee05af3b43be9\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-test-macro-0.3.34",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-backend/wayland-backend-0.1.2.crate",
+        "sha256": "41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8",
+        "dest": "cargo/vendor/wayland-backend-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41b48e27457e8da3b2260ac60d0a94512f5cba36448679f3747c0865b7893ed8\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-backend-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.29.5.crate",
+        "sha256": "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715",
+        "dest": "cargo/vendor/wayland-client-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.30.2.crate",
+        "sha256": "489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8",
+        "dest": "cargo/vendor/wayland-client-0.30.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"489c9654770f674fc7e266b3c579f4053d7551df0ceb392f153adb1f9ed06ac8\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-client-0.30.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-commons/wayland-commons-0.29.5.crate",
+        "sha256": "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902",
+        "dest": "cargo/vendor/wayland-commons-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-commons-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.29.5.crate",
+        "sha256": "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661",
+        "dest": "cargo/vendor/wayland-cursor-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-cursor-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.30.0.crate",
+        "sha256": "2d0c3a0d5b4b688b07b0442362d3ed6bf04724fcc16cd69ab6285b90dbc487aa",
+        "dest": "cargo/vendor/wayland-cursor-0.30.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d0c3a0d5b4b688b07b0442362d3ed6bf04724fcc16cd69ab6285b90dbc487aa\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-cursor-0.30.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.29.5.crate",
+        "sha256": "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6",
+        "dest": "cargo/vendor/wayland-protocols-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.30.1.crate",
+        "sha256": "3b28101e5ca94f70461a6c2d610f76d85ad223d042dd76585ab23d3422dd9b4d",
+        "dest": "cargo/vendor/wayland-protocols-0.30.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b28101e5ca94f70461a6c2d610f76d85ad223d042dd76585ab23d3422dd9b4d\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-0.30.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-protocols-wlr/wayland-protocols-wlr-0.1.0.crate",
+        "sha256": "fce991093320e4a6a525876e6b629ab24da25f9baef0c2e0080ad173ec89588a",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fce991093320e4a6a525876e6b629ab24da25f9baef0c2e0080ad173ec89588a\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-protocols-wlr-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.29.5.crate",
+        "sha256": "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53",
+        "dest": "cargo/vendor/wayland-scanner-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.30.1.crate",
+        "sha256": "b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e",
+        "dest": "cargo/vendor/wayland-scanner-0.30.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9b873b257fbc32ec909c0eb80dea312076a67014e65e245f5eb69a6b8ab330e\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-scanner-0.30.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.29.5.crate",
+        "sha256": "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4",
+        "dest": "cargo/vendor/wayland-sys-0.29.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.29.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.30.1.crate",
+        "sha256": "96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06",
+        "dest": "cargo/vendor/wayland-sys-0.30.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96b2a02ac608e07132978689a6f9bf4214949c85998c247abadd4f4129b1aa06\", \"files\": {}}",
+        "dest": "cargo/vendor/wayland-sys-0.30.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.64.crate",
+        "sha256": "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b",
+        "dest": "cargo/vendor/web-sys-0.3.64"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.64",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-time/web-time-0.2.0.crate",
+        "sha256": "19353897b48e2c4d849a2d73cb0aeb16dc2be4e00c565abfc11eb65a806e47de",
+        "dest": "cargo/vendor/web-time-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"19353897b48e2c4d849a2d73cb0aeb16dc2be4e00c565abfc11eb65a806e47de\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.7.crate",
+        "sha256": "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb",
+        "dest": "cargo/vendor/weezl-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wgpu/wgpu-0.17.1.crate",
+        "sha256": "ed547920565c56c7a29afb4538ac5ae5048865a5d2f05bff3ad4fbeb921a9a2c",
+        "dest": "cargo/vendor/wgpu-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed547920565c56c7a29afb4538ac5ae5048865a5d2f05bff3ad4fbeb921a9a2c\", \"files\": {}}",
+        "dest": "cargo/vendor/wgpu-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wgpu-core/wgpu-core-0.17.1.crate",
+        "sha256": "0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7",
+        "dest": "cargo/vendor/wgpu-core-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7\", \"files\": {}}",
+        "dest": "cargo/vendor/wgpu-core-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wgpu-hal/wgpu-hal-0.17.1.crate",
+        "sha256": "0df4fc240da3c460a52cf0ff8f1b71fd6544a6b49f74ff2330238fcb0fd99512",
+        "dest": "cargo/vendor/wgpu-hal-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0df4fc240da3c460a52cf0ff8f1b71fd6544a6b49f74ff2330238fcb0fd99512\", \"files\": {}}",
+        "dest": "cargo/vendor/wgpu-hal-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wgpu-types/wgpu-types-0.17.0.crate",
+        "sha256": "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67",
+        "dest": "cargo/vendor/wgpu-types-0.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67\", \"files\": {}}",
+        "dest": "cargo/vendor/wgpu-types-0.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/widestring/widestring-1.0.2.crate",
+        "sha256": "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8",
+        "dest": "cargo/vendor/widestring-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8\", \"files\": {}}",
+        "dest": "cargo/vendor/widestring-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "dest": "cargo/vendor/winapi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.5.crate",
+        "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
+        "dest": "cargo/vendor/winapi-util-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-util-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-wsapoll/winapi-wsapoll-0.1.1.crate",
+        "sha256": "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e",
+        "dest": "cargo/vendor/winapi-wsapoll-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-wsapoll-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.42.0.crate",
+        "sha256": "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5",
+        "dest": "cargo/vendor/windows-0.42.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.42.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.44.0.crate",
+        "sha256": "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b",
+        "dest": "cargo/vendor/windows-0.44.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.44.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.42.0.crate",
+        "sha256": "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7",
+        "dest": "cargo/vendor/windows-sys-0.42.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.42.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
+        "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
+        "dest": "cargo/vendor/windows-sys-0.45.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.45.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
+        "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+        "dest": "cargo/vendor/windows-sys-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
+        "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
+        "dest": "cargo/vendor/windows-targets-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.48.0.crate",
+        "sha256": "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5",
+        "dest": "cargo/vendor/windows-targets-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.2.crate",
+        "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.48.0.crate",
+        "sha256": "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
+        "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.48.0.crate",
+        "sha256": "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.2.crate",
+        "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.48.0.crate",
+        "sha256": "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
+        "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.48.0.crate",
+        "sha256": "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.2.crate",
+        "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.48.0.crate",
+        "sha256": "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.2.crate",
+        "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.48.0.crate",
+        "sha256": "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.2.crate",
+        "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.48.0.crate",
+        "sha256": "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winit/winit-0.29.1-beta.crate",
+        "sha256": "ab977231134a3123c5382f0358b728118e70c216ec99017aa24e9eed35d5e3e1",
+        "dest": "cargo/vendor/winit-0.29.1-beta"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab977231134a3123c5382f0358b728118e70c216ec99017aa24e9eed35d5e3e1\", \"files\": {}}",
+        "dest": "cargo/vendor/winit-0.29.1-beta",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.3.6.crate",
+        "sha256": "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966",
+        "dest": "cargo/vendor/winnow-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-clipboard/x11-clipboard-0.7.1.crate",
+        "sha256": "980b9aa9226c3b7de8e2adb11bf20124327c054e0e5812d2aac0b5b5a87e7464",
+        "dest": "cargo/vendor/x11-clipboard-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"980b9aa9226c3b7de8e2adb11bf20124327c054e0e5812d2aac0b5b5a87e7464\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-clipboard-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.20.0.crate",
+        "sha256": "0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6",
+        "dest": "cargo/vendor/x11-dl-2.20.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-dl-2.20.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.10.1.crate",
+        "sha256": "592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507",
+        "dest": "cargo/vendor/x11rb-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"592b4883219f345e712b3209c62654ebda0bb50887f330cbd018d0f654bfd507\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.12.0.crate",
+        "sha256": "b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a",
+        "dest": "cargo/vendor/x11rb-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b1641b26d4dec61337c35a1b1aaf9e3cba8f46f0b43636c609ab0291a648040a\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.10.0.crate",
+        "sha256": "56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67",
+        "dest": "cargo/vendor/x11rb-protocol-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56b245751c0ac9db0e006dc812031482784e434630205a93c73cfefcaabeac67\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.12.0.crate",
+        "sha256": "82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc",
+        "dest": "cargo/vendor/x11rb-protocol-0.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82d6c3f9a0fb6701fab8f6cea9b0c0bd5d6876f1f89f7fada07e558077c344bc\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xcursor/xcursor-0.3.4.crate",
+        "sha256": "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7",
+        "dest": "cargo/vendor/xcursor-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7\", \"files\": {}}",
+        "dest": "cargo/vendor/xcursor-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xi-unicode/xi-unicode-0.3.0.crate",
+        "sha256": "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a",
+        "dest": "cargo/vendor/xi-unicode-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a\", \"files\": {}}",
+        "dest": "cargo/vendor/xi-unicode-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xkbcommon-dl/xkbcommon-dl-0.4.1.crate",
+        "sha256": "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699",
+        "dest": "cargo/vendor/xkbcommon-dl-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699\", \"files\": {}}",
+        "dest": "cargo/vendor/xkbcommon-dl-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xkeysym/xkeysym-0.2.0.crate",
+        "sha256": "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621",
+        "dest": "cargo/vendor/xkeysym-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621\", \"files\": {}}",
+        "dest": "cargo/vendor/xkeysym-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.4.crate",
+        "sha256": "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3",
+        "dest": "cargo/vendor/xml-rs-0.8.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3\", \"files\": {}}",
+        "dest": "cargo/vendor/xml-rs-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xmlparser/xmlparser-0.13.5.crate",
+        "sha256": "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd",
+        "dest": "cargo/vendor/xmlparser-0.13.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd\", \"files\": {}}",
+        "dest": "cargo/vendor/xmlparser-0.13.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-inflate/zune-inflate-0.2.54.crate",
+        "sha256": "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02",
+        "dest": "cargo/vendor/zune-inflate-0.2.54"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-inflate-0.2.54",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
+]

--- a/io.raphamorim.Rio.appdata.xml
+++ b/io.raphamorim.Rio.appdata.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <content_rating type="oars-1.0" />
+  <id>io.raphamorim.Rio</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>rio</name>
+  <summary>A hardware-accelerated GPU terminal emulator powered by WebGPU, focusing to run in desktops and browsers. </summary>
+  <description>
+    <p>
+      Rio is a terminal application that's built with Rust, WebGPU, Tokio runtime. It targets to
+      have the best frame per second experience as long you want, but is also configurable to use as
+      minimal from GPU.
+    </p>
+
+    <p>
+      The terminal renderer is based on redux state machine, lines that has not updated will not
+      suffer a redraw. Looking for the minimal rendering process in most of the time. Rio is also
+      designed to support WebAssembly runtime so in the future you will be able to define how a tab
+      system will work with a WASM plugin written in your favorite language.
+    </p>
+
+    <p>
+      Rio uses WGPU, which is an implementation of WebGPU for use outside of a browser and as
+      backend for firefox's WebGPU implementation. WebGPU allows for more efficient usage of modern
+      GPUs than WebGL.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.raphamorim.Rio.desktop</launchable>
+
+  <url type="homepage">https://raphamorim.io/rio/</url>
+  <url type="help">https://raphamorim.io/rio/docs/</url>
+  <url type="bugtracker">https://github.com/raphamorim/rio/issues</url>
+  <url type="donation">https://github.com/sponsors/raphamorim</url>
+  <url type="donation">https://www.patreon.com/raphamorim</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Navigation under X11 (bottom tabs)</caption>
+      <image>https://raphamorim.io/rio/assets/posts/0.0.15/demo-navigation-x11.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Navigation under Wayland (minimal tabs)</caption>
+      <image>https://raphamorim.io/rio/assets/posts/0.0.15/demo-navigation-wayland.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Breadcrumbs</caption>
+      <video>https://raphamorim.io/rio/assets/features/demo-breadcrumb.png</video>
+    </screenshot>
+    <screenshot>
+      <caption>High performance renderer</caption>
+      <image>https://miro.medium.com/v2/resize:fit:1400/1*1enyoIVZivAcHY_kfYXUvQ.gif</image>
+    </screenshot>
+  </screenshots>
+
+  <developer_name>Raphael Amorim</developer_name>
+
+  <releases>
+    <release version="v0.0.22" date="2023-10-02">
+      <description>
+        <p>
+          <ul>
+            <li>Now you can add extra fonts to load:<br/>
+                <pre>
+                [fonts]
+                extras = [{ family = "Microsoft JhengHei" }]
+                </pre></li>
+            <li>Added ScrollLineUp, ScrollLineDown, ScrollHalfPageUp, ScrollHalfPageDown, ScrollToTopand ScrollToBottom to bindings.</li>
+            <li>Fix japanese characters on Microsoft Windows (Ref: #266).</li>
+            <li>Navigation fonts now use the CascadiaCode built-in font and cannot be changed.</li>
+            <li>Proper select adapter with is_srgb filter check.</li>
+            <li>Switched to queue rendering instead of use staging_belt.</li>
+            <li>Fixed leaks whenever buffer dropped map callbacks.</li>
+            <li>Forked and embedded glyph-brush project to sugarloaf. Glyph-brush was originally created Alex Butler and is licensed under Apache-2.0 license.</li>
+            <li>Upgrate wgpu to 0.17.1.</li>
+          </ul>
+        </p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.raphamorim.Rio.json
+++ b/io.raphamorim.Rio.json
@@ -1,0 +1,53 @@
+{
+    "app-id": "io.raphamorim.Rio",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "23.08",
+    "sdk": "org.freedesktop.Sdk",
+    "sdk-extensions" : [
+        "org.freedesktop.Sdk.Extension.rust-stable"
+    ],
+    "command": "rio",
+    "finish-args": [
+        "--filesystem=xdg-config/rio",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "modules": [
+        {
+            "name": "rio",
+            "buildsystem": "simple",
+            "build-options": {
+                "append-path" : "/usr/lib/sdk/rust-stable/bin",
+                "env": {
+                    "CARGO_HOME": "/run/build/rio/cargo",
+                    "RUSTFLAGS": "-C link-arg=-s"
+                }
+            },
+            "build-commands": [
+                "cargo --offline fetch --manifest-path Cargo.toml --verbose",
+                "cargo --offline build --release --no-default-features --features=x11 --features=wayland --verbose",
+                "install -Dm644 io.raphamorim.Rio.appdata.xml /app/share/metainfo/io.raphamorim.Rio.appdata.xml",
+                "install -Dm644 ./misc/logo.svg /app/share/icons/hicolor/128x128/apps/io.raphamorim.Rio.svg",
+                "install -Dm644 ./misc/rio.desktop /app/share/applications/io.raphamorim.Rio.desktop",
+                "sed -i 's/^Icon=rio/Icon=io.raphamorim.Rio/' /app/share/applications/io.raphamorim.Rio.desktop",
+                "install -Dm755 ./target/release/rio -t /app/bin/"
+              ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "archive-type": "tar-gzip",
+                    "url": "https://github.com/raphamorim/rio/archive/refs/tags/v0.0.22.tar.gz",
+                    "sha256": "936fa0f1d648016a53f845c6a24d91eaa2cc93e08b7a4d08e98417e294ba40ab"
+                },
+                {
+                  "type": "file",
+                  "path": "io.raphamorim.Rio.appdata.xml"
+                },
+                "generated-sources.json"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - `--filesystem=xdg-config/rio`: configuration files for rio itself
  - `--socket=fallback-x11` and `--socket=wayland`: rio is a GUI application and it is able to use X.org as a fallback (but runs natively on wayland).
  - `--device=dri`: rio uses hardware acceleration for rendering the terminal
  - `--talk-name=org.freedesktop.Flatpak`: rio is a terminal and it needs to be able to spawn the user's shell running on the host. Obviously this is not great for sandboxing, but otherwise there is no point in a flatpak for a terminal.
  - `--talk-name=org.freedesktop.Notifications`: rio can send notifications
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. https://github.com/raphamorim/rio/issues/198
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge). - Upstream (@raphamorim) owns the domain. I'm submitting this PR in agreement with him (see the above linked github issue). If this flatpak is accepted, I will be maintaining it for a while, but @raphamorim should also be added to the created flathub repo. 
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
