### PR TITLE
Add org.kde.kjournaldbrowser

### DIFF
--- a/org.kde.kjournaldbrowser.yml
+++ b/org.kde.kjournaldbrowser.yml
@@ -1,0 +1,27 @@
+id: org.kde.kjournaldbrowser
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: kjournaldbrowser
+finish-args:
+  # X11
+  - --share=ipc
+  # Windowing
+  - --socket=fallback-x11
+  - --socket=wayland
+  # Hardware Acceleration
+  - --device=dri
+  # Browse the system journal
+  - --filesystem=/var/log/journal:ro
+modules:
+  - name: kjournald
+    buildsystem: cmake-ninja
+    sources:
+      - type: archive
+        url: https://download.kde.org/stable/release-service/26.04.3/src/kjournald-26.04.3.tar.xz
+        sha256: 6a97ac76c006dcd0ccdb33933ab71c611b79cc9ae20666deb8074a8ac43993ce
+        x-checker-data:
+          type: anitya
+          project-id: 8763
+          stable-only: true
+          url-template: https://download.kde.org/stable/release-service/$version/src/kjournald-$version.tar.xz


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

This PR is  related to a required linter exception: https://github.com/flathub-infra/flatpak-builder-lint/pull/798

- [X] Please describe the application briefly. < Please insert the description here >
KJournaldbrowser is a log viewer application for systemd's journald journal. It provides different filters and graphical highlights. The application is released as part of the KDE application releases.
- [X] Please attach a video showcasing the application on Linux using the Flatpak.  [kjournald_20251218_090912.webm](https://github.com/user-attachments/assets/0ea1f301-4a86-40d7-9880-51d50c3db68a)
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an upstream contributor to the project.
      If not, I contacted upstream developers about this submission. **Link:**

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
