### PR TITLE
Add com.github.cristianocastro.gnome-backup

### DIFF
--- a/com.github.cristianocastro.gnome-backup/com.github.cristianocastro.gnome-backup.json
+++ b/com.github.cristianocastro.gnome-backup/com.github.cristianocastro.gnome-backup.json
@@ -1,0 +1,45 @@
+{
+    "app-id": "com.github.cristianocastro.gnome-backup",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "47",
+    "sdk": "org.gnome.Sdk",
+    "command": "gnome-extensions-backup",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=session-bus",
+        "--filesystem=xdg-data/gnome-shell/extensions:rw",
+        "--filesystem=home",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [
+        {
+            "name": "gnome-extensions-backup",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 main.py /app/bin/gnome-extensions-backup",
+                "install -Dm644 com.github.cristianocastro.gnome-backup.desktop /app/share/applications/com.github.cristianocastro.gnome-backup.desktop",
+                "install -Dm644 com.github.cristianocastro.gnome-backup.svg /app/share/icons/hicolor/scalable/apps/com.github.cristianocastro.gnome-backup.svg"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "path": "main.py"
+                },
+                {
+                    "type": "file",
+                    "path": "data/com.github.cristianocastro.gnome-backup.desktop",
+                    "dest-filename": "com.github.cristianocastro.gnome-backup.desktop"
+                },
+                {
+                    "type": "file",
+                    "path": "icons/com.github.cristianocastro.gnome-backup.svg",
+                    "dest-filename": "com.github.cristianocastro.gnome-backup.svg"
+                }
+            ]
+        }
+    ]
+}
+


### PR DESCRIPTION
GNOME Extensions Backup é uma ferramenta moderna baseada em GTK 4, criada para facilitar o backup e a restauração de extensões do GNOME Shell, incluindo arquivos de extensão e configurações registradas via dconf.

Principais recursos:
- Seleção individual ou em massa de extensões para backup
- Restauração automática do ambiente completo de extensões e configurações
- Interface intuitiva feita com GTK 4 e libadwaita, totalmente integrada ao GNOME
- Salva backups em arquivo compactado para portabilidade e segurança
- Utilitário confiável, ideal para usuários iniciantes e avançados do GNOME

Repositório: https://github.com/ccastromediaperformance/gnome-extensions-backup
Screenshot: https://github.com/ccastromediaperformance/gnome-extensions-backup/raw/main/screenshot.png

Esta submissão visa disponibilizar gratuitamente essa ferramenta no Flathub. Obrigado pela revisão e pelo incentivo ao software livre!
