### PR TITLE
Add com.obsproject.Studio.Plugin.AitumMultistream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Aitum Multistream OBS Plugin for Flatpak
+
+Multistreaming shouldn't be difficult. Aitum Multistream makes that a reality.
+
+The Aitum Multistream Plugin lets you go live on as many platforms as possible, completely free.
+
+Stop paying for expensive Multistreaming services and make the full use of your internet bandwidth.
+
+Aitum Multistream guides you through getting set up.
+You shouldn't need to be a stream professor to get started.
+
+For support on usage or bugs, please visit https://aitum.help
+
+Please raise an issue against this repository for packaging related issues only.

--- a/com.obsproject.Studio.Plugin.AitumMultistream.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.AitumMultistream.metainfo.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.AitumMultistream</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>Aitum Multistream</name>
+  <developer id="tv.aitum">
+    <name>Aitum Team</name>
+  </developer>
+  <summary>The Aitum Multistream Plugin lets you go live on as many platforms as possible, completely free</summary>
+  <description>
+    <p>Multistreaming shouldn't be difficult. Aitum Multistream makes that a reality.</p>
+    <p>The Aitum Multistream Plugin lets you go live on as many platforms as possible, completely free.</p>
+    <p>Stop paying for expensive Multistreaming services and make the full use of your internet bandwidth.</p>
+    <p>Aitum Multistream guides you through getting set up.</p>
+    <p>You shouldn't need to be a stream professor to get started.</p>
+  </description>
+  <url type="homepage">https://aitum.tv/products/multi</url>
+  <url type="vcs-browser">https://github.com/Aitum/obs-aitum-multistream</url>
+  <url type="help">https://aitum.help</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <releases>
+    <release version="1.0.3" date="2023-08-09"/>
+  </releases>
+</component>

--- a/com.obsproject.Studio.Plugin.AitumMultistream.yml
+++ b/com.obsproject.Studio.Plugin.AitumMultistream.yml
@@ -1,0 +1,32 @@
+id: com.obsproject.Studio.Plugin.AitumMultistream
+branch: stable
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.kde.Sdk//6.6
+build-extension: true
+separate-locales: false
+build-options:
+  prefix: /app/plugins/AitumMultistream
+modules:
+  - name: obs-aitum-multistream
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      # TODO - use FLATPAK_ARCH when available: https://github.com/flatpak/flatpak-builder/issues/340#issuecomment-1177355121
+      - --preset linux-ci-x86_64
+      - -DBUILD_OUT_OF_TREE=On
+      # Correct build dir in preset
+      - -B ../_flatpak_build
+    post-install:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_BUILDER_BUILDDIR}/${FLATPAK_ID}.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/Aitum/obs-aitum-multistream
+        tag: 1.0.3
+        commit: 4bcc6c3cdc3a12ef60db69619dac6fa2bb5d6aa3
+        x-checker-data:
+          type: git
+          is-main-source: true
+          tag-pattern: ^([\d.]+)$
+      - type: file
+        path: com.obsproject.Studio.Plugin.AitumMultistream.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+    "skip-icons-check": true,
+    "only-arches": ["x86_64"]
+}


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [x] Please describe the application briefly.
This is a plugin for OBS Studio using the plugin extension point infrastructure. It is used to provide the ability to stream to multiple services at once, without the need of an intermediate restreaming service

- [ ] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.

This is an extension of com.obsproject.Studio, which follows the pattern of com.obsproject.Studio.Plugin.*

- [X] I have read the and followed all the [Submission and licence requirements][reqs].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor of the project.


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
