### PR TITLE
Update name for io.github.mak448a.Qtcord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Build instructions
+
+Download flatpak-pip-generator
+`curl -o flatpak-pip-generator https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator`
+
+Do a `python3 flatpak-pip-generator requests platformdirs, etc.` to generate a json file (keep this separate!).
+Manually go to pypi and update the hashes and download links for PySide6 dependencies.
+
+
+`flatpak-builder build-dir io.github.mak448a.Qtcord.yml`
+`flatpak-builder --user --install --force-clean build-dir io.github.mak448a.Qtcord.yml`
+
+## Resources
+https://docs.flatpak.org/en/latest/first-build.html
+https://docs.flatpak.org/en/latest/sandbox-permissions.html

--- a/io.github.mak448a.Qtcord.yml
+++ b/io.github.mak448a.Qtcord.yml
@@ -1,0 +1,31 @@
+app-id: io.github.mak448a.Qtcord
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: io.github.mak448a.Qtcord
+base: io.qt.PySide.BaseApp
+base-version: '6.7'
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+finish-args:
+  - --socket=wayland
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --device=dri
+modules:
+  - python3-modules.json
+  - name: BuildQtcord
+    buildsystem: simple
+    build-commands:
+      - install -D src/flatpak_builder/io.github.mak448a.Qtcord /app/bin/io.github.mak448a.Qtcord
+      - mv licenses/ /app/bin/
+      - install -Dm 644 src/flatpak_builder/io.github.mak448a.Qtcord.metainfo.xml /app/share/metainfo/io.github.mak448a.Qtcord.metainfo.xml
+      - install -Dm 644 src/assets/smiley.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -Dm644 src/flatpak_builder/io.github.mak448a.Qtcord.desktop /app/share/applications/io.github.mak448a.Qtcord.desktop
+      - mv src/* /app/bin
+    sources:
+      - type: git
+        url: https://github.com/mak448a/Qtcord
+        tag: v0.0.17
+        commit: 525f71b4e1840f3c47725afb0a2c09692a4f3498

--- a/io.github.mak448a.Qtcord.yml
+++ b/io.github.mak448a.Qtcord.yml
@@ -28,4 +28,4 @@ modules:
       - type: git
         url: https://github.com/mak448a/Qtcord
         tag: v0.0.18
-        commit: dd688a9649e242de48103cd2593773f657789851
+        commit: 82abb8064ba750bbf3c5ba32a518324ee7548bea

--- a/io.github.mak448a.Qtcord.yml
+++ b/io.github.mak448a.Qtcord.yml
@@ -27,5 +27,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/mak448a/Qtcord
-        tag: v0.0.17
-        commit: 525f71b4e1840f3c47725afb0a2c09692a4f3498
+        tag: v0.0.18
+        commit: dd688a9649e242de48103cd2593773f657789851

--- a/python3-modules.json
+++ b/python3-modules.json
@@ -1,0 +1,127 @@
+{
+    "name": "python3-modules",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5b/11/1e78951465b4a225519b8c3ad29769c49e0d8d157a070f681d5b6d64737f/certifi-2024.6.2-py3-none-any.whl",
+                    "sha256": "ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
+                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl",
+                    "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl",
+                    "sha256": "a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472"
+                }
+            ]
+        },
+        {
+            "name": "python3-platformdirs",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"platformdirs\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl",
+                    "sha256": "2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee"
+                }
+            ]
+        },
+        {
+            "name": "python3-pyside6",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyside6\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/34/a6/278c7ed2f76ccfa471c49eb66538243dc0d892fe481b9b6a8bbad8846ba0/PySide6-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "15e7696a09072ee977f6e6179ab1e48184953df8417bcaa83cfadf0b79747242",
+                    "only-arches": ["x86_64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/f2/2128d3876f0c45fcb73000b272be64e1f3b1189f77d79820d7a706051e55/PySide6_Addons-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "94b9bf6a2a4a7ac671e1776633e50d51326c86f4184f1c6e556f4dd5498fd52a",
+                    "only-arches": ["x86_64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/75/be/527e41a7744142d931e46685dd9c2bdfff39432962abf8a5263be319c2cb/PySide6_Essentials-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "a1a4c09f1e916b9cfe53151fe4a503a6acb1f6621ba28204d1bfe636f80d6780",
+                    "only-arches": ["x86_64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/57/ba/3e38bb62b285d73e46a86f44e7765cea5c42a79b0bba867dfabbdd12b54d/shiboken6-6.7.2-cp39-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "70e80737b27cd5d83504b373013b55e70462bd4a27217d919ff9a83958731990",
+                    "only-arches": ["x86_64"]
+                },
+                
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/71/d7/794d490899f0118b2a40221508e4fd7ea67ffd6e790a627a39e7582841cb/PySide6-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl",
+                    "sha256": "6e0acb471535de303f56e3077aa86f53496b4de659b99ecce80520bcee508a63",
+                    "only-arches": ["aarch64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7c/bb/06a19d1b00d46b3840595e43d7fa648b21683e4e98c4a69d0ea06aaf5e7f/shiboken6-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl",
+                    "sha256": "98bedf9a15f1d8ba1af3e4d1e7527f7946ce36da541e08074fd9dc9ab5ff1adf",
+                    "only-arches": ["aarch64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e8/3c/6250b74da83a8a8a26c27d8a3041a31880b20ede88d004ef9dbe49d108bc/PySide6_Addons-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl",
+                    "sha256": "22979b1aa09d9cf1d7a86c8a9aa0cb4791d6bd1cc94f96c5b6780c5ef8a9e34e",
+                    "only-arches": ["aarch64"]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/42/e0/40994873471ab7fabbff098560a9fe0c08a2182c2eb501e31b1148e7bd44/PySide6_Essentials-6.7.2-cp39-abi3-manylinux_2_31_aarch64.whl",
+                    "sha256": "9135513e1c4c6e2fbb1e4f9afcb3d42e54708b0d9ed870cb3213ea4874cafa1e",
+                    "only-arches": ["aarch64"]
+                }
+            ]
+        },
+        {
+            "name": "python3-websocket-client",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"websocket-client\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl",
+                    "sha256": "17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [X] Please describe the application briefly.
  <!-- insert the description here -->
Qtcord is the updated name for QTCord. I just changed the capitalization.
- [X] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read the and followed all the [Submission and licence requirements][reqs].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link:** https://github.com/mak448a/Qtcord


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
