### PR TITLE
TSClient GTK RDP/SSH connection manager

### DIFF
--- a/com.tsclient.app.yml
+++ b/com.tsclient.app.yml
@@ -1,0 +1,33 @@
+app-id: com.tsclient.app
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: tsclient
+
+finish-args:
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+
+modules:
+  - name: rdesktop
+    buildsystem: autotools
+    config-opts:
+      - --prefix=/app
+      - --disable-smartcard
+    sources:
+      - type: archive
+        url: https://github.com/rdesktop/rdesktop/releases/download/v1.9.0/rdesktop-1.9.0.tar.gz
+        sha256: 473c2f312391379960efe41caad37852c59312bc8f100f9b5f26609ab5704288
+  - name: tsclient
+    buildsystem: simple
+    build-commands:
+      - make -C src
+      - install -D src/tsclient /app/bin/tsclient
+      - install -d /app/share/tsclient/icons
+      - cp -r icons/* /app/share/tsclient/icons/
+    sources:
+      # For local testing, build from your working tree
+      - type: dir
+        path: .


### PR DESCRIPTION
Add Flatpak manifest for TSClient (GTK 4-based RDP/SSH connection manager).