### PR TITLE
Add com.github.storo.Guanaco

### DIFF
--- a/com.github.storo.Guanaco.json
+++ b/com.github.storo.Guanaco.json
@@ -1,0 +1,53 @@
+{
+    "app-id": "com.github.storo.Guanaco",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "46",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.golang"
+    ],
+    "command": "guanaco",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=network",
+        "--filesystem=home:ro"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/golang/bin",
+        "env": {
+            "GOPATH": "/run/build/guanaco/go",
+            "GOCACHE": "/run/build/guanaco/go-cache",
+            "GO111MODULE": "on",
+            "GOFLAGS": "-mod=vendor"
+        }
+    },
+    "modules": [
+        {
+            "name": "guanaco",
+            "buildsystem": "simple",
+            "build-commands": [
+                "go build -trimpath -ldflags='-s -w -X main.version=0.1.0' -o guanaco ./cmd/guanaco",
+                "install -Dm755 guanaco ${FLATPAK_DEST}/bin/guanaco",
+                "install -Dm644 assets/icons/com.github.storo.Guanaco.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/com.github.storo.Guanaco.svg",
+                "install -Dm644 assets/com.github.storo.Guanaco.desktop ${FLATPAK_DEST}/share/applications/com.github.storo.Guanaco.desktop",
+                "install -Dm644 assets/com.github.storo.Guanaco.metainfo.xml ${FLATPAK_DEST}/share/metainfo/com.github.storo.Guanaco.metainfo.xml",
+                "install -Dm644 LICENSE ${FLATPAK_DEST}/share/licenses/com.github.storo.Guanaco/LICENSE"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/storo/guanaco.git",
+                    "tag": "v0.1.0",
+                    "commit": "6fa62d1163e05df5a0d853b1e93d9449db3c530b"
+                },
+                {
+                    "type": "archive",
+                    "url": "https://github.com/storo/guanaco/releases/download/v0.1.0/vendor.tar.gz",
+                    "sha256": "84b0cda5c756a0bd4e4b8c15f5bb5c0670de4c6b77b9cb8dcaf954903c6f0665"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Application Details

- **Name:** Guanaco
- **Homepage:** https://github.com/storo/guanaco
- **License:** MIT
- **Category:** Utility/Chat

## Description

Guanaco is a modern GTK4/Libadwaita desktop application for chatting with local AI models powered by Ollama.

### Features
- Stream responses in real-time
- Markdown rendering with code highlighting
- Drag and drop documents (PDF, TXT, Markdown)
- Persistent chat history
- Native GNOME interface

## Checklist

- [x] Manifest follows naming convention
- [x] Application builds from source
- [x] MetaInfo file validates correctly
- [x] Desktop file included
- [x] Icon included (SVG)
- [x] License allows redistribution (MIT)
- [x] Screenshots included in MetaInfo
- [x] Release information included