### PR TITLE
Add org.luanti.luanti

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules

--- a/0001-Fix-duplicate-provides-tag-in-metainfo.patch
+++ b/0001-Fix-duplicate-provides-tag-in-metainfo.patch
@@ -1,0 +1,35 @@
+From d822902f9ef38f8a13052a9b5851919163cbc299 Mon Sep 17 00:00:00 2001
+From: Lars Mueller <appgurulars@gmx.de>
+Date: Sat, 24 May 2025 14:46:23 +0200
+Subject: [PATCH] Fix duplicate provides tag in metainfo
+
+---
+ misc/org.luanti.luanti.metainfo.xml | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/misc/org.luanti.luanti.metainfo.xml b/misc/org.luanti.luanti.metainfo.xml
+index 0c5b1a717..2bc9a93ac 100644
+--- a/misc/org.luanti.luanti.metainfo.xml
++++ b/misc/org.luanti.luanti.metainfo.xml
+@@ -3,6 +3,7 @@
+     <id>org.luanti.luanti</id>
+     <provides>
+         <id>net.minetest.minetest</id>
++        <binary>luanti</binary>
+     </provides>
+     <replaces>
+         <id>net.minetest.minetest</id>
+@@ -165,10 +166,6 @@
+     <url type="vcs-browser">https://github.com/luanti-org/luanti</url>
+     <url type="contribute">https://www.luanti.org/get-involved</url>
+ 
+-    <provides>
+-        <binary>luanti</binary>
+-    </provides>
+-
+     <translation type="gettext">luanti</translation>
+ 
+     <update_contact>celeron55@gmail.com</update_contact>
+-- 
+2.49.0
+

--- a/org.luanti.luanti.yaml
+++ b/org.luanti.luanti.yaml
@@ -1,0 +1,48 @@
+app-id: org.luanti.luanti
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: luanti
+rename-icon: luanti
+copy-icon: true
+finish-args:
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=all
+  - --share=ipc
+  - --share=network
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/gtk-doc
+  - /share/man
+  - '*.la'
+  - '*.a'
+
+modules:
+  - shared-modules/luajit/luajit.json
+
+  - name: luanti
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_CURSES=0
+      - -DENABLE_GETTEXT=1
+    cleanup:
+      - /share/minetest/games/devtest
+    post-install:
+      - mv $FLATPAK_DEST/bin/luanti $FLATPAK_DEST/bin/luanti.bin
+      - install -Dm755 luanti.sh $FLATPAK_DEST/bin/luanti
+    sources:
+      - type: git
+        url: https://github.com/luanti-org/luanti.git
+        tag: 5.12.0
+        x-checker-data:
+          type: git
+          tag-pattern: ([\d.]+)$
+          is-important: true
+      - type: script
+        dest-filename: luanti.sh
+        commands:
+          - MINETEST_USER_PATH=$HOME/.var/app/org.luanti.luanti/.minetest exec
+            luanti.bin "$@"

--- a/org.luanti.luanti.yaml
+++ b/org.luanti.luanti.yaml
@@ -41,6 +41,8 @@ modules:
           type: git
           tag-pattern: ([\d.]+)$
           is-important: true
+      - type: patch
+        path: 0001-Fix-duplicate-provides-tag-in-metainfo.patch
       - type: script
         dest-filename: luanti.sh
         commands:


### PR DESCRIPTION


<!-- 💡 Go to the preview tab to click the links below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

- [x] Please describe the application briefly: Luanti (formerly Minetest) is "an open source voxel game engine". See https://luanti.org for details. This PR is a resubmission of [Minetest](https://github.com/flathub/flathub/pull/20) following [the rename](https://blog.luanti.org/2024/10/13/Introducing-Our-New-Name/) a while ago.
- [x] The domain used for the application ID is [controlled by the application developer(s)][appid-domain] and the [application id guidelines][appid] are followed: Yes, https://luanti.org is controlled by the Luanti core developer and documentation teams. See https://github.com/luanti-org/luanti-org.github.io.
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am a Luanti core developer (see [here](https://github.com/orgs/luanti-org/teams/engine)). 

> Mention the GitHub usernames of any additional maintainers needed below

The GitHub team also lists other core devs. I'm not sure if it's helpful to ping all 16 here. I recall @sfan5 @rubenwardy have touched the Flatpak in the past. It would be ideal if all core devs in that team could be granted access.

We plan to EOL rebase net.minetest.Minetest after this is done: https://github.com/flathub/net.minetest.Minetest/pull/74

<!-- ⚠️⚠️ DO NOT modify anything below this line ⚠️⚠️  -->

[appid-domain]: https://docs.flathub.org/docs/for-app-authors/requirements/#control-over-domain-or-repository
[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
