### PR TITLE
Add sh.shard.launcher

### DIFF
--- a/sh.shard.launcher.metainfo.xml
+++ b/sh.shard.launcher.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>sh.shard.launcher</id>
+  <name>Shard Launcher</name>
+  <summary>A minimal, content-addressed Minecraft launcher</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="md.thomas">
+    <name>Thomas Marchand</name>
+  </developer>
+  <description>
+    <p>
+      Shard is a minimal, clean, CLI-first Minecraft launcher focused on stability,
+      reproducibility, and low duplication.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Content-addressed storage for mods and resource packs - no duplicates</li>
+      <li>Declarative profiles for reproducible setups</li>
+      <li>Support for Fabric, Forge, Quilt, and NeoForge</li>
+      <li>Modrinth and CurseForge integration</li>
+      <li>Multiple Microsoft account support</li>
+      <li>CLI-first design - everything can be scripted</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">sh.shard.launcher.desktop</launchable>
+  <url type="homepage">https://shard.thomas.md</url>
+  <url type="bugtracker">https://github.com/th0rgal/shard/issues</url>
+  <url type="vcs-browser">https://github.com/th0rgal/shard</url>
+  <categories>
+    <category>Game</category>
+    <category>Utility</category>
+  </categories>
+  <keywords>
+    <keyword>minecraft</keyword>
+    <keyword>launcher</keyword>
+    <keyword>modrinth</keyword>
+    <keyword>curseforge</keyword>
+    <keyword>fabric</keyword>
+    <keyword>forge</keyword>
+  </keywords>
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">moderate</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="0.1.4" date="2026-01-01">
+      <description>
+        <p>Latest release with bug fixes and improvements.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/sh.shard.launcher.yml
+++ b/sh.shard.launcher.yml
@@ -1,0 +1,60 @@
+id: sh.shard.launcher
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: shard-launcher
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Network for downloads and auth
+  - --share=network
+  # Shard data directory
+  - --filesystem=~/.shard:create
+  # Java runtime access (for launching Minecraft)
+  - --filesystem=/usr/lib/jvm:ro
+  - --filesystem=~/.local/share/java:ro
+  # Minecraft directory (optional, for migration)
+  - --filesystem=~/.minecraft:ro
+  # Environment variable for Flatpak detection
+  - --env=FLATPAK=1
+  # System tray support (optional)
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+modules:
+  - name: shard-launcher
+    buildsystem: simple
+    sources:
+      - type: file
+        url: https://github.com/th0rgal/shard/releases/download/v0.1.4/shard-launcher-linux-x64.deb
+        sha256: a5ec1d388c0f83f5fd81682c441b7217c20dcbee8c79f91af946e924227fc8e8
+        dest-filename: shard-launcher.deb
+        only-arches:
+          - x86_64
+      - type: file
+        path: sh.shard.launcher.metainfo.xml
+    build-commands:
+      # Extract deb package
+      - ar x shard-launcher.deb
+      - tar xf data.tar.*
+      # Install binary
+      - install -Dm755 usr/bin/shard-launcher /app/bin/shard-launcher
+      # Install desktop file
+      - install -Dm644 usr/share/applications/*.desktop /app/share/applications/sh.shard.launcher.desktop
+      # Install icons
+      - |
+        for size in 32 128 256 512; do
+          if [ -f "usr/share/icons/hicolor/${size}x${size}/apps/"*.png ]; then
+            install -Dm644 "usr/share/icons/hicolor/${size}x${size}/apps/"*.png \
+              "/app/share/icons/hicolor/${size}x${size}/apps/sh.shard.launcher.png"
+          fi
+        done
+      # Install metainfo
+      - install -Dm644 sh.shard.launcher.metainfo.xml /app/share/metainfo/sh.shard.launcher.metainfo.xml
+    post-install:
+      # Fix desktop file for Flatpak
+      - sed -i 's|Exec=.*|Exec=shard-launcher|' /app/share/applications/sh.shard.launcher.desktop
+      - sed -i 's|Icon=.*|Icon=sh.shard.launcher|' /app/share/applications/sh.shard.launcher.desktop


### PR DESCRIPTION
Shard is a minimal, content-addressed Minecraft launcher focused on stability, reproducibility, and low duplication.

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.

Shard is a minimal, clean, CLI-first Minecraft launcher focused on stability, reproducibility, and low duplication. It uses content-addressed storage to deduplicate mods and resource packs across profiles. Features include support for Fabric, Forge, Quilt, and NeoForge mod loaders, Modrinth and CurseForge integration, and multiple Microsoft account support.

- [ ] Please attach a video showcasing the application on Linux using the Flatpak.

N/A - This is the initial submission. A video can be provided upon request once the Flatpak builds successfully.

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [X] I am an author/developer/upstream contributor to the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission