### PR TITLE
Add im.pidgin.Pidgin3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.build
+.flatpak
+.flatpak-builder
+repo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Flatpak setup for [Pidgin3](https://pidgin.im).

--- a/im.pidgin.Pidgin3.yml
+++ b/im.pidgin.Pidgin3.yml
@@ -1,0 +1,123 @@
+app-id: im.pidgin.Pidgin3
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: pidgin3
+finish-args:
+  # X11 + XShm access
+  - "--share=ipc"
+  - "--socket=fallback-x11"
+  # Wayland access
+  - "--socket=wayland"
+  # GPU acceleration if needed
+  - "--device=dri"
+  # Needs to talk to the network:
+  - "--share=network"
+  # Audio
+  - "--socket=pulseaudio"
+  # Accessibility
+  - "--talk-name=org.a11y.Bus"
+  # libsecret plugin
+  - "--talk-name=org.freedesktop.secrets"
+  # kwallet plugin
+  - "--talk-name=org.kde.kwalletd5"
+  - "--talk-name=org.kde.kwalletd6"
+  # Bonjour
+  - "--system-talk-name=org.freedesktop.Avahi"
+  # Plugin Paths
+  - "--env=PURPLE_PLUGIN_PATH=/app/plugins/purple-3"
+  - "--env=PIDGIN_PLUGIN_PATH=/app/plugins/pidgin-3"
+
+add-extensions:
+  im.pidgin.Purple3.Plugin:
+    directory: plugins
+    add-ld-path: lib
+    merge-dirs: purple-3
+    no-autodownload: true
+    autodelete: true
+    subdirectories: true
+  im.pidgin.Pidgin3.Plugin:
+    directory: plugins
+    add-ld-path: lib
+    merge-dirs: pidgin-3
+    no-autodownload: true
+    autodelete: true
+    subdirectories: true
+
+modules:
+  - name: libidn
+    buildsystem: autotools
+    cleanup:
+      - /lib/*.la
+    config-opts:
+      - "--disable-static"
+    sources:
+      - type: archive
+        url: https://ftp.gnu.org/gnu/libidn/libidn-1.42.tar.gz
+        sha256: d6c199dcd806e4fe279360cb4b08349a0d39560ed548ffd1ccadda8cdecb4723
+  - name: birb
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-xz
+        url: https://sourceforge.net/projects/pidgin/files/birb/0.2.0/birb-0.2.0-dev.tar.xz/download
+        sha256: b4c24426a6c9aeb959a7a8d60d31def8e90cfb17680c90a0cc54d582789ecc38
+  - name: hasl
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-xz
+        url: https://sourceforge.net/projects/pidgin/files/hasl/0.3.2/hasl-0.3.2.tar.xz/download
+        sha256: d67ba1ce29c6f1fcdc69dadae0bafe12cf60b9e8be80bb67b5f4f9e0db44c427
+  - name: ibis
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-xz
+        url: https://sourceforge.net/projects/pidgin/files/ibis/0.10.2/ibis-0.10.2.tar.xz/download
+        sha256: 5a67b3089deac9632c908a71a2950aec12195a111c2ca1fe517c6f156bddd6a4
+  - name: xeme
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-gzip
+        url: https://keep.imfreedom.org/xeme/xeme/archive/5d0707ab10a2.tar.gz
+        sha256: eabb0f88fdc54775e9aab63d277d0d0cf54c456ee09580d45bd516d1117088da
+  - name: gplugin
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "-Dlua=false"
+      - "-Dpython3=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-xz
+        url: https://sourceforge.net/projects/pidgin/files/gplugin/0.44.2/gplugin-0.44.2.tar.xz/download
+        sha256: aea244e1add9628b50ec042c54cf93803f4577f8f142678f09b91fd4c0b20f72
+  - name: pidgin3
+    buildsystem: meson
+    config-opts:
+      - "-Ddoc=false"
+      - "--wrap-mode=nofallback"
+    sources:
+      - type: archive
+        archive-type: tar-xz
+        url: https://sourceforge.net/projects/pidgin/files/Pidgin3/2.90.1/pidgin-2.90.1.tar.xz/download
+        sha256: 9ad2f9168258bedd9e4de4deb7948e4f2fa099715f2abad7a14494521cded3b6
+    post-install:
+      - install -d /app/plugins/pidgin-3
+      - install -d /app/plugins/purple-3
+


### PR DESCRIPTION
This is still technically unreleased, but flatpak is one of our preferred installation methods so we are using a development tarball.

We debated about using flathub beta, but flathub proper is probably the way to go, but we are going to have many releases before we have a stable release.

<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [x] Please describe the application briefly. <!-- insert the description here --> Pidgin3 is the next major version of Pidgin Universal Chat. It is still pre-release quality, but we're starting to do experimental releases. It's been updated to be able to support modern chat applications and is using GTK4. You can find more information at [pidgin.im](https://pidgin.im).

- [x] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
