### PR TITLE
Add de.wagnermartin.Plattenalbum

### DIFF
--- a/de.wagnermartin.Plattenalbum.json
+++ b/de.wagnermartin.Plattenalbum.json
@@ -34,15 +34,11 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/SoongNoonien/plattenalbum.git",
-        "tag": "v2.0.0",
-        "commit": "9cf9d8f5af471fbaa882888e0dab14d688a1b8da"
+        "tag": "v2.0.0a",
+        "commit": "da20c9e68bf626216d1d2d4636192c53948004ad"
       }],
-      "buildsystem": "simple",
-      "build-commands": [
-        "meson setup builddir --prefix=/app",
-        "ninja -C builddir install",
-        "glib-compile-schemas /app/share/glib-2.0/schemas"
-      ]
+      "builddir" : true,
+      "buildsystem": "meson"
     }
   ]
 }

--- a/de.wagnermartin.Plattenalbum.json
+++ b/de.wagnermartin.Plattenalbum.json
@@ -12,9 +12,7 @@
     "--share=network",
     "--filesystem=xdg-music:ro",
     "--filesystem=xdg-run/mpd",
-    "--talk-name=org.freedesktop.Notifications",
-    "--talk-name=org.freedesktop.FileManager1",
-    "--own-name=org.mpris.MediaPlayer2.Plattenalbum"
+    "--talk-name=org.freedesktop.FileManager1"
   ],
   "modules": [
     {
@@ -34,8 +32,8 @@
       "sources": [{
         "type": "git",
         "url": "https://github.com/SoongNoonien/plattenalbum.git",
-        "tag": "v2.0.0a",
-        "commit": "da20c9e68bf626216d1d2d4636192c53948004ad"
+        "tag": "v2.0.1",
+        "commit": "733f80a0938660c6fef24d88b735827e159c5aad"
       }],
       "builddir" : true,
       "buildsystem": "meson"

--- a/de.wagnermartin.Plattenalbum.json
+++ b/de.wagnermartin.Plattenalbum.json
@@ -1,0 +1,48 @@
+{
+  "app-id": "de.wagnermartin.Plattenalbum",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "45",
+  "sdk": "org.gnome.Sdk",
+  "command": "plattenalbum",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--share=network",
+    "--filesystem=xdg-music:ro",
+    "--filesystem=xdg-run/mpd",
+    "--talk-name=org.freedesktop.Notifications",
+    "--talk-name=org.freedesktop.FileManager1",
+    "--own-name=org.mpris.MediaPlayer2.Plattenalbum"
+  ],
+  "modules": [
+    {
+      "name": "python3-mpd2",
+      "sources": [{
+        "type": "file",
+        "url": "https://files.pythonhosted.org/packages/53/be/e77206eb35eb37ccd3506fba237e1431431d04c482707730ce2a6802e95c/python-mpd2-3.1.1.tar.gz",
+        "sha256": "4baec3584cc43ed9948d5559079fafc2679b06b2ade273e909b3582654b2b3f5"
+      }],
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"python-mpd2\""
+      ]
+    },
+    {
+      "name": "plattenalbum",
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/SoongNoonien/plattenalbum.git",
+        "tag": "v2.0.0",
+        "commit": "9cf9d8f5af471fbaa882888e0dab14d688a1b8da"
+      }],
+      "buildsystem": "simple",
+      "build-commands": [
+        "meson setup builddir --prefix=/app",
+        "ninja -C builddir install",
+        "glib-compile-schemas /app/share/glib-2.0/schemas"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

Plattenalbum is a client for the Music Player Daemon (MPD). It was previously developed under the name of "mpdevil" (`org.mpdevil.mpdevil`), which needs to be archived/replaced after the merge.

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
