### PR TITLE
Add com.linuxlaghouatalgeria.CleanLinuxpc

### DIFF
--- a/com.linuxlaghouatalgeria.CleanLinuxpc/com.linuxlaghouatalgeria.CleanLinuxpc.json
+++ b/com.linuxlaghouatalgeria.CleanLinuxpc/com.linuxlaghouatalgeria.CleanLinuxpc.json
@@ -1,0 +1,32 @@
+{
+    "app-id": "com.linuxlaghouatalgeria.CleanLinuxpc",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.6",
+    "sdk": "org.kde.Sdk",
+    "command": "CleanLinuxpc",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=host",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--env=QT_QPA_PLATFORM=xcb"
+    ],
+    "modules": [
+        {
+            "name": "CleanLinuxpc",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/LinuxLaghouatAlgeria/CleanLinuxpc.git",
+                    "tag": "v1.0.0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Application Summary
**CleanLinuxpc** is a Python-based utility designed for Linux users to clean and optimize their systems by removing unnecessary files and managing system resources.

## Key Features
* Easy-to-use interface.
* System cleaning and optimization.
* Built using Python and GTK.

## Verification
I have tested the build locally using `flatpak-builder` and it works as expected.