### PR TITLE
Add io.github.equicord.equibop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# Equibop Flatpak
+
+<!-- This flatpak is a fork of dev.vencord.Vesktop @ https://github.com/flathub/dev.vencord.Vesktop -->
+
+This is the flatpak for Equibop, a fork of Vesktop.
+
+## Tray icons
+
+This flatpak has the appropriate permissions for tray icons out of the box; however, GNOME does not provide native tray icons support out of the box, due to the current specification being *horribly* outdated and not being sandbox-friendly.
+
+The extension that should be used to obtain tray icons is [appindicator-support](https://extensions.gnome.org/extension/615/appindicator-support/). Enable this extension and disable any other alternatives and tray icons will function as expected.
+
+## Discord Rich Presence
+### Native applications
+A solution that works short-term is to run `ln -sf $XDG_RUNTIME_DIR/{.flatpak/io.github.equicord.equibop/xdg-run,}/discord-ipc-0`.
+For something longer lasting, run the following:
+
+```sh
+mkdir -p ~/.config/user-tmpfiles.d
+echo 'L %t/discord-ipc-0 - - - - .flatpak/io.github.equicord.equibop/xdg-run/discord-ipc-0' > ~/.config/user-tmpfiles.d/discord-rpc.conf
+systemctl --user enable --now systemd-tmpfiles-setup.service
+```
+Now, native applications will be able to use Rich Presence on every system start.
+
+### Flatpak applications
+<!-- TAKEN FROM https://github.com/flathub/com.discordapp.Discord/wiki/Rich-Precense-(discord-rpc) -->
+
+Flatpak applications need certain changes inside of the flatpak environment to connect properly:
+
+1. Permission to access `$XDG_RUNTIME_DIR/.flatpak/io.github.equicord.equibop/`
+2. A symlink at `$XDG_RUNTIME_DIR/discord-ipc-0` pointing to `$XDG_RUNTIME_DIR/.flatpak/io.github.equicord.equibop/xdg-run/discord-ipc-0`
+
+Suggested changes to accomplish these needs :
+
+1. Add `--filesystem=xdg-run/.flatpak/io.github.equicord.equibop:create` and `--filesystem=xdg-run/discord-ipc-*` to the global Flatpak permissions
+2. Restart

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -22,7 +22,7 @@ finish-args:
   - --filesystem=xdg-pictures:ro
   - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
   - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
-  - --filesystem=xdg-run/speech-dispatcher # For TTS and VcNarrator
+  - --filesystem=xdg-run/speech-dispatcher:ro # For TTS and VcNarrator
   - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
 

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -48,7 +48,7 @@ modules:
 
       - type: file
         url: https://raw.githubusercontent.com/Equicord/Equibop/main/meta/io.github.equicord.equibop.metainfo.xml
-        sha512: 29c40bf8a930e8519425ea4181b5b3543c38c9cd48b4a3d647d237000af1772a89565d04878181032b67edaff343d378c23d0195fe7df5d44706f0b52a67840d
+        sha512: 38ec4d16081fca17306d50a9c4c3ea287e1089e29548fe4b8f06dd842ffb41aa50288dccf19d7fe0552afd562c107744bd37fe9856039b662fac85b838eab8f7
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Equicord/Equibop/contents/meta/io.github.equicord.equibop.metainfo.xml
@@ -56,18 +56,18 @@ modules:
           url-query: .download_url
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.6/Equibop-linux-x86_64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.7/Equibop-linux-x86_64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: 58535fdc3dbf1b51eb37ccb591bf6225419fdd4e10108d0615e930a8ef5ee0d5d9589d855f11100f76ff26626ea33160fb13423d0d90bd683f845d0418e22828
+        sha512: a44a5d88dac175d5e197f9290a02dc2101c42a7eeb159a01b45c77cd6dc63b9c77ad64618f7258f0902bfe2917e16ce920b85fe8cc87249a34c24f22df2762d5
         only-arches: [x86_64]
         x-checker-data:
           type: electron-updater
           url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux.yml
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.6/Equibop-linux-arm64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.7/Equibop-linux-arm64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: 31c9a2d41fb22938e2c4d1785994834c3765426e18a92a7b9926e71168645ef30d3d80f0e0e37d8d97769d0c34b761134868b5491d7416109255b19017abbfd7
+        sha512: 3b1f1ffc220b3343374f4756607269ea9b9ff875faab10cef117904fb25b2239476f5229429d505a6afa00ecacfbea5ba9135356be1ea923326076b8488cb251
         only-arches: [aarch64]
         x-checker-data:
           type: electron-updater

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -34,8 +34,8 @@ modules:
       - ./Equibop.AppImage --appimage-extract
       - desktop-file-edit --set-key="Exec" --set-value="startequibop" --set-icon=$FLATPAK_ID
         squashfs-root/equibop.desktop
-      - install -D squashfs-root/usr/share/icons/hicolor/256x256/apps/equibop.png
-        /app/share/icons/hicolor/256x256/apps/io.github.equicord.equibop.png
+      - install -D squashfs-root/usr/share/icons/hicolor/512x512/apps/equibop.png
+        /app/share/icons/hicolor/512x512/apps/io.github.equicord.equibop.png
       - install -D squashfs-root/usr/share/icons/hicolor/16x16/apps/equibop.png /app/share/icons/hicolor/16x16/apps/io.github.equicord.equibop.png
       - install -D squashfs-root/equibop.desktop /app/share/applications/io.github.equicord.equibop.desktop
       - install -Dm755 startequibop /app/bin/startequibop
@@ -48,7 +48,7 @@ modules:
 
       - type: file
         url: https://raw.githubusercontent.com/Equicord/Equibop/main/meta/io.github.equicord.equibop.metainfo.xml
-        sha512: 7e6b181c4dbc72733dfeef37c2d06733a05cf8a0076c1ee102b05bd46274685d957ecc82259fd81fa6ab7039c4d108915ee40701699d1e6d0133790b86490a0b
+        sha512: 499acec8fa17edd3029348b322a1b6851104c088d9537100a284a038d26111baf3a92923e6cc8b3f86cfe2d711f8dcf4bb59ccb2d09f96fc01d23f2727728cf6
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Equicord/Equibop/contents/meta/io.github.equicord.equibop.metainfo.xml
@@ -56,7 +56,7 @@ modules:
           url-query: ".download_url"
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.1.0/Equibop-linux-x86_64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.8/Equibop-linux-x86_64.AppImage
         dest-filename: Equibop.AppImage
         sha512: fa6fb910a86f9687413da8d64b5037c69b40c7856adcc4f5357e72f34607664f908a10bf1ba0b96fce07e9c09c1088d1002283ab8ccc81252d27995e68ad278c
         only-arches: [x86_64]
@@ -65,7 +65,7 @@ modules:
           url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux.yml
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.1.0/Equibop-linux-arm64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.8/Equibop-linux-arm64.AppImage
         dest-filename: Equibop.AppImage
         sha512: 156f197a8de1b1e53c497eba402b6d6d089238aa95178e83aa7cb95866827477f6dc925890a81b52412c8e715c2b7a8af6cf426f7bedddb7d807f6fc58c1b07e
         only-arches: [aarch64]

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -1,0 +1,74 @@
+app-id: io.github.equicord.equibop
+
+runtime: org.freedesktop.Platform
+runtime-version: "23.08"
+sdk: org.freedesktop.Sdk
+
+base: org.electronjs.Electron2.BaseApp
+base-version: "23.08"
+
+command: startequibop
+separate-locales: false
+
+finish-args:
+  - --socket=pulseaudio
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --share=network
+  - --talk-name=org.kde.StatusNotifierWatcher # Tray functionalities on KDE
+  - --device=all # Needed for GPU acceleration and the webcam
+  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-pictures:ro
+  - --filesystem=xdg-download # This and the above two are used for drag-n-drop, and download managing
+  - --filesystem=xdg-run/pipewire-0 # Pipewire interfacing
+  - --filesystem=xdg-run/speech-dispatcher # For TTS and VcNarrator
+  - --filesystem=~/.steam # Needed for SteamOS integration, as the XDG OpenURL portal doesn't work properly in Game Mode. We only need ~/.steam/steam.pipe but Flatpak can't correctly mount just that: 'File "/home/deck/.steam/steam.pipe" has unsupported type 0o10000'
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons # This is used to show the correct cursor on Wayland
+
+modules:
+  - name: Equibop
+    buildsystem: simple
+    build-commands:
+      - chmod +x Equibop.AppImage
+      - ./Equibop.AppImage --appimage-extract
+      - desktop-file-edit --set-key="Exec" --set-value="startequibop" --set-icon=$FLATPAK_ID
+        squashfs-root/equibop.desktop
+      - install -D squashfs-root/usr/share/icons/hicolor/256x256/apps/equibop.png
+        /app/share/icons/hicolor/256x256/apps/io.github.equicord.equibop.png
+      - install -D squashfs-root/usr/share/icons/hicolor/16x16/apps/equibop.png /app/share/icons/hicolor/16x16/apps/io.github.equicord.equibop.png
+      - install -D squashfs-root/equibop.desktop /app/share/applications/io.github.equicord.equibop.desktop
+      - install -Dm755 startequibop /app/bin/startequibop
+      - install -D io.github.equicord.equibop.metainfo.xml -t /app/share/metainfo/
+      - mv squashfs-root /app/bin/equibop
+
+    sources:
+      - type: file
+        path: startequibop
+
+      - type: file
+        url: https://raw.githubusercontent.com/Equicord/Equibop/main/meta/io.github.equicord.equibop.metainfo.xml
+        sha512: 29c40bf8a930e8519425ea4181b5b3543c38c9cd48b4a3d647d237000af1772a89565d04878181032b67edaff343d378c23d0195fe7df5d44706f0b52a67840d
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/Equicord/Equibop/contents/meta/io.github.equicord.equibop.metainfo.xml
+          version-query: .sha
+          url-query: .download_url
+
+      - type: file
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.6/Equibop-linux-x86_64.AppImage
+        dest-filename: Equibop.AppImage
+        sha512: 58535fdc3dbf1b51eb37ccb591bf6225419fdd4e10108d0615e930a8ef5ee0d5d9589d855f11100f76ff26626ea33160fb13423d0d90bd683f845d0418e22828
+        only-arches: [x86_64]
+        x-checker-data:
+          type: electron-updater
+          url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux.yml
+
+      - type: file
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.6/Equibop-linux-arm64.AppImage
+        dest-filename: Equibop.AppImage
+        sha512: 31c9a2d41fb22938e2c4d1785994834c3765426e18a92a7b9926e71168645ef30d3d80f0e0e37d8d97769d0c34b761134868b5491d7416109255b19017abbfd7
+        only-arches: [aarch64]
+        x-checker-data:
+          type: electron-updater
+          url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux-arm64.yml

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -48,26 +48,26 @@ modules:
 
       - type: file
         url: https://raw.githubusercontent.com/Equicord/Equibop/main/meta/io.github.equicord.equibop.metainfo.xml
-        sha512: 38ec4d16081fca17306d50a9c4c3ea287e1089e29548fe4b8f06dd842ffb41aa50288dccf19d7fe0552afd562c107744bd37fe9856039b662fac85b838eab8f7
+        sha512: 7e6b181c4dbc72733dfeef37c2d06733a05cf8a0076c1ee102b05bd46274685d957ecc82259fd81fa6ab7039c4d108915ee40701699d1e6d0133790b86490a0b
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Equicord/Equibop/contents/meta/io.github.equicord.equibop.metainfo.xml
-          version-query: .sha
-          url-query: .download_url
+          version-query: ".sha"
+          url-query: ".download_url"
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.7/Equibop-linux-x86_64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.1.0/Equibop-linux-x86_64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: a44a5d88dac175d5e197f9290a02dc2101c42a7eeb159a01b45c77cd6dc63b9c77ad64618f7258f0902bfe2917e16ce920b85fe8cc87249a34c24f22df2762d5
+        sha512: fa6fb910a86f9687413da8d64b5037c69b40c7856adcc4f5357e72f34607664f908a10bf1ba0b96fce07e9c09c1088d1002283ab8ccc81252d27995e68ad278c
         only-arches: [x86_64]
         x-checker-data:
           type: electron-updater
           url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux.yml
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.7/Equibop-linux-arm64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.1.0/Equibop-linux-arm64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: 3b1f1ffc220b3343374f4756607269ea9b9ff875faab10cef117904fb25b2239476f5229429d505a6afa00ecacfbea5ba9135356be1ea923326076b8488cb251
+        sha512: 156f197a8de1b1e53c497eba402b6d6d089238aa95178e83aa7cb95866827477f6dc925890a81b52412c8e715c2b7a8af6cf426f7bedddb7d807f6fc58c1b07e
         only-arches: [aarch64]
         x-checker-data:
           type: electron-updater

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -48,7 +48,7 @@ modules:
 
       - type: file
         url: https://raw.githubusercontent.com/Equicord/Equibop/main/meta/io.github.equicord.equibop.metainfo.xml
-        sha512: 499acec8fa17edd3029348b322a1b6851104c088d9537100a284a038d26111baf3a92923e6cc8b3f86cfe2d711f8dcf4bb59ccb2d09f96fc01d23f2727728cf6
+        sha512: acc37ccf88667abd8d411719de4831746e19041e1ee3cd2c4a2cb2fb2fad46d4660c7accda475d12a3784580555c9a799c14250ce904f6e09ab22b25452bb3b2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/Equicord/Equibop/contents/meta/io.github.equicord.equibop.metainfo.xml
@@ -56,18 +56,18 @@ modules:
           url-query: ".download_url"
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.8/Equibop-linux-x86_64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.9/Equibop-linux-x86_64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: fa6fb910a86f9687413da8d64b5037c69b40c7856adcc4f5357e72f34607664f908a10bf1ba0b96fce07e9c09c1088d1002283ab8ccc81252d27995e68ad278c
+        sha512: e72aec89f36574a0fea507aaedf1b05f5ef31f0fa1206b598247a591cbd140c1c2cb2a6d706ec17ab5c3f19db513cd323e348791cb653d7dca020f77e84ca3bf
         only-arches: [x86_64]
         x-checker-data:
           type: electron-updater
           url: https://github.com/Equicord/Equibop/releases/latest/download/latest-linux.yml
 
       - type: file
-        url: https://github.com/Equicord/Equibop/releases/download/v2.0.8/Equibop-linux-arm64.AppImage
+        url: https://github.com/Equicord/Equibop/releases/download/v2.0.9/Equibop-linux-arm64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: 156f197a8de1b1e53c497eba402b6d6d089238aa95178e83aa7cb95866827477f6dc925890a81b52412c8e715c2b7a8af6cf426f7bedddb7d807f6fc58c1b07e
+        sha512: 60207e51c248c6695f31f28a72bcbd182de36185ba9bb609cb669b3f6856339f95f3cf4a239f58a96a683d96145d55d74c46493c9120f0972188844d88c16a58
         only-arches: [aarch64]
         x-checker-data:
           type: electron-updater

--- a/io.github.equicord.equibop.yml
+++ b/io.github.equicord.equibop.yml
@@ -67,7 +67,7 @@ modules:
       - type: file
         url: https://github.com/Equicord/Equibop/releases/download/v2.0.9/Equibop-linux-arm64.AppImage
         dest-filename: Equibop.AppImage
-        sha512: 60207e51c248c6695f31f28a72bcbd182de36185ba9bb609cb669b3f6856339f95f3cf4a239f58a96a683d96145d55d74c46493c9120f0972188844d88c16a58
+        sha512: 973dff8914d845f84ca1b197b4a9f7455455a1423b4f1c8732d34a524e355ffe7855b837f2b40df549f0a24e7ced34636c5ef46a4da3d0782c4e89ced6bc0825
         only-arches: [aarch64]
         x-checker-data:
           type: electron-updater

--- a/startequibop
+++ b/startequibop
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+export TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-io.github.thororen.equibop}"
+
+declare -a FLAGS=(--enable-speech-dispatcher)
+
+if [[ $XDG_SESSION_TYPE == "wayland" ]]; then
+    if [[ -c /dev/nvidia0 ]]; then
+        echo "Using NVIDIA on Wayland, disabling gpu sandbox"
+        FLAGS+=(--disable-gpu-sandbox)
+    fi
+
+    WAYLAND_SOCKET=${WAYLAND_DISPLAY:-"wayland-0"}
+    if [[ "${WAYLAND_SOCKET:0:1}" != "/" ]]; then
+        WAYLAND_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_SOCKET"
+    fi
+
+    if [[ -e "$WAYLAND_SOCKET" ]]; then
+        echo "Wayland socket is available, running natively on Wayland."
+        echo "To disable, remove the --socket=wayland permission."
+        FLAGS+=(--ozone-platform-hint=auto)
+    fi
+fi
+
+echo "Passing the following arguments to Electron:" "${FLAGS[@]}"
+zypak-wrapper /app/bin/equibop/equibop.bin "${FLAGS[@]}" "$@"


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [X] Please describe the application briefly.
Equibop is a fork of Vesktop which aims at adding extra plugins, but still keeping Discord optimized and running smoothly with ease
The Creator of [Sunroof](https://github.com/verticalsync/Sunroof) with flathub package [io.github.verticalsync.sunroof](https://github.com/flathub/io.github.verticalsync.sunroof) announced that it reached EOL and requested to people to [migrate to Equibop for better maintaining and more](https://github.com/verticalsync/Sunroof?tab=readme-ov-file#eol-read-thanks), Prompting the Request of adding this package.

- [X] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read the and followed all the [Submission and licence requirements][reqs].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link:**


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
