### PR TITLE
Add hu.irl.sysex-controls

### DIFF
--- a/hu.irl.sysex-controls.yml
+++ b/hu.irl.sysex-controls.yml
@@ -1,0 +1,35 @@
+app-id: hu.irl.sysex-controls
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: sysex-controls
+finish-args:
+  # show windows with Wayland
+  - --socket=wayland
+  # show windows using X11, if Wayland is not available
+  - --socket=fallback-x11
+  # share IPC namespace with the host (necessary for X11)
+  - --share=ipc
+  # access direct rendering (OpenGL/Vulkan)
+  - --device=dri
+  # MIDI
+  - --socket=pulseaudio
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /man
+  - /share/doc
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - "*.la"
+  - "*.a"
+modules:
+  - name: sysex-controls
+    builddir: true
+    buildsystem: meson
+    sources:
+    - type: git
+      url: https://github.com/soyersoyer/sysex-controls
+      tag: v0.2.0
+      commit: 97f42fc8d971b1a3a9d8964f2fb80b25869c38cc


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [x] Please describe the application briefly.
This is a GTK UI that allows to configure the Arturia KeyStep 37 MIDI keyboard.
It currently allows for reading the controls, changing them and writing back to the device.

- [x] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [x] have read the and followed all the [Submission and licence requirements][reqs].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link:**


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
