### PR TITLE
Add CleanLinuxpc application

### DIFF
--- a/com.linuxlaghouatalgeria.CleanLinuxpc.json
+++ b/com.linuxlaghouatalgeria.CleanLinuxpc.json
@@ -6,12 +6,11 @@
   "command": "CleanLinuxpc",
   "finish-args": [
     "--share=ipc",
-    "--socket=wayland",
-    "--socket=fallback-x11",
-    "--device=dri",
-    "--filesystem=home", 
-    "--filesystem=host",
-    "--talk-name=org.freedesktop.Notifications"
+    "--socket=x11",
+    "--filesystem=home",
+    "--filesystem=/var/cache:ro",
+    "--filesystem=/var/log:ro",
+    "--device=all"
   ],
   "cleanup": [
     "/include",


### PR DESCRIPTION
Hello, I am submitting CleanLinuxpc, a system cleaning utility. I have updated the permissions to be more specific instead of using global host access. This app needs access to cache and logs to perform its cleaning tasks.