### PR TITLE
Add rocks.noise.qspeakers

### DIFF
--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -1,0 +1,21 @@
+app-id: rocks.noise.QSpeakers
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: qspeakers
+finish-args:
+  # X11 + XShm access
+  - --share=ipc
+  - --socket=fallback-x11
+  # Wayland access
+  - --socket=wayland
+  - --device=dri
+rename-desktop-file: qspeakers.desktop
+rename-icon: qspeakers
+modules:
+  - name: qspeakers
+    buildsystem: qmake
+    sources:
+      - type: git
+        url: https://github.com/be1/qspeakers.git
+        commit: "ad4ac333ad1c1411f52846eed4c888e13c7fb7df"

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -18,4 +18,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/be1/qspeakers.git
-        commit: "07b21320dc6369ce90c6d20987bcb85645394880"
+        commit: "09988f1dc85b581d5dc38462786ebbe7ae42d265"

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -11,7 +11,7 @@ finish-args:
   - --socket=wayland
   - --device=dri
 rename-desktop-file: qspeakers.desktop
-rename-icon: qspeakers
+copy-icon: qspeakers
 modules:
   - name: qspeakers
     buildsystem: qmake

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -18,4 +18,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/be1/qspeakers.git
-        commit: "ad4ac333ad1c1411f52846eed4c888e13c7fb7df"
+        commit: "ad1cc27e9774b39a56a46087a06c6ab02cff421b"

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -11,7 +11,8 @@ finish-args:
   - --socket=wayland
   - --device=dri
 rename-desktop-file: qspeakers.desktop
-copy-icon: qspeakers
+rename-icon: qspeakers
+copy-icon: true
 modules:
   - name: qspeakers
     buildsystem: qmake

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -1,6 +1,6 @@
 app-id: rocks.noise.QSpeakers
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 command: qspeakers
 finish-args:

--- a/rocks.noise.QSpeakers.yaml
+++ b/rocks.noise.QSpeakers.yaml
@@ -18,4 +18,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/be1/qspeakers.git
-        commit: "ad1cc27e9774b39a56a46087a06c6ab02cff421b"
+        commit: "07b21320dc6369ce90c6d20987bcb85645394880"

--- a/rocks.noise.qspeakers.yaml
+++ b/rocks.noise.qspeakers.yaml
@@ -1,4 +1,4 @@
-app-id: rocks.noise.QSpeakers
+app-id: rocks.noise.qspeakers
 runtime: org.kde.Platform
 runtime-version: '6.8'
 sdk: org.kde.Sdk
@@ -19,4 +19,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/be1/qspeakers.git
-        commit: "09988f1dc85b581d5dc38462786ebbe7ae42d265"
+        commit: "db58f37a587daac640e4cc48003bade331afe3ee"


### PR DESCRIPTION
See https://discourse.flathub.org/t/authorship-verification-issue/9330

<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [x] Please describe the application briefly. "Loudspeaker design software"
- [x] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed. "rocks.noise.QSpeakers"
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].
- [x] I have [built][build] and tested the submission locally.
- [x] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

<!-- 💡 Mention any additional maintainers needed below 💡 -->
This is a resubmission with app id changed from fr.free.brouits.qspeakers to rocks.noise.QSpeakers to allow authorship verification on my website.
<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
