### PR TITLE
Add org.fcitx.Fcitx5.Addon.Hangul

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-icons-check": true
+}

--- a/org.fcitx.Fcitx5.Addon.Hangul.yaml
+++ b/org.fcitx.Fcitx5.Addon.Hangul.yaml
@@ -1,0 +1,43 @@
+app-id: org.fcitx.Fcitx5.Addon.Hangul
+branch: stable
+runtime: org.fcitx.Fcitx5
+runtime-version: stable
+sdk: org.kde.Sdk//6.8
+build-extension: true
+separate-locales: false
+build-options:
+  prefix: /app/addons/Hangul
+  prepend-pkg-config-path: /app/addons/Hangul/lib/pkgconfig
+cleanup:
+  - /bin
+  - /include
+  - /lib/pkgconfig
+  - '*.la'
+modules:
+  - name: libhangul
+    sources:
+      - type: git
+        url: https://github.com/libhangul/libhangul
+        tag: libhangul-0.1.0
+        x-checker-data:
+          type: anitya
+          project-id: 1630
+          stable-only: true
+          tag-template: libhangul-${version}
+        commit: 9fe2d4e8c225b1797d2c5bb78ccfdc703af7b886
+    buildsystem: simple
+    build-commands:
+      - ./autogen.sh
+      - automake --add-missing
+      - autoreconf
+      - ./configure --prefix=${FLATPAK_DEST}
+      - make
+      - make install
+  - name: fcitx5-hangul
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/fcitx/fcitx5-hangul
+        tag: 5.1.6
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly. <!-- insert the description here --> Hangul Input method engine based on libhangul for Fcitx 5. Allow user to type Korean with Fcitx 5
- [ ] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed. fcitx.org is not owned by project for historical reason but since the id is already being used for dbus service we can not change it.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
