### PR TITLE
Add dev.geopjr.Calligraphy

### DIFF
--- a/dev.geopjr.Calligraphy.yaml
+++ b/dev.geopjr.Calligraphy.yaml
@@ -1,0 +1,34 @@
+app-id: dev.geopjr.Calligraphy
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: calligraphy
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --device=dri
+  - --socket=wayland
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /man
+  - /share/doc
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - '*.la'
+  - '*.a'
+modules:
+  - python3-pyfiglet.json
+  - name: calligraphy
+    builddir: true
+    buildsystem: meson
+    run-tests: true
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GeopJr/Calligraphy.git
+        tag: v1.0.1
+        commit: 5940cf2b77d17dc76b5f8877bf82e5190465343e
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$

--- a/python3-pyfiglet.json
+++ b/python3-pyfiglet.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pyfiglet",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyfiglet\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1a/03/bef6fff907e212d67a0003f8ea4819307bba91b2856074a0763dd483ccc4/pyfiglet-1.0.2-py3-none-any.whl",
+            "sha256": "889b351d79c99e50a3f619c8f8e6ffdb27fd8c939fc43ecbd7559bd57d5f93ea"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

This is a continuation of Calligraphy after its archival (#5194 #4194). It's an app that creates ASCII ART text banners.

Both the original app author and the icon artist have been contacted and given permission to use the same branding https://gitlab.gnome.org/GeopJr/Calligraphy/-/issues/1

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [X] Please describe your application briefly.
- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I have [built][build] and tested the submission locally.
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
