### PR TITLE
Add org.gnome.gitlab.cheywood.Buffer

### DIFF
--- a/org.gnome.gitlab.cheywood.Buffer.json
+++ b/org.gnome.gitlab.cheywood.Buffer.json
@@ -1,0 +1,53 @@
+{
+    "app-id": "org.gnome.gitlab.cheywood.Buffer",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "46",
+    "sdk": "org.gnome.Sdk",
+    "command": "buffer",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "*.a",
+        "*.la",
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/aclocal",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig"
+    ],
+    "modules": [
+        {
+          "name": "libspelling",
+          "buildsystem": "meson",
+          "config-opts": ["-Ddocs=false"],
+          "sources": [
+            {
+                "type": "git",
+                "url": "https://gitlab.gnome.org/chergert/libspelling.git",
+                "commit": "0e9b8b2187ecda4dc1ce48a9bcc9a9976490fda2",
+                "tag": "0.2.1"
+            }
+          ]
+        },
+        {
+            "name" : "buffer",
+            "buildsystem" : "meson",
+            "builddir" : true,
+            "sources" : [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/cheywood/buffer.git",
+                    "tag": "0.9.0",
+                    "commit": "1bc4bbd4622369f2932e023399cd3fc0b67a579b"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Buffer - Embrace ephemeral text.

Celebrating transience, Buffer provides a minimal editing space for all those things that don't need keeping. Designed for keyboard workflows on desktop.

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
