### PR TITLE
Add org.kde.kwalletmanager

### DIFF
--- a/0001-Complete-rename-to-kwalletmanager.patch
+++ b/0001-Complete-rename-to-kwalletmanager.patch
@@ -1,0 +1,583 @@
+From 2ecd9b9fc0279c7d364f03971766034ce0d174ea Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timoth=C3=A9e=20Ravier?= <tim@siosm.fr>
+Date: Sat, 6 Dec 2025 13:04:30 +0100
+Subject: [PATCH 1/2] Complete rename to kwalletmanager
+
+See: https://invent.kde.org/utilities/kwalletmanager/-/merge_requests/51
+
+BUG: https://bugs.kde.org/show_bug.cgi?id=489916
+---
+ CMakeLists.txt                                |  8 +--
+ Mainpage.dox                                  |  6 +-
+ doc/index.docbook                             | 65 ++++++++++---------
+ ...desktop => kwalletmanager-kwalletd.desktop |  4 +-
+ ....xml => org.kde.kwalletmanager.appdata.xml | 12 ++--
+ org.kde.kwalletmanager.desktop                |  2 +-
+ src/konfigurator/CMakeLists.txt               | 22 +++----
+ src/konfigurator/konfigurator.cpp             | 12 ++--
+ src/konfigurator/kwallet.actions              |  2 +-
+ src/konfigurator/kwalletconfig.json           |  2 +-
+ src/konfigurator/savehelper.cpp               |  2 +-
+ src/manager/CMakeLists.txt                    | 24 +++----
+ src/manager/kwalletmanager.cpp                |  2 +-
+ src/manager/main.cpp                          |  2 +-
+ 14 files changed, 82 insertions(+), 83 deletions(-)
+ rename kwalletmanager5-kwalletd.desktop => kwalletmanager-kwalletd.desktop (98%)
+ rename org.kde.kwalletmanager5.appdata.xml => org.kde.kwalletmanager.appdata.xml (98%)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index de653062..749d0e83 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,7 +5,7 @@ set (RELEASE_SERVICE_VERSION_MAJOR "26")
+ set (RELEASE_SERVICE_VERSION_MINOR "03")
+ set (RELEASE_SERVICE_VERSION_MICRO "70")
+ set (RELEASE_SERVICE_VERSION "${RELEASE_SERVICE_VERSION_MAJOR}.${RELEASE_SERVICE_VERSION_MINOR}.${RELEASE_SERVICE_VERSION_MICRO}")
+-project(kwalletmanager5 VERSION ${RELEASE_SERVICE_VERSION})
++project(kwalletmanager VERSION ${RELEASE_SERVICE_VERSION})
+ 
+ set(QT_MIN_VERSION "6.7.0")
+ set(KF_MIN_VERSION "6.3.0")
+@@ -76,11 +76,11 @@ add_subdirectory( src )
+ 
+ 
+ ########### install files ###############
+-install( PROGRAMS org.kde.kwalletmanager.desktop kwalletmanager5-kwalletd.desktop  DESTINATION ${KDE_INSTALL_APPDIR})
+-install(FILES org.kde.kwalletmanager5.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
++install( PROGRAMS org.kde.kwalletmanager.desktop kwalletmanager-kwalletd.desktop  DESTINATION ${KDE_INSTALL_APPDIR})
++install(FILES org.kde.kwalletmanager.appdata.xml DESTINATION ${KDE_INSTALL_METAINFODIR})
+ ecm_generate_dbus_service_file(
+     NAME org.kde.kwalletmanager
+-    EXECUTABLE ${KDE_INSTALL_FULL_BINDIR}/kwalletmanager5
++    EXECUTABLE ${KDE_INSTALL_FULL_BINDIR}/kwalletmanager
+     DESTINATION ${KDE_INSTALL_DBUSSERVICEDIR}
+ )
+ 
+diff --git a/Mainpage.dox b/Mainpage.dox
+index a07e260b..134275db 100644
+--- a/Mainpage.dox
++++ b/Mainpage.dox
+@@ -1,8 +1,8 @@
+-/** @mainpage kwallet
++/** @mainpage kwalletmanager
+ 
+-The kwallet application
++The kwalletmanager application
+ 
+ */
+ 
+ // DOXYGEN_REFERENCES = kdecore
+-// DOXYGEN_SET_PROJECT_NAME = kwallet
++// DOXYGEN_SET_PROJECT_NAME = kwalletmanager
+diff --git a/doc/index.docbook b/doc/index.docbook
+index 5369d086..8f77355e 100644
+--- a/doc/index.docbook
++++ b/doc/index.docbook
+@@ -4,9 +4,9 @@
+   <!ENTITY % English "INCLUDE">
+ ]>
+ 
+-<book id="kwallet5" lang="&language;">
++<book id="kwalletmanager" lang="&language;">
+ <bookinfo>
+-<title>The &kwallet5; Handbook</title>
++<title>The &kwalletmanager; Handbook</title>
+ 
+ <authorgroup>
+ <author>
+@@ -38,6 +38,7 @@ passwords.</para>
+ <keywordset>
+ <keyword>KDE</keyword>
+ <keyword>Kwallet</keyword>
++<keyword>Kwalletmanager</keyword>
+ <keyword>passwords</keyword>
+ <keyword>forms</keyword>
+ </keywordset>
+@@ -52,7 +53,7 @@ which is sensitive.  In particular, you will typically have many passwords
+ to manage.  Remembering them is difficult and writing them down on paper or in
+ a text file is insecure.</para>
+ 
+-<para>&kwallet5; provides a secure way to store passwords and other secret information,
++<para>&kwalletmanager; provides a secure way to store passwords and other secret information,
+ allowing the user to remember only a single password instead of numerous different passwords and credentials.
+ </para>
+ 
+@@ -60,7 +61,7 @@ allowing the user to remember only a single password instead of numerous differe
+ 
+ <title>Create a Wallet</title>
+ 
+-<para>Wallet is a password storage. It is usually sufficient to have just one wallet secured by one master password but you can organize your large collection of passwords by wallets using &kwalletmanager5;.</para>
++<para>Wallet is a password storage. It is usually sufficient to have just one wallet secured by one master password but you can organize your large collection of passwords by wallets using &kwalletmanager;.</para>
+ 
+ <para>By default a wallet named <guilabel>kdewallet</guilabel> will be used to store your passwords.
+ This wallet is secured by your login password and will automatically be opened at login,
+@@ -73,16 +74,16 @@ if kwallet_pam is installed and properly configured. On certain distros (&eg; Ar
+ 
+ <itemizedlist>
+ <listitem><para>Use the menu item <menuchoice><guimenu>File</guimenu><guimenuitem>New
+-Wallet</guimenuitem></menuchoice> in the &kwalletmanager5;</para></listitem>
++Wallet</guimenuitem></menuchoice> in the &kwalletmanager;</para></listitem>
+ 
+ <listitem><para>Use the <guibutton>New</guibutton> button in the &systemsettings; module
+ <guilabel>KDE Wallet</guilabel></para></listitem>
+ </itemizedlist>
+ 
+-<para>If you have not created a wallet yet, see section <link linkend="kwallet-using">Using &kwallet5;</link>.
++<para>If you have not created a wallet yet, see section <link linkend="kwallet-using">Using &kwalletmanager;</link>.
+ </para>
+ 
+-<para>&kwallet5; offers two different ways to store your data:</para>
++<para>&kwalletmanager; offers two different ways to store your data:</para>
+ 
+ <screenshot>
+ <screeninfo>Select encryption</screeninfo>
+@@ -97,7 +98,7 @@ Wallet</guimenuitem></menuchoice> in the &kwalletmanager5;</para></listitem>
+ <varlistentry>
+ <term>Blowfish encryption</term>
+ <listitem>
+-<para>&kwallet5; saves this sensitive data for you in a strongly encrypted
++<para>&kwalletmanager; saves this sensitive data for you in a strongly encrypted
+ file, accessible by all applications, and protected with a master
+ password that you define.</para>
+ 
+@@ -145,13 +146,13 @@ found on the system. Please use applications like &kgpg; or &kleopatra; to creat
+ </mediaobject>
+ </screenshot>
+ 
+-<para>&kwallet5; will now use GPG when storing wallets and when opening them.
++<para>&kwalletmanager; will now use GPG when storing wallets and when opening them.
+ The passphrase dialog only shows once. Even if the wallet is closed after initial open,
+ subsequent opening will occur silently during the same session.
+ </para>
+ 
+ <para>
+-The same session can handle simultaneously both file formats. &kwallet5; will transparently detect
++The same session can handle simultaneously both file formats. &kwalletmanager; will transparently detect
+ the file format and load the correct backend to handle it.</para>
+ 
+ <para>
+@@ -159,7 +160,7 @@ To use your sensitive data from your classic wallet with the new backend follow
+ 
+ <itemizedlist>
+ <listitem><para>Create a new GPG based wallet</para></listitem>
+-<listitem><para>Launch &kwalletmanager5; using &krunner; (<keycombo>&Alt; <keycap>F2</keycap></keycombo>)
++<listitem><para>Launch &kwalletmanager; using &krunner; (<keycombo>&Alt; <keycap>F2</keycap></keycombo>)
+ or other application launcher (menu) and select your old wallet.
+ Then choose <menuchoice><guimenu>File</guimenu>
+ <guimenuitem>Export as encrypted</guimenuitem></menuchoice> to create an archive file with your sensitive data.
+@@ -185,10 +186,10 @@ in <userinput>qtpaths --paths GenericDataLocation</userinput>.
+ </variablelist>
+ 
+ <tip>
+-<para>&kwallet5; supports multiple wallets, so
++<para>&kwalletmanager; supports multiple wallets, so
+ for the most secure operation, you should use one wallet for local
+ passwords, and another for network passwords and form data.  You can
+-configure this behavior in the &kwallet5; &systemsettings; module, however
++configure this behavior in the &kwalletmanager; &systemsettings; module, however
+ the default setting is to store everything in one wallet named <guilabel>kdewallet</guilabel>.</para>
+ </tip>
+ 
+@@ -198,7 +199,7 @@ be read by any user process, so this may be a security issue.</para>
+ </sect1>
+ 
+ <sect1 id="kwallet-using">
+-<title>Using &kwallet5;</title>
++<title>Using &kwalletmanager;</title>
+ 
+ <para>If you visit &eg; the &kde; bugtracker and enter the login data for
+ the first time, a dialog pops up offering to store the password in an
+@@ -247,26 +248,26 @@ the wallet, it can automatically restore any login information stored in the wal
+ 
+ </chapter>
+ 
+-<chapter id="kwalletmanager5">
+-<title>&kwalletmanager5;</title>
++<chapter id="kwalletmanager">
++<title>&kwalletmanager;</title>
+ 
+-<para>&kwalletmanager5; serves a number of functions.  Firstly it allows you to see if
++<para>&kwalletmanager; serves a number of functions.  Firstly it allows you to see if
+ any wallets are open, which wallets those are, and which applications are
+ using each wallet.  You can disconnect an application's access to a wallet
+-from within the &kwalletmanager5;.</para>
++from within the &kwalletmanager;.</para>
+ 
+ <para>You may also manage the wallets installed on the system, creating and
+ deleting wallets and manipulating their contents (changing keys, ...).</para>
+ 
+-<para>The &kwalletmanager5; application is launched with <menuchoice>
++<para>The &kwalletmanager; application is launched with <menuchoice>
+ <guimenu>Applications</guimenu><guisubmenu>System</guisubmenu>
+ <guimenuitem>Wallet Management Tool</guimenuitem></menuchoice> from the
+ application launcher.
+ Alternatively start &krunner; with shortcut <keycombo
+ action="simul">&Alt;<keycap>F2</keycap></keycombo> and enter
+-<command>kwalletmanager5</command>.</para>
++<command>kwalletmanager</command>.</para>
+ 
+-<para>Click once on the system tray wallet icon to display the &kwalletmanager5;
++<para>Click once on the system tray wallet icon to display the &kwalletmanager;
+ window.</para>
+ <para>
+ <screenshot>
+@@ -293,7 +294,7 @@ see also https://bugs.kde.org/show_bug.cgi?id=290309
+ 
+ <para>If you have more than one wallet all available wallets are shown on the left.</para>
+ 
+-<para>Clicking on a wallet in the &kwalletmanager5; window will display
++<para>Clicking on a wallet in the &kwalletmanager; window will display
+ that wallet's status and the contents of an opened wallet. A wallet may contain any number
+ of folders, which allow storing of password information. By default a wallet
+ will contain folders named Form Data and Passwords.
+@@ -403,18 +404,18 @@ Use the button right of each entry in the list to revoke the access.
+ </chapter>
+ 
+ <chapter id="kwallet-kcontrol-module">
+-<title>Configuring &kwallet5;</title>
++<title>Configuring &kwalletmanager;</title>
+ 
+ <sect1 id="wallet-preferences">
+ <title>Wallet Preferences</title>
+ 
+-<para>&kwallet5; contains a small configuration panel with several options
+-that allow you to tune &kwallet5; to your personal preferences.  The
+-default settings for &kwallet5; are sufficient for most users.</para>
++<para>&kwalletmanager; contains a small configuration panel with several options
++that allow you to tune &kwalletmanager; to your personal preferences.  The
++default settings for &kwalletmanager; are sufficient for most users.</para>
+ 
+ <para>Check the box to enable or disable the &kde; wallet subsystem
+-entirely.  If this box is unchecked, then &kwallet5; is entirely disabled and
+-none of the other options here have any effect, nor will &kwallet5; record
++entirely.  If this box is unchecked, then &kwalletmanager; is entirely disabled and
++none of the other options here have any effect, nor will &kwalletmanager; record
+ any information, or offer to fill in forms for you.</para>
+ 
+ <variablelist>
+@@ -489,7 +490,7 @@ system tray.</para>
+ 
+ <para>Finally, there is a button labeled <guibutton>Launch Wallet
+ Manager</guibutton>, which does precisely that.</para>
+-<para>This button is only visible if &kwalletmanager5; is not running</para>
++<para>This button is only visible if &kwalletmanager; is not running</para>
+ </sect1>
+ 
+ <sect1 id="wallet-access-control">
+@@ -531,7 +532,7 @@ context menu that appears, or by simply selecting it and pressing the
+ <para>An application that has been allowed access to a wallet is granted access to
+ all passwords stored inside.</para>
+ 
+-<para>If you erroneously configured an application not to use the &kwallet5;
++<para>If you erroneously configured an application not to use the &kwalletmanager;
+ delete the policy for this application here.</para>
+ <!-- FIXME difference to Revoke Authorization in kwallermanager?-->
+ <para>
+@@ -557,7 +558,7 @@ On the next start of this application you can define a new policy for access to
+ <chapter id="advanced-features">
+ <title>Advanced Features</title>
+ 
+-<para>Wallets can be dragged from the &kwalletmanager5; window.  This allows
++<para>Wallets can be dragged from the &kwalletmanager; window.  This allows
+ you to drag the wallet to a file browser window, where you can choose to
+ copy, move, or link the wallet, as desired.</para>
+ 
+@@ -570,7 +571,7 @@ on a vacation, and still have easy access to important sites.</para>
+ <chapter id="credits-and-license">
+ <title>Credits and License</title>
+ 
+-<para>&kwallet5; &copy; 2003 &George.Staikos;</para>
++<para>&kwalletmanager; &copy; 2003 &George.Staikos;</para>
+ <para>Documentation &copy; &Lauri.Watts; and &George.Staikos;</para>
+ 
+ <!-- TRANS:CREDIT_FOR_TRANSLATORS -->
+diff --git a/kwalletmanager5-kwalletd.desktop b/kwalletmanager-kwalletd.desktop
+similarity index 98%
+rename from kwalletmanager5-kwalletd.desktop
+rename to kwalletmanager-kwalletd.desktop
+index 0944a4af..ebe1d9b9 100755
+--- a/kwalletmanager5-kwalletd.desktop
++++ b/kwalletmanager-kwalletd.desktop
+@@ -129,9 +129,9 @@ GenericName[tr]=Parola Yöneticisi
+ GenericName[uk]=Менеджер паролів
+ GenericName[zh_CN]=密码管理器
+ GenericName[zh_TW]=密碼管理員
+-Exec=kwalletmanager5 --kwalletd
++Exec=kwalletmanager --kwalletd
+ Icon=kwalletmanager
+ Type=Application
+ StartupNotify=false
+ NoDisplay=true
+-X-DocPath=help:/kwallet5/index.html
++X-DocPath=help:/kwalletmanager/index.html
+diff --git a/org.kde.kwalletmanager5.appdata.xml b/org.kde.kwalletmanager.appdata.xml
+similarity index 98%
+rename from org.kde.kwalletmanager5.appdata.xml
+rename to org.kde.kwalletmanager.appdata.xml
+index 07e92924..059340a3 100644
+--- a/org.kde.kwalletmanager5.appdata.xml
++++ b/org.kde.kwalletmanager.appdata.xml
+@@ -1,6 +1,6 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <component type="desktop-application">
+-  <id>org.kde.kwalletmanager5</id>
++  <id>org.kde.kwalletmanager</id>
+   <metadata_license>FSFAP</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+   <developer id="org.kde">
+@@ -133,8 +133,8 @@
+   </description>
+   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?format=guided&amp;product=kwalletmanager</url>
+   <url type="donation">https://www.kde.org/community/donations/?app=kwalletmanager&amp;source=appdata</url>
+-  <url type="help">https://docs.kde.org/?application=kwallet5</url>
+-  <url type="homepage">https://apps.kde.org/kwalletmanager5</url>
++  <url type="help">https://docs.kde.org/?application=kwalletmanager</url>
++  <url type="homepage">https://apps.kde.org/kwalletmanager</url>
+   <content_rating type="oars-1.1"/>
+   <screenshots>
+     <screenshot type="default">
+@@ -143,8 +143,12 @@
+   </screenshots>
+   <project_group>KDE</project_group>
+   <provides>
+-    <binary>kwalletmanager5</binary>
++    <binary>kwalletmanager</binary>
++    <id>org.kde.kwalletmanager5</id>
+   </provides>
++  <replaces>
++    <id>org.kde.kwalletmanager5</id>
++  </replaces>
+   <launchable type="desktop-id">org.kde.kwalletmanager.desktop</launchable>
+   <releases>
+     <release version="25.12.0" date="2025-12-11"/>
+diff --git a/org.kde.kwalletmanager.desktop b/org.kde.kwalletmanager.desktop
+index 57e9faca..73f54280 100755
+--- a/org.kde.kwalletmanager.desktop
++++ b/org.kde.kwalletmanager.desktop
+@@ -129,7 +129,7 @@ GenericName[tr]=Parola Yöneticisi
+ GenericName[uk]=Менеджер паролів
+ GenericName[zh_CN]=密码管理器
+ GenericName[zh_TW]=密碼管理員
+-Exec=kwalletmanager5 %F
++Exec=kwalletmanager %F
+ MimeType=application/x-kwallet;
+ InitialPreference=6
+ Icon=kwalletmanager
+diff --git a/src/konfigurator/CMakeLists.txt b/src/konfigurator/CMakeLists.txt
+index cba75123..12c3ce03 100644
+--- a/src/konfigurator/CMakeLists.txt
++++ b/src/konfigurator/CMakeLists.txt
+@@ -1,14 +1,14 @@
+ ########### next target ###############
+ add_definitions(-DTRANSLATION_DOMAIN=\"kcmkwallet\")
+ 
+-add_library(kcm_kwallet5 MODULE)
+-target_sources(kcm_kwallet5 PRIVATE konfigurator.cpp konfigurator.h)
++add_library(kcm_kwallet MODULE)
++target_sources(kcm_kwallet PRIVATE konfigurator.cpp konfigurator.h)
+ 
+-ki18n_wrap_ui(kcm_kwallet5 walletconfigwidget.ui )
++ki18n_wrap_ui(kcm_kwallet walletconfigwidget.ui )
+ 
+ 
+ 
+-target_link_libraries(kcm_kwallet5
++target_link_libraries(kcm_kwallet
+     Qt6::Core
+     KF6::AuthCore
+     KF6::CoreAddons
+@@ -18,21 +18,21 @@ target_link_libraries(kcm_kwallet5
+     Qt6::DBus
+ )
+ 
+-install(TARGETS kcm_kwallet5  DESTINATION ${KDE_INSTALL_PLUGINDIR}/plasma/kcms/systemsettings_qwidgets)
++install(TARGETS kcm_kwallet  DESTINATION ${KDE_INSTALL_PLUGINDIR}/plasma/kcms/systemsettings_qwidgets)
+ 
+ ########### kauth helper ################
+-add_executable(kcm_kwallet_helper5)
+-target_sources(kcm_kwallet_helper5 PRIVATE savehelper.cpp savehelper.h)
++add_executable(kcm_kwallet_helper)
++target_sources(kcm_kwallet_helper PRIVATE savehelper.cpp savehelper.h)
+ 
+-target_link_libraries(kcm_kwallet_helper5
++target_link_libraries(kcm_kwallet_helper
+     Qt6::Core
+     KF6::AuthCore
+     KF6::Wallet
+     KF6::CoreAddons
+ )
+ 
+-install(TARGETS kcm_kwallet_helper5 DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
++install(TARGETS kcm_kwallet_helper DESTINATION ${KAUTH_HELPER_INSTALL_DIR})
+ 
+-kauth_install_helper_files(kcm_kwallet_helper5 org.kde.kcontrol.kcmkwallet5 root)
+-kauth_install_actions(org.kde.kcontrol.kcmkwallet5 kwallet.actions)
++kauth_install_helper_files(kcm_kwallet_helper org.kde.kcontrol.kcmkwallet root)
++kauth_install_actions(org.kde.kcontrol.kcmkwallet kwallet.actions)
+ 
+diff --git a/src/konfigurator/konfigurator.cpp b/src/konfigurator/konfigurator.cpp
+index 36ad4b9a..95ef3936 100644
+--- a/src/konfigurator/konfigurator.cpp
++++ b/src/konfigurator/konfigurator.cpp
+@@ -37,7 +37,7 @@ KWalletConfig::KWalletConfig(QObject *parent, const KPluginMetaData &data)
+     , _wcw(new WalletConfigWidget(widget()))
+     , _cfg(KSharedConfig::openConfig(QStringLiteral("kwalletrc"), KConfig::NoGlobals))
+ {
+-    setAuthActionName(QStringLiteral("org.kde.kcontrol.kcmkwallet5.save"));
++    setAuthActionName(QStringLiteral("org.kde.kcontrol.kcmkwallet.save"));
+     auto vbox = new QVBoxLayout(widget());
+     vbox->setContentsMargins(0, 0, 0, 0);
+     vbox->addWidget(_wcw);
+@@ -144,10 +144,10 @@ void KWalletConfig::newNetworkWallet()
+ 
+ void KWalletConfig::launchManager()
+ {
+-    if (!QDBusConnection::sessionBus().interface()->isServiceRegistered(QStringLiteral("org.kde.kwalletmanager5"))) {
+-        QProcess::startDetached(QStringLiteral("kwalletmanager5"), QStringList(QStringLiteral("--show")));
++    if (!QDBusConnection::sessionBus().interface()->isServiceRegistered(QStringLiteral("org.kde.kwalletmanager"))) {
++        QProcess::startDetached(QStringLiteral("kwalletmanager"), QStringList(QStringLiteral("--show")));
+     } else {
+-        QDBusInterface kwalletd(QStringLiteral("org.kde.kwalletmanager5"), QStringLiteral("/kwalletmanager5/MainWindow_1"));
++        QDBusInterface kwalletd(QStringLiteral("org.kde.kwalletmanager"), QStringLiteral("/kwalletmanager/MainWindow_1"));
+         kwalletd.call(QStringLiteral("show"));
+         kwalletd.call(QStringLiteral("raise"));
+     }
+@@ -240,8 +240,8 @@ void KWalletConfig::load()
+ void KWalletConfig::save()
+ {
+     QVariantMap args;
+-    KAuth::Action action(QLatin1String("org.kde.kcontrol.kcmkwallet5.save"));
+-    action.setHelperId(QStringLiteral("org.kde.kcontrol.kcmkwallet5"));
++    KAuth::Action action(QLatin1String("org.kde.kcontrol.kcmkwallet.save"));
++    action.setHelperId(QStringLiteral("org.kde.kcontrol.kcmkwallet"));
+ 
+     widget()->window()->winId();
+     action.setParentWindow(widget()->window()->windowHandle());
+diff --git a/src/konfigurator/kwallet.actions b/src/konfigurator/kwallet.actions
+index e65c66bf..43741b58 100644
+--- a/src/konfigurator/kwallet.actions
++++ b/src/konfigurator/kwallet.actions
+@@ -55,7 +55,7 @@ Name[zh_CN]=KDE 密码库系统
+ Name[zh_TW]=KDE 錢包系統
+ Icon=kwalletmanager
+ 
+-[org.kde.kcontrol.kcmkwallet5.save]
++[org.kde.kcontrol.kcmkwallet.save]
+ Name=Save wallet configuration
+ Name[ar]=احفظ ضبط المحفظة
+ Name[az]=Cüzdan tənzimləmələrini saxlamaq
+diff --git a/src/konfigurator/kwalletconfig.json b/src/konfigurator/kwalletconfig.json
+index ca080bf8..5e51b171 100644
+--- a/src/konfigurator/kwalletconfig.json
++++ b/src/konfigurator/kwalletconfig.json
+@@ -117,7 +117,7 @@
+         "Name[zh_CN]": "KDE 密码库",
+         "Name[zh_TW]": "KDE 錢包"
+     },
+-    "X-DocPath": "kwallet5/kwallet-kcontrol-module.html",
++    "X-DocPath": "kwalletmanager/kwallet-kcontrol-module.html",
+     "X-KDE-Keywords": "wallet,form fill,passwords,form data,secret service,kwallet,kdewallet,kde wallet,keepassxc,keyring,encryption,decryption,blowfish,pgp,access control,confidential,wallet manager",
+     "X-KDE-Keywords[ar]": "محفظة,مدير محفظة,أسرار,خدمة الأسرار,محفظتك,تعمية,تعمية,فك التعمية,تحكم,الوصول,كلمة السر,كلمة مرور,سرية",
+     "X-KDE-Keywords[bg]": "портфейл, попълване на формуляр, пароли, данни от формуляр, тайна служба, kwallet, kdewallet, kde портфейл,keepassxc,ключодържател,шифроване,декриптиране,blowfish,pgp,контрол на достъпа,поверително, мениджър на портфейла",
+diff --git a/src/konfigurator/savehelper.cpp b/src/konfigurator/savehelper.cpp
+index 6ae4ac90..de317606 100644
+--- a/src/konfigurator/savehelper.cpp
++++ b/src/konfigurator/savehelper.cpp
+@@ -20,6 +20,6 @@ ActionReply SaveHelper::save(const QVariantMap &args)
+     return ActionReply::SuccessReply();
+ }
+ 
+-KAUTH_HELPER_MAIN("org.kde.kcontrol.kcmkwallet5", SaveHelper)
++KAUTH_HELPER_MAIN("org.kde.kcontrol.kcmkwallet", SaveHelper)
+ 
+ #include "moc_savehelper.cpp"
+diff --git a/src/manager/CMakeLists.txt b/src/manager/CMakeLists.txt
+index 4d0efaad..72619c5d 100644
+--- a/src/manager/CMakeLists.txt
++++ b/src/manager/CMakeLists.txt
+@@ -1,6 +1,5 @@
+-########### next target ###############
+-add_executable(kwalletmanager5)
+-target_sources(kwalletmanager5 PRIVATE
++add_executable(kwalletmanager)
++target_sources(kwalletmanager PRIVATE
+     kwalletmanager.cpp
+     kwalletmanagerwidget.cpp
+     kwalletmanagerwidgetitem.cpp
+@@ -46,30 +45,28 @@ target_sources(kwalletmanager5 PRIVATE
+     kwalletmanager.qrc
+ )
+ 
+-ecm_qt_declare_logging_category(kwalletmanager5
++ecm_qt_declare_logging_category(kwalletmanager
+                                 HEADER kwalletmanager_debug.h
+                                 IDENTIFIER KWALLETMANAGER_LOG
+-				CATEGORY_NAME org.kde.kwalletmanager DESCRIPTION "kwalletmanager" EXPORT KWALLETMANAGER)
++                                CATEGORY_NAME org.kde.kwalletmanager DESCRIPTION "kwalletmanager" EXPORT KWALLETMANAGER)
+ 
+ qt_add_dbus_interface(kwalletmanager_SRCS
+     ${KWALLET_DBUS_INTERFACES_DIR}/kf6_org.kde.KWallet.xml kwallet_interface
+ )
+-target_sources(kwalletmanager5 PRIVATE ${kwalletmanager_SRCS})
++target_sources(kwalletmanager PRIVATE ${kwalletmanager_SRCS})
+ 
+-ki18n_wrap_ui(kwalletmanager5
++ki18n_wrap_ui(kwalletmanager
+     walletwidget.ui
+     kbetterthankdialogbase.ui
+     walletcontrolwidget.ui
+     applicationsmanager.ui
+ )
+ 
+-
+ # Sets the icon on Windows and OSX
+ file(GLOB ICONS_SRCS "${CMAKE_CURRENT_SOURCE_DIR}/icons/*-apps-kwalletmanager.png")
+-ecm_add_app_icon(kwalletmanager5 ICONS ${ICONS_SRCS})
++ecm_add_app_icon(kwalletmanager ICONS ${ICONS_SRCS})
+ 
+-
+-target_link_libraries(kwalletmanager5
++target_link_libraries(kwalletmanager
+     Qt6::Core
+     KF6::CoreAddons
+     KF6::I18n
+@@ -88,9 +85,6 @@ target_link_libraries(kwalletmanager5
+     KF6::StatusNotifierItem
+ )
+ 
+-install(TARGETS kwalletmanager5  ${KDE_INSTALL_TARGETS_DEFAULT_ARGS} )
++install(TARGETS kwalletmanager ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
+ 
+ add_subdirectory(icons)
+-
+-########### install files ###############
+-
+diff --git a/src/manager/kwalletmanager.cpp b/src/manager/kwalletmanager.cpp
+index 723585a2..ede02585 100644
+--- a/src/manager/kwalletmanager.cpp
++++ b/src/manager/kwalletmanager.cpp
+@@ -404,7 +404,7 @@ void KWalletManager::shuttingDown()
+ 
+ void KWalletManager::setupWallet()
+ {
+-    auto job = new KIO::CommandLauncherJob(QStringLiteral("kcmshell6"), {QStringLiteral("kcm_kwallet5")});
++    auto job = new KIO::CommandLauncherJob(QStringLiteral("kcmshell6"), {QStringLiteral("kcm_kwallet")});
+     job->start();
+ }
+ 
+diff --git a/src/manager/main.cpp b/src/manager/main.cpp
+index a9ca63fc..7797ee59 100644
+--- a/src/manager/main.cpp
++++ b/src/manager/main.cpp
+@@ -29,7 +29,7 @@ int main(int argc, char **argv)
+                          KAboutLicense::GPL,
+                          i18n("Copyright ©2013–2017, KWallet Manager authors"),
+                          QString(),
+-                         QStringLiteral("https://apps.kde.org/kwalletmanager5"));
++                         QStringLiteral("https://apps.kde.org/kwalletmanager"));
+ 
+     aboutData.addAuthor(i18nc("@info:credit", "Valentin Rusu"), i18n("Former Maintainer, user interface refactoring"), QStringLiteral("kde@rusu.info"));
+     aboutData.addAuthor(i18nc("@info:credit", "George Staikos"), i18n("Original author and former maintainer"), QStringLiteral("staikos@kde.org"));
+-- 
+2.52.0
+

--- a/0002-manager-Drop-old-icons.patch
+++ b/0002-manager-Drop-old-icons.patch
@@ -1,0 +1,41 @@
+From cf09650c3f9b5c81964fced35b4b6af467b82e6e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timoth=C3=A9e=20Ravier?= <tim@siosm.fr>
+Date: Sat, 6 Dec 2025 12:41:49 +0100
+Subject: [PATCH 2/2] manager: Drop old icons
+
+---
+ src/manager/icons/128-apps-kwalletmanager2.png | Bin 23807 -> 0 bytes
+ src/manager/icons/16-apps-kwalletmanager2.png  | Bin 1006 -> 0 bytes
+ src/manager/icons/32-apps-kwalletmanager2.png  | Bin 2710 -> 0 bytes
+ src/manager/icons/48-apps-kwalletmanager2.png  | Bin 5249 -> 0 bytes
+ src/manager/icons/64-apps-kwalletmanager2.png  | Bin 8090 -> 0 bytes
+ src/manager/icons/CMakeLists.txt               |   6 ------
+ 6 files changed, 6 deletions(-)
+ delete mode 100644 src/manager/icons/128-apps-kwalletmanager2.png
+ delete mode 100644 src/manager/icons/16-apps-kwalletmanager2.png
+ delete mode 100644 src/manager/icons/32-apps-kwalletmanager2.png
+ delete mode 100644 src/manager/icons/48-apps-kwalletmanager2.png
+ delete mode 100644 src/manager/icons/64-apps-kwalletmanager2.png
+
+diff --git a/src/manager/icons/CMakeLists.txt b/src/manager/icons/CMakeLists.txt
+index 7419eed9..c9c55e10 100644
+--- a/src/manager/icons/CMakeLists.txt
++++ b/src/manager/icons/CMakeLists.txt
+@@ -1,14 +1,8 @@
+ ecm_install_icons( ICONS
+-128-apps-kwalletmanager2.png
+ 128-apps-kwalletmanager.png
+-16-apps-kwalletmanager2.png
+ 16-apps-kwalletmanager.png
+ 22-apps-kwalletmanager.png
+-32-apps-kwalletmanager2.png
+ 32-apps-kwalletmanager.png
+-48-apps-kwalletmanager2.png
+ 48-apps-kwalletmanager.png
+-64-apps-kwalletmanager2.png
+ 64-apps-kwalletmanager.png
+ DESTINATION ${KDE_INSTALL_ICONDIR} )
+-
+-- 
+2.52.0
+

--- a/org.kde.kwalletmanager.json
+++ b/org.kde.kwalletmanager.json
@@ -1,0 +1,47 @@
+{
+    "id": "org.kde.kwalletmanager",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.10",
+    "sdk": "org.kde.Sdk",
+    "command": "kwalletmanager",
+    "finish-args": [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--talk-name=org.kde.kwalletd5",
+        "--talk-name=org.kde.kwalletd6"
+    ],
+    "rename-icon": "kwalletmanager",
+    "modules": [
+        {
+            "name": "kwalletmanager",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DENABLE_KAUTH=OFF",
+                "-DBUILD_DOC=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.kde.org/stable/release-service/25.08.3/src/kwalletmanager-25.08.3.tar.xz",
+                    "sha256": "54b6b63eb55fd554d31215319c20bbafd2e1bf948ab6b4fa4d84b5614b6dc52d",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 8763,
+                        "stable-only": true,
+                        "url-template": "https://download.kde.org/stable/release-service/$version/src/kwalletmanager-$version.tar.xz"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Complete-rename-to-kwalletmanager.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "0002-manager-Drop-old-icons.patch"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Renamed from: https://github.com/flathub/org.kde.kwalletmanager5 / https://flathub.org/en/apps/org.kde.kwalletmanager5 due to upstream name change.

### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.
  - `KWalletManager is a tool to manage the passwords on your system. By using the Frameworks wallet subsystem it not only allows you to keep your own secrets but also to access and manage the passwords of every application that integrates with the wallet.`
- [x] Please attach a video showcasing the application on Linux using the Flatpak.
  - No doing that for now as it's only a rename for an app that already exists.
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an upstream contributor to the project.

@flathub/kde 

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
