### PR TITLE
Add io.github.vdirienzo.TmuxGUI

### DIFF
--- a/io.github.vdirienzo.TmuxGUI.yml
+++ b/io.github.vdirienzo.TmuxGUI.yml
@@ -1,0 +1,56 @@
+app-id: io.github.vdirienzo.TmuxGUI
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: tmuxgui
+
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # All devices (required for PTY/terminal)
+  - --device=all
+  # Home directory access
+  - --filesystem=home
+  # Tmp for tmux sockets
+  - --filesystem=/tmp
+  # Run directory for tmux socket
+  - --filesystem=xdg-run/tmux
+  # Required to run tmux on host via flatpak-spawn
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  # VTE terminal library (GTK4 version)
+  - name: vte
+    buildsystem: meson
+    config-opts:
+      - -Ddocs=false
+      - -Dvapi=false
+      - -Dgtk4=true
+      - -Dgtk3=false
+      - -Dgir=true
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/vte/0.78/vte-0.78.0.tar.xz
+        sha256: 07f09c6228a8bb3c1599dd0f5a6ec797b30d3010c3ac91cf21b69d9635dfaf7c
+
+  # Main application
+  - name: tmuxgui
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/tmuxgui
+      - cp -r src/gnome_tmux /app/share/tmuxgui/
+      - cp run.py /app/share/tmuxgui/
+      - install -Dm755 tmuxgui.sh /app/bin/tmuxgui
+      - install -Dm644 data/io.github.vdirienzo.TmuxGUI.desktop /app/share/applications/io.github.vdirienzo.TmuxGUI.desktop
+      - install -Dm644 data/io.github.vdirienzo.TmuxGUI.metainfo.xml /app/share/metainfo/io.github.vdirienzo.TmuxGUI.metainfo.xml
+      - install -Dm644 data/icons/hicolor/48x48/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/48x48/apps/io.github.vdirienzo.TmuxGUI.png
+      - install -Dm644 data/icons/hicolor/64x64/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/64x64/apps/io.github.vdirienzo.TmuxGUI.png
+      - install -Dm644 data/icons/hicolor/128x128/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/128x128/apps/io.github.vdirienzo.TmuxGUI.png
+      - install -Dm644 data/icons/hicolor/512x512/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/512x512/apps/io.github.vdirienzo.TmuxGUI.png
+    sources:
+      - type: git
+        url: https://github.com/vdirienzo/tmuxgui.git
+        tag: v0.4.2
+        commit: 32734b2b80053259ecd89b6dc302115562e591f1


### PR DESCRIPTION
## App Description

TmuxGUI is a native GNOME frontend for tmux terminal multiplexer. It provides a graphical interface to manage tmux sessions, windows, and terminals with an integrated file browser.

Built with GTK4 and Libadwaita following GNOME Human Interface Guidelines.

## Permissions Justification

This app requires some elevated permissions due to its nature as a tmux frontend:

### `--filesystem=home`
Required for the integrated file browser that allows users to navigate their home directory and drag folders to the terminal.

### `--filesystem=/tmp`
Required because tmux stores its control sockets in `/tmp/tmux-*` by default. Without this, the app cannot communicate with tmux sessions.

### `--talk-name=org.freedesktop.Flatpak`
**This is the core requirement.** TmuxGUI is a GUI wrapper that runs tmux from the host system using `flatpak-spawn --host tmux`. Without this permission, the app cannot function at all since tmux must run on the host, not inside the sandbox.

## Checklist

- [x] App builds and runs correctly
- [x] Manifest passes flatpak-builder-lint (except for justified permissions above)
- [x] AppStream metainfo is valid
- [x] Icons are included (48x48, 64x64, 128x128, 512x512)
- [x] Desktop file is included
- [x] License is MIT

## Links

- Repository: https://github.com/vdirienzo/tmuxgui
- Screenshots: Available in metainfo