### PR TITLE
Add io.github.bcpierce00.unison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+
+# Unison Flatpak build
+
+Building this requires a patch to org.freedesktop.Sdk.Extension.ocaml to build
+the "dune-configurator" library, which was just merged to the 24.08 branch.
+
+The following features should work:
+- local files
+- SSH
+
+Not supported:
+- socket server (a bad idea anyway)
+- fsmonitor (unknown if possible)
+
+When using SSH, unison needs to be invoked on the remote end, which operates
+independently of the unison started by the local user. By default, the
+program "unison" will be invoked, which works if it is installed by
+traditional packages, but not with Flatpak; to run the unison server via
+Flatpak, put this in the profile file:
+
+```
+servercmd = flatpak run --command=unison io.github.bcpierce00.unison
+```
+
+The .desktop and .metainfo.xml files were taken from the Fedora package and
+modified.
+

--- a/io.github.bcpierce00.unison.desktop
+++ b/io.github.bcpierce00.unison.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Exec=unison-gui
+Name=Unison
+GenericName=File Synchronizer
+Comment=Multi-master File synchronization tool
+Terminal=false
+Icon=io.github.bcpierce00.unison.svg
+StartupNotify=true
+Categories=Utility;

--- a/io.github.bcpierce00.unison.desktop
+++ b/io.github.bcpierce00.unison.desktop
@@ -5,6 +5,6 @@ Name=Unison
 GenericName=File Synchronizer
 Comment=Multi-master File synchronization tool
 Terminal=false
-Icon=io.github.bcpierce00.unison.svg
+Icon=io.github.bcpierce00.unison
 StartupNotify=true
 Categories=Utility;

--- a/io.github.bcpierce00.unison.metainfo.xml
+++ b/io.github.bcpierce00.unison.metainfo.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.github.bcpierce00.unison</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>
+    <!-- unison -->GPL-3.0-or-later AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-2.1-or-later <!-- camlp-streams, lablgtk3 --> AND (LGPL-2.1-only WITH OCaml-LGPL-linking-exception) <!-- ocaml-cairo --> AND (LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception)</project_license>
+  <name>Unison</name>
+  <summary>File Synchronizer</summary>
+  <description>
+    <p>
+      Unison is a file-synchronization tool for POSIX-compliant systems
+      (e.g. *BSD, GNU/Linux, macOS) and Windows. It allows two replicas of a
+      collection of files and directories to be stored on different hosts (or
+      different disks on the same host), modified separately, and then brought
+      up to date by propagating the changes in each replica to the other.
+    </p>
+    <p>
+      Note: if you want to connect to this Flatpak build remotely via SSH, put this in the profile file:
+    </p>
+    <p>
+      <code>servercmd = flatpak run --command=unison io.github.bcpierce00.unison</code>
+    </p>
+  </description>
+  <url type="homepage">https://github.com/bcpierce00/unison</url>
+  <launchable type="desktop-id">io.github.bcpierce00.unison.desktop</launchable>
+  <releases>
+    <release version="2.53.7" date="2025-04-21">
+      <url type="details">https://github.com/bcpierce00/unison/releases/tag/v2.53.7</url>
+      <description>
+        <p>First version on Flathub</p>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1" />
+  <developer id="io.github.bcpierce00">
+    <name>The Unison Project</name>
+  </developer>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://people.freedesktop.org/~mst/unison-screenshot-1.png</image>
+      <caption>The main window, showing changed files</caption>
+    </screenshot>
+  </screenshots>
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </recommends>
+</component>

--- a/io.github.bcpierce00.unison.metainfo.xml
+++ b/io.github.bcpierce00.unison.metainfo.xml
@@ -2,8 +2,7 @@
 <component type="desktop">
   <id>io.github.bcpierce00.unison</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>
-    <!-- unison -->GPL-3.0-or-later AND LGPL-2.0-only AND LGPL-2.1-only AND LGPL-2.1-or-later <!-- camlp-streams, lablgtk3 --> AND (LGPL-2.1-only WITH OCaml-LGPL-linking-exception) <!-- ocaml-cairo --> AND (LGPL-3.0-or-later WITH OCaml-LGPL-linking-exception)</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <name>Unison</name>
   <summary>File Synchronizer</summary>
   <description>

--- a/io.github.bcpierce00.unison.yml
+++ b/io.github.bcpierce00.unison.yml
@@ -9,6 +9,8 @@ command: "unison-gui"
 finish-args:
   # must be able to sync anything
   - "--filesystem=home"
+  # user may want to sync flatpak apps' data/config, is not included in "=home"
+  - "--filesystem=~/.var/app"
   # external backup media
   - "--filesystem=/run/media"
   - "--share=network"

--- a/io.github.bcpierce00.unison.yml
+++ b/io.github.bcpierce00.unison.yml
@@ -11,13 +11,9 @@ finish-args:
   - "--filesystem=home"
   # external backup media
   - "--filesystem=/run/media"
-# is there some use case for expanding this to "host"?
-#  - "--filesystem=host"
   - "--share=network"
-  # need ssh-agent
   - "--socket=ssh-auth"
   - "--socket=wayland"
-  # required for x11
   - "--share=ipc"
   - "--socket=fallback-x11"
 
@@ -65,18 +61,8 @@ modules:
         url: "https://github.com/bcpierce00/unison.git"
         tag: "v2.53.7"
         commit: "96e15a800bb0e619da6f7092ddefc47101c3092f"
-    build-options:
-      - cflags: "-O2 -g"
-      - cflags-override: true
     buildsystem: "simple"
     build-commands:
-      # note: make fails to find "Gpointer" module - unclear why but dune works!
-      #- "make -j${FLATPAK_BUILDER_N_JOB} tui gui fsmonitor"
-      #- "ls -l src/unison*"
-      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison"
-      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison-gui"
-      # fsmonitor is untested, no idea how to use it
-      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison-fsmonitor"
       - "dune build -p unison"
       - "install -Dm0755 -t ${FLATPAK_DEST}/bin _build/install/default/bin/unison"
       - "dune build -p unison-gui"

--- a/io.github.bcpierce00.unison.yml
+++ b/io.github.bcpierce00.unison.yml
@@ -1,7 +1,7 @@
 app-id: "io.github.bcpierce00.unison"
-runtime: "org.gnome.Platform"
-runtime-version: "48"
-sdk: "org.gnome.Sdk"
+runtime: "org.freedesktop.Platform"
+runtime-version: "24.08"
+sdk: "org.freedesktop.Sdk"
 sdk-extensions:
   - "org.freedesktop.Sdk.Extension.ocaml"
 
@@ -21,6 +21,11 @@ build-options:
   append-path: "/usr/lib/sdk/ocaml/bin"
   env:
     OCAMLPATH: "/app/share/runtime/ocaml/lib"
+
+cleanup:
+  # delete ocaml static libs, leave license files in place (in doc/)...
+  - "/share/runtime/ocaml/bin"
+  - "/share/runtime/ocaml/lib"
 
 modules:
   - name: "camlp-streams"
@@ -61,6 +66,10 @@ modules:
         url: "https://github.com/bcpierce00/unison.git"
         tag: "v2.53.7"
         commit: "96e15a800bb0e619da6f7092ddefc47101c3092f"
+      - type: "file"
+        path: "io.github.bcpierce00.unison.desktop"
+      - type: "file"
+        path: "io.github.bcpierce00.unison.metainfo.xml"
     buildsystem: "simple"
     build-commands:
       - "dune build -p unison"
@@ -69,20 +78,6 @@ modules:
       - "install -Dm0755 -t ${FLATPAK_DEST}/bin _build/install/default/bin/unison-gui"
       - "install -Dm0644 -t ${FLATPAK_DEST}/share/doc/unison LICENSE README.md NEWS.md"
       - "install -Dm0644 icons/U.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.bcpierce00.unison.svg"
-
-  - name: "unison-extras"
-    sources:
-      - type: "file"
-        path: "io.github.bcpierce00.unison.desktop"
-      - type: "file"
-        path: "io.github.bcpierce00.unison.metainfo.xml"
-    buildsystem: "simple"
-    build-commands:
       - "install -Dm0644 -t ${FLATPAK_DEST}/share/applications io.github.bcpierce00.unison.desktop"
       - "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo io.github.bcpierce00.unison.metainfo.xml"
-
-cleanup:
-  # delete ocaml static libs, leave license files in place (in doc/)...
-  - "/share/runtime/ocaml/bin"
-  - "/share/runtime/ocaml/lib"
 

--- a/io.github.bcpierce00.unison.yml
+++ b/io.github.bcpierce00.unison.yml
@@ -1,0 +1,102 @@
+app-id: "io.github.bcpierce00.unison"
+runtime: "org.gnome.Platform"
+runtime-version: "48"
+sdk: "org.gnome.Sdk"
+sdk-extensions:
+  - "org.freedesktop.Sdk.Extension.ocaml"
+
+command: "unison-gui"
+finish-args:
+  # must be able to sync anything
+  - "--filesystem=home"
+  # external backup media
+  - "--filesystem=/run/media"
+# is there some use case for expanding this to "host"?
+#  - "--filesystem=host"
+  - "--share=network"
+  # need ssh-agent
+  - "--socket=ssh-auth"
+  - "--socket=wayland"
+  # required for x11
+  - "--share=ipc"
+  - "--socket=fallback-x11"
+
+build-options:
+  append-path: "/usr/lib/sdk/ocaml/bin"
+  env:
+    OCAMLPATH: "/app/share/runtime/ocaml/lib"
+
+modules:
+  - name: "camlp-streams"
+    sources:
+      - type: "git"
+        url: "https://github.com/ocaml/camlp-streams"
+        tag: "v5.0.1"
+        commit: "567fa15f32192a6a7cd12e6c9e804fec43460126"
+    buildsystem: "simple"
+    build-commands:
+      - "dune build"
+      - "dune install --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+
+  - name: "ocaml-cairo"
+    sources:
+      - type: "archive"
+        url: "https://github.com/Chris00/ocaml-cairo/releases/download/0.6.5/cairo2-0.6.5.tbz"
+        sha256: "25dc41c9436d9abcf56caad9a105944ff7346041b8cc6a2a654ab8848b657372"
+    buildsystem: "simple"
+    build-commands:
+      # avoid building stuff that depends on lablgtk...
+      - "dune build -p cairo2 @install"
+      - "dune install -p cairo2 --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+
+  - name: "lablgtk"
+    sources:
+      - type: "archive"
+        url: "https://github.com/garrigue/lablgtk/releases/download/3.1.5/lablgtk3-3.1.5.tbz"
+        sha256: "d4821cdbecf3ae374f20317d63e43fe58030c3ba9657b51a2e83e652197e8eac"
+    buildsystem: "simple"
+    build-commands:
+      - "dune build -p lablgtk3"
+      - "dune install -p lablgtk3 --prefix ${FLATPAK_DEST}/share/runtime/ocaml"
+
+  - name: "unison"
+    sources:
+      - type: "git"
+        url: "https://github.com/bcpierce00/unison.git"
+        tag: "v2.53.7"
+        commit: "96e15a800bb0e619da6f7092ddefc47101c3092f"
+    build-options:
+      - cflags: "-O2 -g"
+      - cflags-override: true
+    buildsystem: "simple"
+    build-commands:
+      # note: make fails to find "Gpointer" module - unclear why but dune works!
+      #- "make -j${FLATPAK_BUILDER_N_JOB} tui gui fsmonitor"
+      #- "ls -l src/unison*"
+      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison"
+      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison-gui"
+      # fsmonitor is untested, no idea how to use it
+      #- "install -Dm0755 -t ${FLATPAK_DEST}/bin src/unison-fsmonitor"
+      - "dune build -p unison"
+      - "install -Dm0755 -t ${FLATPAK_DEST}/bin _build/install/default/bin/unison"
+      - "dune build -p unison-gui"
+      - "install -Dm0755 -t ${FLATPAK_DEST}/bin _build/install/default/bin/unison-gui"
+      - "install -Dm0644 -t ${FLATPAK_DEST}/share/doc/unison LICENSE README.md NEWS.md"
+      - "install -Dm0644 icons/U.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.bcpierce00.unison.svg"
+
+  - name: "unison-extras"
+    sources:
+      - type: "file"
+        path: "io.github.bcpierce00.unison.desktop"
+      - type: "file"
+        path: "io.github.bcpierce00.unison.metainfo.xml"
+    buildsystem: "simple"
+    build-commands:
+      - "install -Dm0644 -t ${FLATPAK_DEST}/share/applications io.github.bcpierce00.unison.desktop"
+      - "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo io.github.bcpierce00.unison.metainfo.xml"
+
+cleanup:
+  # delete ocaml static libs, leave license files in place (in doc/)...
+  - "/share/runtime/ocaml/bin"
+  - "/share/runtime/ocaml/lib"
+


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly.

Unison is a simple application that can synchronize files, locally and remotely (via SSH). There is both a text-mode UI and a GTK3 UI, of course the latter is the default. It is not the most user friendly of applications, it's one where you should read the manual first to create the required configuration files with a text editor.

- [X] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.

Following the recommendations, the ID is io.github.bcpierce00.unison which should be controlled by the upstream project, although currently the corresponding URL has no content. (Note that i'm not part of the upstream project)

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2].

- [X] I have [built][build] and tested the submission locally.

Tested local and SSH connection works.

- [ ] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

i'm not involved with the upstream project at all; they appear to be clearly uninterested in maintaining any builds other than their own CI so i haven't bothered them with it.
See comments

https://github.com/bcpierce00/unison/issues/459#issuecomment-749099015
https://github.com/bcpierce00/unison/issues/370#issuecomment-691737432


<!-- 💡 Mention any additional maintainers needed below 💡 -->

In case one of the upstream developer changes their mind, i'm happy to add them as maintainer, but hopefully it shouldn't require lots of maintenance, given that upstream has resolved the various version incompatibility issues since version 2.52.

Also i notice there was a previous attempt to flatpak this at https://github.com/hfiguiere/flathub/tree/unison which was apparently abandoned; might be worth a try to ask...

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[build]: https://docs.flathub.org/docs/for-app-authors/submission/#before-submission
