### PR TITLE
Add cc.cubocore.CoreStats

### DIFF
--- a/cc.cubocore.CoreStats.yml
+++ b/cc.cubocore.CoreStats.yml
@@ -6,10 +6,10 @@ command: corestats
 finish-args:
   - --device=dri
   - --share=ipc
-  - --share=network # Required to show weather info
+  - --share=network # Required to get network stats
   - --socket=wayland
-  - --filesystem=home # For xdg-config
-  - --filesystem=host:ro # reading sensor info, network data
+  - --filesystem=~/.config # For shared config for all cubocore apps
+  - --filesystem=host:ro # reading sensor, hardware data
   - --talk-name=org.freedesktop.Notifications # Required for notifications
   - --system-talk-name=org.freedesktop.UDisks2 # Required to show disk info
   - --system-talk-name=org.freedesktop.UPower # Required to show battery info


### PR DESCRIPTION
This PR is to update the domain/ name org.cubocore.CoreStats to cc.cubocore.CoreStats . It also updates the version to the newest v5.0.0

<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [ ] Please describe the application briefly. < Please insert the description here >
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. < Please insert the video here >
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an _(please keep whichever is applicable and remove the rest)_ author/developer/upstream contributor to the project.
      If not, I contacted upstream developers about this submission. **Link:**

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
