### PR TITLE
Add io.github.pantheon_tweaks.pantheon-tweaks

### DIFF
--- a/dconf-override.patch
+++ b/dconf-override.patch
@@ -1,0 +1,23 @@
+diff --git a/engine/dconf-engine-source-user.c b/engine/dconf-engine-source-user.c
+index 1657875..e4f8786 100644
+--- a/engine/dconf-engine-source-user.c
++++ b/engine/dconf-engine-source-user.c
+@@ -39,11 +39,17 @@ dconf_engine_source_user_open_gvdb (const gchar *name)
+ {
+   GvdbTable *table;
+   gchar *filename;
++  const gchar *override;
++
++  override = g_getenv ("DCONF_USER_CONFIG_DIR");
++  if (override == NULL)
++    filename = g_build_filename (g_get_user_config_dir (), "dconf", name, NULL);
++  else
++    filename = g_build_filename (g_get_home_dir (), override, name, NULL);
+ 
+   /* This can fail in the normal case of the user not having any
+    * settings.  That's OK and it shouldn't be considered as an error.
+    */
+-  filename = g_build_filename (g_get_user_config_dir (), "dconf", name, NULL);
+   table = gvdb_table_new (filename, FALSE, NULL);
+   g_free (filename);
+ 

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -10,7 +10,7 @@ finish-args:
   - '--socket=fallback-x11'
 
   # Grant read, write, and create access for settings.ini of GTK and theme dirs
-  - '--filesystem=xdg-config/gtk-3.0:create'
+  - '--filesystem=~/.config/gtk-3.0:create'
   - '--filesystem=~/.icons:create'
   - '--filesystem=~/.local/share/sounds:create'
   - '--filesystem=~/.local/share/themes:create'

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -10,10 +10,10 @@ finish-args:
   - '--socket=fallback-x11'
 
   # Grant read, write, and create access for settings.ini of GTK and theme dirs
-  - '--filesystem=home/.config/gtk-3.0:create'
-  - '--filesystem=home/.icons:create'
-  - '--filesystem=home/.local/share/sounds:create'
-  - '--filesystem=home/.local/share/themes:create'
+  - '--filesystem=xdg-config/gtk-3.0:create'
+  - '--filesystem=~/.icons:create'
+  - '--filesystem=~/.local/share/sounds:create'
+  - '--filesystem=~/.local/share/themes:create'
   # Pass the directory where the host's /usr is mounted under, so that we can load system theme files
   - '--env=USR_DIR_PREFIX=/var/run/host'
 

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -95,8 +95,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.1.tar.gz
-        sha256: d124555e8afe75a1f3ce2b5198a2f6f7d576423c50d329473e530fb38251b1c1
+        url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.2.tar.gz
+        sha256: 2396645aaa53ce4340cb5e7780d5caf924fecf213c9eb0ed6b5ea39fe2d9be2d
       - type: file
         path: start-pantheon-tweaks.sh
     post-install:

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -95,8 +95,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.0.tar.gz
-        sha256: b17daaf37c52ae86221c42743395379a9bdfb76a876893b094590b88823bb9f7
+        url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.1.tar.gz
+        sha256: d124555e8afe75a1f3ce2b5198a2f6f7d576423c50d329473e530fb38251b1c1
       - type: file
         path: start-pantheon-tweaks.sh
     post-install:

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -38,10 +38,10 @@ modules:
     config-opts:
       - '-Dbash_completion=false'
       - '-Dman=false'
-      - '-Dsystemduserunitdir=/app/lib/systemd/user'
     cleanup:
       - '/include'
       - '/lib/pkgconfig'
+      - '/lib/systemd'
       - '/libexec'
       - '/share/dbus-1'
     sources:
@@ -97,16 +97,12 @@ modules:
       - type: archive
         url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.0.tar.gz
         sha256: b17daaf37c52ae86221c42743395379a9bdfb76a876893b094590b88823bb9f7
+      - type: file
+        path: start-pantheon-tweaks.sh
     post-install:
+      # Install wrapper script
+      - install -Dm 755 $FLATPAK_BUILDER_BUILDDIR/start-pantheon-tweaks.sh /app/bin/start-pantheon-tweaks
       # Run the wrapper script instead of the executable
       - 'desktop-file-edit --set-key=Exec --set-value=start-pantheon-tweaks /app/share/applications/io.github.pantheon_tweaks.pantheon-tweaks.desktop'
       # Tell the real executable name to the WM to prevent duplicated dock icons
       - 'desktop-file-edit --set-key=StartupWMClass --set-value=pantheon-tweaks /app/share/applications/io.github.pantheon_tweaks.pantheon-tweaks.desktop'
-
-  - name: wrapper-script
-    buildsystem: simple
-    sources:
-      - type: file
-        path: start-pantheon-tweaks.sh
-    build-commands:
-      - install -Dm 755 start-pantheon-tweaks.sh /app/bin/start-pantheon-tweaks

--- a/io.github.pantheon_tweaks.pantheon-tweaks.yml
+++ b/io.github.pantheon_tweaks.pantheon-tweaks.yml
@@ -1,0 +1,112 @@
+app-id: io.github.pantheon_tweaks.pantheon-tweaks
+# elementary SDK is not available on Flathub, so use GNOME SDK and install elementary stylesheet and granite as modules
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: start-pantheon-tweaks
+finish-args:
+  - '--share=ipc'
+  - '--socket=wayland'
+  - '--socket=fallback-x11'
+
+  # Grant read, write, and create access for settings.ini of GTK and theme dirs
+  - '--filesystem=home/.config/gtk-3.0:create'
+  - '--filesystem=home/.icons:create'
+  - '--filesystem=home/.local/share/sounds:create'
+  - '--filesystem=home/.local/share/themes:create'
+  # Pass the directory where the host's /usr is mounted under, so that we can load system theme files
+  - '--env=USR_DIR_PREFIX=/var/run/host'
+
+  # Needed to read/write GSettings of the host
+  - '--talk-name=ca.desrt.dconf'
+  - '--filesystem=xdg-run/dconf'
+  - '--filesystem=host:ro'
+  - '--env=DCONF_USER_CONFIG_DIR=.config/dconf'
+  - '--env=GIO_EXTRA_MODULES=/app/lib/gio/modules/'
+  # This is not recommended by Flathub though, we need it to access host's GSettings.
+  # From https://docs.flathub.org/docs/for-app-authors/linter/#finish-args-flatpak-spawn-access
+  #   This allows applications to launch arbitrary commands on the host and is restricted and granted on a case-by-case basis.
+  #   This must not be used unless absolutely necessary and when no existing solutions using Flatpak or portals exist.
+  - '--talk-name=org.freedesktop.Flatpak'
+
+  # Needed for PrefersAccentColor
+  - '--system-talk-name=org.freedesktop.Accounts'
+modules:
+  # Patch dconf to read/write GSettings of the host
+  - name: dconf
+    buildsystem: meson
+    config-opts:
+      - '-Dbash_completion=false'
+      - '-Dman=false'
+      - '-Dsystemduserunitdir=/app/lib/systemd/user'
+    cleanup:
+      - '/include'
+      - '/lib/pkgconfig'
+      - '/libexec'
+      - '/share/dbus-1'
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/dconf/0.40/dconf-0.40.0.tar.xz
+        sha256: cf7f22a4c9200421d8d3325c5c1b8b93a36843650c9f95d6451e20f0bcb24533
+      - type: patch
+        path: dconf-override.patch
+
+  - name: elementary-stylesheet
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/elementary/stylesheet/archive/refs/tags/7.3.0.tar.gz
+        sha256: 2fa0428a53ff79a67e518a5883ecfe4e0a7944ad79b3ae070567aad1ea2f459b
+    modules:
+      - name: sassc
+        cleanup:
+          - '*'
+        buildsystem: autotools
+        sources:
+          - type: archive
+            url: https://github.com/sass/sassc/archive/refs/tags/3.6.2.tar.gz
+            sha256: 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
+          - type: script
+            dest-filename: autogen.sh
+            commands:
+              - autoreconf -si
+        modules:
+          - name: libsass
+            cleanup:
+              - '*'
+            buildsystem: autotools
+            sources:
+              - type: archive
+                url: https://github.com/sass/libsass/archive/refs/tags/3.6.5.tar.gz
+                sha256: 89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582
+              - type: script
+                dest-filename: autogen.sh
+                commands:
+                  - autoreconf -si
+
+  - name: granite
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/elementary/granite/archive/refs/tags/6.2.0.tar.gz
+        sha256: 067d31445da9808a802fca523630c3e4b84d2d7c78ae547ced017cb7f3b9c6b5
+
+  - name: pantheon-tweaks
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/pantheon-tweaks/pantheon-tweaks/archive/refs/tags/2.0.0.tar.gz
+        sha256: b17daaf37c52ae86221c42743395379a9bdfb76a876893b094590b88823bb9f7
+    post-install:
+      # Run the wrapper script instead of the executable
+      - 'desktop-file-edit --set-key=Exec --set-value=start-pantheon-tweaks /app/share/applications/io.github.pantheon_tweaks.pantheon-tweaks.desktop'
+      # Tell the real executable name to the WM to prevent duplicated dock icons
+      - 'desktop-file-edit --set-key=StartupWMClass --set-value=pantheon-tweaks /app/share/applications/io.github.pantheon_tweaks.pantheon-tweaks.desktop'
+
+  - name: wrapper-script
+    buildsystem: simple
+    sources:
+      - type: file
+        path: start-pantheon-tweaks.sh
+    build-commands:
+      - install -Dm 755 start-pantheon-tweaks.sh /app/bin/start-pantheon-tweaks

--- a/start-pantheon-tweaks.sh
+++ b/start-pantheon-tweaks.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/bash
+# Wrapper script to get/set GSettings from the host in the sandboxed Pantheon Tweaks.
+# Originally from https://github.com/flathub/ca.desrt.dconf-editor/blob/master/start-dconf-editor.sh
+
+trap "finalize; exit 1" SIGINT
+
+finalize()
+{
+  for dir in "${HOST_XDG_DATA_DIRS//:/ }"; do
+    unlink $dir/glib-2.0/schemas
+    rmdir $dir/glib-2.0
+    rmdir $dir
+  done
+
+  rmdir "$bridge_dir"
+}
+
+IFS=: read -ra host_data_dirs < <(flatpak-spawn --host sh -c 'echo "$XDG_DATA_DIRS"')
+
+# To avoid potentially muddying up $XDG_DATA_DIRS too much, we link the schema paths
+# into a temporary directory.
+bridge_dir=$XDG_RUNTIME_DIR/dconf-bridge
+mkdir -p "$bridge_dir"
+
+HOST_XDG_DATA_DIRS=""
+
+for dir in "${host_data_dirs[@]}"; do
+  if [[ "$dir" == /usr/* ]]; then
+    dir=/run/host/"$dir"
+  fi
+
+  schemas="$dir/glib-2.0/schemas"
+  if [[ -d "$schemas" ]]; then
+    bridged=$(mktemp -d XXXXXXXXXX -p "$bridge_dir")
+    mkdir -p "$bridged"/glib-2.0
+    ln -s "$schemas" "$bridged"/glib-2.0
+    HOST_XDG_DATA_DIRS="${HOST_XDG_DATA_DIRS}:${bridged}"
+  fi
+done
+
+# We MUST prepend the host's data dirs BEFORE the Flatpak environment's own dirs,
+# otherwise data (such as default values) load in the wrong order and would then
+# incorrectly prefer the Flatpak's internal defaults instead of the host's defaults!
+if [[ ! -z "${HOST_XDG_DATA_DIRS}" ]]; then
+  XDG_DATA_DIRS="${HOST_XDG_DATA_DIRS:1}:${XDG_DATA_DIRS}"
+fi
+
+export XDG_DATA_DIRS
+
+pantheon-tweaks "$@"
+RET=$?
+
+finalize
+exit $RET

--- a/start-pantheon-tweaks.sh
+++ b/start-pantheon-tweaks.sh
@@ -4,6 +4,7 @@
 
 trap "finalize; exit 1" SIGINT
 
+# Cleanup temporary symlinks and directories this script created.
 finalize()
 {
   for dir in "${HOST_XDG_DATA_DIRS//:/ }"; do


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

Pantheon Tweaks is a system customization app for the Pantheon desktop environment.

Note that the app won't be shown in your app launcher nor launch from terminal other than on Pantheon desktop environment, so that we can prevent the app from accessing GSettings keys that only exist on Pantheon and crashing.

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
  - We need extra permissions to read/write the config file of GTK and theme files direcotry. The app creates the parent directory of the config file and themes if not exists, so create access is also required.
  - The most important thing: we need access to GSettings in the host system because the app gets/sets preferences of the host system. The workaround for this is equivalent that [dconf-editor](https://github.com/flathub/ca.desrt.dconf-editor/tree/master) does.
    - We'd like to get exception of [finish-args-flatpak-spawn-access](https://docs.flathub.org/docs/for-app-authors/linter/#finish-args-flatpak-spawn-access), because we run `flatpak-swapn` command in `start-pantheon-tweaks.sh` to bridge host's gschemas directory.
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
  - I and @Philip-Scott is the current maintainers of the project. We've discussed about submitting to Flathub [here](https://github.com/pantheon-tweaks/pantheon-tweaks/issues/187).
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*
  - `dconf-override.patch` for dconf is not submitted because it's just a workaround for the problem that `g_get_user_config_dir ()` doesn't return the host's `~/.config` directory in the sandboxed environment of Flatpak.

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
