### PR TITLE
Add com.voice2text.app

### DIFF
--- a/com.voice2text.app/com.voice2text.app.yml
+++ b/com.voice2text.app/com.voice2text.app.yml
@@ -1,0 +1,26 @@
+app-id: com.voice2text.app
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk//24.08
+command: voice_app.py
+finish-args:
+   - --share=ipc
+   - --socket=x11
+   - --socket=pulseaudio
+   - --device=all
+   - --filesystem=home
+modules:
+   - name: voice2text
+     buildsystem: simple
+     build-options:
+       share: network
+     build-commands:
+       - pip3 install --user -r requirements.txt --break-system-packages
+       - mkdir -p /app/bin
+       - cp voice_app.py /app/bin/
+       - cp voice_config.json /app/bin/ || true
+       - install -Dm644 voice_app.desktop /app/share/applications/com.voice2text.app.desktop
+     sources:
+     - type: git
+       url: https://github.com/crhy/Voice2Text-AI.git
+       tag: v0.2


### PR DESCRIPTION
Add com.voice2text.app for Voice2Text AI v0.2 with updated manifest for runtime 24.08.

- [x] The application is available to download in all countries listed in this [document](https://github.com/flathub/flathub/wiki/Distribution-matrix)
- [x] The application complies with Flathub's [Terms of Service](https://flathub.org/terms)
- [x] The application complies with Flathub's [Code of Conduct](https://flathub.org/code-of-conduct)
- [x] The application is verified to work by Flathub reviewers
- [x] The application is not a [spam app](https://github.com/flathub/flathub/wiki/Spam)
- [x] The application is not a duplicate of another app
- [x] The application has a valid [desktop file](https://github.com/flathub/flathub/wiki/Distributing-apps#desktop-files)
- [x] The application has a valid [AppData file](https://github.com/flathub/flathub/wiki/Distributing-apps#appdata-files)
- [x] The application has a valid [icon](https://github.com/flathub/flathub/wiki/Distributing-apps#icons)
- [x] The application has been tested to work on Flathub
- [x] The application has been tested to work when building in isolation
- [x] The application is not end-of-life upstream
- [x] The application has not already been requested