### PR TITLE
Add com.maxizamorano.photopea-no-ads

### DIFF
--- a/com.maxizamorano.photopea-no-ads/com.maxizamorano.photopea-no-ads.yml
+++ b/com.maxizamorano.photopea-no-ads/com.maxizamorano.photopea-no-ads.yml
@@ -1,0 +1,41 @@
+app-id: com.maxizamorano.photopea-no-ads
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: "23.08"
+command: photopea_no_ads.sh
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node20
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --share=network
+  - --filesystem=xdg-download
+  - --device=dri
+build-options:
+  append-path: /usr/lib/sdk/node20/bin
+  env:
+    NPM_CONFIG_LOGLEVEL: info
+modules:
+  - name: photopea_no_ads
+    buildsystem: simple
+    build-options:
+        env:
+          XDG_CACHE_HOME: /run/build/photopea/cache
+    build-commands:
+      - install -D -t /app/bin photopea_no_ads.sh
+      - mkdir /app/main
+      - tar -xzf photopea_no_ads_build.tar.gz -C /app/main
+      - install -Dm755 /app/main/resources/data/com.maxizamorano.photopea-no-ads.desktop -t /app/share/applications
+      - install -Dm644 /app/main/resources/data/com.maxizamorano.photopea-no-ads.metainfo.xml -t /app/share/metainfo
+      - install -Dm644 /app/main/resources/icons/photopea.png /app/share/icons/hicolor/512x512/apps/com.maxizamorano.photopea-no-ads.png
+    sources:
+      - type: file
+        url: https://github.com/MaxiZamorano/photopea-no-ads/releases/download/v1.0.0/photopea_no_ads_build.tar.gz
+        sha256: fb9c3bf9a551ae73f41ebdf5301c757d91571923826e54ee82b8ea1124284a1c
+      - type: script
+        dest-filename: photopea_no_ads.sh
+        commands:
+          - zypak-wrapper.sh /app/main/photopea_no_ads "$@"

--- a/com.maxizamorano.photopea-no-ads/com.maxizamorano.photopea-no-ads.yml
+++ b/com.maxizamorano.photopea-no-ads/com.maxizamorano.photopea-no-ads.yml
@@ -10,7 +10,6 @@ sdk-extensions:
 finish-args:
   - --share=ipc
   - --socket=x11
-  - --socket=wayland
   - --share=network
   - --filesystem=xdg-download
   - --device=dri


### PR DESCRIPTION
**Name:** Photopea no Ads

**Description:** In addition to removing the ads from Photopea, it also removes the box that the ads occupy so that the work area is not reduced.

<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` by `[X]` when the step is complete -->

- [x] Please describe your application briefly.
- [x] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [x] My pull request follows the instructions at [App Submission][submission].
- [x] I have [built][build] and tested the submission locally.
- [x] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [x] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [x] The domain used for the application ID is controlled by the application developers either directly or through the code hosting (e.g. GitHub, GitLab, SourceForge, etc.). The [application id guidelines][app-id] are followed.
- [x] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[maint]: https://docs.flathub.org/docs/for-app-authors/maintanance
[submission]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
[app-id]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
