### PR TITLE
Add com.linuxlaghouatalgeria.CleanLinuxpc

### DIFF
--- a/com.linuxlaghouatalgeria.CleanLinuxpc.json
+++ b/com.linuxlaghouatalgeria.CleanLinuxpc.json
@@ -1,0 +1,32 @@
+{
+    "app-id": "com.linuxlaghouatalgeria.CleanLinuxpc",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.6",
+    "sdk": "org.kde.Sdk",
+    "command": "CleanLinuxpc",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--env=QT_QPA_PLATFORM=xcb"
+    ],
+    "modules": [
+        {
+            "name": "CleanLinuxpc",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/LinuxLaghouatAlgeria/CleanLinuxpc.git",
+                    "tag": "v1.0.0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Application Summary
**CleanLinuxpc** is a system maintenance utility designed to help Linux users clean temporary files, manage system caches, and optimize disk space. It provides a user-friendly interface to keep the operating system lean and efficient.

## Checklist
- [x] The App ID matches the manifest filename.
- [x] The application is built from source.
- [x] I have tested the build locally using `flatpak-builder`.
- [x] Permissions are limited to what is necessary (Filesystem access is required for cleaning system-wide temporary files).

## Technical Details
- **Runtime:** KDE Platform 6.6
- **Build System:** CMake
- **Permissions:** - `--filesystem=host`: Necessary to allow the app to scan and remove junk files from system and user directories.
    - `--socket=wayland/x11`: For the graphical user interface.

This is the initial submission for this application.