### PR TITLE
Create io.github.vdirienzo.TmuxGUI.yml

### DIFF
--- a/io.github.vdirienzo.TmuxGUI.yml
+++ b/io.github.vdirienzo.TmuxGUI.yml
@@ -1,0 +1,56 @@
+app-id: io.github.vdirienzo.TmuxGUI
+  runtime: org.gnome.Platform
+  runtime-version: '49'
+  sdk: org.gnome.Sdk
+  command: tmuxgui
+
+  finish-args:
+    # Display
+    - --share=ipc
+    - --socket=fallback-x11
+    - --socket=wayland
+    # All devices (required for PTY/terminal)
+    - --device=all
+    # Home directory access
+    - --filesystem=home
+    # Tmp for tmux sockets
+    - --filesystem=/tmp
+    # Run directory for tmux socket
+    - --filesystem=xdg-run/tmux
+    # Required to run tmux on host via flatpak-spawn
+    - --talk-name=org.freedesktop.Flatpak
+
+  modules:
+    # VTE terminal library (GTK4 version)
+    - name: vte
+      buildsystem: meson
+      config-opts:
+        - -Ddocs=false
+        - -Dvapi=false
+        - -Dgtk4=true
+        - -Dgtk3=false
+        - -Dgir=true
+      sources:
+        - type: archive
+          url: https://download.gnome.org/sources/vte/0.78/vte-0.78.0.tar.xz
+          sha256: 07f09c6228a8bb3c1599dd0f5a6ec797b30d3010c3ac91cf21b69d9635dfaf7c
+
+    # Main application
+    - name: tmuxgui
+      buildsystem: simple
+      build-commands:
+        - mkdir -p /app/share/tmuxgui
+        - cp -r src/gnome_tmux /app/share/tmuxgui/
+        - cp run.py /app/share/tmuxgui/
+        - install -Dm755 tmuxgui.sh /app/bin/tmuxgui
+        - install -Dm644 data/io.github.vdirienzo.TmuxGUI.desktop /app/share/applications/io.github.vdirienzo.TmuxGUI.desktop
+        - install -Dm644 data/io.github.vdirienzo.TmuxGUI.metainfo.xml /app/share/metainfo/io.github.vdirienzo.TmuxGUI.metainfo.xml
+        - install -Dm644 data/icons/hicolor/48x48/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/48x48/apps/io.github.vdirienzo.TmuxGUI.png
+        - install -Dm644 data/icons/hicolor/64x64/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/64x64/apps/io.github.vdirienzo.TmuxGUI.png
+        - install -Dm644 data/icons/hicolor/128x128/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/128x128/apps/io.github.vdirienzo.TmuxGUI.png
+        - install -Dm644 data/icons/hicolor/512x512/apps/io.github.vdirienzo.TmuxGUI.png /app/share/icons/hicolor/512x512/apps/io.github.vdirienzo.TmuxGUI.png
+      sources:
+        - type: git
+          url: https://github.com/vdirienzo/tmuxgui.git
+          tag: v0.4.2
+          commit: 32734b2b80053259ecd89b6dc302115562e591f1


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

  - [X] Please describe the application briefly. TmuxGUI is a modern GTK4/Libadwaita frontend for tmux terminal multiplexer. It provides visual session and window management, an integrated terminal with automatic tmux attachment, a file browser with drag-and-drop support, and multiple color themes (Nord, Dracula, Catppuccin, etc.).
  - [X] Please attach a video showcasing the application on Linux using the Flatpak. https://github.com/vdirienzo/tmuxgui/raw/main/screenshots/demo.webm
  - [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
  - [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
  - [X] I am an _(please keep whichever is applicable and remove the rest)_ author/developer to the project.

  ## Permission Justifications

  This application requires the following special permissions:

  ### --talk-name=org.freedesktop.Flatpak
  Required to execute tmux on the host system via flatpak-spawn. tmux is a terminal multiplexer that manages PTY sessions and cannot run inside the Flatpak sandbox - it must run on the host to persist sessions across application restarts.

  ### --filesystem=home
  Required for the integrated file browser feature. Users can navigate their home directory, open files, and drag folders into the terminal. This is a core feature of the application.

  ### --filesystem=/tmp
  Required for tmux socket communication. tmux creates its control sockets in /tmp/tmux-{uid}/ by default. Without this access, the application cannot communicate with t
[demo.webm](https://github.com/user-attachments/assets/cb054ffc-c3b1-4c5f-b366-6acb6b8c555d)
[demo.webm](https://github.com/user-attachments/assets/5850a6d0-5494-467b-af91-b70d654fa4f0)
mux sessions.

  ### --filesystem=xdg-run/tmux
  Alternative location for tmux sockets on some systems.

  ### --device=all
  Required for PTY (pseudoterminal) allocation in the integrated VTE terminal emulator.

  [appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
  [reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
  [reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[demo.webm](https://github.com/user-attachments/assets/86e182dc-ebce-4f84-a8fa-44409c0c1153)

