### PR TITLE
Add uz.mohirlab.senbrua

### DIFF
--- a/uz.mohirlab.senbrua.json
+++ b/uz.mohirlab.senbrua.json
@@ -1,0 +1,46 @@
+{
+    "app-id": "uz.mohirlab.senbrua",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "48",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [],
+    "command": "senbrua",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--socket=pulseaudio",
+        "--device=dri",
+        "--filesystem=xdg-music:rw",
+        "--filesystem=xdg-download:rw"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "build-options": {
+    },
+    "modules": [
+        {
+            "name": "senbrua",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dskip_ts=true"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/otabekoff/senbrua.git",
+                    "tag": "v1.0.0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## New App Submission

**App ID:** uz.mohirlab.senbrua  
**App Name:** Senbrua  
**Summary:** A simple, modern sound recorder for GNOME

### Description
Senbrua is a modern remake of Vocalis - a simple and elegant sound recorder application for the GNOME desktop with RNNoise-powered noise cancellation.

### Features
- Record audio in multiple formats (Opus, Vorbis, FLAC, MP3)
- RNNoise-powered noise reduction
- Playback recordings with waveform visualization
- Theme mode switch (System, Light, Dark)
- Rename and export recordings
- Modern GNOME design with libadwaita

### Links
- **Homepage:** https://github.com/otabekoff/senbrua
- **Source:** https://github.com/otabekoff/senbrua

### Checklist
- [x] App builds and runs locally
- [x] Manifest passes flatpak-builder-lint
- [x] Screenshots use public URLs
- [x] AppStream metainfo included
- [x] Valid SPDX license (GPL-3.0-or-later)