### PR TITLE
Migrate FontManager with upstream App-Id change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build-dir/
+.flatpak-builder/
+testing-repo/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = git@github.com:flathub/shared-modules.git

--- a/com.github.FontManager.FontManager.yaml
+++ b/com.github.FontManager.FontManager.yaml
@@ -1,0 +1,91 @@
+app-id: com.github.FontManager.FontManager
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+
+command: font-manager
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --share=network
+
+  # XDG Data/Fonts location
+  - --filesystem=xdg-data/fonts
+  - --persist=xdg-data/fonts
+
+  # XDG complient locations for font config
+  - --filesystem=xdg-config/fontconfig
+  - --persist=xdg-config/fontconfig
+
+cleanup:
+  - /app/include
+  - /app/lib/*.a
+  - /app/lib/*.la
+  - /app/lib/pkgconfig
+
+modules:
+
+  - shared-modules/intltool/intltool-0.51.json
+  - shared-modules/libsoup/libsoup-2.4.json
+
+  # Borrowed from Poedit
+  # https://github.com/flathub/net.poedit.Poedit
+  - name: unifdef
+    no-autogen: true
+    make-install-args:
+      - prefix=${FLATPAK_DEST}
+    sources:
+      - type: archive
+        url: https://dotat.at/prog/unifdef/unifdef-2.12.tar.xz
+        sha256: 43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400
+    cleanup:
+      - '*'
+
+  - name: backtrace
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/ianlancetaylor/libbacktrace/archive/7ead8c1ea2f4aeafe9c5b9ef8a9461a9ba781aa8.zip
+        sha256: 3b07ffe9a6302ccfdf5771ab8631814303f5bc15d19a2f5a1907c64a391ec29f
+
+  - name: webkit2gtk-4.0
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DPORT=GTK
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DENABLE_DOCUMENTATION=OFF
+      - -DENABLE_BUBBLEWRAP_SANDBOX=OFF
+      - -DENABLE_WEBDRIVER=OFF
+      - -DENABLE_GAMEPAD=OFF
+    sources:
+      - type: archive
+        url: https://webkitgtk.org/releases/webkitgtk-2.44.2.tar.xz
+        sha256: 523f42c8ff24832add17631f6eaafe8f9303afe316ef1a7e1844b952a7f7521b
+        x-checker-data:
+          type: html
+          url: https://webkitgtk.org/releases/
+          version-pattern: LATEST-STABLE-(\d[\.\d]+\d)
+          url-template: https://webkitgtk.org/releases/webkitgtk-$version.tar.xz
+
+  - name: fontmanager
+    buildsystem: meson
+    config-opts:
+      - -Dreproducible=true
+      - -Dviewer=false
+      - -Dbuildtype=release
+    sources:
+      - type: git
+        url: https://github.com/FontManager/font-manager.git
+        tag: 0.9.0
+        commit: 091d2896d623c3e5aac7613a95da694a0b36699a
+        x-checker-data:
+          type: git
+          tag-pattern: ^([\d.]+)$
+    post-install:
+      # Changes to minetype support are currently on the roadmap
+      - rm /app/share/applications/mimeinfo.cache
+      - sed -i '6 i <developer_name>Font Manager project</developer_name>' /app/share/metainfo/com.github.FontManager.FontManager.appdata.xml
+      - desktop-file-edit /app/share/applications/com.github.FontManager.FontManager.desktop --remove-key=MimeType
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+clear
+flatpak-builder --repo=testing-repo --force-clean build-dir com.github.FontManager.FontManager.yaml
+flatpak --user remote-add --if-not-exists --no-gpg-verify fm-testing-repo testing-repo
+flatpak --user install fm-testing-repo com.github.FontManager.FontManager -y
+flatpak --user install fm-testing-repo com.github.FontManager.FontManager.Debug -y
+flatpak update -y


### PR DESCRIPTION
This is an existing app, that I've been maintaining for some time. This is just an administrative change based on this issue: https://github.com/flathub/org.gnome.FontManager/issues/40

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.
- [X] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read the and followed all the [Submission and licence requirements][reqs].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. [**Link**](https://github.com/FontManager/font-manager/issues/319)


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements#control-over-domain
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
