### PR TITLE
Add io.github.speeko.QuickWebmRecorder

### DIFF
--- a/io.github.speeko.QuickWebmRecorder.yml
+++ b/io.github.speeko.QuickWebmRecorder.yml
@@ -1,0 +1,64 @@
+app-id: io.github.speeko.QuickWebmRecorder
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: quick-webm-recorder
+
+finish-args:
+  # X11 access for screen capture
+  - --share=ipc
+  - --socket=x11
+  # Audio access
+  - --socket=pulseaudio
+  # Filesystem access for saving recordings
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-config/quick-webm-recorder
+  # For clipboard
+  - --share=network
+
+modules:
+  # pynput dependency
+  - name: python3-pynput
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pynput" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/2b/27/1a33e3cabf17a7b8b60e528d4a050276e237c09e71d602ea8a624584b236/evdev-1.7.1.tar.gz
+        sha256: 0c72c370bda29d857e188d931019c32651a9c1ea977c08c8d939b1ced1637fde
+      - type: file
+        url: https://files.pythonhosted.org/packages/3f/0b/de69b69cbf684dac5a8e27b26f1cd8a2e61ca64e8ecb130e8ea7ed8a893c/pynput-1.7.7-py2.py3-none-any.whl
+        sha256: cd6591e7ccc5cc8ff5e39e29260a9a0aba67178c9ddc168eb78bc702a8f0c5b0
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/57/92f1d820d74091c1cafc78697e65c9cddf3c5f0b5be86ebdddae02e79556/python_xlib-0.33-py2.py3-none-any.whl
+        sha256: b4262d4e440b91afdf71719d8fbb7a8a1e5874f087a26cc64a9c7ef3b874518d
+      - type: file
+        url: https://files.pythonhosted.org/packages/76/53/73869eed1beaf43d4fd79b7f80da3d1aa2fd20e51eb2c634bbed47ff5140/six-1.16.0-py2.py3-none-any.whl
+        sha256: 8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+
+  # xclip for clipboard
+  - name: xclip
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/astrand/xclip/archive/refs/tags/0.13.tar.gz
+        sha256: ca5b8804e3c910a66423a882d79bf3c9450b875ac8528571f39c6f0d855a000d
+
+  # Main application
+  - name: quick-webm-recorder
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 src/main.py ${FLATPAK_DEST}/lib/quick-webm-recorder/main.py
+      - install -Dm644 src/config.py ${FLATPAK_DEST}/lib/quick-webm-recorder/config.py
+      - install -Dm644 src/hotkey.py ${FLATPAK_DEST}/lib/quick-webm-recorder/hotkey.py
+      - install -Dm644 src/overlay.py ${FLATPAK_DEST}/lib/quick-webm-recorder/overlay.py
+      - install -Dm644 src/recorder.py ${FLATPAK_DEST}/lib/quick-webm-recorder/recorder.py
+      - install -Dm755 quick-webm-recorder.sh ${FLATPAK_DEST}/bin/quick-webm-recorder
+      - install -Dm644 flatpak/io.github.speeko.QuickWebmRecorder.desktop ${FLATPAK_DEST}/share/applications/io.github.speeko.QuickWebmRecorder.desktop
+      - install -Dm644 flatpak/io.github.speeko.QuickWebmRecorder.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.speeko.QuickWebmRecorder.metainfo.xml
+      - install -Dm644 flatpak/io.github.speeko.QuickWebmRecorder.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.speeko.QuickWebmRecorder.svg
+    sources:
+      - type: git
+        url: https://github.com/Speeko/quick-webm-recorder.git
+        commit: 1aecaaeb0ba537aae11f5b1af4387bd24424bee3


### PR DESCRIPTION
## Summary
Quick WebM Recorder is a lightweight ShareX-style screen region recorder for Linux (X11).

**Features:**
- Global hotkeys for MP4 and GIF recording (Super+Shift+C / Super+Shift+G)
- Click and drag region selection with darkened overlay
- System audio capture via PulseAudio/PipeWire
- H.264/MP4 output compatible with all devices
- High-quality GIF output with palette generation
- Quality presets from Lossless to Tiny
- File path copied to clipboard after recording
- System tray integration

**Homepage:** https://github.com/Speeko/quick-webm-recorder

**Verification:**
- [x] Screenshots hosted in the source repository
- [x] Metainfo file included with OARS content rating
- [x] Desktop file with proper categories
- [x] SVG icon included