### PR TITLE
Add AutoClean 1.0.0 by CrowDEV

### DIFF
--- a/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.desktop.in
+++ b/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=AutoClean
+Comment=Analyse et nettoyage sécurisé de votre système
+Exec=autoclean
+Icon=autoclean
+Terminal=false
+Type=Application
+Categories=Utility;
+StartupNotify=true

--- a/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.json
+++ b/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.json
@@ -1,0 +1,41 @@
+{
+    "id": "fr.crowdev.autoclean",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "48",
+    "sdk": "org.gnome.Sdk",
+    "command": "autoclean",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "autoclean",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -D src/main.py /app/bin/autoclean"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Itm0zLegends/AutoClean.git",
+                    "branch": "main"
+                }
+            ]
+        }
+    ]
+}

--- a/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.metainfo.xml.in
+++ b/apps/fr.crowdev.autoclean/fr.crowdev.autoclean.metainfo.xml.in
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>fr.crowdev.autoclean</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <name>AutoClean</name>
+  <summary>Nettoyage rapide et sécurisé</summary>
+  <description>
+    <p>AutoClean est une application GNOME permettant d’analyser et de nettoyer en toute sécurité le cache, les fichiers temporaires et les logs de l’utilisateur.</p>
+    <p>Elle offre une interface simple et moderne, avec analyse et suppression en un clic des fichiers inutiles.</p>
+  </description>
+
+  <developer id="fr.crowdev">
+    <name>CrowDEV</name>
+  </developer>
+
+  <!-- Liens -->
+  <url type="homepage">https://itm0zlegends.github.io/CrowDev/</url>
+  <url type="vcs-browser">https://github.com/Itm0zLegends/AutoClean</url>
+  <url type="bugtracker">https://github.com/Itm0zLegends/AutoClean/issues</url>
+  <url type="help">https://github.com/Itm0zLegends/AutoClean#readme</url>
+
+  <translation type="gettext">autoclean</translation>
+  <launchable type="desktop-id">fr.crowdev.autoclean.desktop</launchable>
+  <content_rating type="oars-1.1" />
+
+  <!-- Branding -->
+  <branding>
+    <color type="primary" scheme_preference="light">#1565c0</color>
+    <color type="primary" scheme_preference="dark">#1c1f26</color>
+  </branding>
+
+  <!-- Screenshots -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/Itm0zLegends/AutoClean/refs/heads/main/screenshots/screen1.png</image>
+      <caption>Choix des catégories à nettoyer</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/Itm0zLegends/AutoClean/refs/heads/main/screenshots/screen2.png</image>
+      <caption>Analyse des fichiers en cours</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/Itm0zLegends/AutoClean/refs/heads/main/screenshots/screen3.png</image>
+      <caption>Nettoyage des fichiers terminé</caption>
+    </screenshot>
+  </screenshots>
+
+  <!-- Releases -->
+  <releases>
+    <release version="1.0.0" date="2025-12-28">
+      <url type="details">https://github.com/Itm0zLegends/AutoClean/releases/tag/1.0.0</url>
+      <description translate="no">
+        <p>Première version publique sur Flathub.</p>
+        <ul>
+          <li>Analyse des caches et fichiers temporaires</li>
+          <li>Nettoyage sécurisé en un clic</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>
+


### PR DESCRIPTION
AutoClean is a GNOME application for safely analyzing and cleaning user caches, temporary files, and logs. 
It provides a simple GTK4 / libadwaita interface with one-click analysis and cleaning.

- Version: 1.0.0
- Features:
  - Analyze user caches and temporary files
  - One-click secure cleaning
- Homepage: https://itm0zlegends.github.io/CrowDev/
- Source: https://github.com/Itm0zLegends/AutoClean