### PR TITLE
Add org.cb.rgbkbd.controller

### DIFF
--- a/org.cb.rgbkbd.controller.yml
+++ b/org.cb.rgbkbd.controller.yml
@@ -1,0 +1,16 @@
+app-id: org.cb.rgbkbd.controller
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: cb_rgbkbd_controller.py
+modules:
+  - name: cb-rgbkbd-controller
+    buildsystem: simple
+    build-commands:
+      - install -D gui/cb_rgbkbd_controller.py /app/bin/cb_rgbkbd_controller.py
+      - install -D gui/rgb_utils.py /app/bin/rgb_utils.py
+      - install -D snap/gui/icon.png /app/share/icons/hicolor/256x256/apps/org.cb.rgbkbd.controller.png
+      - install -D snap/gui/cb-rgbkbd-controller.desktop /app/share/applications/org.cb.rgbkbd.controller.desktop
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
This Flatpak manifest adds CB-RGBKBD-CONTROLLER, a cross-platform RGB keyboard controller for Linux and ChromeOS. It includes:

GUI controller (cb_rgbkbd_controller.py)

Utility module (rgb_utils.py)

Desktop launcher and icon

Plugin-ready architecture

Originally packaged for Snapcraft, now ported to Flatpak for broader accessibility.