### PR TITLE
Add io.nanoboyadvance.NanoBoyAdvance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "skip-arches": ["aarch64"]
+}

--- a/io.nanoboyadvance.NanoBoyAdvance.desktop
+++ b/io.nanoboyadvance.NanoBoyAdvance.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=NanoBoyAdvance
+GenericName=Emulator
+Comment=A cycle-accurate Nintendo Game Boy Advance emulator
+Icon=io.nanoboyadvance.NanoBoyAdvance
+TryExec=NanoBoyAdvance
+Exec=NanoBoyAdvance %f
+MimeType=application/x-gameboy-advance-rom;application/x-agb-rom;application/x-gba-rom;
+Categories=Game;Emulator;
+Keywords=Emulator;Nintendo;GameBoy;Game Boy Advance;GBA;GB;
+SingleMainWindow=true

--- a/io.nanoboyadvance.NanoBoyAdvance.desktop
+++ b/io.nanoboyadvance.NanoBoyAdvance.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=NanoBoyAdvance
 GenericName=Emulator
-Comment=A cycle-accurate Nintendo Game Boy Advance emulator
+Comment=Cycle-accurate Nintendo Game Boy Advance emulator
 Icon=io.nanoboyadvance.NanoBoyAdvance
 TryExec=NanoBoyAdvance
 Exec=NanoBoyAdvance %f

--- a/io.nanoboyadvance.NanoBoyAdvance.desktop
+++ b/io.nanoboyadvance.NanoBoyAdvance.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=NanoBoyAdvance
-GenericName=Emulator
+GenericName=Game Boy Advance Emulator
 Comment=Cycle-accurate Nintendo Game Boy Advance emulator
 Icon=io.nanoboyadvance.NanoBoyAdvance
 TryExec=NanoBoyAdvance

--- a/io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
+++ b/io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
@@ -1,0 +1,168 @@
+<?xml version='1.0' encoding='utf-8'?>
+<component type="desktop">
+  <id>io.nanoboyadvance.NanoBoyAdvance</id>
+  <name>NanoBoyAdvance</name>
+  <summary>A cycle-accurate Nintendo Game Boy Advance emulator</summary>
+  <developer_name>fleroviux</developer_name>
+  <launchable type="desktop-id">io.nanoboyadvance.NanoBoyAdvance.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0+</project_license>
+  <description>
+    <p>NanoBoyAdvance is a cycle-accurate Game Boy Advance emulator.
+It aims to be as accurate as possible, while also offering enhancements such as improved audio quality.</p>
+    <p>Features</p>
+    <ul>
+      <li>Very high compatibility and accuracy</li>
+      <li>HQ audio mixer (for games which use Nintendo's MusicPlayer2000 sound engine)</li>
+      <li>Post-processing options (color correction, xBRZ upscaling and LCD ghosting simulation)</li>
+      <li>Save State support (10x save slots available)</li>
+      <li>Game controller support (buttons and axises can be remapped)</li>
+      <li>Loading ROMs from archives (Zip, 7z, Tar and limited RAR support)</li>
+      <li>RTC emulation</li>
+      <li>Solar Sensor emulation (for example: for Boktai - The Sun is in Your Hand)</li>
+      <li>Debug tools: PPU palette, tile, background and sprite viewers</li>
+    </ul>
+    <p>Accuracy</p>
+    <p>A lot of research and attention to detail has been put into developing this core and making it accurate.</p>
+    <ul>
+      <li>Cycle-accurate emulation of most components, including: CPU, DMA, timers, PPU and Game Pak prefetch</li>
+      <li>Passes all AGS aging cartridge tests (NBA was the first public emulator to achieve this)</li>
+      <li>Passes most tests in the mGBA test suite</li>
+      <li>Passes ARMWrestler, gba-suite and FuzzARM CPU tests</li>
+      <li>Very high compatibility, including games that require emulation of peculiar hardware edge-cases</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://raw.githubusercontent.com/nba-emu/NanoBoyAdvance/master/docs/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.8.0" date="2024-02-18" tyle="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.8.0</url>
+      <description>
+        <ul>
+          <li>UI: implement "Sharp" video filter for better nearest interpolation at non-integer scales (thanks GranMinigun)</li>
+          <li>UI: implemented PPU viewers for palettes, tiles, backgrounds and sprites</li>
+          <li>UI: add an option to set the audio volume</li>
+          <li>UI: add an option to set the audio volume</li>
+          <li>Input: fix input dropping regression introduced in NBA 1.7.1</li>
+          <li>Input: move from SDL game controller to SDL joystick API (fixes broken mapping on some controllers)</li>
+          <li>APU: MP2K HLE: interpolate envelopes and use floating-point math</li>
+          <li>APU: MP2K HLE: implement a better reverb algorithm</li>
+          <li>APU: MP2K HLE: add an option to force-enable reverb</li>
+          <li>APU: remove "Zombie" mode emulation (does not appear to exist on GBA)</li>
+          <li>APU: fix mid-note envelope frequency changes</li>
+          <li>APU: FIFO writes should happen in place</li>
+          <li>APU: reset FIFOs on overflow</li>
+          <li>APU: add master-enable checks for 16-bit/32-bit IO writes</li>
+          <li>PPU: fix sprite pixels from previous scanline displayed in the last scanline</li>
+          <li>PPU: more accurate update of attribute buffer for OBJWIN sprites</li>
+          <li>PPU: more accurate emulation of horizontal and vertical sprite mosaic</li>
+          <li>PPU: more accurate handling of mid-frame vertical mosaic reconfiguration</li>
+          <li>PPU: fix out-of-bounds bitmap fetches in Mode 3 to 5</li>
+          <li>DMA: fix incorrect mapping of DMA channel to APU FIFO</li>
+          <li>Timer: somewhat handle timer overflow during one cycle enable delay (thanks alyosha)</li>
+          <li>Game Pak: simulate ~6 ms EEPROM device busy period after write (not yet accurate to cartridges that e.g. have been in the freezer for 30 minutes)</li>
+          <li>Game Pak: emulate the Mask ROM internal address register</li>
+          <li>Audio: fix clicking artifacts when using Sinc resampling</li>
+          <li>Audio: fix incorrect liner interpolation in Cosine resampling</li>
+          <li>PlatformCore: fixed hang when fast-forwarding while the emulator is paused</li>
+          <li>Misc: implemented support for unicode paths</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.7.1" date="2023-05-15" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.7.1</url>
+      <description>
+        <ul>
+          <li>PPU: disallow out-of-bounds BG VRAM tile fetches and return open bus</li>
+          <li>Core: do not skip to the next event if the CPU woke up during a DMA</li>
+          <li>KeyPad: always request IRQs from the emulator (not the calling) thread</li>
+          <li>GameDB: fix entries for a bunch of Classic NES and Famicom Mini titles</li>
+          <li>IO: do not enter STOP mode when it is not implemented</li>
+          <li>mGBA log: clear the message buffer after printing the message</li>
+          <li>mGBA log: flush STDOUT after each message</li>
+          <li>Catch fmt::system_error when fmt::print() fails to write to STDOUT</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.7" date="2023-03-26" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.7</url>
+      <description>
+        <ul>
+          <li>UI: implement a 'Use integer scaling' option</li>
+          <li>UI: allow limiting the screen scale</li>
+          <li>UI: allow accessing the menu during fullscreen gameplay</li>
+          <li>UI: allow setting a custom save folder</li>
+          <li>Core: implement save compatibility with mGBA 0.10.0+</li>
+          <li>Core: implement basic support for the mGBA logging interface</li>
+          <li>PPU: rewrite the PPU to be mostly cycle-accurate</li>
+          <li>PPU: implement the GREENSWAP register</li>
+          <li>PPU: use the 6-th green channel bit during blending</li>
+          <li>PPU: round the blending result to the nearest integer</li>
+          <li>ARM: fix a minor timing oversight in ARM mode</li>
+          <li>ARM: SWP and SWPB should lock the bus (no DMA interleave is possible)</li>
+          <li>ARM: do not force-align mis-aligned PC in ARM mode</li>
+          <li>Bus: allow the CPU to execute idle cycles in parallel to DMA</li>
+          <li>Bus: more accurately emulate disabling the prefetch buffer</li>
+          <li>Bus: force the first CPU access after a DMA to be non-sequential</li>
+          <li>Bus: implement penalty for ROM code access during the last ROM prefetch cycle</li>
+          <li>IRQ: delay IO writes by one cycle</li>
+          <li>IRQ: delay update of the IE&amp;IF condition for unhalting the CPU</li>
+          <li>SIO: implement basic serial transfer timing</li>
+          <li>APU: emulate the master enable bit</li>
+          <li>APU: cancel a potentially pending event whan starting a channel</li>
+          <li>Scheduler: allow for (de)serialization of events for save states</li>
+        </ul>
+      </description>
+    </release>
+    <release version="1.6" date="2022-08-13" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.6</url>
+    </release>
+    <release version="1.5" date="2022-05-29" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.5</url>
+    </release>
+    <release version="1.4" date="2021-12-20" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.4</url>
+    </release>
+    <release version="1.3" date="2021-02-01" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/1.3</url>
+    </release>
+    <release version="1.2" date="2020-07-30" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.2</url>
+    </release>
+    <release version="1.1" date="2020-05-10" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.1</url>
+    </release>
+    <release version="1.0" date="2020-05-10" type="stable">
+      <url>https://github.com/nba-emu/NanoBoyAdvance/releases/tag/v1.0</url>
+    </release>
+  </releases>
+  <url type="homepage">https://github.com/nba-emu/NanoBoyAdvance</url>
+  <url type="bugtracker">https://github.com/nba-emu/NanoBoyAdvance</url>
+  <categories>
+    <category>Game</category>
+    <category>Emulator</category>
+  </categories>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+  </recommends>
+  <content_rating type="oars-1.1"/>
+  <provides>
+    <binary>NanoBoyAdvance</binary>
+    <mediatype>application/x-gameboy-advance-rom</mediatype>
+    <mediatype>application/x-agb-rom</mediatype>
+    <mediatype>application/x-gba-rom</mediatype>
+  </provides>
+  <keywords>
+    <keyword>Emulator</keyword>
+    <keyword>Nintendo</keyword>
+    <keyword>GameBoy</keyword>
+    <keyword>Game Boy Advance</keyword>
+    <keyword>GBA</keyword>
+    <keyword>GB</keyword>
+  </keywords>
+</component>

--- a/io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
+++ b/io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop">
   <id>io.nanoboyadvance.NanoBoyAdvance</id>
   <name>NanoBoyAdvance</name>
-  <summary>A cycle-accurate Nintendo Game Boy Advance emulator</summary>
+  <summary>Cycle-accurate Nintendo Game Boy Advance emulator</summary>
   <developer_name>fleroviux</developer_name>
   <launchable type="desktop-id">io.nanoboyadvance.NanoBoyAdvance.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
@@ -34,7 +34,7 @@ It aims to be as accurate as possible, while also offering enhancements such as 
   </description>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://raw.githubusercontent.com/nba-emu/NanoBoyAdvance/master/docs/screenshot.png</image>
+      <image type="source">https://raw.githubusercontent.com/nba-emu/NanoBoyAdvance/c8493948743f6e9e6f72abe057ba3ed5d03ad16a/docs/screenshot.png</image>
     </screenshot>
   </screenshots>
   <releases>
@@ -140,7 +140,7 @@ It aims to be as accurate as possible, while also offering enhancements such as 
     </release>
   </releases>
   <url type="homepage">https://github.com/nba-emu/NanoBoyAdvance</url>
-  <url type="bugtracker">https://github.com/nba-emu/NanoBoyAdvance</url>
+  <url type="bugtracker">https://github.com/nba-emu/NanoBoyAdvance/issues</url>
   <categories>
     <category>Game</category>
     <category>Emulator</category>

--- a/io.nanoboyadvance.NanoBoyAdvance.yml
+++ b/io.nanoboyadvance.NanoBoyAdvance.yml
@@ -58,10 +58,8 @@ modules:
         commit: 752d4604ce3d1f978c8fca17b6f37e0d96703ec0
       - type: file
         path: io.nanoboyadvance.NanoBoyAdvance.desktop
-        sha256: 9590f87b1692a5f69467046da64d2ec31b45054daa738e576432b41f505bc308
       - type: file
         path: io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
-        sha256: c942851ba74b540629e8d8c9331d780730a4e2bd2ad63505cf9fc562e2115694
     # Replace .desktop and .metainfo.xml files with local versions
     # (shouldn't be necessary for versions later than v1.8.0)
     post-install:

--- a/io.nanoboyadvance.NanoBoyAdvance.yml
+++ b/io.nanoboyadvance.NanoBoyAdvance.yml
@@ -1,0 +1,69 @@
+id: io.nanoboyadvance.NanoBoyAdvance
+runtime: org.kde.Platform
+runtime-version: '5.15-23.08'
+sdk: org.kde.Sdk
+command: NanoBoyAdvance
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --filesystem=host # for save files
+  - --device=all      # for GPU and controllers
+cleanup:
+  - '/include'
+  - '/lib/cmake'
+  - '/lib/pkgconfig'
+  - '*.a'
+modules:
+  - shared-modules/glew/glew.json
+  - shared-modules/glu/glu-9.json
+
+  - name: fmtlib
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/fmtlib/fmt
+        tag: 10.1.1
+        commit: f5e54359df4c26b6230fc61d38aa294581393084
+
+  - name: toml11
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/ToruNiina/toml11
+        tag: v3.7.1
+        commit: dcfe39a783a94e8d52c885e5883a6fbb21529019
+
+  - name: unarr
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/selmf/unarr
+        tag: v1.1.1
+        commit: b211040df83dee513362cdeb9bd87afa26fd5e38
+
+  - name: NanoBoyAdvance
+    buildsystem: cmake-ninja
+    config-opts:
+      - -D CMAKE_BUILD_TYPE=Release
+      - -D PORTABLE_MODE=OFF
+      - -D USE_SYSTEM_FMT=ON
+      - -D USE_SYSTEM_TOML11=ON
+      - -D USE_SYSTEM_UNARR=ON
+    sources:
+      - type: git
+        url: https://github.com/nba-emu/NanoBoyAdvance
+        tag: v1.8.0
+        commit: 752d4604ce3d1f978c8fca17b6f37e0d96703ec0
+      - type: file
+        path: io.nanoboyadvance.NanoBoyAdvance.desktop
+        sha256: 9590f87b1692a5f69467046da64d2ec31b45054daa738e576432b41f505bc308
+      - type: file
+        path: io.nanoboyadvance.NanoBoyAdvance.metainfo.xml
+        sha256: c942851ba74b540629e8d8c9331d780730a4e2bd2ad63505cf9fc562e2115694
+    # Replace .desktop and .metainfo.xml files with local versions
+    # (shouldn't be necessary for versions later than v1.8.0)
+    post-install:
+      - install -Dm644 io.nanoboyadvance.NanoBoyAdvance.desktop /app/share/applications/io.nanoboyadvance.NanoBoyAdvance.desktop
+      - install -Dm644 io.nanoboyadvance.NanoBoyAdvance.metainfo.xml /app/share/metainfo/io.nanoboyadvance.NanoBoyAdvance.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id

The upstream developer is @fleroviux. [Here](https://github.com/nba-emu/NanoBoyAdvance/issues/330)'s the discussion in which submission to FlatHub was discussed.

Non-standard permissions:
- `--filesystem=host`: the emulator stores save files in the same directory of the ROM (e.g. `/path/game.gba` and `/path/game.sav`) and since ROMs may be located anywhere the user can write to, the emulator needs to be able to write save files anywhere.
- `--device=all`: for controller support.

The `.desktop` and `.metainfo.xml` files present upstream are, in the current release, outdated. So I put the newer versions here in this repository, but they should be upstream from the next release onward.