### PR TITLE
Add FullScreen Meeting Notifier

### DIFF
--- a/com.github.Ofear.fullscreen-meeting-notifier.yml
+++ b/com.github.Ofear.fullscreen-meeting-notifier.yml
@@ -1,0 +1,47 @@
+app-id: com.github.Ofear.fullscreen-meeting-notifier
+runtime: org.gnome.Platform
+runtime-version: '45'
+sdk: org.gnome.Sdk
+command: fullscreen-meeting-notifier
+finish-args:
+  # X11/Wayland access
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # Network access for Google Calendar
+  - --share=network
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # Sound
+  - --socket=pulseaudio
+  # File access for settings and credentials
+  - --filesystem=xdg-config/meeting-notifier:create
+  # For opening links in browser
+  - --talk-name=org.freedesktop.portal.OpenURI
+  # For GTK theme
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+
+modules:
+  - name: python3-requirements
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps .
+    sources:
+      - type: dir
+        path: .
+
+  - name: fullscreen-meeting-notifier
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 run.sh /app/bin/fullscreen-meeting-notifier
+      - install -Dm644 icons/fullscreen-meeting-notifier.svg /app/share/icons/hicolor/scalable/apps/com.github.Ofear.fullscreen-meeting-notifier.svg
+      - install -Dm644 AppDir/usr/share/metainfo/fullscreen-meeting-notifier.appdata.xml /app/share/metainfo/com.github.Ofear.fullscreen-meeting-notifier.appdata.xml
+      - install -Dm644 fullscreen-meeting-notifier.desktop /app/share/applications/com.github.Ofear.fullscreen-meeting-notifier.desktop
+    sources:
+      - type: dir
+        path: . 


### PR DESCRIPTION
Add FullScreen Meeting Notifier, a GTK application that displays full-screen notifications for upcoming Google Calendar meetings.

- Application repository: https://github.com/Ofear/fullscreen-meeting-notifier
- I am the developer of this application
- The application is open source under the MIT license
- The application has been tested locally with flatpak-builder