### PR TITLE
Add org.kde.okular.kirigami

### DIFF
--- a/0001-mobile-Clip-DocumentView.patch
+++ b/0001-mobile-Clip-DocumentView.patch
@@ -1,0 +1,25 @@
+From 30456eddb351e6b9977b73144329df881143ecfb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonah=20Br=C3=BCchert?= <jbb@kaidan.im>
+Date: Wed, 3 Jul 2024 16:55:07 +0200
+Subject: [PATCH 1/2] mobile: Clip DocumentView
+
+---
+ mobile/components/DocumentView.qml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/mobile/components/DocumentView.qml b/mobile/components/DocumentView.qml
+index 3d5ada172..4ebd7de21 100644
+--- a/mobile/components/DocumentView.qml
++++ b/mobile/components/DocumentView.qml
+@@ -20,6 +20,8 @@ QQC2.ScrollView {
+     property DocumentItem document
+     property PageItem page: mouseArea.currPageDelegate.pageItem
+     signal clicked
++
++    clip: true
+     
+     //NOTE: on some themes it tries to set the flickable to interactive
+     //but we need it always non interactive as we need to manage
+-- 
+2.43.0
+

--- a/0002-Mobile-Fix-switch-pages.patch
+++ b/0002-Mobile-Fix-switch-pages.patch
@@ -1,0 +1,56 @@
+From c09cdc0ef7ec85ccf8fd4c2f27ec163096115e47 Mon Sep 17 00:00:00 2001
+From: Albert Astals Cid <aacid@kde.org>
+Date: Thu, 4 Jul 2024 00:25:40 +0200
+Subject: [PATCH 2/2] Mobile: Fix switch pages
+
+---
+ mobile/components/DocumentView.qml | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/mobile/components/DocumentView.qml b/mobile/components/DocumentView.qml
+index 4ebd7de21..7ad6a4229 100644
+--- a/mobile/components/DocumentView.qml
++++ b/mobile/components/DocumentView.qml
+@@ -187,33 +187,39 @@ QQC2.ScrollView {
+                     target: mouseArea.currPageDelegate
+                     property: "pageNumber"
+                     value: root.document.currentPage
++                    restoreMode: Binding.RestoreNone
+                 }
+                 Binding {
+                     target: mouseArea.currPageDelegate
+                     property: "visible"
+                     value: true
++                    restoreMode: Binding.RestoreNone
+                 }
+ 
+                 Binding {
+                     target: mouseArea.prevPageDelegate
+                     property: "pageNumber"
+                     value: root.document.currentPage - 1
++                    restoreMode: Binding.RestoreNone
+                 }
+                 Binding {
+                     target: mouseArea.prevPageDelegate
+                     property: "visible"
+                     value: !mouseArea.incrementing && root.document.currentPage > 0
++                    restoreMode: Binding.RestoreNone
+                 }
+ 
+                 Binding {
+                     target: mouseArea.nextPageDelegate
+                     property: "pageNumber"
+                     value: root.document.currentPage + 1
++                    restoreMode: Binding.RestoreNone
+                 }
+                 Binding {
+                     target: mouseArea.nextPageDelegate
+                     property: "visible"
+                     value: mouseArea.incrementing && root.document.currentPage < document.pageCount-1
++                    restoreMode: Binding.RestoreNone
+                 }
+                 
+                 SequentialAnimation {
+-- 
+2.43.0
+

--- a/0003-mobile-complement-appstream.patch
+++ b/0003-mobile-complement-appstream.patch
@@ -1,0 +1,47 @@
+From b7c5f14021ff76d5b51e4d3f0ce3e00718e2ff01 Mon Sep 17 00:00:00 2001
+From: Max Buchholz <max.buchholz@gmx.de>
+Date: Sun, 21 Apr 2024 15:17:30 +0000
+Subject: [PATCH] Complement org.kde.okular.kirigami.appdata.xml
+
+Based on what is already available in the [LinuxPhoneApps listing](https://linuxphoneapps.org/apps/org.kde.okular.kirigami.desktop/) I added some missing metainfo:
+- Adds vcs-browser url
+- Adds developer information
+- Adds categories
+---
+ mobile/app/org.kde.okular.kirigami.appdata.xml | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/mobile/app/org.kde.okular.kirigami.appdata.xml b/mobile/app/org.kde.okular.kirigami.appdata.xml
+index 32d1cc332c..20b7a68022 100644
+--- a/mobile/app/org.kde.okular.kirigami.appdata.xml
++++ b/mobile/app/org.kde.okular.kirigami.appdata.xml
+@@ -99,6 +99,10 @@
+   <summary xml:lang="x-test">xxDocument Viewerxx</summary>
+   <summary xml:lang="zh-CN">文档查看器</summary>
+   <summary xml:lang="zh-TW">文件檢視器</summary>
++  <developer id="org.kde">
++    <name>KDE</name>
++    <url>https://kde.org</url>
++  </developer>
+   <description>
+     <p>
+    Okular is a universal document viewer developed by KDE. Okular works on multiple platforms, including but not limited to Linux, Windows, Mac OS X, *BSD, etc.
+@@ -390,8 +394,15 @@
+       <image>https://cdn.kde.org/screenshots/okular/okular-mobile.png</image>
+     </screenshot>
+   </screenshots>
++  <categories>
++    <category>Qt</category>
++    <category>KDE</category>
++    <category>Office</category>
++    <category>Viewer</category>
++  </categories>
+   <url type="homepage">https://okular.kde.org/</url>
+   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=okular</url>
++  <url type="vcs-browser">https://invent.kde.org/graphics/okular</url>
+   <project_group>KDE</project_group>
+   <provides>
+     <binary>okularkirigami</binary>
+-- 
+GitLab
+

--- a/0004-mobile-Add-more-appstream-tags-required-by-flathub.patch
+++ b/0004-mobile-Add-more-appstream-tags-required-by-flathub.patch
@@ -1,0 +1,62 @@
+From 947c017042835100dbbe705df4c2a39483f18c4c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonah=20Br=C3=BCchert?= <jbb@kaidan.im>
+Date: Thu, 18 Jul 2024 01:25:07 +0200
+Subject: [PATCH 1/2] mobile: Add more appstream tags required by flathub
+
+---
+ mobile/app/org.kde.okular.kirigami.appdata.xml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/mobile/app/org.kde.okular.kirigami.appdata.xml b/mobile/app/org.kde.okular.kirigami.appdata.xml
+index c8d2e92589..73effa7438 100644
+--- a/mobile/app/org.kde.okular.kirigami.appdata.xml
++++ b/mobile/app/org.kde.okular.kirigami.appdata.xml
+@@ -407,6 +407,8 @@
+   <provides>
+     <binary>okularkirigami</binary>
+   </provides>
++  <content_rating type="oars-1.1"/>
++  <launchable type="desktop-id">org.kde.okular.kirigami.desktop</launchable>
+   <releases>
+     <release version="24.05.2" date="2024-07-04"/>
+     <release version="24.05.1" date="2024-06-13"/>
+-- 
+GitLab
+
+
+From 43ef4b07835016bb268925ab3c7d642e65f8f5e4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonah=20Br=C3=BCchert?= <jbb@kaidan.im>
+Date: Thu, 18 Jul 2024 11:21:43 +0200
+Subject: [PATCH 2/2] mobile: Rename appstream id to org.kde.okular.kirigami
+
+---
+ mobile/app/org.kde.okular.kirigami.appdata.xml | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/mobile/app/org.kde.okular.kirigami.appdata.xml b/mobile/app/org.kde.okular.kirigami.appdata.xml
+index 73effa7438..9c2122975a 100644
+--- a/mobile/app/org.kde.okular.kirigami.appdata.xml
++++ b/mobile/app/org.kde.okular.kirigami.appdata.xml
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <component type="desktop">
+-  <id>org.kde.okular.kirigami.desktop</id>
++  <id>org.kde.okular.kirigami</id>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+ and GFDL-1.3</project_license>
+   <name>Okular Mobile</name>
+@@ -406,7 +406,11 @@
+   <project_group>KDE</project_group>
+   <provides>
+     <binary>okularkirigami</binary>
++    <id>org.kde.okular.kirigami.desktop</id>
+   </provides>
++  <replaces>
++    <id>org.kde.okular.kirigami.desktop</id>
++  </replaces>
+   <content_rating type="oars-1.1"/>
+   <launchable type="desktop-id">org.kde.okular.kirigami.desktop</launchable>
+   <releases>
+-- 
+GitLab
+

--- a/chmlib-arm.patch
+++ b/chmlib-arm.patch
@@ -1,0 +1,21 @@
+diff -urN a/src/chm_lib.c b/src/chm_lib.c
+--- a/src/chm_lib.c	2009-05-23 08:43:31.000000000 -0600
++++ b/src/chm_lib.c	2015-07-18 14:15:00.588557608 -0600
+@@ -153,7 +153,7 @@
+ /* Sparc        */
+ /* MIPS         */
+ /* PPC          */
+-#elif __i386__ || __sun || __sgi || __ppc__
++#elif __i386__ || __sun || __sgi || __ppc__ || __arm__
+ typedef unsigned char           UChar;
+ typedef short                   Int16;
+ typedef unsigned short          UInt16;
+@@ -164,7 +164,7 @@
+ 
+ /* x86-64 */
+ /* Note that these may be appropriate for other 64-bit machines. */
+-#elif __x86_64__ || __ia64__
++#elif __x86_64__ || __ia64__ || __aarch64__
+ typedef unsigned char           UChar;
+ typedef short                   Int16;
+ typedef unsigned short          UInt16;

--- a/okular-mimetypes.patch
+++ b/okular-mimetypes.patch
@@ -1,0 +1,12 @@
+diff --git a/shell/org.kde.okular.desktop b/shell/org.kde.okular.desktop
+index 8e0141735..370b82277 100755
+--- a/shell/org.kde.okular.desktop
++++ b/shell/org.kde.okular.desktop
+@@ -164,6 +164,6 @@ Type=Application
+ X-DocPath=okular/index.html
+ InitialPreference=7
+ Categories=Qt;KDE;Graphics;Office;Viewer;
+-MimeType=application/vnd.kde.okular-archive;
++MimeType=application/epub+zip;application/oxps;application/pdf;application/postscript;application/prs.plucker;application/vnd.kde.okular-archive;application/vnd.ms-xpsdocument;application/x-bzdvi;application/x-bzpdf;application/x-bzpostscript;application/x-cbr;application/x-cbt;application/x-cbz;application/x-dvi;application/x-fictionbook+xml;application/x-gzdvi;application/x-gzpdf;application/x-gzpostscript;application/x-chm;application/x-mobipocket-ebook;application/x-wwf;image/bmp;image/fax-g3;image/gif;image/g3fax;image/jpeg;image/jp2;image/png;image/tiff;image/vnd.djvu;image/x-bzeps;image/x-dds;image/x-eps;image/x-exr;image/x-gzeps;image/x-hdr;image/x-ico;image/x-pcx;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-psd;image/x-rgb;image/x-tga;image/x-xbitmap;image/x-xcf;image/x-xpixmap;text/markdown;text/plain;video/x-mng;
+ X-DBUS-ServiceName=org.kde.okular
+ 

--- a/org.kde.okular.json
+++ b/org.kde.okular.json
@@ -1,0 +1,481 @@
+{
+    "id": "org.kde.okular",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.7",
+    "sdk": "org.kde.Sdk",
+    "command": "okular",
+    "rename-icon": "okular",
+    "finish-args": [
+        "--share=ipc",
+        "--share=network",
+        "--socket=cups",
+        "--socket=pulseaudio",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/*.a",
+        "/lib/*.la",
+        "/lib/cmake",
+        "/share/man",
+        "/share/doc",
+        "/share/pkgconfig",
+        "/share/cmake"
+    ],
+    "modules": [
+        {
+            "name": "gnustep-make",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make -j $FLATPAK_BUILDER_N_JOBS install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/gnustep/tools-make/archive/make-2_9_2.tar.gz",
+                    "sha256": "b3fdee058879675f6979c553fb6172b160ca79ffd0f170f51379326b7922941a",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1220,
+                        "stable-only": true,
+                        "url-template": "https://github.com/gnustep/tools-make/archive/make-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "gnustep",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./configure --prefix=/app",
+                "make -j $FLATPAK_BUILDER_N_JOBS install",
+                "ls /app/include"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/gnustep/libs-base/releases/download/base-1_30_0/gnustep-base-1.30.0.tar.gz",
+                    "sha256": "00b5bc4179045b581f9f9dc3751b800c07a5d204682e3e0eddd8b5e5dee51faa",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 9105,
+                        "stable-only": true,
+                        "url-template": "https://github.com/gnustep/libs-base/releases/download/base-$version/gnustep-base-1.$patch.0.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "unarchiver",
+            "buildsystem": "simple",
+            "build-commands": [
+                "sed -s -i 's#/usr/include/GNUstep#/app/include#g' */Makefile.linux && cd XADMaster && make -j $FLATPAK_BUILDER_N_JOBS -f Makefile.linux",
+                "install -m755 XADMaster/unar XADMaster/lsar /app/bin/"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://cdn.theunarchiver.com/downloads/TheUnarchiverSource.zip",
+                    "sha256": "ac4cedf9b49375c0f805bda010fa03629d05ab283a0a8e35bf2dd01ae477e0a1",
+                    "strip-components": 0
+                }
+            ]
+        },
+        {
+            "name": "discount",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./configure.sh --prefix=/app --enable-all-features --with-fenced-code --shared",
+                "sed -e 's|/sbin/ldconfig|/sbin/ldconfig -n|' -i librarian.sh",
+                "make install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Orc/discount/archive/v3.0.0d.tar.gz",
+                    "sha256": "0ed8cc27ac5d46dc6a8beedd5e5673ac8b466a6474bdb7d35f37c815f670385f",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 12139,
+                        "stable-only": true,
+                        "url-template": "https://github.com/Orc/discount/archive/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "boost",
+            "buildsystem": "simple",
+            "build-commands": [
+                "./bootstrap.sh --prefix=/app --with-libraries=system",
+                "./b2 -j $FLATPAK_BUILDER_N_JOBS install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.bz2",
+                    "sha256": "7009fe1faa1697476bdc7027703a2badb84e849b7b0baad5086b087b971f8617",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 6845,
+                        "stable-only": true,
+                        "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libzip",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://libzip.org/download/libzip-1.10.1.tar.xz",
+                    "sha256": "dc3c8d5b4c8bbd09626864f6bcf93de701540f761d76b85d7c7d710f4bd90318",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 10649,
+                        "stable-only": true,
+                        "url-template": "https://libzip.org/download/libzip-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "chmlib",
+            "rm-configure": true,
+            "sources": [
+                {
+                    "type": "script",
+                    "dest-filename": "autogen.sh",
+                    "commands": [
+                        "AUTOMAKE=\"automake --foreign\" autoreconf -vfi"
+                    ]
+                },
+                {
+                    "type": "archive",
+                    "url": "http://www.jedrea.com/chmlib/chmlib-0.40.tar.bz2",
+                    "sha256": "3449d64b0cf71578b2c7e3ddc048d4af3661f44a83941ea074a7813f3a59ffa3",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 17678,
+                        "stable-only": true,
+                        "url-template": "http://www.jedrea.com/chmlib/chmlib-$version.tar.bz2"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "chmlib-arm.patch"
+                }
+            ]
+        },
+        {
+            "name": "ebook-tools",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://downloads.sourceforge.net/project/ebook-tools/ebook-tools/0.2.2/ebook-tools-0.2.2.tar.gz",
+                    "sha256": "cbc35996e911144fa62925366ad6a6212d6af2588f1e39075954973bbee627ae",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 17771,
+                        "stable-only": true,
+                        "url-template": "https://downloads.sourceforge.net/project/ebook-tools/ebook-tools/$version/ebook-tools-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "djvulibre",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://downloads.sourceforge.net/djvu/djvulibre-3.5.28.tar.gz",
+                    "sha256": "fcd009ea7654fde5a83600eb80757bd3a76998e47d13c66b54c8db849f8f2edc",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 10159,
+                        "stable-only": true,
+                        "url-template": "http://downloads.sourceforge.net/djvu/djvulibre-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ghostscript",
+            "config-opts": [
+                "--disable-cups"
+            ],
+            "make-args": [
+                "so"
+            ],
+            "make-install-args": [
+                "soinstall"
+            ],
+            "post-install": [
+                "mv -f ${FLATPAK_DEST}/bin/{gsc,gs} "
+            ],
+            "cleanup": [
+                "/share/ghostscript/*/doc/",
+                "/share/ghostscript/*/examples"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10031/ghostscript-10.03.1.tar.gz",
+                    "sha256": "31cd01682ad23a801cc3bbc222a55f07c4ea3e068bdfb447792d54db21a2e8ad",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1157,
+                        "stable-only": true,
+                        "url-template": "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${major}0$minor$patch/ghostscript-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "libspectre",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://libspectre.freedesktop.org/releases/libspectre-0.2.12.tar.gz",
+                    "sha256": "55a7517cd3572bd2565df0cf450944a04d5273b279ebb369a895391957f0f960",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1724,
+                        "stable-only": true,
+                        "url-template": "http://libspectre.freedesktop.org/releases/libspectre-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "openjpeg",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "cleanup": [
+                "/bin",
+                "/lib/openjpeg-*"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/uclouvain/openjpeg/archive/v2.5.2.tar.gz",
+                    "sha256": "90e3896fed910c376aaf79cdd98bdfdaf98c6472efd8e1debf0a854938cbda6a",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 2550,
+                        "stable-only": true,
+                        "url-template": "https://github.com/uclouvain/openjpeg/archive/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "poppler-data",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz",
+                    "sha256": "c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 3687,
+                        "stable-only": true,
+                        "url-template": "https://poppler.freedesktop.org/poppler-data-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "poppler",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DBUILD_GTK_TESTS=OFF",
+                "-DBUILD_QT5_TESTS=OFF",
+                "-DBUILD_QT6_TESTS=OFF",
+                "-DBUILD_CPP_TESTS=OFF",
+                "-DENABLE_UTILS=OFF",
+                "-DENABLE_CPP=OFF",
+                "-DENABLE_GLIB=OFF",
+                "-DENABLE_QT5=OFF",
+                "-DENABLE_QT6=ON"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://poppler.freedesktop.org/poppler-24.07.0.tar.xz",
+                    "sha256": "19eb4f49198e4ae3fd9e5a6cf24d0fc7e674e8802046a7de14baab1e40cc2f1d",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 3686,
+                        "stable-only": true,
+                        "url-template": "https://poppler.freedesktop.org/poppler-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "inih",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Ddefault_library=shared",
+                "-Ddistro_install=true",
+                "-Dwith_INIReader=true"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/benhoyt/inih/archive/refs/tags/r58.tar.gz",
+                    "sha256": "e79216260d5dffe809bda840be48ab0eec7737b2bb9f02d2275c1b46344ea7b7",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 11600,
+                        "stable-only": true,
+                        "url-template": "https://github.com/benhoyt/inih/archive/refs/tags/r$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "exiv2",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.3.tar.gz",
+                    "sha256": "1315e17d454bf4da3cc0edb857b1d2c143670f3485b537d0f946d9ed31d87b70",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 769,
+                        "stable-only": true,
+                        "url-template": "https://github.com/Exiv2/exiv2/archive/refs/tags/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "pcre",
+            "config-opts": [
+                "--enable-unicode-properties"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://prdownloads.sourceforge.net/pcre/pcre-8.45.tar.bz2",
+                    "sha256": "4dae6fdcd2bb0bb6c37b5f97c33c2be954da743985369cddac3546e3218bffb8"
+                }
+            ]
+        },
+        {
+            "name": "libkexiv2",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DQT_MAJOR_VERSION=6"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/24.05.2/src/libkexiv2-24.05.2.tar.xz",
+                    "sha256": "90595f61e2f4dcb3d8b32cb0a4a1c7f4fc5e3105111add514c99db24f734e313",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 8763,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/libkexiv2-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "kdegraphics-mobipocket",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DQT_MAJOR_VERSION=6"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/24.05.2/src/kdegraphics-mobipocket-24.05.2.tar.xz",
+                    "sha256": "0408ec55e3df317b29763f56662bf3ca0844ca538ab4471f316832c197a58fc1",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 8763,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/kdegraphics-mobipocket-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "okular",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DBUILD_OKULARKIRIGAMI=OFF"
+            ],
+            "post-install": [
+                "mv /app/bin/okular /app/bin/okular-bin",
+                "install -Dm755 ../okular-wrapper /app/bin/okular"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/24.05.2/src/okular-24.05.2.tar.xz",
+                    "sha256": "e718d4884b46fbf430033c2ed0e80cb50e6d476e76ccfda4a2c71d840051034e",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 8763,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/okular-$version.tar.xz"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "okular-mimetypes.patch"
+                },
+                {
+                    "type": "script",
+                    "dest-filename": "okular-wrapper",
+                    "commands": [
+                        "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
+                        "exec /app/bin/okular-bin \"$@\""
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/org.kde.okular.kirigami.json
+++ b/org.kde.okular.kirigami.json
@@ -488,6 +488,14 @@
                     "path": "okular-mimetypes.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "0001-mobile-Clip-DocumentView.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0002-Mobile-Fix-switch-pages.patch"
+                },
+                {
                     "type": "script",
                     "dest-filename": "okularkirigami-wrapper",
                     "commands": [

--- a/org.kde.okular.kirigami.json
+++ b/org.kde.okular.kirigami.json
@@ -496,6 +496,14 @@
                     "path": "0002-Mobile-Fix-switch-pages.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "0003-mobile-complement-appstream.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0004-mobile-Add-more-appstream-tags-required-by-flathub.patch"
+                },
+                {
                     "type": "script",
                     "dest-filename": "okularkirigami-wrapper",
                     "commands": [

--- a/org.kde.okular.kirigami.json
+++ b/org.kde.okular.kirigami.json
@@ -1,9 +1,9 @@
 {
-    "id": "org.kde.okular",
+    "id": "org.kde.okular.kirigami",
     "runtime": "org.kde.Platform",
     "runtime-version": "6.7",
     "sdk": "org.kde.Sdk",
-    "command": "okular",
+    "command": "okularkirigami",
     "rename-icon": "okular",
     "finish-args": [
         "--share=ipc",
@@ -12,8 +12,7 @@
         "--socket=pulseaudio",
         "--socket=fallback-x11",
         "--socket=wayland",
-        "--device=dri",
-        "--filesystem=host"
+        "--device=dri"
     ],
     "cleanup": [
         "/include",
@@ -440,16 +439,37 @@
             ]
         },
         {
+            "name": "kirigami-addons",
+            "config-opts": [
+                "-DBUILD_TESTING=OFF",
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            ],
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.3.0.tar.xz",
+                    "sha256": "f5e44d7a7d7dfd866c529bb004f7204013609a16c9757091fcdb2c6c5be00ff3",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 242933,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
+                    }
+                }
+            ]
+        },
+        {
             "name": "okular",
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-                "-DBUILD_OKULARKIRIGAMI=OFF"
+                "-DOKULAR_UI=mobile"
             ],
             "post-install": [
-                "mv /app/bin/okular /app/bin/okular-bin",
-                "install -Dm755 ../okular-wrapper /app/bin/okular"
+                "mv /app/bin/okularkirigami /app/bin/okularkirigami-bin",
+                "install -Dm755 ../okularkirigami-wrapper /app/bin/okularkirigami"
             ],
             "sources": [
                 {
@@ -469,10 +489,10 @@
                 },
                 {
                     "type": "script",
-                    "dest-filename": "okular-wrapper",
+                    "dest-filename": "okularkirigami-wrapper",
                     "commands": [
                         "export TMPDIR=\"$XDG_RUNTIME_DIR/app/$FLATPAK_ID\"",
-                        "exec /app/bin/okular-bin \"$@\""
+                        "exec /app/bin/okularkirigami-bin \"$@\""
                     ]
                 }
             ]


### PR DESCRIPTION
This is based directly on the Okular manifest, and the changes are split into separate commits to make review easy.

- [x] Please describe the application briefly.
  Mobile interface for the Okular PDF viewer

- [x] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read the and followed all the [Submission and licence requirements][reqs].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link:** https://matrix.to/#/!iotruiWARuYNvXiTDB:kde.org/$XRybn93-Pn2iBITRe964G2O-FlZk0kSPD4_dLYW1zcc?via=matrix.org&via=kde.org&via=im.kde.org



[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements#control-over-domain
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
