### PR TITLE
Add com.obsproject.Studio.Plugin.DistroAV

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,31 @@
+name: Check for updates
+on:
+  schedule:
+  - cron: "0 * * * *"
+  workflow_dispatch: 
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        # Do not check extra-data
+        filter-type: [ file, archive, git ]
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --filter-type  ${{ matrix.filter-type }} --update --never-fork com.obsproject.Studio.Plugin.NDI.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.flatpak-builder
+builddir
+repo

--- a/0001-mathops-clip-constants-used-with-shift.patch
+++ b/0001-mathops-clip-constants-used-with-shift.patch
@@ -1,0 +1,73 @@
+From effadce6c756247ea8bae32dc13bb3e6f464f0eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Denis-Courmont?= <remi@remlab.net>
+Date: Sun, 16 Jul 2023 18:18:02 +0300
+Subject: [PATCH] avcodec/x86/mathops: clip constants used with shift
+ instructions within inline assembly
+
+Fixes assembling with binutil as >= 2.41
+
+Signed-off-by: James Almer <jamrial@gmail.com>
+---
+ libavcodec/x86/mathops.h | 26 +++++++++++++++++++++++---
+ 1 file changed, 23 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/x86/mathops.h b/libavcodec/x86/mathops.h
+index 6298f5ed1983b..ca7e2dffc1076 100644
+--- a/libavcodec/x86/mathops.h
++++ b/libavcodec/x86/mathops.h
+@@ -35,12 +35,20 @@
+ static av_always_inline av_const int MULL(int a, int b, unsigned shift)
+ {
+     int rt, dummy;
++    if (__builtin_constant_p(shift))
+     __asm__ (
+         "imull %3               \n\t"
+         "shrdl %4, %%edx, %%eax \n\t"
+         :"=a"(rt), "=d"(dummy)
+-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
++        :"a"(a), "rm"(b), "i"(shift & 0x1F)
+     );
++    else
++        __asm__ (
++            "imull %3               \n\t"
++            "shrdl %4, %%edx, %%eax \n\t"
++            :"=a"(rt), "=d"(dummy)
++            :"a"(a), "rm"(b), "c"((uint8_t)shift)
++        );
+     return rt;
+ }
+ 
+@@ -113,19 +121,31 @@ __asm__ volatile(\
+ // avoid +32 for shift optimization (gcc should do that ...)
+ #define NEG_SSR32 NEG_SSR32
+ static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("sarl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("sarl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 
+ #define NEG_USR32 NEG_USR32
+ static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
++    if (__builtin_constant_p(s))
+     __asm__ ("shrl %1, %0\n\t"
+          : "+r" (a)
+-         : "ic" ((uint8_t)(-s))
++         : "i" (-s & 0x1F)
+     );
++    else
++        __asm__ ("shrl %1, %0\n\t"
++               : "+r" (a)
++               : "c" ((uint8_t)(-s))
++        );
+     return a;
+ }
+ 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# [DistroAV](https://github.com/DistroAV/DistroAV) Flatpak
+
+Network A/V in OBS Studio with NewTek's NDI technology in a Flatpak.
+
+## Notes
+Make sure that `--system-talk-name=org.freedesktop.Avahi` is set in OBS Studio permissions. Otherwise DistroAV will not be able to see other devices or send to the network, since NDI on Linux rely on the Avahi daemon for network discovery (find other NDI device on the network).
+

--- a/com.obsproject.Studio.Plugin.DistroAV.json
+++ b/com.obsproject.Studio.Plugin.DistroAV.json
@@ -1,0 +1,190 @@
+{
+    "app-id": "com.obsproject.Studio.Plugin.DistroAV",
+    "runtime": "com.obsproject.Studio",
+    "runtime-version": "stable",
+    "sdk": "org.kde.Sdk//6.6",
+    "build-extension": true,
+    "separate-locales": false,
+    "appstream-compose": false,
+    "build-options": {
+        "prefix": "/app/plugins/DistroAV"
+    },
+    "modules": [
+        {
+            "name": "avahi",
+            "cleanup": [
+                "/bin",
+                "/include",
+                "/lib/avahi",
+                "/lib/pkgconfig",
+                "/lib/*.a",
+                "/lib/*.la",
+                "/share/applications/*.desktop",
+                "/share/avahi",
+                "/share/man"
+            ],
+            "config-opts": [
+                "--with-distro=none",
+                "--disable-introspection",
+                "--disable-qt3",
+                "--disable-qt4",
+                "--disable-qt5",
+                "--disable-gtk",
+                "--disable-gtk3",
+                "--disable-core-docs",
+                "--disable-manpages",
+                "--disable-libdaemon",
+                "--disable-libevent",
+                "--disable-python",
+                "--disable-pygobject",
+                "--disable-mono",
+                "--disable-monodoc",
+                "--disable-autoipd",
+                "--disable-doxygen-doc",
+                "--disable-doxygen-dot",
+                "--disable-doxygen-xml",
+                "--disable-doxygen-html",
+                "--disable-manpages",
+                "--disable-xmltoman"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.avahi.org/download/avahi-0.8.tar.gz",
+                    "sha256": "060309d7a333d38d951bc27598c677af1796934dbd98e1024e7ad8de798fedda",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 147,
+                        "url-template": "https://www.avahi.org/download/avahi-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "ffmpeg4.4",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/libavcodec.so",
+                "/lib/libavutil.so",
+                "/share/ffmpeg"
+            ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-doc",
+                "--disable-programs",
+                "--disable-devices",
+                "--enable-shared",
+                "--disable-avdevice",
+                "--disable-avformat",
+                "--disable-swresample",
+                "--disable-swscale",
+                "--disable-postproc",
+                "--disable-avfilter",
+                "--enable-pthreads",
+                "--disable-alsa",
+                "--disable-bzlib",
+                "--disable-iconv",
+                "--disable-libxcb-shm",
+                "--disable-libxcb-xfixes",
+                "--disable-libxcb-shape",
+                "--disable-lzma",
+                "--disable-sdl2",
+                "--disable-xlib",
+                "--disable-zlib",
+                "--disable-v4l2-m2m",
+                "--disable-ffnvcodec",
+                "--disable-nvdec",
+                "--disable-nvenc",
+                "--enable-vaapi",
+                "--enable-vdpau",
+                "--enable-libopus",
+                "--enable-libopenh264"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/FFmpeg/FFmpeg.git",
+                    "tag": "n4.4.4",
+                    "commit": "71fb6132637a2a430375c24afc381fff8b854fe7",
+                    "disable-shallow-clone": true
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-mathops-clip-constants-used-with-shift.patch"
+                }
+            ]
+        },
+        {
+            "name": "distroav",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DENABLE_FRONTEND_API=ON",
+                "-DENABLE_QT=ON"
+            ],
+            "post-install": [
+                "install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ../${FLATPAK_ID}.metainfo.xml",
+                "appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/DistroAV/DistroAV.git",
+                    "tag": "6.0.0",
+                    "commit": "9871ed64cb036dff41f737a5f7894b057d7ee7a5",
+                    "x-checker-data": {
+                        "type": "git",
+                        "is-main-source": true,
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i 's|/usr|/app/plugins/DistroAV/extra|g' src/plugin-main.cpp"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "path": "com.obsproject.Studio.Plugin.DistroAV.metainfo.xml"
+                }
+            ]
+        },
+        {
+            "name": "libndi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D apply_extra $FLATPAK_DEST/bin/apply_extra"
+            ],
+            "sources": [
+                {
+                    "type": "script",
+                    "dest-filename": "apply_extra",
+                    "commands": [
+                        "bsdtar -xf Install_NDI_SDK_v5_Linux.tar.gz",
+                        "_target_line=\"$(sed -n '/^__NDI_ARCHIVE_BEGIN__$/=' Install_NDI_SDK_v5_Linux.sh)\"",
+                        "_target_line=\"$((_target_line + 1))\"",
+                        "tail -n +\"$_target_line\" Install_NDI_SDK_v5_Linux.sh | tar -zxf - \"NDI SDK for Linux/lib/x86_64-linux-gnu/\" \"NDI SDK for Linux/NDI SDK License Agreement.txt\" \"NDI SDK for Linux/licenses/libndi_licenses.txt\"",
+                        "install -D -m755 \"NDI SDK for Linux/lib/x86_64-linux-gnu/libndi.so.5\".*.* -t ./lib",
+                        "install -D -m644 \"NDI SDK for Linux/NDI SDK License Agreement.txt\" -t ./share/licenses",
+                        "install -D -m644 \"NDI SDK for Linux/licenses/libndi_licenses.txt\" -t ./share/licenses",
+                        "rm -rf \"NDI SDK for Linux\"",
+                        "rm -f Install_NDI_SDK_v5_Linux.*",
+                        "cd ./lib",
+                        "ln -s libndi.so.5.*.* libndi.so.5"
+                    ]
+                },
+                {
+                    "type": "extra-data",
+                    "filename": "Install_NDI_SDK_v5_Linux.tar.gz",
+                    "url": "https://downloads.ndi.tv/SDK/NDI_SDK_Linux/Install_NDI_SDK_v5_Linux.tar.gz",
+                    "sha256": "1cfcc32ee26bc2571c5cbf71e81dafc676e3887e5724a89ce508f49e3c5e0572",
+                    "size": 53865049,
+                    "installed-size": 26212591
+                }
+            ]
+        }
+    ]
+}

--- a/com.obsproject.Studio.Plugin.DistroAV.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.DistroAV.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.DistroAV</id>
+  <provides>
+    <id>com.obsproject.Studio.Plugin.NDI</id>
+  </provides>
+  <replaces>
+    <id>com.obsproject.Studio.Plugin.NDI</id>
+  </replaces>
+  <extends>com.obsproject.Studio</extends>
+  <name>DistroAV</name>
+  <developer id="org.distroav">
+    <name translate="no">DistroAV</name>
+  </developer>
+  <summary>NewTek NDI integration for OBS Studio</summary>
+  <url type="homepage">https://github.com/DistroAV/DistroAV</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later AND LicenseRef-proprietary=https://downloads.ndi.tv/SDK/NDI_SDK/NDI%20License%20Agreement.pdf</project_license>
+  <releases>
+    <release version="6.0.0" date="2024-10-26">
+      <url type="details">https://github.com/DistroAV/DistroAV/releases/tag/6.0.0</url>
+    </release>
+    <release version="4.14.1" date="2024-08-02">
+      <url type="details">https://github.com/DistroAV/DistroAV/releases/tag/4.14.1</url>
+    </release>
+    <release version="4.14.0" date="2024-07-21">
+      <url type="details">https://github.com/DistroAV/DistroAV/releases/tag/4.14.0</url>
+    </release>
+    <release version="4.13.0" date="2023-11-14">
+      <url type="details">https://github.com/DistroAV/DistroAV/releases/tag/4.13.0</url>
+    </release>
+  </releases>
+</component>

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,6 @@
+{
+  "skip-icons-check": true,
+  "only-arches": [ "x86_64" ],
+  "disable-external-data-checker": true
+}
+


### PR DESCRIPTION
<!-- ⚠️  The submission PR must be against the `new-pr` branch ⚠️  -->

### Please confirm your submission meets all the criteria

<!-- Please replace each `[ ]` with `[X]` when the step is complete -->

- [x] Please describe the ~~application~~ extension briefly.
  <!-- insert the description here -->
  Network A/V in OBS Studio with NewTek's NDI technology in a Flatpak.
  
  Resubmission of [com.obsproject.Studio.Plugin.NDI](https://github.com/flathub/com.obsproject.Studio.Plugin.NDI) (#4701) as DistroAV, the plugin has rebranded to remove OBS and NDI from their name.

- [x] The domain used for the application ID is [controlled by the application developers][appid-domain] and the [application id guidelines][appid] are followed.
  - This is an OBS Studio plugin
- [x] I have read the and followed all the [Submission and licence requirements][reqs].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor of the project. If not, I contacted upstream developers about this submission.
   - Request: https://github.com/obs-ndi/obs-ndi/issues/724#issuecomment-1808136817
  - Answer: https://github.com/obs-ndi/obs-ndi/issues/724#issuecomment-1812959827
  - The upstream contributor @paulpv wishes to have access to the repo, and also asked @Palakis to be added.
  - **Please do not forget to re-add them to new repo** (#4707)

<!-- ⚠️  Don't modify anything below this line ⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
