### PR TITLE
Add de.z_ray.OptimusUI

### DIFF
--- a/de.z_ray.OptimusUI.json
+++ b/de.z_ray.OptimusUI.json
@@ -34,7 +34,7 @@
         {
           "type": "git",
           "url": "https://github.com/Z-Ray-Entertainment/optimus-ui",
-          "tag": "24.10.5"
+          "tag": "24.10.6"
         }
       ]
     }

--- a/de.z_ray.OptimusUI.json
+++ b/de.z_ray.OptimusUI.json
@@ -1,0 +1,42 @@
+{
+  "app-id": "de.z_ray.OptimusUI",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "47",
+  "sdk": "org.gnome.Sdk",
+  "command": "optimus-ui",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--socket=wayland",
+    "--talk-name=org.freedesktop.Flatpak"
+  ],
+  "modules": [
+    {
+        "name": "python3-packaging",
+        "buildsystem": "simple",
+        "build-commands": [
+            "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"packaging~=24.1\" --no-build-isolation"
+        ],
+        "sources": [
+            {
+                "type": "file",
+                "url": "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz",
+                "sha256": "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
+            }
+        ]
+    },
+    {
+      "name": "optimusui",
+      "builddir": true,
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/Z-Ray-Entertainment/optimus-ui",
+          "tag": "24.10.5"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.
OptimusUI is a graphical user interface to allow users to control nvidia prime tools such as SUSEPrime, nvidia-prime, fedora-prime-select or nvidia-prime-select in a convenient way.

These prime tools are aimed at nVidia Optimus Laptops with older GPUs (such as Pascal or earlier) which lack proper power management with the proprietary Linux driver (they do not get powered down if not needed).
For this use case there are these mentioned prime-tools developed to allow a user to configure the way their Desktop is run. Most of them support an Integrated only mode hence the iGPU does everything and the dGPU is turned off or entirely on the dedicated GPU. Hence the nvidia GPU runs the entire dekstop.
Some of them even support the PRIME Render Offload mode which nVidia introduces in driver 435 which is actually the default for Optimus Laptops.  
Anyhow that is about the Prime Tools not OptimusUI.

OptimusUI does abstract the need to open up a terminal window and also which commands to type to change the driver mode. Also it is a unified interface for these tools as each tool has a different features as others. Or certain commands are named different (offload vs on-demand for example). 

While there are already other interfaces for these tools they are often aimed at one specific tool and/or are not flatpak compatible. Or simply are no longer working / maintained.

**Note:** This also means OptimusUI requires flatpak-spawn to gain access to certain system resources outside the sandbox.

These are:
- `cat /etc/os-release`
  - To get some info about the actual distro and not "org.FlatpakRunntime.Something"
  - This is done as not all prime tools on all distros (despite being named similar sometimes) do have the same features
- `which -f /usr/bin/PRIME_TOOL_BINARY`, `which -f /usr/sbin/PRIME_TOOL_BINARY`, `which -f /bin/PRIME_TOOL_BINARY` or `which -f /sbin/PRIME_TOOL_BINARY`
  - To find out the actual prime tool installed on the host
  - To actually call the detected prime tool with the required parameters (eg. `pkexec /usr/prime-select nvidia`)
- `cat /proc/modules`
  - To validate if the `bbswtich` kernel module is installed on the host system
  - bbswitch is used to actually power down the nvidia GPU if not in use
  - While all prime tools do work without it it somehow invalidates their use case if they can not turn off the GPU
  - To check this and to display a notification dialog OptimusUI does read these modules

While reviewing the code you may see access to `/sys/bus/pci/devices/` but these are done entirely inside the sandbox. As this is only used to get some info about the available GPUs in the system and OptimusUI has access to DRI devices.  
If any of the above can be solved differently and I simply missed it please let me know and I will change the behavior of OptimusUI and reduce the amounts of flatpak-spawn calls if possible.

Also I like to state that OptimusUI does not store or phone any of the information gathered above anywhere. Only the bare minimum is even kept in memory while the app is running.

- [x] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read the and followed all the [Submission and license requirements][reqs].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission. **Link: https://z-ray.de/flathub.html**


<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
