### PR TITLE
Add im.nheko.Nheko

### DIFF
--- a/im.nheko.Nheko.yaml
+++ b/im.nheko.Nheko.yaml
@@ -4,19 +4,22 @@ runtime: org.kde.Platform
 runtime-version: '6.6'
 sdk: org.kde.Sdk
 finish-args:
-  - --device=dri
-  # needed for webcams, see #517
+  # needed for webcams, see https://github.com/Nheko-Reborn/nheko/issues/517
   - --device=all
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=wayland
+  # Since we need access to the X11 socket for sharing some X11 apps and the pipewire sharing is still experimental, default to X11.
+  # Since we default to X11, we are not supposed to add the wayland socket.
   - --socket=x11
+  #- --socket=wayland
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --talk-name=org.freedesktop.StatusNotifierItem
   # needed for tray icon
-  - --talk-name=org.kde.*
+  - --talk-name=org.kde.StatusNotifierWatcher
 cleanup:
   - /include
   - /lib/pkgconfig
@@ -183,6 +186,7 @@ modules:
         tag: 1.22.12
         type: git
         url: https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+        disable-submodules: true
     config-opts:
       - --auto-features=disabled
       -  -Dgood=enabled

--- a/im.nheko.Nheko.yaml
+++ b/im.nheko.Nheko.yaml
@@ -1,0 +1,247 @@
+id: im.nheko.Nheko
+command: im.nheko.Nheko
+runtime: org.kde.Platform
+runtime-version: '6.6'
+sdk: org.kde.Sdk
+finish-args:
+  - --device=dri
+  # needed for webcams, see #517
+  - --device=all
+  - --share=ipc
+  - --share=network
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=x11
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.StatusNotifierItem
+  # needed for tray icon
+  - --talk-name=org.kde.*
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /bin/mdb*
+  - '*.a'
+  - /libexec
+  - /lib/cmake
+  - /bin/cmark
+  - /bin/event_rpcgen.py
+  - /bin/playout
+  - /bin/secret-tool
+  - /bin/gst-*
+  - /share/gdb
+  - /share/gst*
+  - /lib/girepository-1.0/
+  - /lib/gst-validate-launcher/
+  - /lib/gstreamer-1.0/include
+  - /lib/gstreamer-1.0/include/
+  - /lib/gstreamer-1.0/libgstcoreelements.so
+  - /lib/gstreamer-1.0/libgstopengl*
+  - /lib/gstreamer-1.0/libgstximagesink.so
+  - /lib/gstreamer-1.0/validate/
+  - /lib/libgst*
+modules:
+  - name: lmdb
+    sources:
+      - sha256: c0937223bba3c37c896809883a3c9b43049354578b239d6ed2476236a87f40c9
+        type: archive
+        url: https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.32/openldap-LMDB_0.9.32.tar.gz
+    make-install-args:
+      - prefix=/app
+    no-autogen: true
+    subdir: libraries/liblmdb
+  - name: libevent
+    buildsystem: autotools
+    config-opts:
+      - --disable-shared
+      - --prefix=/app
+      - --disable-openssl
+    sources:
+      - sha256: 92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb
+        type: archive
+        url: https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz
+    make-install-args:
+      - prefix=/app
+    no-autogen: true
+  - name: cmark
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMARK_TESTS=OFF
+    sources:
+      - sha256: 6c7d2bcaea1433d977d8fed0b55b71c9d045a7cdf616e3cd2dce9007da753db3
+        type: archive
+        url: https://github.com/commonmark/cmark/archive/0.30.2.tar.gz
+  - name: spdlog
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSPDLOG_BUILD_EXAMPLES=0
+      - -DSPDLOG_BUILD_BENCH=0
+      - -DSPDLOG_BUILD_TESTING=0
+    sources:
+      - sha256: 5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb
+        type: archive
+        url: https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz
+  - name: olm
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    buildsystem: cmake-ninja
+    sources:
+      - commit: 92769cec711c604a1f682b95d6944578d2a1bb3d
+        disable-shallow-clone: true
+        tag: 3.2.12
+        type: git
+        url: https://gitlab.matrix.org/matrix-org/olm.git
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dmanpage=false
+      - -Dvapi=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+      # https://gitlab.gnome.org/GNOME/libsecret/-/issues/49
+      - -Dgcrypt=false
+    sources:
+      - commit: 3fe635e64efd4b8dbc9ec3548b0bc8034c7665c4
+        tag: 0.20.4
+        type: git
+        url: https://gitlab.gnome.org/GNOME/libsecret.git
+  #- config-opts:
+  #    - -DCMAKE_BUILD_TYPE=Release
+  #    - -DAVIF_CODEC_AOM=ON
+  #    #- -DBUILD_SHARED_LIBS=OFF
+  #  buildsystem: cmake-ninja
+  #  name: libavif
+  #  sources:
+  #    - sha256: 66e82854ceb84a3e542bc140a343bc90e56c68f3ecb4fff63e636c136ed9a05e
+  #      type: archive
+  #      url: https://github.com/AOMediaCodec/libavif/archive/refs/tags/v0.10.1.tar.gz
+  #- config-opts:
+  #    - -DCMAKE_BUILD_TYPE=Release
+  #    - -DWITH_EXAMPLES=OFF
+  #    #- -DBUILD_SHARED_LIBS=OFF
+  #  buildsystem: cmake-ninja
+  #  name: libheif
+  #  sources:
+  #    - sha256: e1ac2abb354fdc8ccdca71363ebad7503ad731c84022cf460837f0839e171718
+  #      type: archive
+  #      url: https://github.com/strukturag/libheif/releases/download/v1.12.0/libheif-1.12.0.tar.gz
+  #- config-opts:
+  #    - -DCMAKE_BUILD_TYPE=Release
+  #    - -DKIMAGEFORMATS_HEIF=ON
+  #  buildsystem: cmake-ninja
+  #  name: KImageFormats
+  #  sources:
+  #    - commit: ae6b724824fc2fdf71d50dc7ae0052ad1551b25a
+  #      tag: v5.93.0
+  #      type: git
+  #      url: https://invent.kde.org/frameworks/kimageformats.git
+  - name: QtKeychain
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TEST_APPLICATION=OFF
+      - -DQTKEYCHAIN_STATIC=ON
+      - -DBUILD_WITH_QT6=ON
+    buildsystem: cmake-ninja
+    sources:
+      - commit: 69f993c47efed7e557d79a30a367014d9a27d809
+        tag: 0.14.1
+        type: git
+        url: https://github.com/frankosterfeld/qtkeychain.git
+  - name: nlohmann
+    config-opts:
+      - -DJSON_BuildTests=OFF
+    buildsystem: cmake-ninja
+    sources:
+      - sha256: d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273
+        type: archive
+        url: https://github.com/nlohmann/json/archive/v3.11.2.tar.gz
+  - name: kdsingleapplication
+    config-opts:
+      - -DKDSingleApplication_EXAMPLES=OFF
+      - -DKDSingleApplication_QT6=ON
+    buildsystem: cmake-ninja
+    sources:
+      - sha256: c92355dc10f3ebd39363458458fb5bdd9662e080cf77d91f0437763c4d936520
+        type: archive
+        url: https://github.com/KDAB/KDSingleApplication/releases/download/v1.0.0/kdsingleapplication-1.0.0.tar.gz
+  - name: re2
+    buildsystem: simple
+    build-commands:
+      - make static
+      - make prefix=/app static-install
+    sources:
+      - sha256: f89c61410a072e5cbcf8c27e3a778da7d6fd2f2b5b1445cd4f4508bee946ab0f
+        type: archive
+        url: https://github.com/google/re2/archive/refs/tags/2022-06-01.tar.gz
+  - name: gstreamer
+    buildsystem: meson
+    sources:
+      - commit: 4d13eddc8b6d3f42ba44682ba42048acf170547f
+        tag: 1.22.7
+        type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+    config-opts:
+      - --auto-features=disabled
+      -  -Dgood=enabled
+      -  -Dgst-plugins-good:qt6=enabled
+      -  -Dgst-plugins-good:qt-egl=enabled
+      -  -Dgst-plugins-good:qt-wayland=enabled
+      -  -Dgst-plugins-good:qt-x11=enabled
+      -  -Dbase=enabled
+      -  -Dgst-plugins-base:gl=enabled
+      -  -Dgst-plugins-base:gl_platform=glx,egl
+      -  -Dgst-plugins-base:gl_winsys=x11,wayland
+      -  -Dgst-plugins-base:x11=enabled
+      -  -Dgst-plugins-base:xshm=enabled
+  - name: qt-jdenticon
+    buildsystem: cmake-ninja
+    no-make-install: true
+    build-commands:
+      - mkdir -p /app/bin/
+      - cp libqtjdenticon.so /app/bin/
+    sources:
+      - commit: 39cde33d4b23b57aa5b94e94071d6ff18d2bd92a
+        tag: v0.3.1
+        type: git
+        url: https://github.com/Nheko-Reborn/qt-jdenticon.git
+  - name: coeurl
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=static
+    sources:
+      - commit: 3007387745cf84138d0855e0f04ff94261fc7175
+        #tag: v0.3.0
+        type: git
+        url: https://nheko.im/nheko-reborn/coeurl.git
+  - name: mtxclient
+    config-opts:
+      - -DBUILD_LIB_TESTS=OFF
+      - -DBUILD_LIB_EXAMPLES=OFF
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=OFF
+    buildsystem: cmake-ninja
+    sources:
+      - commit: 457bc52773b40142848f0b2ab025516bf6ed634d
+        tag: v0.10.0
+        type: git
+        url: https://github.com/Nheko-Reborn/mtxclient.git
+  - name: nheko
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLMDBXX_INCLUDE_DIR=.deps/lmdbxx
+      - -DCOMPILE_QML=ON
+      - -DMAN=OFF
+      - -DFLATPAK=ON
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        tag: v0.12.0
+        commit: 24c687d5cdae793cfecbb8c91a733a89ac7b2510
+        url: https://github.com/Nheko-Reborn/nheko.git
+      - dest: .deps/lmdbxx
+        sha256: 5e12eb3aefe9050068af7df2c663edabc977ef34c9e7ba7b9d2c43e0ad47d8df
+        type: archive
+        url: https://github.com/hoytech/lmdbxx/archive/1.0.0.tar.gz

--- a/im.nheko.Nheko.yaml
+++ b/im.nheko.Nheko.yaml
@@ -179,8 +179,8 @@ modules:
   - name: gstreamer
     buildsystem: meson
     sources:
-      - commit: 4d13eddc8b6d3f42ba44682ba42048acf170547f
-        tag: 1.22.7
+      - commit: d2c02bb704b5804ca057fc7e6c7b16b4466fd7d5
+        tag: 1.22.12
         type: git
         url: https://gitlab.freedesktop.org/gstreamer/gstreamer.git
     config-opts:


### PR DESCRIPTION
Because our old app id didn't match our github organization and also didn't match our domain, we weren't able to verify it. Additionally it didn't match our dbus interface and other ids we were using. As such switching to a new app id seemed like the easiest way forward. Additionally the Qt6 port seemed like a good time to do so.

Apart from that the packaging has barely any changes compared to io.github.NhekoReborn.Nheko. I plan to do an eol-rebase with that package soon.

# Description

Nheko is a Matrix client built with Qt, that aims to feel like a mainstream chat app.

# Permissions

The permissions are not as minimal as we would like, however they match what the old package used. Tray icon support sadly still requires claiming almost all of the kde namespace. Similarly we still default to x11 because of the screenshare support. We plan to default to wayland soon, after we gave the new pipewire screenshare support a bit more testing. Webcam support also still seems to need device permissions.

<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
