### PR TITLE
Add org.sugarlabs.PyEyes

### DIFF
--- a/org.sugarlabs.PyEyes.json
+++ b/org.sugarlabs.PyEyes.json
@@ -1,0 +1,60 @@
+{
+    "app-id": "org.sugarlabs.PyEyes",
+    "base": "org.sugarlabs.BaseApp",
+    "base-version": "23.06",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "44",
+    "sdk": "org.gnome.Sdk",
+    "separate-locales": false,
+    "command": "sugarapp",
+    "finish-args": [
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--share=ipc",
+        "--device=dri",
+        "--env=SUGAR_BUNDLE_ID=org.sugarlabs.PyEyes",
+        "--env=SUGAR_BUNDLE_PATH=/app/share/sugar/activities/PyEyes.activity"
+    ],
+    "modules": [
+        {
+            "name": "pyeyes",
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 setup.py install --prefix=${FLATPAK_DEST} --skip-install-desktop-file --skip-install-mime"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/sugarlabs/pyeyes-activity.git",
+		    "commit": "478fcaf51df5556a3fc26503dfbb63d9d13d1405"
+                },
+                {
+                    "type": "patch",
+                    "path": "pyeyes-port.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "pyeyes-info.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "pyeyes-screen.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "pyeyes-setup.patch"
+                }
+            ],
+            "post-install": [
+                "sugarapp-gen-mimetypes activity/activity.info mimetypes",
+                "sugarapp-gen-appdata activity/activity.info appdata",
+                "sugarapp-gen-desktop activity/activity.info desktop --mimetypes mimetypes",
+                "install -D mimetypes /app/share/mime/packages/org.sugarlabs.PyEyes.xml",
+                "install -D mimetypes /app/share/sugar/activities/PyEyes.activity/activity/mimetypes.xml",
+                "install -D appdata /app/share/metainfo/org.sugarlabs.PyEyes.appdata.xml",
+                "install -D desktop /app/share/applications/org.sugarlabs.PyEyes.desktop",
+                "install -D activity/activity.svg /app/share/icons/hicolor/scalable/apps/org.sugarlabs.PyEyes.svg"
+            ]
+        }
+    ]
+}

--- a/pyeyes-info.patch
+++ b/pyeyes-info.patch
@@ -1,0 +1,23 @@
+diff --git a/activity/activity.info b/activity/activity.info
+index eabf592..07d4039 100644
+--- a/activity/activity.info
++++ b/activity/activity.info
+@@ -2,8 +2,16 @@
+ name = PyEyes
+ activity_version = 2
+ host_version = 1
+-bundle_id = org.laptop.community.PyEyes
++bundle_id = org.sugarlabs.PyEyes
++release_date = 2011-04-05
+ icon = activity
+ exec = sugar-activity3 activity.PyEyesActivity
+ license = GPLv3
++metadata_license = CC0-1.0
+ repository = https://github.com/sugarlabs/pyeyes-activity.git
++developer_name = Sugar Labs Community
++screenshots = http://activities.sugarlabs.org/en-US/sugar/images/t/602/1302138013
++tags = Education
++update_contact = tch@sugarlabs.org
++summary = Eyes following the cursor
++description = PyEyes is a program where eyes follow the mouse pointer and move according to it.
+\ No newline at end of file

--- a/pyeyes-port.patch
+++ b/pyeyes-port.patch
@@ -1,0 +1,32 @@
+diff --git a/activity.py b/activity.py
+index 3698232..6c2d768 100755
+--- a/activity.py
++++ b/activity.py
+@@ -9,14 +9,15 @@ from gi.repository import Gdk
+ 
+ from sugar3.activity.activity import Activity
+ from sugar3.activity.widgets import StopButton
+-from sugar3.activity.widgets import ActivityToolbarButton
++from sugarapp.widgets import ExtendedActivityToolbarButton
+ from sugar3.graphics.toolbarbox import ToolbarBox
+ 
++from sugarapp.widgets import SugarCompatibleActivity
+ 
+-class PyEyesActivity(Activity):
+ 
++class PyEyesActivity(SugarCompatibleActivity):
+     def __init__(self, handle):
+-        Activity.__init__(self, handle)
++        SugarCompatibleActivity.__init__(self, handle)
+ 
+         self.add_events(Gdk.EventMask.POINTER_MOTION_MASK)
+         self.connect("motion-notify-event", lambda w, e: self.look_at((e.x, e.y)))
+@@ -46,7 +47,7 @@ class PyEyesActivity(Activity):
+         toolbarbox = ToolbarBox()
+         self.set_toolbar_box(toolbarbox)
+ 
+-        toolbarbox.toolbar.insert(ActivityToolbarButton(self), -1)
++        toolbarbox.toolbar.insert(ExtendedActivityToolbarButton(self), -1)
+         toolbarbox.toolbar.insert(StopButton(self), -1)
+ 
+         separator = Gtk.SeparatorToolItem()

--- a/pyeyes-screen.patch
+++ b/pyeyes-screen.patch
@@ -1,0 +1,24 @@
+diff --git a/activity.py b/activity.py
+index 3698232..98a3a17 100755
+--- a/activity.py
++++ b/activity.py
+@@ -7,6 +7,7 @@ gi.require_version('Gtk', '3.0')
+ from gi.repository import Gtk
+ from gi.repository import Gdk
+ 
++from sugarapp.helpers import PrimaryMonitor
+ from sugar3.activity.activity import Activity
+ from sugar3.activity.widgets import StopButton
+ from sugar3.activity.widgets import ActivityToolbarButton
+@@ -26,9 +27,8 @@ class PyEyesActivity(Activity):
+         box = Gtk.HBox()
+         self.set_canvas(box)
+ 
+-        screen = Gdk.Screen.get_default()
+-        rw = screen.get_width() / 2
+-        rh = screen.get_height() / 2
++        rw = PrimaryMonitor.width() / 2
++        rh = PrimaryMonitor.height() / 2
+ 
+         self.eye1 = eyes.Eye(Gdk.Color.parse("#FFFFFF")[1])
+         self.eye1.set_size_request(rw, rh)

--- a/pyeyes-setup.patch
+++ b/pyeyes-setup.patch
@@ -1,0 +1,10 @@
+diff --git a/setup.py b/setup.py
+index c6d0886..dc6a3f0 100755
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,4 @@
+ #!/usr/bin/env python3
+ from sugar3.activity import bundlebuilder
+ if __name__ == "__main__":
+-    bundlebuilder.start("PyEyes")
++    bundlebuilder.start()


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
PyEyes is a part of [sugar apps](https://sugarlabs.org). It is a simple activity where the eyes in the application follow the mouse cursor, much like xeyes.
- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub.

Migration guide enables anyone to port to flatpak.

- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.

Yes the migration guide mentions the use of sugarlabs.org domain

- [ ] Any additional patches or files have been submitted to the upstream projects concerned.

The patches have not been upstreamed as SugarLabs flatpak migration guide states, that those are to come at later stage when sugarapps (the library enabling sugar apps to port to flathub) gets mature. (https://github.com/tchx84/sugarapp/blob/master/flatpak-guide.md)