### PR TITLE
Add dev.tchx84.Gameeky.ThematicPack.Blasterman

### DIFF
--- a/dev.tchx84.Gameeky.ThematicPack.Blasterman.json
+++ b/dev.tchx84.Gameeky.ThematicPack.Blasterman.json
@@ -1,0 +1,35 @@
+{
+    "id": "dev.tchx84.Gameeky.ThematicPack.Blasterman",
+    "runtime": "dev.tchx84.Gameeky",
+    "runtime-version": "stable",
+    "sdk": "org.gnome.Sdk//45",
+    "build-extension": true,
+    "separate-locales": false,
+    "build-options": {
+        "prefix": "/app/extensions/Blasterman"
+    },
+    "modules": [
+        {
+            "name": "pack",
+            "buildsystem": "simple",
+            "build-commands": [
+                "cp gameeky.project ${FLATPAK_DEST}/",
+                "cp -r actuators ${FLATPAK_DEST}/",
+                "cp -r assets ${FLATPAK_DEST}/",
+                "cp -r entities ${FLATPAK_DEST}/",
+                "cp -r scenes ${FLATPAK_DEST}/"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/tchx84/Blasterman.git",
+                    "tag": "v0.2.0",
+                    "commit": "fb97e708a5f83c2be08c3dca8b640f47e08c1a6c"
+                }
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo packaging/dev.tchx84.Gameeky.ThematicPack.Blasterman.metainfo.xml"
+            ]
+        }
+    ]
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

Blasterman is an thematic pack extension for [Gameeky](https://flathub.org/apps/dev.tchx84.Gameeky).

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [X] Please describe your application briefly.
- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
