### PR TITLE
Add io.github.wwmm.easyeffects.Presets.LoudnessEqualizer

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "automerge-flathubbot-prs": true
+}

--- a/io.github.wwmm.easyeffects.Presets.LoudnessEqualizer.json
+++ b/io.github.wwmm.easyeffects.Presets.LoudnessEqualizer.json
@@ -1,0 +1,33 @@
+{
+    "id": "io.github.wwmm.easyeffects.Presets.LoudnessEqualizer",
+    "runtime": "com.github.wwmm.easyeffects",
+    "sdk": "org.freedesktop.Sdk//23.08",
+    "branch": "stable",
+    "runtime-version": "stable",
+    "build-extension": true,
+    "separate-locales": false,
+    "modules": [
+        {
+            "name": "presets",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 io.github.wwmm.easyeffects.Presets.LoudnessEqualizer.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo",
+                "install -Dm644 LoudnessEqualizer.json -t ${FLATPAK_DEST}/output/LoudnessEqualizer"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Digitalone1/Easyeffects-Presets.git",
+                    "commit": "e97b21aa96161b8673a85c43370cd3dba2e4142d",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/Digitalone1/Easyeffects-Presets/commits",
+                        "commit-query": "first( .[].sha )",
+                        "version-query": "first( .[].sha )",
+                        "timestamp-query": "first( .[].commit.committer.date )"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

Please also add @Digitalone1 as a collaborator for this repo.

This is the first "preset package" for Easy Effects. The idea is that users can install this package to make "presets" and their associated files available in Easy Effects. Right now users have to download various files straight from GitHub repos which is not the easiest unless you know how GitHub works. [Some documentation meant for future packagers is here]( https://github.com/wwmm/easyeffects/blob/master/COMMUNITY_PRESETS_GUIDELINES.md).

Note, currently this package cannot be fully tested without building from upstream master, most of the changes to add support for these packages have not been released (will be in `7.2.0`). However, the Flathub package [has already been changed](https://github.com/flathub/com.github.wwmm.easyeffects/blob/38ef3e53652721850f68ef45222c6f2ccd2434e6/com.github.wwmm.easyeffects.json#L30C1-L36C11) to support the extension point since we need that to build this preset package, and the files are indeed mounted to the correct path.

Main possible issue here is what the name should be. Easy Effects on Flathub is `com.github.wwmm.easyeffects`. But since 
`com.github.*` is not accepted for new submissions, these new packages use the extension point `io.github.*`. It is inconsistent and weird but works fine, I am not sure if it is worth EOL rebasing `com.github.wwmm.easyeffects` to `io.github.wwmm.easyeffects` .

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
