### PR TITLE
Add io.github.heidefinnischen.resolutionary

### DIFF
--- a/io.github.heidefinnischen.resolutionary.json
+++ b/io.github.heidefinnischen.resolutionary.json
@@ -1,0 +1,38 @@
+{
+    "id" : "io.github.heidefinnischen.resolutionary",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "48",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "resolutionary",
+    "finish-args" : [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "resolutionary",
+            "builddir" : true,
+            "buildsystem" : "meson",
+            "sources" : [
+                {
+                    "type" : "archive",
+                    "url" : "https://github.com/heidefinnischen/resolutionary/archive/refs/tags/v1.0.1.tar.gz",
+                    "sha256" : "696585d668390b0d9db2db56f3d82e6bcdcb071a67ac838b2f2072b3b961d62e"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️⚠️ Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [X] Please describe the application briefly: 

**Resolutionary** is a simple screen resolution calculator built with GTK4 and Libadwaita. It calculates the effective (HiDPI-adjusted) resolution of a monitor, given physical resolution and scaling factor. This helps figuring out the intended UI Resolution the Desktop is rendered at if it was a low-DPI screen. GNOME nowadays offers fractional scaling in 25% increments, which Resolutionary supports like every arbritrary scaling percentage.

- [X] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am the author and developer of this project.

<!-- 💡 Mention the GitHub usernames of any additional maintainers needed below 💡 -->

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
