### PR TITLE
Add io.github.cleomenezesjr.aurea

### DIFF
--- a/io.github.cleomenezesjr.aurea.json
+++ b/io.github.cleomenezesjr.aurea.json
@@ -60,7 +60,7 @@
         {
           "type": "git",
           "url": "https://github.com/CleoMenezesJr/Aurea.git",
-          "tag": "1.0",
+          "tag": "1.1",
           "commit": "39a39d8e6aa2e790c0e2f31baa797f1b032f7740"
         }
       ]

--- a/io.github.cleomenezesjr.aurea.json
+++ b/io.github.cleomenezesjr.aurea.json
@@ -1,0 +1,69 @@
+{
+  "app-id": "io.github.cleomenezesjr.aurea",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "46",
+  "sdk": "org.gnome.Sdk",
+  "command": "aurea",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--socket=wayland",
+    "--filesystem=home"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "blueprint-compiler",
+      "buildsystem": "meson",
+      "cleanup": [
+        "*"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
+          "tag": "v0.10.0"
+        }
+      ]
+    },
+    {
+      "name": "python3-Pillow",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Pillow\" --no-build-isolation"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/0f/8b/2ebaf9adcf4260c00f842154865f8730cf745906aa5dd499141fb6063e26/Pillow-10.0.0.tar.gz",
+          "sha256": "9c82b5b3e043c7af0d95792d0d20ccf68f61a1fec6b3530e718b688422727396"
+        }
+      ]
+    },
+    {
+      "name": "aurea",
+      "builddir": true,
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/CleoMenezesJr/Aurea.git",
+          "tag": "1.0",
+          "commit": "f556d7064763ce36c2004e5fd98f7bbd479583b3"
+        }
+      ]
+    }
+  ]
+}

--- a/io.github.cleomenezesjr.aurea.json
+++ b/io.github.cleomenezesjr.aurea.json
@@ -61,7 +61,7 @@
           "type": "git",
           "url": "https://github.com/CleoMenezesJr/Aurea.git",
           "tag": "1.0",
-          "commit": "f556d7064763ce36c2004e5fd98f7bbd479583b3"
+          "commit": "39a39d8e6aa2e790c0e2f31baa797f1b032f7740"
         }
       ]
     }


### PR DESCRIPTION
Aurea is a simple preview banner made to read metainfo files from Flatpak apps and represent them as they would on Flathub.
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- - home: the file dialog returns the temp dir, the app needs the real file path
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project.
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
