### PR TITLE
Add org.freedesktop.Sdk.Extension.openjdk21

### DIFF
--- a/0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
+++ b/0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
@@ -1,0 +1,29 @@
+From c9230ce05d9596df22443d564a03d8de63f137d6 Mon Sep 17 00:00:00 2001
+From: Mat Booth <mat.booth@gmail.com>
+Date: Mon, 13 Sep 2021 15:44:32 +0100
+Subject: [PATCH] Avoid requiring pcsc development files at runtime
+
+JDK should try to use the versioned name of the .so instead of the
+unversioned name
+---
+ .../unix/classes/sun/security/smartcardio/PlatformPCSC.java   | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+index 38fa3da9e..12086acac 100644
+--- a/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
++++ b/src/java.smartcardio/unix/classes/sun/security/smartcardio/PlatformPCSC.java
+@@ -46,8 +46,8 @@ class PlatformPCSC {
+ 
+     private static final String PROP_NAME = "sun.security.smartcardio.library";
+ 
+-    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so";
+-    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so";
++    private static final String LIB1 = "/usr/$LIBISA/libpcsclite.so.1";
++    private static final String LIB2 = "/usr/local/$LIBISA/libpcsclite.so.1";
+     private static final String PCSC_FRAMEWORK = "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC";
+ 
+     PlatformPCSC() {
+-- 
+2.31.1
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# SDK Extension for OpenJDK 21
+
+This extension contains the OpenJDK 21 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
+
+OpenJDK 21 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+
+For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
+
+For the previous LTS version, see the [OpenJDK 11](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11) extension.
+
+## Usage
+
+You can bundle the JRE with your Flatpak application by adding this SDK extension to your Flatpak manifest and calling the install.sh script. For example:
+
+```
+{
+  "id" : "org.example.MyApp",
+  "branch" : "1.0",
+  "runtime" : "org.freedesktop.Platform",
+  "runtime-version" : "22.08",
+  "sdk" : "org.freedesktop.Sdk",
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
+  "modules" : [ {
+    "name" : "openjdk",
+    "buildsystem" : "simple",
+    "build-commands" : [ "/usr/lib/sdk/openjdk/install.sh" ]
+  }, {
+    "name" : "myapp",
+    "buildsystem" : "simple",
+    ....
+  } ]
+  ....
+  "finish-args" : [ "--env=PATH=/app/jre/bin:/usr/bin" ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This extension contains the OpenJDK 21 Java Runtime Environment (JRE) and Java Developement Kit (JDK).
 
-OpenJDK 21 is the current latest version. This is *not* a long-term support (LTS) version and will be periodically updated as new JDKs are released.
+OpenJDK 21 is the current long-term support (LTS) version.
 
-For the current LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
+For the previous LTS version, see the [OpenJDK 17](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17) extension.
 
-For the previous LTS version, see the [OpenJDK 11](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk11) extension.
+For the current latest (non-LTS) version, see the [OpenJDK](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk) extension.
 
 ## Usage
 
@@ -17,13 +17,13 @@ You can bundle the JRE with your Flatpak application by adding this SDK extensio
   "id" : "org.example.MyApp",
   "branch" : "1.0",
   "runtime" : "org.freedesktop.Platform",
-  "runtime-version" : "22.08",
+  "runtime-version" : "23.08",
   "sdk" : "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk" ],
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.openjdk21" ],
   "modules" : [ {
     "name" : "openjdk",
     "buildsystem" : "simple",
-    "build-commands" : [ "/usr/lib/sdk/openjdk/install.sh" ]
+    "build-commands" : [ "/usr/lib/sdk/openjdk21/install.sh" ]
   }, {
     "name" : "myapp",
     "buildsystem" : "simple",

--- a/extract_cacerts.sh
+++ b/extract_cacerts.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Tool to generate a Java-style "cacerts" keystore from the installed
+# system certificates
+
+set -e
+
+jdk=${1:-/app/jdk}
+
+function get_alias() {
+	local alias=""
+	local issuer="${1// /},"
+	# Determine which attribute to use for the alias
+	if [[ $issuer =~ CN= ]] ; then
+		# Use the "Common Name" if available
+		alias=$(echo "$issuer" | sed -e 's/.*CN=\([^,]*\),.*/\1/')
+		# Unless it's GlobalSign, because of non-uniqueness
+		if [[ $alias == GlobalSign ]] ; then
+			# In which case use the "Organisational Unit" instead
+			alias=$(echo "$issuer" | sed -e 's/.*OU=\([^,]*\),.*/\1/')
+		fi
+	elif [[ $issuer =~ OU= ]] ; then
+		# Use the "Organisational Unit" if CN is unavailable
+		alias=$(echo "$issuer" | sed -e 's/.*OU=\([^,]*\),.*/\1/')
+	else
+		# Use the "Organisation" if CN and OU are unavailable
+		alias=$(echo "$issuer" | sed -e 's/.*O=\([^,]*\),.*/\1/')
+	fi
+	# Return only acsii chars, all lowercase, all one word, just to be consistent with what p11-kit would do
+	echo "$alias" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9()._-]//g'
+}
+
+for certificate in $(ls /etc/ssl/certs/*.pem) ; do
+	cert=$($jdk/bin/keytool -printcert -file $certificate)
+	issuer=$(echo "$cert" | grep '^Issuer' | cut -d' ' -f1 --complement)
+	fprint=$(echo "$cert" | grep 'SHA1:' | cut -d' ' -f3)
+	alias=$(get_alias "$issuer")
+	echo "Adding $fprint ($alias, $certificate)"
+	${jdk}/bin/keytool -importcert -noprompt -alias "${alias}" -storepass changeit -storetype JKS -keystore cacerts -file "${certificate}" || \
+		${jdk}/bin/keytool -importcert -noprompt -alias "${alias}_1" -storepass changeit -storetype JKS -keystore cacerts -file "${certificate}" # Since there was a certificate that ended up getting the same alias (<filename>.pem versus <filename>_1.pem)
+done
+
+rm $jdk/lib/security/cacerts
+mv cacerts $jdk/lib/security/cacerts
+

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+	"skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2023 Mat Booth <mat.booth@gmail.com> -->
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.openjdk21</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>0BSD AND Apache-1.1 AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND FTL AND GPL-2.0 AND GPL-2.0-with-classpath-exception AND IJG AND ISC AND LGPL-2.1-or-later AND MIT AND MPL-2.0 AND RSA-MD AND SAX-PD AND W3C AND Zlib</project_license>
+  <name>OpenJDK 21 SDK Extension</name>
+  <summary>The LTS (long term support) version of the OpenJDK JRE and JDK</summary>
+  <description>
+    <p>
+      This SDK extension allows the building and running of Java-based applications.
+    </p>
+  </description>
+  <url type="homepage">https://openjdk.java.net/</url>
+  <url type="bugtracker">https://bugs.openjdk.java.net/</url>
+  <developer_name>Mat Booth</developer_name>
+  <update_contact>mat.booth@gmail.com</update_contact>
+  <releases>
+    <release version="jdk-21.0.1+12" date="2023-10-27"/>
+    <release version="jdk-21.0.0+35" date="2023-10-11"/>
+  </releases>
+</component>

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -1,0 +1,205 @@
+id: org.freedesktop.Sdk.Extension.openjdk21
+branch: '23.08'
+runtime: org.freedesktop.Sdk
+runtime-version: '23.08'
+build-extension: true
+sdk: org.freedesktop.Sdk
+separate-locales: false
+appstream-compose: false
+cleanup:
+  - /share/info
+  - /share/man
+build-options:
+  no-debuginfo: true
+  strip: true
+  prefix: /usr/lib/sdk/openjdk21
+  env:
+    V: '1'
+modules:
+  - name: bootstrap_jdk
+    buildsystem: simple
+    cleanup:
+      - '*'
+    sources:
+      - type: file
+        only-arches:
+          - x86_64
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz
+        dest-filename: java-openjdk.tar.bz2
+        sha512: 496ed15dcba607cd1b9e6786932429f9d213d2ea22203bf8cbed61880655ee046bfc4c07b7b0d54285081ddf242fd8957ba34c8be75f5fb2ae0aac16f9b8ef3a
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
+          versions:
+            -  "==": 21
+      - type: file
+        only-arches:
+          - aarch64
+        url: https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.1_12.tar.gz
+        dest-filename: java-openjdk.tar.bz2
+        sha512: ed05b9733e8270fe73dab86fb9320689a6613dd2d6a5807a47a2e22f081feefd9729e39521c85f3f443687bd103918850a9bd3a27d1a64b8519bb37c7454e5e8
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=aarch64&image_type=jdk
+          version-query: .[0].version.semver
+          url-query: .[0].binary.package.link
+          versions:
+            -  "==": 21
+    build-commands:
+      - mkdir -p $FLATPAK_DEST/bootstrap-java
+      - tar xf java-openjdk.tar.bz2 --strip-components=1 --directory=$FLATPAK_DEST/bootstrap-java
+  - name: java
+    buildsystem: autotools
+    no-parallel-make: true
+    config-opts:
+      - --with-boot-jdk=/usr/lib/sdk/openjdk21/bootstrap-java
+      - --with-jvm-variants=server
+      - --with-version-build=2
+      - --with-version-pre=
+      - --with-version-opt=
+      - --with-vendor-version-string=21.9
+      - --with-vendor-name=Flathub
+      - --with-vendor-url=https://flathub.org
+      - --with-vendor-bug-url=https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk21/issues
+      - --with-debug-level=release
+      - --with-native-debug-symbols=internal
+      - --enable-unlimited-crypto
+      - --with-zlib=system
+      - --with-libjpeg=system
+      - --with-giflib=system
+      - --with-libpng=system
+      - --with-lcms=system
+      - --with-harfbuzz=system
+      - --with-stdc++lib=dynamic
+      - --with-extra-cxxflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
+        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
+      - --with-extra-cflags=-grecord-gcc-switches -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS
+        -fstack-protector-strong -fasynchronous-unwind-tables -fstack-clash-protection
+      - --with-extra-ldflags=-Wl,-z,relro -Wl,-z,now -Wl,--as-needed
+      - --disable-javac-server
+      - --disable-warnings-as-errors
+    make-args:
+      - LOG=info
+      - images
+    post-install:
+      - (cd $FLATPAK_DEST/jvm && ln -s openjdk-21.* openjdk-21)
+    sources:
+      - type: archive
+        url: https://github.com/openjdk/jdk21u/archive/refs/tags/jdk-21.0.1+12.tar.gz
+        sha512: a21f39ad489455a25093a7d6e216418efa991aa92dbd631d3dfcb2847ec7f5ca85277cb7a192f44549687fe5323236404c80e4b3e4fe54b7b03230c2fa38e07a
+        x-checker-data:
+          type: json
+          url: https://api.adoptium.net/v3/assets/latest/21/hotspot?os=linux&architecture=x64&image_type=jdk
+          version-query: .[0].release_name
+          url-query: '"https://github.com/openjdk/jdk21u/archive/refs/tags/" + $version
+            + ".tar.gz"'
+          versions:
+            -  "==": 21
+          is-main-source: true
+      - type: patch
+        path: 0001-Avoid-requiring-pcsc-development-files-at-runtime.patch
+      - type: shell
+        commands:
+          - chmod a+x configure
+          - sed -i -e "s|@prefix@|$FLATPAK_DEST|" make/autoconf/spec.gmk.in
+  - name: cacerts
+    buildsystem: simple
+    sources:
+      - type: file
+        path: extract_cacerts.sh
+    build-commands:
+      - ./extract_cacerts.sh $FLATPAK_DEST/jvm/openjdk-21
+  - name: ant
+    buildsystem: simple
+    cleanup:
+      - '*.bat'
+      - '*.cmd'
+    sources:
+      - type: file
+        url: http://archive.apache.org/dist/ant/binaries/apache-ant-1.10.14-bin.tar.gz
+        dest-filename: apache-ant-bin.tar.gz
+        sha512: 4e74b382dd8271f9eac9fef69ba94751fb8a8356dbd995c4d642f2dad33de77bd37d4001d6c8f4f0ef6789529754968f0c1b6376668033c8904c6ec84543332a
+        x-checker-data:
+          type: anitya
+          project-id: 50
+          stable-only: true
+          url-template: http://archive.apache.org/dist/ant/binaries/apache-ant-$version-bin.tar.gz
+    build-commands:
+      - mkdir -p $FLATPAK_DEST/ant
+      - tar xf apache-ant-bin.tar.gz --strip-components=1 --directory=$FLATPAK_DEST/ant
+      - ln -s $FLATPAK_DEST/ant/bin/ant $FLATPAK_DEST/bin
+  - name: maven
+    buildsystem: simple
+    cleanup:
+      - '*.bat'
+      - '*.cmd'
+    sources:
+      - type: file
+        url: http://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
+        dest-filename: apache-maven-bin.tar.gz
+        sha512: 706f01b20dec0305a822ab614d51f32b07ee11d0218175e55450242e49d2156386483b506b3a4e8a03ac8611bae96395fd5eec15f50d3013d5deed6d1ee18224
+        x-checker-data:
+          type: anitya
+          project-id: 1894
+          stable-only: true
+          url-template: http://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz
+    build-commands:
+      - mkdir -p $FLATPAK_DEST/maven
+      - tar xf apache-maven-bin.tar.gz --strip-components=1 --exclude=jansi-native
+        --directory=$FLATPAK_DEST/maven
+      - ln -s $FLATPAK_DEST/maven/bin/mvn $FLATPAK_DEST/maven/bin/mvnDebug $FLATPAK_DEST/bin
+  - name: gradle
+    buildsystem: simple
+    cleanup:
+      - '*.bat'
+    sources:
+      - type: file
+        url: https://services.gradle.org/distributions/gradle-8.5-bin.zip
+        dest-filename: gradle-bin.zip
+        sha512: c0c07fcee0802cbdf8156475280f961ef9c0d928252642363314e25da69803fd878ab65bdc1647efa5f4b1e9b7f71e6a4daa6946d9f9923628248e9f35e8b14b
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/gradle/gradle/releases
+          version-query: map(select(.prerelease == false)) | first | .name
+          url-query: '["https://services.gradle.org/distributions/gradle-" + $version
+            + "-bin.zip"][0]'
+    build-commands:
+      - unzip -q gradle-bin.zip -d $FLATPAK_DEST
+      - mv $FLATPAK_DEST/gradle-* $FLATPAK_DEST/gradle
+      - ln -s $FLATPAK_DEST/gradle/bin/gradle $FLATPAK_DEST/bin
+  - name: scripts
+    buildsystem: simple
+    sources:
+      - type: script
+        commands:
+          - mkdir -p /app/jre/bin
+          - cd /usr/lib/sdk/openjdk21/jvm/openjdk-21
+          - cp -ra conf lib release /app/jre/
+          - rm /app/jre/lib/src.zip /app/jre/lib/ct.sym
+          - cp -ra bin/{java,keytool,rmiregistry} /app/jre/bin
+        dest-filename: install.sh
+      - type: script
+        commands:
+          - mkdir -p /app/jdk/
+          - cd /usr/lib/sdk/openjdk21/jvm/openjdk-21
+          - cp -ra bin conf include jmods lib release /app/jdk/
+        dest-filename: installjdk.sh
+      - type: script
+        commands:
+          - export JAVA_HOME=/usr/lib/sdk/openjdk21/jvm/openjdk-21
+          - export PATH=$PATH:/usr/lib/sdk/openjdk21/bin
+        dest-filename: enable.sh
+    build-commands:
+      - cp enable.sh install.sh installjdk.sh /usr/lib/sdk/openjdk21/
+  - name: appdata
+    buildsystem: simple
+    sources:
+      - type: file
+        path: org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+    build-commands:
+      - mkdir -p ${FLATPAK_DEST}/share/metainfo
+      - cp org.freedesktop.Sdk.Extension.openjdk.appdata.xml ${FLATPAK_DEST}/share/metainfo
+      - appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST}
+        --origin=flatpak org.freedesktop.Sdk.Extension.openjdk

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -197,9 +197,9 @@ modules:
     buildsystem: simple
     sources:
       - type: file
-        path: org.freedesktop.Sdk.Extension.openjdk.appdata.xml
+        path: org.freedesktop.Sdk.Extension.openjdk21.appdata.xml
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/share/metainfo
-      - cp org.freedesktop.Sdk.Extension.openjdk.appdata.xml ${FLATPAK_DEST}/share/metainfo
+      - cp org.freedesktop.Sdk.Extension.openjdk21.appdata.xml ${FLATPAK_DEST}/share/metainfo
       - appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST}
         --origin=flatpak org.freedesktop.Sdk.Extension.openjdk

--- a/org.freedesktop.Sdk.Extension.openjdk21.yaml
+++ b/org.freedesktop.Sdk.Extension.openjdk21.yaml
@@ -201,5 +201,4 @@ modules:
     build-commands:
       - mkdir -p ${FLATPAK_DEST}/share/metainfo
       - cp org.freedesktop.Sdk.Extension.openjdk21.appdata.xml ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=org.freedesktop.Sdk.Extension.openjdk --prefix=${FLATPAK_DEST}
-        --origin=flatpak org.freedesktop.Sdk.Extension.openjdk
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}


### PR DESCRIPTION
When this gets added to Flathub, please add @mbooth101 (sorry for the ping) as a maintainer/collaborator, since this Flatpak is based off of _his_ existing work and maintenance.

The patch file in this Flatpak is also in the [`openjdk`](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/) and [`openjdk17`](https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk17/) Flatpaks, hence why the patch hasn't been submitted to its upstream source as of now.

Fixes https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk/issues/38

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
