### PR TITLE
Add dev.skynomads.Seabird

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.flatpak-builder

--- a/dev.skynomads.Seabird.appdata.xml
+++ b/dev.skynomads.Seabird.appdata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>dev.skynomads.Seabird</id>
+  <name>Seabird</name>
+  <summary>Kubernetes desktop client</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MPL-2.0</project_license>
+  <description>
+    <p>Seabird is the native desktop app that simplifies working with Kubernetes.</p>
+  </description>
+  <launchable type="desktop-id">dev.skynomads.Seabird.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Seabird main application window</caption>
+      <image>https://getseabird.github.io/images/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://getseabird.github.io/</url>
+  <developer_name>Seabird Project</developer_name>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="v0.0.19" date="2024-01-29"/>
+  </releases>
+</component> 

--- a/dev.skynomads.Seabird.desktop
+++ b/dev.skynomads.Seabird.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+
+Name=Seabird
+Comment=Kubernetes desktop client
+Categories=Development;Network;
+Keywords=kubernetes;
+
+Icon=dev.skynomads.Seabird
+Exec=seabird
+Terminal=false

--- a/dev.skynomads.Seabird.yaml
+++ b/dev.skynomads.Seabird.yaml
@@ -1,0 +1,38 @@
+app-id: dev.skynomads.Seabird
+runtime: org.gnome.Platform
+runtime-version: "45"
+sdk: org.gnome.Sdk
+command: seabird
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --filesystem=home
+
+modules:
+  - name: seabird
+    buildsystem: simple
+    build-commands:
+      - |
+        install -Dm00755 -t /app/bin linux_amd64/seabird
+        install -Dm00644 seabird.svg /app/share/icons/hicolor/scalable/apps/$FLATPAK_ID.svg
+        install -Dm00644 -t /app/share/applications $FLATPAK_ID.desktop
+        install -Dm00644 -t /app/share/metainfo $FLATPAK_ID.appdata.xml
+    sources:
+      - type: file
+        path: dev.skynomads.Seabird.desktop
+      - type: file
+        path: dev.skynomads.Seabird.appdata.xml
+      - type: file
+        filename: seabird.svg
+        url: https://raw.githubusercontent.com/getseabird/seabird/d1c2366c5e6d5f12f070e446ceb99511f56ab7e8/icon/seabird.svg
+        sha256: 6593267d7c60a8a84c350250854fc3f2929c17af612a3b4e44d958b5301cd4fe
+      - type: archive
+        strip-components: 0
+        dest: linux_amd64
+        url: https://github.com/getseabird/seabird/releases/download/v0.0.19/seabird_linux_amd64.tar.gz
+        sha256: 79fdbc6a992e9a3cacb8526b073f03d8fe084c38b141a9000eb15d27f986401f


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
   * --filesystem=home is required to read certs when a user loads a kubeconfig
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an upstream contributor to the project.
- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
    * Yes, I own the domain
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
    * No additions

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id

This is using official release binaries. I initially tried to build from source, but there's currently no working solution for Go dependencies in builder-tools. Apparently this isn't a concern anyway but I thought I'd mention it. We also have no arm64 binaries yet, they'll be added once some build troubles are ironed out.

No linter errors aside from `appstream-screenshots-not-mirrored-in-ostree`.

Upstream link: https://github.com/getseabird/seabird
