### PR TITLE
Add org.freeciv.gtk4

### DIFF
--- a/0001-Mark-flathub-as-the-distributor.patch
+++ b/0001-Mark-flathub-as-the-distributor.patch
@@ -1,0 +1,40 @@
+From 1c9c337e3bbff5ea2c91925c547ced9e92afdb21 Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Fri, 26 Apr 2024 07:15:03 +0300
+Subject: [PATCH 1/2] Mark flathub as the distributor
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ configure  | 2 +-
+ fc_version | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index eb6a2b25c5..1a3ad6a8da 100755
+--- a/configure
++++ b/configure
+@@ -5686,7 +5686,7 @@ DEFAULT_FOLLOW_TAG=stable
+ #     so would break network capability of supposedly "compatible" releases.
+ #
+ NETWORK_CAPSTRING="+Freeciv-3.1-network city-original rsdesc32 obsinv ids32"
+-FREECIV_DISTRIBUTOR=""
++FREECIV_DISTRIBUTOR="flathub"
+ 
+ if test "x$FREECIV_LABEL_FORCE" != "x" ; then
+   VERSION_LABEL=$(echo $FREECIV_LABEL_FORCE | sed "s/<base>/$VERSION_LABEL/g")
+diff --git a/fc_version b/fc_version
+index df857c28f0..8806fe52df 100755
+--- a/fc_version
++++ b/fc_version
+@@ -73,7 +73,7 @@ DEFAULT_FOLLOW_TAG=stable
+ #     so would break network capability of supposedly "compatible" releases.
+ #
+ NETWORK_CAPSTRING="+Freeciv-3.1-network city-original rsdesc32 obsinv ids32"
+-FREECIV_DISTRIBUTOR=""
++FREECIV_DISTRIBUTOR="flathub"
+ 
+ if test "x$FREECIV_LABEL_FORCE" != "x" ; then
+   VERSION_LABEL=$(echo $FREECIV_LABEL_FORCE | sed "s/<base>/$VERSION_LABEL/g")
+-- 
+2.43.0
+

--- a/0002-Rename-modpack-installer-icon.patch
+++ b/0002-Rename-modpack-installer-icon.patch
@@ -1,0 +1,117 @@
+From 3331c345cde27c215e74b33006ffa2c586613c9f Mon Sep 17 00:00:00 2001
+From: Marko Lindqvist <cazfi74@gmail.com>
+Date: Sat, 18 May 2024 13:14:32 +0300
+Subject: [PATCH 2/2] Rename modpack installer icon
+
+Signed-off-by: Marko Lindqvist <cazfi74@gmail.com>
+---
+ bootstrap/org.freeciv.gtk4.mp.desktop               |   2 +-
+ data/Makefile.am                                    |   2 +-
+ .../128x128/org.freeciv.gtk4.mp.png}                | Bin
+ ...{freeciv-modpack.png => org.freeciv.gtk4.mp.png} | Bin
+ ...{freeciv-modpack.png => org.freeciv.gtk4.mp.png} | Bin
+ ...{freeciv-modpack.png => org.freeciv.gtk4.mp.png} | Bin
+ ...{freeciv-modpack.png => org.freeciv.gtk4.mp.png} | Bin
+ data/icons/Makefile.am                              |  10 +++++-----
+ .../freeciv-modpack.png => org.freeciv.gtk4.mp.png} | Bin
+ tools/fcmp/mpgui_qt.cpp                             |   3 ++-
+ 10 files changed, 9 insertions(+), 8 deletions(-)
+ rename data/{freeciv-modpack.png => icons/128x128/org.freeciv.gtk4.mp.png} (100%)
+ rename data/icons/16x16/{freeciv-modpack.png => org.freeciv.gtk4.mp.png} (100%)
+ rename data/icons/32x32/{freeciv-modpack.png => org.freeciv.gtk4.mp.png} (100%)
+ rename data/icons/48x48/{freeciv-modpack.png => org.freeciv.gtk4.mp.png} (100%)
+ rename data/icons/64x64/{freeciv-modpack.png => org.freeciv.gtk4.mp.png} (100%)
+ rename data/{icons/128x128/freeciv-modpack.png => org.freeciv.gtk4.mp.png} (100%)
+
+diff --git a/bootstrap/org.freeciv.gtk4.mp.desktop b/bootstrap/org.freeciv.gtk4.mp.desktop
+index 7b73181cac..c595e7290c 100644
+--- a/bootstrap/org.freeciv.gtk4.mp.desktop
++++ b/bootstrap/org.freeciv.gtk4.mp.desktop
+@@ -4,7 +4,7 @@ Name[ru]=Установщик модпаков Freeciv (gtk4)
+ Comment=Download and install add-ons for Freeciv
+ Comment[ru]=Скачивайте и устанавливайте дополнения для Freeciv
+ Exec=freeciv-mp-gtk4
+-Icon=freeciv-modpack
++Icon=org.freeciv.gtk4.mp
+ StartupNotify=true
+ Terminal=false
+ Type=Application
+diff --git a/data/Makefile.am b/data/Makefile.am
+index e8970454ca..6f22a55e7d 100644
+--- a/data/Makefile.am
++++ b/data/Makefile.am
+@@ -56,7 +56,7 @@ DATAPATH_ICONS =
+ RULEDITDIRS =
+ endif
+ if MODINST
+-DATAPATH_ICONS += freeciv-modpack.png
++DATAPATH_ICONS += org.freeciv.gtk4.mp.png
+ endif
+ 
+ pkgdata_DATA = $(SERVER_FILES) $(CLIENT_FILES) $(DATAPATH_ICONS)
+diff --git a/data/freeciv-modpack.png b/data/icons/128x128/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/freeciv-modpack.png
+rename to data/icons/128x128/org.freeciv.gtk4.mp.png
+diff --git a/data/icons/16x16/freeciv-modpack.png b/data/icons/16x16/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/icons/16x16/freeciv-modpack.png
+rename to data/icons/16x16/org.freeciv.gtk4.mp.png
+diff --git a/data/icons/32x32/freeciv-modpack.png b/data/icons/32x32/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/icons/32x32/freeciv-modpack.png
+rename to data/icons/32x32/org.freeciv.gtk4.mp.png
+diff --git a/data/icons/48x48/freeciv-modpack.png b/data/icons/48x48/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/icons/48x48/freeciv-modpack.png
+rename to data/icons/48x48/org.freeciv.gtk4.mp.png
+diff --git a/data/icons/64x64/freeciv-modpack.png b/data/icons/64x64/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/icons/64x64/freeciv-modpack.png
+rename to data/icons/64x64/org.freeciv.gtk4.mp.png
+diff --git a/data/icons/Makefile.am b/data/icons/Makefile.am
+index d13ced3676..664676e0ed 100644
+--- a/data/icons/Makefile.am
++++ b/data/icons/Makefile.am
+@@ -40,15 +40,15 @@ endif
+ 
+ if MODINST
+ icons_16_m = \
+-	16x16/freeciv-modpack.png
++	16x16/org.freeciv.gtk4.mp.png
+ icons_32_m = \
+-	32x32/freeciv-modpack.png
++	32x32/org.freeciv.gtk4.mp.png
+ icons_48_m = \
+-	48x48/freeciv-modpack.png
++	48x48/org.freeciv.gtk4.mp.png
+ icons_64_m = \
+-	64x64/freeciv-modpack.png
++	64x64/org.freeciv.gtk4.mp.png
+ icons_128_m = \
+-	128x128/freeciv-modpack.png
++	128x128/org.freeciv.gtk4.mp.png
+ else
+ icons_16_m =
+ icons_32_m =
+diff --git a/data/icons/128x128/freeciv-modpack.png b/data/org.freeciv.gtk4.mp.png
+similarity index 100%
+rename from data/icons/128x128/freeciv-modpack.png
+rename to data/org.freeciv.gtk4.mp.png
+diff --git a/tools/fcmp/mpgui_qt.cpp b/tools/fcmp/mpgui_qt.cpp
+index 57bb0c6bcb..550bcc1015 100644
+--- a/tools/fcmp/mpgui_qt.cpp
++++ b/tools/fcmp/mpgui_qt.cpp
+@@ -112,7 +112,8 @@ int main(int argc, char **argv)
+     QWidget *central;
+     const char *errmsg;
+     QPixmap *pm;
+-    const char *full_icon_path = fileinfoname(get_data_dirs(), "freeciv-modpack.png");
++    const char *full_icon_path = fileinfoname(get_data_dirs(),
++                                              "org.freeciv.gtk4.mp.png");
+     const QString fip = QString(full_icon_path);
+ 
+     load_install_info_lists(&fcmp);
+-- 
+2.43.0
+

--- a/about
+++ b/about
@@ -1,0 +1,5 @@
+Manifest is based on one in Freeciv tree, with minimal changes.
+In the future we may automate the process of using that
+"nightly builds" manifest from the release, or otherwise
+arrange things so that we don't need to maintain these
+separately - so try not to deviate too much.

--- a/org.freeciv.gtk4.yml
+++ b/org.freeciv.gtk4.yml
@@ -1,0 +1,28 @@
+app-id: org.freeciv.gtk4
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: freeciv-gtk4
+rename-icon: freeciv-client
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --share=network
+  - --socket=pulseaudio
+  - --filesystem=~/.freeciv:create
+modules:
+  - name: freeciv-gtk4
+    buildsystem: autotools
+    config-opts:
+      - --enable-client=gtk4
+      - --enable-fcmp=gtk4
+      - --disable-freeciv-manual
+    sources:
+      - type: archive
+        url: "https://sourceforge.net/projects/freeciv/files/Freeciv 3.1/3.1.1/freeciv-3.1.1.tar.xz"
+        sha256: b2bd00c0e2a6c81bcb52aa0dddf81f2f4543705bf7a9fcd5afac3f7b3fff5ef6
+      - type: patch
+        path: 0001-Mark-flathub-as-the-distributor.patch
+      - type: patch
+        path: 0002-Rename-modpack-installer-icon.patch


### PR DESCRIPTION
In a recent poll about freeciv flatpak features,
request for a new flatpak for gtk4-client came out top.

Next new client will be sdl3-client in 2026 release of freeciv-3.2.

<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [X] Please describe your application briefly.
- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  Permissions to ~/.freeciv are so that various freeciv modpacks can share some data (e.g. installed modpack) there. The same permission is already given to all existing freeciv flatpaks.
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
