### PR TITLE
Add app.devsuite.Manuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.flatpak-builder/
+*.swp
+repo/
+builddir/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/app.devsuite.Manuals.json
+++ b/app.devsuite.Manuals.json
@@ -243,7 +243,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/chergert/manuals.git",
-                    "commit" : "e8de91853cb2c04af49e0038f8a7247a8d398dfe"
+                    "commit" : "dee0bd168f4f1e30cceabf04fabc38e3c7cc2fdf"
                 }
             ]
         }

--- a/app.devsuite.Manuals.json
+++ b/app.devsuite.Manuals.json
@@ -25,7 +25,6 @@
     "cleanup" : [
         "*.a",
         "*.la",
-        "/bin/intltool*",
         "/bin/ostree",
         "/bin/pk*",
         "/etc",
@@ -47,7 +46,6 @@
         "/share/fish",
         "/share/gir-1.0",
         "/share/gtk-doc",
-        "/share/intltool/",
         "/share/man",
         "/share/pkgconfig",
         "/share/polkit-1",
@@ -56,19 +54,7 @@
     ],
     "modules" : [
         "python3-pyparsing.json",
-        {
-            "name" : "intltool",
-            "cleanup" : [
-                "*"
-            ],
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
-                    "sha256" : "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
-                }
-            ]
-        },
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name" : "polkit",
             "config-opts" : [

--- a/app.devsuite.Manuals.json
+++ b/app.devsuite.Manuals.json
@@ -25,8 +25,6 @@
     "cleanup" : [
         "*.a",
         "*.la",
-        "/bin/flatpak-bisect",
-        "/bin/flatpak-coredumpctl",
         "/bin/intltool*",
         "/bin/ostree",
         "/bin/pk*",
@@ -47,7 +45,6 @@
         "/share/dbus-1/system-services",
         "/share/doc",
         "/share/fish",
-        "/share/gir-1.0",
         "/share/gir-1.0",
         "/share/gtk-doc",
         "/share/intltool/",

--- a/app.devsuite.Manuals.json
+++ b/app.devsuite.Manuals.json
@@ -1,0 +1,268 @@
+{
+    "app-id" : "app.devsuite.Manuals",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "46",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "manuals",
+    "finish-args" : [
+        "--allow=devel",
+        "--device=dri",
+        "--filesystem=/var/lib/flatpak",
+        "--filesystem=host:ro",
+        "--filesystem=~/.local/share/flatpak",
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.Flatpak"
+    ],
+    "build-options" : {
+        "env" : {
+            "BASH_COMPLETIONSDIR" : "/app/share/bash-completion/completions",
+            "MOUNT_FUSE_PATH" : "../tmp/"
+        }
+    },
+    "cleanup" : [
+        "*.a",
+        "*.la",
+        "/bin/flatpak-bisect",
+        "/bin/flatpak-coredumpctl",
+        "/bin/intltool*",
+        "/bin/ostree",
+        "/bin/pk*",
+        "/etc",
+        "/include",
+        "/lib/ostree/",
+        "/lib/pkgconfig",
+        "/lib/python3.*",
+        "/lib/systemd/",
+        "/lib/tmpfiles.d/",
+        "/libexec/libostree",
+        "/man",
+        "/share/aclocal",
+        "/share/bash-completions",
+        "/share/dbus-1/interfaces/",
+        "/share/dbus-1/services/org.flatpak.*",
+        "/share/dbus-1/services/org.freedesktop.*",
+        "/share/dbus-1/system-services",
+        "/share/doc",
+        "/share/fish",
+        "/share/gir-1.0",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/intltool/",
+        "/share/man",
+        "/share/pkgconfig",
+        "/share/polkit-1",
+        "/share/vala",
+        "/share/zsh"
+    ],
+    "modules" : [
+        "python3-pyparsing.json",
+        {
+            "name" : "intltool",
+            "cleanup" : [
+                "*"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256" : "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ]
+        },
+        {
+            "name" : "polkit",
+            "config-opts" : [
+                "--disable-polkitd",
+                "--disable-man-pages",
+                "--disable-introspection",
+                "--disable-examples",
+                "--disable-gtk-doc",
+                "--disable-libelogind",
+                "--disable-libsystemd-login",
+                "--with-systemdsystemunitdir=no",
+                "--with-authdb=dummy",
+                "--with-authfw=none"
+            ],
+            "rm-configure" : true,
+            "cleanup" : [
+                "/bin/*",
+                "/etc/pam.d",
+                "/etc/dbus-1",
+                "/share/dbus-1/system-services/*",
+                "/share/polkit-1",
+                "/lib/polkit-1"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://www.freedesktop.org/software/polkit/releases/polkit-0.116.tar.gz",
+                    "sha256" : "88170c9e711e8db305a12fdb8234fac5706c61969b94e084d0f117d8ec5d34b1"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "polkit-build-Add-option-to-build-without-polkitd.patch"
+                },
+                {
+                    "type" : "file",
+                    "path" : "polkit-autogen",
+                    "dest-filename" : "autogen.sh"
+                }
+            ]
+        },
+        {
+            "name" : "libfuse",
+            "config-opts" : [
+                "UDEV_RULES_PATH=/app/etc/udev/rules.d",
+                "INIT_D_PATH=/app/etc/init.d"
+            ],
+            "cleanup" : [
+                "/bin/ulockmgr_server"
+            ],
+            "post-install" : [
+                "install -m a+rx fusermount-wrapper.sh /app/bin/fusermount"
+            ],
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz",
+                    "sha256" : "d0e69d5d608cc22ff4843791ad097f554dd32540ddc9bed7638cc6fea7c1b4b5"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fuse-2.9.2-namespace-conflict-fix.patch"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fuse-disable-sys-mount-under-flatpak.patch"
+                },
+                {
+                    "type" : "patch",
+                    "path" : "fuse-2.9.2-closefrom.patch"
+                },
+                {
+                    "type" : "file",
+                    "path" : "fusermount-wrapper.sh"
+                }
+            ]
+        },
+        {
+            "name" : "ostree",
+            "config-opts" : [
+                "--disable-man",
+                "--with-curl",
+                "--without-soup",
+                "--without-libsystemd"
+            ],
+            "cleanup" : [
+                "/bin",
+                "/etc/grub.d",
+                "/etc/ostree",
+                "/share/ostree",
+                "/libexec"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/ostreedev/ostree.git",
+                    "tag" : "v2024.5"
+                }
+            ]
+        },
+        {
+            "name" : "flatpak",
+            "config-opts" : [
+                "--disable-documentation",
+                "--disable-seccomp",
+                "--disable-sandboxed-triggers",
+                "--disable-system-helper",
+                "--with-curl",
+                "--with-system-install-dir=/var/lib/flatpak",
+                "--sysconfdir=/var/run/host/etc"
+            ],
+            "cleanup" : [
+                "/bin/flatpak-bisect",
+                "/bin/flatpak-coredumpctl",
+                "/etc/profile.d",
+                "/lib/systemd",
+                "/share/dbus-1/interfaces/org.freedesktop.*",
+                "/share/dbus-1/services/org.freedesktop.*",
+                "/share/flatpak/triggers",
+                "/share/gdm",
+                "/share/zsh"
+            ],
+            "post-install" : [
+                "cp /usr/bin/update-mime-database /app/bin",
+                "cp /usr/bin/update-desktop-database /app/bin"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/flatpak/flatpak.git",
+                    "tag" : "1.14.5"
+                }
+            ]
+        },
+        {
+            "name" : "gom",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "--buildtype=release"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/gom.git",
+                    "tag" : "0.5.1"
+                }
+            ]
+        },
+        {
+            "name" : "libdex",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "--buildtype=release"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libdex.git",
+                    "tag" : "0.6.1"
+                }
+            ]
+        },
+        {
+            "name" : "libpanel",
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "--buildtype=release",
+                "-Ddocs=disabled"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/GNOME/libpanel.git",
+                    "tag" : "1.6.0"
+                }
+            ]
+        },
+        {
+            "name" : "manuals",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "config-opts" : [
+                "--buildtype=release",
+                "-Ddevelopment=false"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://gitlab.gnome.org/chergert/manuals.git",
+                    "commit" : "e8de91853cb2c04af49e0038f8a7247a8d398dfe"
+                }
+            ]
+        }
+    ]
+}

--- a/fuse-2.9.2-closefrom.patch
+++ b/fuse-2.9.2-closefrom.patch
@@ -1,0 +1,20 @@
+--- fuse-2.9.2/util/ulockmgr_server.c.closefromfix	2019-01-04 05:33:33.000000000 -0800
++++ fuse-2.9.2/util/ulockmgr_server.c	2022-07-12 12:29:56.445402244 -0700
+@@ -124,7 +124,7 @@
+ 	return res;
+ }
+ 
+-static int closefrom(int minfd)
++static int _closefrom(int minfd)
+ {
+ 	DIR *dir = opendir("/proc/self/fd");
+ 	if (dir) {
+@@ -384,7 +384,7 @@
+ 		dup2(nullfd, 1);
+ 	}
+ 	close(3);
+-	closefrom(5);
++	_closefrom(5);
+ 	while (1) {
+ 		char c;
+ 		int sock;

--- a/fuse-2.9.2-namespace-conflict-fix.patch
+++ b/fuse-2.9.2-namespace-conflict-fix.patch
@@ -1,0 +1,21 @@
+diff -up fuse-2.9.2/include/fuse_kernel.h.conflictfix fuse-2.9.2/include/fuse_kernel.h
+--- fuse-2.9.2/include/fuse_kernel.h.conflictfix	2013-06-26 09:31:57.862198038 -0400
++++ fuse-2.9.2/include/fuse_kernel.h	2013-06-26 09:32:19.679198365 -0400
+@@ -88,12 +88,16 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+ 
+-#include <sys/types.h>
++#ifdef __linux__
++#include <linux/types.h>
++#else
++#include <stdint.h>
+ #define __u64 uint64_t
+ #define __s64 int64_t
+ #define __u32 uint32_t
+ #define __s32 int32_t
+ #define __u16 uint16_t
++#endif
+ 
+ /*
+  * Version negotiation:

--- a/fuse-disable-sys-mount-under-flatpak.patch
+++ b/fuse-disable-sys-mount-under-flatpak.patch
@@ -1,0 +1,26 @@
+From 1ec935f4abecd08957affc7b21bae6bf5be78931 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Thu, 12 Apr 2018 01:47:57 -0700
+Subject: [PATCH] libfuse: disable sys mount under flatpak
+
+---
+ lib/mount.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/mount.c b/lib/mount.c
+index 7a18c11..1667db2 100644
+--- a/lib/mount.c
++++ b/lib/mount.c
+@@ -392,6 +392,9 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
+ 	int fd;
+ 	int res;
+ 
++	/* disable in flatpak */
++	return -2;
++
+ 	if (!mnt) {
+ 		fprintf(stderr, "fuse: missing mountpoint parameter\n");
+ 		return -1;
+-- 
+2.17.0.rc2
+

--- a/fusermount-wrapper.sh
+++ b/fusermount-wrapper.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$_FUSE_COMMFD" ]; then
+    FD_ARGS=
+else
+    FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
+fi
+
+exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 --forward-fd=3 $FD_ARGS fusermount "$@"

--- a/polkit-autogen
+++ b/polkit-autogen
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+gtkdocize --flavour no-tmpl
+autoreconf -if

--- a/polkit-build-Add-option-to-build-without-polkitd.patch
+++ b/polkit-build-Add-option-to-build-without-polkitd.patch
@@ -1,0 +1,132 @@
+From 1073a44277316348d40d86ecec908f1d4812f360 Mon Sep 17 00:00:00 2001
+From: Christian Hergert <chergert@redhat.com>
+Date: Mon, 27 May 2019 11:49:09 -0700
+Subject: [PATCH] flatpak: make polkit suitable for use within flatpak
+
+This is based on patches from Patrick Griffis with additional fixes
+to allow us to disable use of PAM within Flaptak.
+---
+ configure.ac                | 20 ++++++++++++++++----
+ src/Makefile.am             |  6 +++++-
+ src/polkitagent/Makefile.am |  5 +++++
+ test/Makefile.am            |  6 +++++-
+ 4 files changed, 31 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 5cedb4e..729d78d 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -79,11 +79,13 @@ PKG_CHECK_MODULES(GLIB, [gmodule-2.0 gio-unix-2.0 >= 2.30.0])
+ AC_SUBST(GLIB_CFLAGS)
+ AC_SUBST(GLIB_LIBS)
+ 
+-PKG_CHECK_MODULES(LIBJS, [mozjs-60])
++AS_IF([test x${enable_polkitd} = yes], [
++  PKG_CHECK_MODULES(LIBJS, [mozjs-60])
+ 
+-AC_SUBST(LIBJS_CFLAGS)
+-AC_SUBST(LIBJS_CXXFLAGS)
+-AC_SUBST(LIBJS_LIBS)
++  AC_SUBST(LIBJS_CFLAGS)
++  AC_SUBST(LIBJS_CXXFLAGS)
++  AC_SUBST(LIBJS_LIBS)
++])
+ 
+ EXPAT_LIB=""
+ AC_ARG_WITH(expat, [  --with-expat=<dir>      Use expat from here],
+@@ -236,6 +238,15 @@ if test "x$with_systemdsystemunitdir" != "xno"; then
+ fi
+ AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$systemdsystemunitdir"])
+ 
++dnl ---------------------------------------------------------------------------
++dnl - Disable polkitd when using library alone
++dnl ---------------------------------------------------------------------------
++
++AC_ARG_ENABLE([polkitd],
++              [AS_HELP_STRING([--disable-polkitd], [Do not build polkitd])],
++              [enable_polkitd=$enableval], [enable_polkitd=yes])
++AM_CONDITIONAL(BUILD_POLKITD, [test x${enable_polkitd} = yes])
++
+ dnl ---------------------------------------------------------------------------
+ dnl - User for running polkitd
+ dnl ---------------------------------------------------------------------------
+@@ -579,6 +590,7 @@ echo "
+         Session tracking:           ${SESSION_TRACKING}
+         PAM support:                ${have_pam}
+         systemdsystemunitdir:       ${systemdsystemunitdir}
++        polkitd:                    ${enable_polkitd}
+         polkitd user:               ${POLKITD_USER}"
+ 
+ if test "$have_pam" = yes ; then
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 09fc7b3..c6fe91b 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -1,5 +1,9 @@
+ 
+-SUBDIRS = polkit polkitbackend polkitagent programs
++SUBDIRS = polkit polkitagent programs
++
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
+ 
+ if BUILD_EXAMPLES
+ SUBDIRS += examples
+diff --git a/src/polkitagent/Makefile.am b/src/polkitagent/Makefile.am
+index 49720db..633f9d4 100644
+--- a/src/polkitagent/Makefile.am
++++ b/src/polkitagent/Makefile.am
+@@ -79,6 +79,7 @@ libpolkit_agent_1_la_LIBADD =                               		\
+ 
+ libpolkit_agent_1_la_LDFLAGS = -export-symbols-regex '(^polkit_.*)'
+ 
++if !POLKIT_AUTHFW_NONE
+ libprivdir = $(prefix)/lib/polkit-1
+ libpriv_PROGRAMS = polkit-agent-helper-1
+ 
+@@ -113,6 +114,8 @@ polkit_agent_helper_1_LDFLAGS = 					\
+ 	$(AM_LDFLAGS)							\
+ 	$(NULL)
+ 
++endif # !POLKIT_AUTHFW_NONE
++
+ if HAVE_INTROSPECTION
+ 
+ girdir = $(INTROSPECTION_GIRDIR)
+@@ -142,6 +145,7 @@ include $(INTROSPECTION_MAKEFILE)
+ 
+ endif # HAVE_INTROSPECTION
+ 
++if !POLKIT_AUTHFW_NONE
+ # polkit-agent-helper-1 need to be setuid root because it's used to
+ # authenticate not only the invoking user, but possibly also root
+ # and/or other users.
+@@ -149,6 +153,7 @@ endif # HAVE_INTROSPECTION
+ install-data-hook:
+ 	-chown root $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
+ 	-chmod 4755 $(DESTDIR)$(libprivdir)/polkit-agent-helper-1
++endif # !POLKIT_AUTHFW_NONE
+ 
+ EXTRA_DIST = polkitagentmarshal.list polkitagentenumtypes.h.template polkitagentenumtypes.c.template
+ CLEANFILES = $(gir_DATA) $(typelibs_DATA)
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 59d0680..d43b0fe 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -1,7 +1,11 @@
+ 
+-SUBDIRS = mocklibc . polkit polkitbackend
++SUBDIRS = mocklibc . polkit
+ AM_CFLAGS = $(GLIB_CFLAGS)
+ 
++if BUILD_POLKITD
++SUBDIRS += polkitbackend
++endif
++
+ noinst_LTLIBRARIES = libpolkit-test-helper.la
+ libpolkit_test_helper_la_SOURCES = polkittesthelper.c polkittesthelper.h
+ libpolkit_test_helper_la_LIBADD = $(GLIB_LIBS)
+-- 
+2.21.0
+

--- a/python3-pyparsing.json
+++ b/python3-pyparsing.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pyparsing",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyparsing\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/39/92/8486ede85fcc088f1b3dba4ce92dd29d126fd96b0008ea213167940a2475/pyparsing-3.1.1-py3-none-any.whl",
+            "sha256": "32c7c0b711493c72ff18a981d24f28aaf9c1fb7ed5e9667c9e84e3db623bdbfb"
+        }
+    ]
+}


### PR DESCRIPTION
Manuals is the documentation component of `org.gnome.Builder` extracted into a standalone application. It not only reads and searches documentation, but allows installing and indexing Flatpak-based documentation SDK extensions such as `org.gnome.Sdk.Docs`.

This will require an exception just like `org.gnome.Builder` as it can install additional SDKs using `libflatpak`.

### Please confirm your submission meets all the criteria

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
