### PR TITLE
Add new app eu.jumplink.Easy6502

### DIFF
--- a/eu.jumplink.Easy6502.desktop
+++ b/eu.jumplink.Easy6502.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Easy6502
+Exec=eu.jumplink.Easy6502
+Icon=eu.jumplink.Easy6502
+Terminal=false
+Type=Application
+Categories=Development;Education;
+StartupNotify=true

--- a/eu.jumplink.Easy6502.json
+++ b/eu.jumplink.Easy6502.json
@@ -1,0 +1,58 @@
+{
+  "id": "eu.jumplink.Easy6502",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "48",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.node22",
+    "org.freedesktop.Sdk.Extension.typescript"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/node22/bin:/usr/lib/sdk/typescript/bin:/app/bin"
+  },
+  "command": "eu.jumplink.Easy6502",
+  "finish-args": [
+    "--device=dri",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--socket=pulseaudio",
+    "--env=GJS_DISABLE_JIT=1"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "blueprint-compiler",
+      "buildsystem": "meson",
+      "builddir": true,
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler/-/archive/v0.16.0/blueprint-compiler-v0.16.0.tar.gz",
+          "sha256": "01feb8263fe7a450b0a9fed0fd54cf88947aaf00f86cc7da345f8b39a0e7bd30"
+        }
+      ]
+    },
+    {
+      "name": "Easy6502",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/JumpLink/Easy6502.git",
+          "tag": "v0.1.0"
+        }
+      ]
+    }
+  ]
+}

--- a/eu.jumplink.Easy6502.metainfo.xml
+++ b/eu.jumplink.Easy6502.metainfo.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>eu.jumplink.Easy6502</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>CC-BY-4.0</project_license>
+  <name>Easy6502</name>
+  <summary>Modern 6502 Assembly Learning Environment</summary>
+  <description>
+    <p>
+      Easy6502 is a modern, native Adwaita application that provides a complete learning environment for 6502 assembly language programming. Built with GJS and TypeScript, this application brings the classic Easy6502 tutorial by Nick Morgan to your desktop as a beautiful, integrated experience.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Interactive Tutorial: A comprehensive step-by-step guide to learning 6502 assembly language, with explanations of all core concepts</li>
+      <li>Code Editor: Write and edit your 6502 assembly code with syntax highlighting</li>
+      <li>Assembler &amp; Debugger: Assemble your code and debug it with a powerful built-in debugger showing registers, flags, and memory in real-time</li>
+      <li>Visual Game Console: See your code in action on a virtual display, perfect for creating simple games and graphics</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">eu.jumplink.Easy6502.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/JumpLink/Easy6502/refs/heads/main/misc/screenshots/1.png</image>
+      <caption>Easy6502 in light Adwaita theme showing the interactive tutorial interface</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/JumpLink/Easy6502/refs/heads/main/misc/screenshots/2.png</image>
+      <caption>Easy6502 in dark Adwaita theme showing the interactive tutorial interface</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/JumpLink/Easy6502/refs/heads/main/misc/screenshots/3.png</image>
+      <caption>The code editor with syntax highlighting for 6502 assembly</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/JumpLink/Easy6502/refs/heads/main/misc/screenshots/4.png</image>
+      <caption>The built-in debugger showing registers, flags, and memory in real-time</caption>
+    </screenshot>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/JumpLink/Easy6502/refs/heads/main/misc/screenshots/5.png</image>
+      <caption>The virtual game console displaying three colored pixels</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/JumpLink/Easy6502</url>
+  <url type="bugtracker">https://github.com/JumpLink/Easy6502/issues</url>
+  <url type="help">https://github.com/JumpLink/Easy6502/wiki</url>
+  <developer id="eu.jumplink">
+    <name translate="no">Pascal Garber</name>
+    <email>pascal@mailfreund.de</email>
+  </developer>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.1.0" date="2025-03-31">
+      <description>
+        <p>Initial release of Easy6502 for GNOME</p>
+      </description>
+    </release>
+  </releases>
+  <kudos>
+    <kudo>ModernToolkit</kudo>
+    <kudo>HiDpiIcon</kudo>
+  </kudos>
+  <categories>
+    <category>Development</category>
+    <category>Education</category>
+  </categories>
+  <keywords>
+    <keyword>6502</keyword>
+    <keyword>Assembly</keyword>
+    <keyword>Programming</keyword>
+    <keyword>Learning</keyword>
+    <keyword>Emulator</keyword>
+  </keywords>
+</component>


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Application Details
Easy6502 is a modern native GNOME application for learning 6502 assembly language programming. Built with GJS and TypeScript, it brings the classic Easy6502 tutorial to your desktop as a beautiful, integrated experience. Features include an interactive tutorial, code editor with syntax highlighting, assembler & debugger, and a visual game console.

### Requirements Checklist
- [x] Please describe the application briefly.
- [x] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:** https://github.com/JumpLink/Easy6502

<!-- 💡 Mention any additional maintainers needed below 💡 -->
No additional maintainers needed at this time.

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission