### PR TITLE
Add im.github.rallep71.DinoX

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "only-arches": ["x86_64", "aarch64"]
+}

--- a/im.github.rallep71.DinoX.json
+++ b/im.github.rallep71.DinoX.json
@@ -1,0 +1,182 @@
+{
+    "id": "im.github.rallep71.DinoX",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "48",
+    "sdk": "org.gnome.Sdk",
+    "command": "dinox",
+    "add-extensions": {
+        "org.freedesktop.Platform.ffmpeg-full": {
+            "directory": "lib/ffmpeg",
+            "version": "24.08",
+            "add-ld-path": "."
+        }
+    },
+    "cleanup-commands": [
+        "mkdir -p /app/lib/ffmpeg"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/cmake",
+        "/share/pkgconfig",
+        "/share/aclocal",
+        "/man",
+        "/share/man",
+        "/share/gtk-doc",
+        "*.la",
+        "*.a"
+    ],
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--socket=gpg-agent",
+        "--filesystem=xdg-run/pipewire-0",
+        "--share=network",
+        "--device=dri",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.ScreenSaver",
+        "--own-name=org.mpris.MediaPlayer2.Dino"
+    ],
+    "modules": [
+        {
+            "name": "protobuf",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-Dprotobuf_BUILD_TESTS=OFF",
+                "-Dprotobuf_BUILD_SHARED_LIBS=ON",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protobuf-cpp-3.21.12.tar.gz",
+                    "sha256": "4eab9b524aa5913c6fffb20b2a8abf5ef7f95a80bc0701f3a6dbb4c607f73460"
+                }
+            ]
+        },
+        {
+            "name": "libprotobuf-c",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/protobuf-c/protobuf-c/releases/download/v1.5.0/protobuf-c-1.5.0.tar.gz",
+                    "sha256": "7b404c63361ed35b3667aec75cc37b54298d56dd2bcf369de3373212cc06fd98"
+                }
+            ]
+        },
+        {
+            "name": "libomemo-c",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dtests=false",
+                "-Ddefault_library=static",
+                "--libdir=lib"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/dino/libomemo-c/releases/download/v0.5.1/libomemo-c-0.5.1.tar.gz",
+                    "sha512": "ff59565406c51663f2944e9a7c12c5b0e3fa01073039f5161472dd81f59194b1cf2685bc1e0cc930a141bc409b965c5d93313cfc3e0e237250102af3b5e88826",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 359676,
+                        "stable-only": true,
+                        "url-template": "https://github.com/dino/libomemo-c/releases/download/v$version/libomemo-c-$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "qrencode",
+            "buildsystem": "autotools",
+            "cleanup": [
+                "*"
+            ],
+            "build-options": {
+                "cflags": "-fPIC"
+            },
+            "config-opts": [
+                "--disable-shared"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/fukuchi/libqrencode/archive/refs/tags/v4.1.1.tar.gz",
+                    "sha512": "584106e7bcaaa1ef2efe63d653daad38d4ff436eb4b185a1db3c747169c1ffa74149c3b1329bb0b8ae007903db0a7034aabf135cc196d91a37b5c61348154a65",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 12834,
+                        "stable-only": true,
+                        "url-template": "https://github.com/fukuchi/libqrencode/archive/refs/tags/v$version.tar.gz"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "intltool",
+            "cleanup": [ "*" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+                    "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+                }
+            ]
+        },
+        {
+            "name": "libdbusmenu",
+            "buildsystem": "autotools",
+            "build-options": {
+                "cflags": "-Wno-error"
+            },
+            "config-opts": [
+                "--disable-dumper",
+                "--disable-tests",
+                "--disable-gtk",
+                "--with-gtk=no"
+            ],
+            "make-install-args": [
+                "typelibdir=/app/lib/girepository-1.0",
+                "girdir=/app/share/gir-1.0"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/rallep71/dinox/raw/vendor/vendor/libdbusmenu-16.04.0.tar.gz",
+                    "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+                },
+                {
+                    "type": "shell",
+                    "commands": [
+                        "sed -i '/AC_OUTPUT/i AM_CONDITIONAL([HAVE_VALGRIND], [test \"x$enable_valgrind\" = \"xyes\"])' configure.ac",
+                        "autoreconf -vfi"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "dinox",
+            "buildsystem": "meson",
+            "builddir": true,
+            "config-opts": [
+                "--libdir=lib"
+            ],
+            "cleanup": [
+                "/include",
+                "/share/vala"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/rallep71/dinox.git",
+                    "tag": "v0.7.1",
+                    "commit": "5ea98d993f067c0efb2dfbfbd9ea981621875a26"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## App Information

- **App ID:** im.github.rallep71.DinoX
- **App Name:** DinoX
- **Summary:** Modern XMPP Messenger for Linux with MUJI group calls
- **Category:** Communication
- **License:** GPL-3.0-or-later
- **Homepage:** https://dinox.handwerker.jetzt
- **Source:** https://github.com/rallep71/dinox

## Features

- OMEMO end-to-end encryption
- MUJI group video calls (mesh-based)
- Voice messages
- System Tray support
- Data backup
- 45 languages (100% translated)
- 67+ XEPs supported
- GTK4/libadwaita interface

## Checklist

- [x] App builds successfully locally
- [x] Manifest follows Flathub requirements
- [x] AppStream metadata included
- [x] Desktop file included
- [x] Icon included