### PR TITLE
Add com.netxms.NetXMSClient52

### DIFF
--- a/com.netxms.NetXMSClient52.yaml
+++ b/com.netxms.NetXMSClient52.yaml
@@ -1,0 +1,48 @@
+app-id: com.netxms.NetXMSClient52
+runtime: org.freedesktop.Sdk
+runtime-version: "24.08"
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
+command: netxms-client.sh
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --share=network
+  - --persist=.nxmc4
+modules:
+  - name: openjdk-17
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk17/install.sh
+  - name: netxms-client
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 netxms-client.sh /app/bin/netxms-client.sh
+      - install -Dm644 nxmc.jar /app/bin/nxmc.jar
+      - install -T -Dm644 netxms.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -t /app/share/applications/ -Dm644 ${FLATPAK_ID}.desktop
+      - install -t /app/share/metainfo/ -Dm644 ${FLATPAK_ID}.metainfo.xml
+    sources:
+      - type: file
+        url: https://netxms.org/download/releases/5.2/nxmc-5.2.0-standalone.jar
+        sha256: 1c6efd170a0ffd74097c726b4bcfc12b49492ca098053c7ea1b41e6bf82eb658
+        dest-filename: nxmc.jar
+        x-checker-data:
+          type: html
+          url: https://netxms.com/downloads/
+          version-pattern: "NetXMS Version [0-9.]+"
+          url-template: >-
+            https://netxms.com/download/releases/$major.$minor/nxmc-$version-standalone.jar
+      - type: file
+        path: netxms-client.sh
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/13f6d864277c25adafe4ee5cb637e45637e53791/5.2/com.netxms.NetXMSClient52.desktop
+        sha256: 2455162ff329183ee5c093b9cbccef4896a0a12c5c1c58cf9f72b6f7a3eae7fe
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/13f6d864277c25adafe4ee5cb637e45637e53791/5.2/com.netxms.NetXMSClient52.metainfo.xml
+        sha256: f37b3caf2c47a08e097741e9b58a288abebab84faf7142aa71b04112655632f4
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/13f6d864277c25adafe4ee5cb637e45637e53791/5.2/netxms-icon.svg
+        sha256: 2be6744ec2dfad5dbfd76c66eb161136bb7294736ebb053dc8f901881c5409bc
+        dest-filename: netxms.svg

--- a/netxms-client.sh
+++ b/netxms-client.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# workaround for https://github.com/eclipse-platform/eclipse.platform.swt/issues/568
+if [ ! -f ~/.swt/trims.prefs ]; then
+    mkdir -p ~/.swt
+    cat > ~/.swt/trims.prefs <<_END
+trimWidths=0 4 6 0 6 0
+trimHeights=0 4 6 0 29 23
+_END
+fi
+
+exec /app/jre/bin/java -jar /app/bin/nxmc.jar "$@"


### PR DESCRIPTION
This package is a rich client for network monitoring system NetXMS. Client is Java (SWT) based and depends on Java17+. Package is build from release version which we publish on our site.

This particular package is for 5.2.x branch. We keep protocol compatibility between server and client across major.minor releases, but some users need to access different versions of the server at the same time (e.g. during test deployment/upgrade).

<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly. <!-- insert the description here -->
- [X] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:** https://netxms.com/about-us, right side of the page

<!-- 💡 Mention any additional maintainers needed below 💡 -->

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
