### PR TITLE
Add com.jeffser.Alpaca.Plugins.Ollama

### DIFF
--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -1,0 +1,47 @@
+{
+    "id": "com.jeffser.Alpaca.Plugins.Ollama",
+    "runtime": "com.jeffser.Alpaca",
+    "runtime-version": "stable",
+    "sdk": "org.gnome.Sdk//46",
+    "build-extension": true,
+    "cleanup": [
+        "*.a",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "ollama",
+            "buildsystem": "simple",
+            "build-commands": [
+                "tar -xvf ollama.tgz -C ${FLATPAK_DEST}"
+            ],
+            "post-install": [
+                "install -Dm0644 com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
+            ],
+            "sources": [
+                {
+            		"type": "file",
+            		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-amd64.tgz",
+            		"sha256": "3a0efab98585b37337485e8d22ebe769d82ec54499275c51fa6c98e0ad7fe573",
+		    	"only-arches": [
+		    		"x86_64"
+		    	],
+		    	"dest-filename": "ollama.tgz"
+            	},
+            	{
+            		"type": "file",
+            		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-arm64.tgz",
+            		"sha256": "7043418b2cb7b605d63d7095dc8504a7100c9c39788c23ffa9ccdbb3c82cc9fe",
+		    	"only-arches": [
+		    		"aarch64"
+		    	],
+		    	"dest-filename": "ollama.tgz"
+            	},
+                {
+                    "type": "file",
+                    "path": "com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml"
+                }
+            ]
+        }
+    ]
+}

--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -2,7 +2,7 @@
     "id": "com.jeffser.Alpaca.Plugins.Ollama",
     "runtime": "com.jeffser.Alpaca",
     "runtime-version": "stable",
-    "sdk": "org.gnome.Sdk//46",
+    "sdk": "org.gnome.Sdk//47",
     "build-extension": true,
     "cleanup": [
         "*.a",

--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -16,6 +16,7 @@
             	"cp -rf --remove-destination ./* ${FLATPAK_DEST}/"
             ],
             "post-install": [
+		"rm ${FLATPAK_DEST}/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml",
                 "install -Dm0644 com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
             ],
             "sources": [

--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -20,7 +20,8 @@
             		"type": "archive",
             		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-amd64.tgz",
             		"sha256": "3a0efab98585b37337485e8d22ebe769d82ec54499275c51fa6c98e0ad7fe573",
-		    	"only-arches": [
+		    	"strip-components": 0,
+			"only-arches": [
 		    		"x86_64"
 		    	]
             	},
@@ -28,7 +29,8 @@
             		"type": "archive",
             		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-arm64.tgz",
             		"sha256": "7043418b2cb7b605d63d7095dc8504a7100c9c39788c23ffa9ccdbb3c82cc9fe",
-		    	"only-arches": [
+		    	"strip-components": 0,
+			"only-arches": [
 		    		"aarch64"
 		    	]
             	},

--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -12,6 +12,9 @@
         {
             "name": "ollama",
             "buildsystem": "simple",
+	    "build-commands": [
+            	"cp -rf --remove-destination ./* ${FLATPAK_DEST}/"
+            ],
             "post-install": [
                 "install -Dm0644 com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
             ],

--- a/com.jeffser.Alpaca.Plugins.Ollama.json
+++ b/com.jeffser.Alpaca.Plugins.Ollama.json
@@ -12,30 +12,25 @@
         {
             "name": "ollama",
             "buildsystem": "simple",
-            "build-commands": [
-                "tar -xvf ollama.tgz -C ${FLATPAK_DEST}"
-            ],
             "post-install": [
                 "install -Dm0644 com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml"
             ],
             "sources": [
                 {
-            		"type": "file",
+            		"type": "archive",
             		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-amd64.tgz",
             		"sha256": "3a0efab98585b37337485e8d22ebe769d82ec54499275c51fa6c98e0ad7fe573",
 		    	"only-arches": [
 		    		"x86_64"
-		    	],
-		    	"dest-filename": "ollama.tgz"
+		    	]
             	},
             	{
-            		"type": "file",
+            		"type": "archive",
             		"url": "https://github.com/ollama/ollama/releases/download/v0.5.12/ollama-linux-arm64.tgz",
             		"sha256": "7043418b2cb7b605d63d7095dc8504a7100c9c39788c23ffa9ccdbb3c82cc9fe",
 		    	"only-arches": [
 		    		"aarch64"
-		    	],
-		    	"dest-filename": "ollama.tgz"
+		    	]
             	},
                 {
                     "type": "file",

--- a/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.jeffser.Alpaca.Plugins.Ollama</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <developer id="tld.vendor">
+    <name>Jeffry Samuel Eduarte Rojas</name>
+  </developer>
+  <extends>com.jeffser.Alpaca</extends>
+  <name>Ollama Instance</name>
+  <summary>Run and create local models</summary>
+  <description>
+    <p>Install Ollama into Alpaca (Does not include support for AMD GPUs).</p>
+  </description>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <url type="homepage">https://jeffser.com/alpaca/</url>
+  <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
+  <releases>
+    <release version="0.5.12" date="2025-02-25"/>
+  </releases>
+</component>

--- a/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
@@ -3,7 +3,7 @@
   <id>com.jeffser.Alpaca.Plugins.Ollama</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <developer id="tld.vendor">
+  <developer id="com.jeffser">
     <name>Jeffry Samuel Eduarte Rojas</name>
   </developer>
   <extends>com.jeffser.Alpaca</extends>

--- a/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
+++ b/com.jeffser.Alpaca.Plugins.Ollama.metainfo.xml
@@ -18,6 +18,6 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="bugtracker">https://github.com/Jeffser/Alpaca/issues</url>
   <releases>
-    <release version="0.5.12" date="2025-02-25"/>
+    <release version="0.5.12" date="2025-03-06"/>
   </releases>
 </component>


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly. <!-- insert the description here -->

[Alpaca](https://flathub.org/apps/com.jeffser.Alpaca) now supports other AI providers (ChatGPT, Gemini, etc), I want to remove Ollama from the base install and add it as an extension to make it optional.

This would also make it possible to update the Ollama instance without having to update the whole app.

Additionally the existing AMD extension will now include Ollama, this is because Ollama stopped working with the extension because of the libraries being in different directories, something I have no control over.

 I was also wondering if I could make it so that the user can't have both extensions installed at the same time to prevent having two Ollama installations.

- [X] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. (I'm the author)

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
