### PR TITLE
adding Vutron Music app to flathub

### DIFF
--- a/io.github.stark81.VutronMusic.metainfo.xml
+++ b/io.github.stark81.VutronMusic.metainfo.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.stark81.VutronMusic</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="io.github.stark81">
+    <name>qier222 and stark81</name>
+  </developer>
+  <name>VutronMusic</name>
+  <summary>A High Appearance Third-Party Netease CloudMusic Player</summary>
+  <summary xml:lang="zh_CN">高颜值的第三方网易云音乐播放器</summary>
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </recommends>
+  <description>
+    <p>A High Appearance Third-Party Netease CloudMusic Player. Support many convenient features.</p>
+    <p xml:lang="zh_CN">高颜值的第三方网易云音乐播放器，支持各种各样的方便的特性</p>
+  </description>
+  <url type="homepage">https://github.com/stark81/VutronMusic</url>
+  <url type="bugtracker">https://github.com/stark81/VutronMusic/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>VutronMusic's Library Page</caption>
+      <image>https://github.com/stark81/VutronMusic/blob/main/images/library.jpg</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.6.0" date="2025-03-31">
+      <description></description>
+  </releases>
+  <launchable type="desktop-id">io.github.stark81.VutronMusic.desktop</launchable>
+  <content_rating type="oars-1.1"/>
+  <update_contact>valigarmanda55@gmail.com</update_contact>
+</component>

--- a/io.github.stark81.VutronMusic.yaml
+++ b/io.github.stark81.VutronMusic.yaml
@@ -1,0 +1,86 @@
+app-id: io.github.stark81.VutronMusic
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+separate-locales: false
+rename-icon: vutron
+rename-desktop-file: vutron.desktop
+command: vutronmusic
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --own-name=org.mpris.MediaPlayer2.vutronmusic
+cleanup:
+  - '*.a'
+  - '*.la'
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /man
+  - /share/man
+  - /share/gtk-doc
+
+modules:
+  - name: yt-dlp
+    no-autogen: true
+    no-make-install: true
+    make-args:
+      - yt-dlp
+      - PYTHON=/usr/bin/python3
+    post-install:
+      - install yt-dlp /app/bin
+    sources:
+      - type: git
+        url: https://github.com/yt-dlp/yt-dlp.git
+        tag: 2025.03.26
+        commit: 6eaa574c8217ea9b9c5177fece0714fa622da34c
+        x-checker-data:
+          type: git
+          tag-pattern: ^(\d{4}\.\d{2}\.\d{2})$
+
+  - name: vutronmusic
+    buildsystem: simple
+    build-options:
+      no-debuginfo: true
+    build-commands:
+      - bsdtar --to-stdout -xf vutronmusic.deb data.* | bsdtar -xf -
+      - cp -a opt/VutronMusic $FLATPAK_DEST/
+      - rm -r usr/share/doc
+      - rm -r usr/share/icons/hicolor/1024x1024
+      - cp -a usr/share $FLATPAK_DEST/
+      - desktop-file-edit --set-key="Exec" --set-value="vutronmusic %U" $FLATPAK_DEST/share/applications/*.desktop
+      - desktop-file-edit --set-key="Categories" --set-value="AudioVideo" $FLATPAK_DEST/share/applications/*.desktop
+      - install -Dm644 io.github.stark81.VutronMusic.metainfo.xml -t /app/share/metainfo
+      - install -Dm755 vutronmusic.sh /app/bin/vutronmusic
+    sources:
+      - type: file
+        dest-filename: vutronmusic.deb
+        only-arches:
+          - x86_64
+        url: https://github.com/stark81/VutronMusic/releases/download/v1.6.0/VutronMusic.1.6.0_amd64.deb
+        sha256: 9dd16e042fe54fcd45b2ee9442cdcd94028e2caa00ff4e553ca60286ac3e8faa
+        x-checker-data:
+          is-main-source: true
+          type: json
+          url: https://api.github.com/repos/stark81/my_vutronmusic/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: >-
+            .assets[] | select(.name | test("vutronmusic_" + $version + "_amd64.deb"))
+            |
+            .browser_download_url
+
+      - type: file
+        path: io.github.stark81.VutronMusic.metainfo.xml
+
+      - type: script
+        dest-filename: vutronmusic.sh
+        commands:
+          - export TMPDIR=$XDG_RUNTIME_DIR/app/$FLATPAK_ID
+          - exec zypak-wrapper.sh /app/VutronMusic/vutron "$@"


### PR DESCRIPTION

- [x] A third-party music player for Netease Cloud Music, which is a popular music platform in China.  Vutron is inspired by YesPlayMusic, but YesPlayMusic is out-of-developed and not maintained very much.
- [x] io.github.stark81.VutronMusic
- [ ]  The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [x] I have [built][build] and tested the submission locally.
- [x] I have contacted with author on github. Notice:  We chatted in Chinese here. **Link: https://github.com/stark81/VutronMusic/issues/115**


<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
