### PR TITLE
Add AMD AMF runtime package

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,6 @@
+{
+  "skip-appstream-check": true,
+  "only-arches": [
+    "x86_64"
+  ]
+}

--- a/org.freedesktop.Platform.GL.amf.yaml
+++ b/org.freedesktop.Platform.GL.amf.yaml
@@ -1,0 +1,25 @@
+id: org.freedesktop.Platform.GL.amf
+branch: '24.08'
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+build-extension: true
+separate-locales: false
+appstream-compose: false
+modules:
+    - name: amf
+      buildsystem: simple
+      build-commands:
+          - ar x amf-amdgpu-pro_*.deb
+          - tar -xf data.tar.xz
+          - ar x libamdenc-amdgpu-pro_*.deb
+          - tar -xf data.tar.xz
+          - mkdir -p /usr/lib/x86_64-linux-gnu/GL/amf/lib
+          - cp -dpr opt/amdgpu-pro/lib/x86_64-linux-gnu/*.so* /usr/lib/x86_64-linux-gnu/GL/amf/lib
+      sources:
+        - type: file
+          url: https://repo.radeon.com/amdgpu/6.4.2.1/ubuntu/pool/proprietary/a/amf-amdgpu-pro/amf-amdgpu-pro_1.4.37-2187634.22.04_amd64.deb
+          sha256: c6f5b80ef1a4b2ef24aaa5688679659038618dc4fb38378b1e3d96faee7c3541
+        - type: file
+          url: https://repo.radeon.com/amdgpu/6.4.2.1/ubuntu/pool/proprietary/liba/libamdenc-amdgpu-pro/libamdenc-amdgpu-pro_25.10-2187634.22.04_amd64.deb
+          sha256: 6dc87bc1bed2caabbd2c29effc3e95c39590069f07c382809906bb9e232c78a9


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly.   
This is a runtime providing the AMF runtime under the .GL extension endpoint. Currently flatpak's active-gl-drivers detection does not automatically load it—see https://github.com/flatpak/flatpak/pull/6287 —thus, `FLATPAK_GL_DRIVERS=default:amf` is required until then.
- [ ] ~~Please attach a video showcasing the application on Linux using the Flatpak.~~ None as this is a GL runtime extension
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [ ] contacted upstream developers about this submission. 

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
