### PR TITLE
Add com.opera.opera.codecs

### DIFF
--- a/com.opera.Opera.Codecs.metainfo.xml
+++ b/com.opera.Opera.Codecs.metainfo.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.opera.Opera.Codecs</id>
+  <extends>com.opera.Opera</extends>
+  <name>Opera codecs</name>
+  <developer_name>Opera</developer_name>
+  <summary>Proprietary codecs for Opera browser</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <url type="homepage">https://opera.com/</url>
+  <update_contact>prace@vseta.cz</update_contact>
+  <releases>
+    <release version="0.86.0" date="2024-04-20"/>
+  </releases>
+</component>

--- a/com.opera.Opera.Codecs.yaml
+++ b/com.opera.Opera.Codecs.yaml
@@ -1,0 +1,30 @@
+id: com.opera.Opera.Codecs
+  #branch: 'nwjs-ffmpeg-0.86.0'
+runtime: com.opera.Opera
+sdk: org.freedesktop.Sdk//23.08
+build-extension: true
+separate-locales: false
+
+modules:
+  - name: codecs
+    buildsystem: simple
+    build-commands:
+      - unzip ffmpeg.zip
+      - install -Dm 644 libffmpeg.so -t ${FLATPAK_DEST}
+    sources:
+      - type: file
+        url: https://github.com/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases/download/nwjs-ffmpeg-0.86.0/0.86.0-linux-x64.zip
+        sha256: 5a1cdf7d45f580f6a30b677e8a402453cba4856bcadd5f946550857d1c04497c
+        dest-filename: ffmpeg.zip
+        x-checker-data:
+          type: rotating-url
+          url: https://github.com/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases/download/nwjs-ffmpeg-/-linux-x64.zip
+          pattern: https://github.com/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases/download/nwjs-ffmpeg-${version}/${version}-linux-x64.zip
+#      - type: git
+#        url: https://github.com/Ld-Hagen/nwjs-ffmpeg-prebuilt
+#        tag: 'nwjs-ffmpeg-0.86.0'
+#        commit: 32a332b7f6e6a0a8190c66315732914b1796abb1
+#        x-checker-data:
+#          type: git
+#          tag-pattern: ^nwjs-ffmpeg-([\d.]+)$
+


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

An extension to Opera flatpak with proprietary codecs.

As for the extra-data part, I couldn't find any way to unzip archive downloaded via extra-data. I also have no idea if this is correct way/place to submit an extension so I ask for advice if this is not the way. O:)

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [ ] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
