### PR TITLE
Merge action: update maintenance guide URL

### DIFF
--- a/.github/actions/merge/entrypoint.py
+++ b/.github/actions/merge/entrypoint.py
@@ -233,7 +233,7 @@ def main():
         "\n",
         f"You will receive an invitation to be a collaborator which will grant you write access to the repository above. The invite can be also viewed [here]({repo.html_url}/invitations).",
         "\n",
-        "If you have never maintained an application before, common questions are answered in [the app maintenance guide](https://github.com/flathub/flathub/wiki/App-Maintenance).",
+        "If you have never maintained an application before, common questions are answered in [the app maintenance guide](https://docs.flathub.org/docs/for-app-authors/maintenance/).",
         "\n",
         "Thanks!",
     )


### PR DESCRIPTION
Rather than linking to the wiki, which links to the docs