### PR TITLE
Add org.vinegarhq.Sober

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+  "only-arches": ["x86_64"],
+  "disable-external-data-checker": true
+}
+

--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -13,8 +13,6 @@ finish-args:
   # SECURITY: shouldn't have much of an impact, although the user should disable this from Flatseal if controller support is unwanted
   # We don't ship this by default for backwards compat :( See above.
   # - --device=input
-  # DRI device. Required for graphics acceleration. Non-optional, since Roblox is a 3D game.
-  - --device=dri
   # Required by the game. Non-optional for now, sadly.
   # SECURITY: How bad is device=shm? should we try making a workaround?
   # SECURITY: ptrace access inside the sandbox should be no big deal, really :)

--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -34,9 +34,6 @@ finish-args:
   # SECURITY: Sober sees your Discord username and Discord ID due to how Discord IPC works, but it shouldn't be allowed to make actions on your behalf. Also, we obviously don't send that stuff to our server.
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/discord-ipc-0
-  # Required for a workaround. Has no security or UX impact, since Sober is sadly English-only for now
-  # TODO: fix the bug and remove this
-  - --env=LC_ALL=en_US.UTF-8
 
 # We download prebuilt binaries from our infra.
 # We build them using GitHub Actions in a private GitHub repository, which pulls from our private source repo (not on GitHub), compiles the code, and uploads the artifact to our S3 bucket.
@@ -61,8 +58,8 @@ modules:
     sources:
       - type: archive
         # *** The notice applies to the binaries we distribute. See: https://sober.vinegarhq.org/notice.txt
-        url: https://sober.vinegarhq.org/artifacts/2025-03-29_bbfda2c-1.0.0/prod/sober-binaries-unified.zip
-        sha256: fdd151adebe0629a3880a7de790bcbcd181226fbebd8725f5df97033a2518733
+        url: https://sober.vinegarhq.org/artifacts/2025-03-30_681930b-1.0.0/prod/sober-binaries-unified.zip
+        sha256: ddd3f084e824f532ae1a6e0bb3ffc0566291d3db01915f135dd3b68b6933618e
         # I mean, we only support x86_64 anyway. But annotating is probably helpful.
         only-arches:
           - x86_64

--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -58,8 +58,8 @@ modules:
     sources:
       - type: archive
         # *** The notice applies to the binaries we distribute. See: https://sober.vinegarhq.org/notice.txt
-        url: https://sober.vinegarhq.org/artifacts/2025-03-30_681930b-1.0.0/prod/sober-binaries-unified.zip
-        sha256: ddd3f084e824f532ae1a6e0bb3ffc0566291d3db01915f135dd3b68b6933618e
+        url: https://sober.vinegarhq.org/artifacts/2025-03-30_b3f658a-1.0.0/prod/sober-binaries-unified.zip
+        sha256: 05f2e1b5027b7ef1846531a145f1573d98369fed39afb1515931cd94149837d9
         # I mean, we only support x86_64 anyway. But annotating is probably helpful.
         only-arches:
           - x86_64

--- a/org.vinegarhq.Sober.yml
+++ b/org.vinegarhq.Sober.yml
@@ -1,0 +1,71 @@
+app-id: org.vinegarhq.Sober
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: sober
+separate-locales: false
+finish-args:
+  # For controller support on old Flatpak versions. Optional.
+  # SECURITY: this allows for a sandbox escape
+  # TODO: don't ship this by default. Like, really.
+  - --device=all
+  # Controller support, though this only works on newer Flatpak versions. Optional.
+  # SECURITY: shouldn't have much of an impact, although the user should disable this from Flatseal if controller support is unwanted
+  # We don't ship this by default for backwards compat :( See above.
+  # - --device=input
+  # DRI device. Required for graphics acceleration. Non-optional, since Roblox is a 3D game.
+  - --device=dri
+  # Required by the game. Non-optional for now, sadly.
+  # SECURITY: How bad is device=shm? should we try making a workaround?
+  # SECURITY: ptrace access inside the sandbox should be no big deal, really :)
+  - --device=shm
+  - --allow=devel
+  # X11 performance, also required by the game. Non-optional for now, sadly.
+  # SECURITY: How bad is sharing IPC namespaces? should we try making a workaround?
+  - --share=ipc
+  # Both Sober & Roblox require network access to work. Non-optional.
+  - --share=network
+  # Window server access is required to display the game & menus. Non-optional.
+  # SECURITY: users should try using Wayland where possible
+  - --socket=wayland
+  - --socket=fallback-x11
+  # Required for game audio & microphone access when using the optional voice chat feature. Optional, but heavily recommended.
+  # SECURITY: allows unprompted microphone access. This is a limitation of the sandbox for now.
+  - --socket=pulseaudio
+  # Required to share what Roblox experience you're playing to your Discord servers & contacts. Optional
+  # SECURITY: Sober sees your Discord username and Discord ID due to how Discord IPC works, but it shouldn't be allowed to make actions on your behalf. Also, we obviously don't send that stuff to our server.
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
+  - --filesystem=xdg-run/discord-ipc-0
+  # Required for a workaround. Has no security or UX impact, since Sober is sadly English-only for now
+  # TODO: fix the bug and remove this
+  - --env=LC_ALL=en_US.UTF-8
+
+# We download prebuilt binaries from our infra.
+# We build them using GitHub Actions in a private GitHub repository, which pulls from our private source repo (not on GitHub), compiles the code, and uploads the artifact to our S3 bucket.
+# S3 bucket is hosted by Cloudflare.
+# We confirm this workflow produces working binaries that are compatible with the Flatpak runtime environment.
+# The url and sha256 of the archive below will be manually updated with each application release.
+# The `sober` binary is the main application which provides the downloading & runtime code.
+# The `sober_services` binary is launched by `sober`, it provides a libadwaita UI (used for stuff like the Onboarding Flow) and GTK WebKit APIs (Roblox sometimes opens WebViews)
+# Sober does *not* repackage or redistribute Roblox's intellectual property. We download game code at runtime.
+# Please read the metainfo.xml for more specific information about the app.
+# SECURITY: We force 2FA, protect branches, and use the principle of least privilege, and we have many people auditing our workflow and getting involved.
+#           Even so, it would be beneficial to sign these archives to attest they came from GitHub Actions, and to attest they used a specific version of our source tree.
+modules:
+  - name: sober
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 sober -t /app/bin/
+      - install -Dm755 sober_services -t /app/bin/
+      - install -Dm644 org.vinegarhq.Sober.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 org.vinegarhq.Sober.desktop /app/share/applications/org.vinegarhq.Sober.desktop
+      - install -Dm644 sober.svg /app/share/icons/hicolor/scalable/apps/org.vinegarhq.Sober.svg
+    sources:
+      - type: archive
+        # *** The notice applies to the binaries we distribute. See: https://sober.vinegarhq.org/notice.txt
+        url: https://sober.vinegarhq.org/artifacts/2025-03-29_bbfda2c-1.0.0/prod/sober-binaries-unified.zip
+        sha256: fdd151adebe0629a3880a7de790bcbcd181226fbebd8725f5df97033a2518733
+        # I mean, we only support x86_64 anyway. But annotating is probably helpful.
+        only-arches:
+          - x86_64
+


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly.

Sober runs Roblox on Linux. The official Android Roblox app is downloaded at runtime, and linked with system libraries, similar to mcpe-launcher.

Even if the Android app is used, *all* Roblox features are available within Sober. So the usage of the Android app is moreso an implementation detail. We download the app at runtime, so there's no redistribution of Roblox IP here.

There's no emulators, virtual machines, or even really translation layers involved here. We have our own repository, where people have been testing Sober since August. We think it's worth a shot publishing to Flathub, though I understand this app may not be the right fit.

We estimate around 60k+ people used our app (derived from Automatic Downloads anonymous metrics, which aren't very accurate; we don't exactly do telemetry here).

We put a lot of effort into integrating with the Linux desktop, including using things like Wayland and libadwaita, staying on top of runtime updates, using the latest SDL3 releases, making sure Sober works great on all desktops.

For more info, I urge you to check out our website, online posts about our app, and of course, our metainfo description.

In terms of what Roblox thinks about us, they said we're not *not* allowed to do it. So you won't be liable for unfounded DMCAs if you accept this app.

To be clear, Sober's closed source because someone at Roblox suggested it'd reduce the likelihood of Sober getting abused for cheating, which would therefore allow the project to last longer without action from Roblox. We don't like proprietary software either, but I think allowing people to play games with friends on an otherwise FOSS operating system is nice. :)

Also, one more thing. Due to the nature of this app, we have to very closely follow Roblox's upstream, which sometimes does OTA config changes. For this reason, we need to roll out updates very quickly to users. I read online that Flathub intentionally adds a 3 hour delay to publishing updates, but given our manifest is very simple and only downloads a 2mb ZIP, perhaps we could be allow-listed to publish immediately? It's okay if not, I just wanted to ask.

- [X] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [X] I have [built][build] and tested the submission locally.
- [X] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:** I'm a developer of Sober since day 1, you can see me making commits to the official repository which is linked on the official website (https://sober.vinegarhq.org/): https://github.com/vinegarhq/sober/commits/gh-pages/


Thanks for considering my submission <3

<!-- 💡 Mention any additional maintainers needed below 💡 -->

Can you add @tunis4 as a maintainer as well? Thanks.

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
