### PR TITLE
Add app.devsuite.Schemes

### DIFF
--- a/app.devsuite.Schemes.json
+++ b/app.devsuite.Schemes.json
@@ -1,0 +1,60 @@
+{
+    "app-id" : "app.devsuite.Schemes",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "46",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "schemes",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig"
+    ],
+    "modules" : [
+        {
+            "name" : "libpanel",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Ddocs=disabled",
+                "-Dintrospection=disabled",
+                "-Dvapi=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://download.gnome.org/sources/libpanel/1.6/libpanel-1.6.0.tar.xz",
+                    "sha256" : "b773494a3c69300345cd8e27027448d1189183026cc137802f886417c6ea30b6",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "libpanel",
+                        "stable-only": true
+                    }
+                }
+            ]
+        },
+        {
+            "name" : "schemes",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "-Ddevelopment=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/chergert/schemes.git",
+                    "commit" : "a3971b955e22395d404e9b5aaee046d4dab251a0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is a move of `me.hergert.Schemes` to its new app-id `app.devsuite.Schemes`.

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
