### PR TITLE
Add io.github.foldynl.QLog

### DIFF
--- a/io.github.foldynl.QLog.metainfo.xml
+++ b/io.github.foldynl.QLog.metainfo.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.foldynl.QLog</id>
+  <launchable type="desktop-id">io.github.foldynl.QLog.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>QLog</name>
+  <developer_name>Ladislav Foldyna</developer_name>
+  <summary>Amateur radio logbook software</summary>
+  <description>
+    <p>
+      QLog is an Amateur Radio logging application for Linux, Windows and Mac OS. It is based on the Qt framework and uses SQLite as database backend.
+      QLog aims to be as simple as possible, but to provide everything the operator expects from the log to be. This log is not currently focused on contests.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Customizable GUI</li>
+      <li>Rig and rotator control via Hamlib</li>
+      <li>HamQTH and QRZ.com callbook integration</li>
+      <li>DX cluster integration</li>
+      <li>LoTW, eQSL, QRZ.com, Clublog, HRDLog.net, ON4KST Chat integration (eQSL includes QSL pictures download)</li>
+      <li>Secure Password Storage for all services with password or security token</li>
+      <li>Online and Offline map</li>
+      <li>Club Member lookup</li>
+      <li>CW Keyer Support - CWDaemon, FLDigi (all supported modes), Morse Over CAT, WinKey V2</li>
+      <li>Bandmap</li>
+      <li>CW Console</li>
+      <li>WSJT-X integration</li>
+      <li>Station Location Profile support</li>
+      <li>Various station statistics</li>
+      <li>Basic Awards support</li>
+      <li>Custom QSO Filters</li>
+      <li>NO ads, NO user tracking, NO hidden telemetry - simply free and open-source</li>
+      <li>SQLite backend</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The QLog main window</caption>
+      <image type="source">https://foldynl.github.io/QLog/screens/qlog_main.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/foldynl/QLog</url>
+  <url type="bugtracker">https://github.com/foldynl/QLog/issues</url>
+  <url type="help">https://github.com/foldynl/QLog/wiki</url>
+  <url type="contact">https://github.com/foldynl</url>
+  <url type="vcs-browser">https://github.com/foldynl/QLog</url>
+  <url type="contribute">https://github.com/foldynl/QLog/blob/master/CONTRIBUTING.md</url>
+  <releases>
+    <release version="0.29.2" date="2023-11-13"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/io.github.foldynl.QLog.yaml
+++ b/io.github.foldynl.QLog.yaml
@@ -1,0 +1,87 @@
+app-id: io.github.foldynl.QLog
+runtime: org.kde.Platform
+runtime-version: '5.15-23.08'
+sdk: org.kde.Sdk
+base: io.qt.qtwebengine.BaseApp
+base-version: '5.15-23.08'
+command: qlog
+rename-desktop-file: qlog.desktop
+rename-icon: qlog
+finish-args:
+  - --device=all
+  - --share=network
+  - --share=ipc
+  - --socket=pulseaudio
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --own-name=org.freedesktop.secrets
+  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - name: hamlib
+    sources:
+      - type: archive
+        url: https://github.com/Hamlib/Hamlib/releases/download/4.5.5/hamlib-4.5.5.tar.gz
+        sha256: 601c89f32ed225e9527ade3d64d0d05d23202c05ae21ffa77e59d70ee4597fcd
+        x-checker-data:
+          type: anitya
+          project-id: 1292
+          url-template: https://github.com/Hamlib/Hamlib/releases/download/$version/hamlib-$version.tar.gz
+
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dgcrypt=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+      - -Dmanpage=false
+      - -Dvapi=false
+    cleanup:
+      - /bin
+      - /include
+      - /lib/pkgconfig
+      - /share/man
+    sources:
+      - type: archive
+        url: https://gitlab.gnome.org/GNOME/libsecret/-/archive/0.21.1/libsecret-0.21.1.tar.gz
+        sha256: 5106cdb7ef9b74cff5666c982e097f1e6cf44eedd705b5999ce46db1cb55ca7c
+        x-checker-data:
+          type: anitya
+          project-id: 13150
+          url-template: https://gitlab.gnome.org/GNOME/libsecret/-/archive/$version/libsecret-$version.tar.gz
+
+  - name: qtkeychain
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://github.com/frankosterfeld/qtkeychain/archive/refs/tags/0.14.1.tar.gz
+        sha256: afb2d120722141aca85f8144c4ef017bd74977ed45b80e5d9e9614015dadd60c
+        x-checker-data:
+          type: anitya
+          project-id: 4138
+          url-template: https://github.com/frankosterfeld/qtkeychain/archive/refs/tags/$version.tar.gz
+
+  - name: qlog
+    buildsystem: qmake
+    build-options:
+      env:
+        - QMAKEPATH=/app/lib
+    config-opts:
+      - QMAKE_LIBS += -L/app/lib
+      - QMAKE_INCDIR+=/app/include/QtWebEngine
+      - QMAKE_INCDIR+=/app/include/QtWebEngineCore
+      - QMAKE_INCDIR+=/app/include/QtWebEngineWidgets
+    sources:
+      - type: git
+        url: https://github.com/foldynl/QLog.git
+        tag: v0.29.2
+        commit: e44fc85da9a71237fbe19ad89398a9962454dc99
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+      - type: file
+        path: io.github.foldynl.QLog.metainfo.xml
+    post-install:
+      - install -Dm644 io.github.foldynl.QLog.metainfo.xml /app/share/metainfo/io.github.foldynl.QLog.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:** https://github.com/foldynl/QLog/issues/264
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
https://github.com/foldynl/QLog/pull/262

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flatpak.org/en/latest/first-build.html

Tested and works without issues. The only problem that I have is that I need to use a Qt5-based, older runtime version because I am not able to get QLog to compile with the recent (6.6) one. It always fails with `Project ERROR: Unknown module(s) in QT: webenginewidgets`.