### PR TITLE
Add dev.hyperpolymath.Bunsenite

### DIFF
--- a/dev.hyperpolymath.Bunsenite.metainfo.xml
+++ b/dev.hyperpolymath.Bunsenite.metainfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>dev.hyperpolymath.Bunsenite</id>
+  <name>Bunsenite</name>
+  <summary>Nickel configuration file parser with multi-language FFI bindings</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      Bunsenite is a Nickel configuration file parser with multi-language
+      FFI bindings. It provides a Rust core library with a stable C ABI
+      layer that enables bindings for Deno, Rescript, and WebAssembly.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Type Safety: Compile-time guarantees via Rust's type system</li>
+      <li>Memory Safety: Rust ownership model, zero unsafe blocks</li>
+      <li>Offline-First: Works completely air-gapped</li>
+      <li>Multi-Language: FFI bindings for Deno, Rescript, and WASM</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/hyperpolymath/bunsenite</url>
+  <url type="bugtracker">https://github.com/hyperpolymath/bunsenite/issues</url>
+
+  <provides>
+    <binary>bunsenite</binary>
+  </provides>
+
+  <releases>
+    <release version="1.0.2" date="2025-12-13">
+      <description>
+        <p>Version 1.0.2 release</p>
+      </description>
+    </release>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+
+  <categories>
+    <category>Development</category>
+    <category>Utility</category>
+  </categories>
+
+  <keywords>
+    <keyword>nickel</keyword>
+    <keyword>config</keyword>
+    <keyword>parser</keyword>
+  </keywords>
+</component>

--- a/dev.hyperpolymath.Bunsenite.yml
+++ b/dev.hyperpolymath.Bunsenite.yml
@@ -1,0 +1,30 @@
+app-id: dev.hyperpolymath.Bunsenite
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+
+command: bunsenite
+
+finish-args:
+  - --filesystem=home:ro
+  - --filesystem=xdg-config:ro
+
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin
+  env:
+    CARGO_HOME: /run/build/bunsenite/cargo
+    RUSTUP_HOME: /usr/lib/sdk/rust-stable
+
+modules:
+  - name: bunsenite
+    buildsystem: simple
+    build-commands:
+      - cargo build --release --features full
+      - install -Dm755 target/release/bunsenite /app/bin/bunsenite
+    sources:
+      - type: git
+        url: https://github.com/hyperpolymath/bunsenite.git
+        tag: v1.0.2
+        commit: 09f2de9ec76e43e3edb42d6b024efa9a4c186a19


### PR DESCRIPTION
## App Information

- App ID: `dev.hyperpolymath.Bunsenite`
- Name: Bunsenite
- License: MIT

## Description

Bunsenite is a Nickel configuration file parser with multi-language FFI bindings. It provides a Rust core library with a stable C ABI layer that enables bindings for Deno, Rescript, and WebAssembly.

## Features

- Type Safety: Compile-time guarantees via Rust's type system
- Memory Safety: Rust ownership model, zero unsafe blocks
- Offline-First: Works completely air-gapped
- Multi-Language: FFI bindings for Deno, Rescript, and WASM

## Links

- Homepage: https://github.com/hyperpolymath/bunsenite
- Release: https://github.com/hyperpolymath/bunsenite/releases/tag/v1.0.2

## Checklist

- [x] App has a valid metainfo.xml
- [x] App is console-application type (CLI tool)
- [x] Manifest pins to specific git commit
- [x] Uses freedesktop runtime 23.08