### PR TITLE
Add com.konstantintutsch.Lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.flatpak-builder
+/builddir
+/repo

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=~/.gnupg:create
   - --socket=gpg-agent
+  - --talk-name=org.gnome.keyring.SystemPrompter
   - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
 cleanup:

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -8,7 +8,6 @@ finish-args:
   - --share=ipc
   - --socket=wayland
   - --socket=fallback-x11
-  - --filesystem=xdg-run/gnupg:ro
   - --filesystem=~/.gnupg:create
   - --socket=gpg-agent
   - --socket=session-bus

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --filesystem=~/.gnupg:create
   - --socket=gpg-agent
   - --socket=session-bus
+  - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
 cleanup:
   - /include

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -1,0 +1,38 @@
+id: com.konstantintutsch.Lock
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: com.konstantintutsch.Lock
+finish-args:
+  - --device=dri
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --filesystem=xdg-run/gnupg:ro
+  - --filesystem=~/.gnupg:create
+  - --socket=gpg-agent
+  - --socket=session-bus
+  - --filesystem=xdg-run/gvfsd
+cleanup:
+  - /include
+  - /share/pkgconfig
+  - "*.la"
+  - "*.a"
+modules:
+  - name: blueprint-compiler
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
+        commit: d7097cad019c032e803d271d3671d0ee933a522b
+    cleanup:
+      - '*'
+  - name: Lock
+    buildsystem: meson
+    run-tests: false
+    config-opts:
+      - -Dprofile=default
+    sources:
+      - type: git
+        url: https://github.com/konstantintutsch/Lock.git
+        commit: 3521779292698974bcd08af659c2846f265af4c4

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -23,7 +23,7 @@ modules:
     sources:
       - type: git
         url: https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-        commit: d7097cad019c032e803d271d3671d0ee933a522b
+        commit: 8e10fcf8692108b9d4ab78f41086c5d7773ef864 # v0.14.0
     cleanup:
       - '*'
   - name: Lock
@@ -34,7 +34,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/konstantintutsch/Lock.git
-        commit: 3521779292698974bcd08af659c2846f265af4c4
+        commit: 3521779292698974bcd08af659c2846f265af4c4 # v0.1.0
   - name: Pinentry
     buildsystem: autotools
     config-opts:
@@ -51,4 +51,4 @@ modules:
     sources:
       - type: git
         url: https://dev.gnupg.org/source/pinentry.git
-        commit: dd8894fa60c1f1c08ecc50ba4657580abc348347
+        commit: dd8894fa60c1f1c08ecc50ba4657580abc348347 # v1.3.1

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -10,7 +10,6 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=~/.gnupg:create
   - --socket=gpg-agent
-  - --socket=session-bus
   - --talk-name=org.gtk.vfs.*
   - --filesystem=xdg-run/gvfsd
 cleanup:
@@ -36,3 +35,20 @@ modules:
       - type: git
         url: https://github.com/konstantintutsch/Lock.git
         commit: 3521779292698974bcd08af659c2846f265af4c4
+  - name: Pinentry
+    buildsystem: autotools
+    config-opts:
+      - --enable-maintainer-mode
+      - --enable-pinentry-gnome3
+      - --disable-pinentry-qt5
+      - --disable-ncurses
+      - --disable-fallback-curses
+      - --disable-pinentry-curses
+      - --disable-pinentry-emacs
+      - --disable-pinentry-fltk
+      - --disable-pinentry-tqt
+      - --disable-pinentry-tty
+    sources:
+      - type: git
+        url: https://dev.gnupg.org/source/pinentry.git
+        commit: dd8894fa60c1f1c08ecc50ba4657580abc348347

--- a/com.konstantintutsch.Lock.yaml
+++ b/com.konstantintutsch.Lock.yaml
@@ -35,20 +35,3 @@ modules:
       - type: git
         url: https://github.com/konstantintutsch/Lock.git
         commit: 3521779292698974bcd08af659c2846f265af4c4 # v0.1.0
-  - name: Pinentry
-    buildsystem: autotools
-    config-opts:
-      - --enable-maintainer-mode
-      - --enable-pinentry-gnome3
-      - --disable-pinentry-qt5
-      - --disable-ncurses
-      - --disable-fallback-curses
-      - --disable-pinentry-curses
-      - --disable-pinentry-emacs
-      - --disable-pinentry-fltk
-      - --disable-pinentry-tqt
-      - --disable-pinentry-tty
-    sources:
-      - type: git
-        url: https://dev.gnupg.org/source/pinentry.git
-        commit: dd8894fa60c1f1c08ecc50ba4657580abc348347 # v1.3.1


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [x] Please describe the application briefly.
  This application is a Gtk4 LibAdwaita graphical front-end for GPG.

- [x] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read the and followed all the [Submission and licence requirements][reqs].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link: [Repository](https://github.com/konstantintutsch/Lock)**


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission

### Permissions summary

- GUI

```
--device=dri
--share=ipc
--socket=wayland
--socket=fallback-x11
```

- Communication with GnuPG and it's imported keys as well as the GPG agent

```
--filesystem=xdg-run/gnupg:ro
--filesystem=~/.gnupg:create
--socket=gpg-agent
```

- Pinentry (password dialog) access/communication

```
--socket=session-bus
```

- File access via portals to encrypt, decrypt, sign or verify files

```
--filesystem=xdg-run/gvfsd
```