### PR TITLE
Fix link to slow connection instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-slow-connection.md
+++ b/.github/ISSUE_TEMPLATE/3-slow-connection.md
@@ -4,7 +4,7 @@ about: "Report slow downloads from Flathub"
 title: "Slow downloads from Flathub (dl.flathub.org) — <Country/ISP>"
 ---
 
-<!-- For detailed instructions, see: https://flathub.org/docs/for-users/slow-connection -->
+<!-- For detailed instructions, see: https://docs.flathub.org/docs/for-users/slow-connection -->
 
 ### Problem Description
 


### PR DESCRIPTION
Updated the link for detailed instructions on reporting slow downloads.

