### PR TITLE
Add com.obsproject.Studio.Plugin.NDI

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,32 @@
+name: Check for updates
+on:
+  schedule:
+  - cron: "0 * * * *"
+  workflow_dispatch: 
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ master ]
+        # Do not check extra-data
+        filter-type: [ file, archive, git ]
+    
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --filter-type  ${{ matrix.filter-type }} --update --never-fork com.obsproject.Studio.Plugin.NDI.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# [obs-ndi](https://github.com/obs-ndi/obs-ndi) Flatpak
+
+Network A/V in OBS Studio with NewTek's NDI technology in a Flatpak.
+
+## Notes
+Make sure that `--system-talk-name=org.freedesktop.Avahi` is set in OBS Studio permissions. Otherwise obs-ndi will not be able to see other devices or send to the network, since NDI on Linux rely on the Avahi daemon for network discovery (find other NDI device on the network).
+

--- a/com.obsproject.Studio.Plugin.NDI.json
+++ b/com.obsproject.Studio.Plugin.NDI.json
@@ -1,0 +1,135 @@
+{
+    "app-id": "com.obsproject.Studio.Plugin.NDI",
+    "runtime": "com.obsproject.Studio",
+    "runtime-version": "stable",
+    "sdk": "org.kde.Sdk//6.5",
+    "build-extension": true,
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/plugins/NDI"
+    },
+    "modules": [
+        {
+            "name": "avahi",
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/avahi",
+                "/lib/pkgconfig",
+                "/lib/*.a",
+                "/lib/*.la",
+                "/share/applications/*.desktop",
+                "/share/avahi",
+                "/share/man"
+            ],
+            "config-opts": [
+                "--with-distro=none",
+                "--disable-introspection",
+                "--disable-qt3",
+                "--disable-qt4",
+                "--disable-qt5",
+                "--disable-gtk",
+                "--disable-gtk3",
+                "--disable-core-docs",
+                "--disable-manpages",
+                "--disable-libdaemon",
+                "--disable-libevent",
+                "--disable-python",
+                "--disable-pygobject",
+                "--disable-mono",
+                "--disable-monodoc",
+                "--disable-autoipd",
+                "--disable-doxygen-doc",
+                "--disable-doxygen-dot",
+                "--disable-doxygen-xml",
+                "--disable-doxygen-html",
+                "--disable-manpages",
+                "--disable-xmltoman"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.avahi.org/download/avahi-0.8.tar.gz",
+                    "sha256": "060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 147,
+                        "url-template": "https://www.avahi.org/download/avahi-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "obs-ndi",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DENABLE_FRONTEND_API=ON",
+                "-DENABLE_QT=ON"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ../${FLATPAK_ID}.metainfo.xml",
+                "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/obs-ndi/obs-ndi.git",
+                    "tag": "4.13.0",
+                    "commit": "bdd6e2610b965f8a743063f768556e318835607a",
+                    "x-checker-data": {
+                        "type": "git",
+                        "is-main-source": true,
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's|/usr|/app/plugins/NDI/extra|g' src/plugin-main.cpp"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "path": "com.obsproject.Studio.Plugin.NDI.metainfo.xml"
+                }
+            ]
+        },
+        {
+            "name": "libndi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D apply_extra $FLATPAK_DEST/bin/apply_extra"
+            ],
+            "sources": [
+                {
+                    "type": "script",
+                    "dest-filename": "apply_extra",
+                    "commands": [
+                        "bsdtar -xf Install_NDI_SDK_v5_Linux.tar.gz",
+                        "_target_line=\"$(sed -n '/^__NDI_ARCHIVE_BEGIN__$/=' Install_NDI_SDK_v5_Linux.sh)\"",
+                        "_target_line=\"$((_target_line + 1))\"",
+                        "tail -n +\"$_target_line\" Install_NDI_SDK_v5_Linux.sh | tar -zxf - \"NDI SDK for Linux/lib/x86_64-linux-gnu/\" \"NDI SDK for Linux/NDI SDK License Agreement.txt\" \"NDI SDK for Linux/licenses/libndi_licenses.txt\"",
+                        "install -D -m755 \"NDI SDK for Linux/lib/x86_64-linux-gnu/libndi.so.5\".*.* -t ./lib",
+                        "install -D -m644 \"NDI SDK for Linux/NDI SDK License Agreement.txt\" -t ./share/licenses",
+                        "install -D -m644 \"NDI SDK for Linux/licenses/libndi_licenses.txt\" -t ./share/licenses",
+                        "rm -rf \"NDI SDK for Linux\"",
+                        "rm -f Install_NDI_SDK_v5_Linux.*",
+                        "cd ./lib",
+                        "ln -s libndi.so.5.*.* libndi.so.5"
+                    ]
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "Install_NDI_SDK_v5_Linux.tar.gz",
+                    "url": "https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v5_Linux.tar.gz",
+                    "sha256": "7e5c54693d6aee6b6f1d6d49f48d4effd7281abd216d9ff601be2d55af12f7f5",
+                    "size": 53225666,
+                    "installed-size": 26241898
+                }
+            ]
+        }
+    ]
+}

--- a/com.obsproject.Studio.Plugin.NDI.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.NDI.metainfo.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.NDI</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>obs-ndi</name>
+  <developer>Paul Peavyhouse</developer>
+  <summary>NewTek NDI integration for OBS Studio</summary>
+  <url type="homepage">https://github.com/obs-ndi/obs-ndi</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later AND LicenseRef-proprietary=https://downloads.ndi.tv/SDK/NDI_SDK/NDI%20License%20Agreement.pdf</project_license>
+  <releases>
+    <release version="4.13.0" date="2023-11-14"/>
+  </releases>
+</component>

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,6 @@
+{
+  "skip-icons-check": true,
+  "only-arches": [ "x86_64" ],
+  "disable-external-data-checker": true
+}
+


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - It requires `--system-talk-name=org.freedesktop.Avahi` to enable network discovery which is already provided by OBS Studio Flatpak for historical reasons.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
  - Request: https://github.com/obs-ndi/obs-ndi/issues/724#issuecomment-1808136817
  - Answer: https://github.com/obs-ndi/obs-ndi/issues/724#issuecomment-1812959827
  - The upstream contributor @paulpv wishes to have access to the repo, and also asked @Palakis to be added.
- [x] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
  - This is an OBS Studio plugin
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
  - The libndi path fix is really Flatpak specific since it patches it to use the extra-data path
  
The workflow was added to replace the external-data-checker, to avoid spamming the NDI download link in extra-data.

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flatpak.org/en/latest/first-build.html
