### PR TITLE
Add BrightEyes (org.jeremy.BrightEyes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# BrightEyes Flathub Submission
+
+This branch contains the Flatpak manifest for submitting BrightEyes to Flathub.
+The source code is pulled from the main repository `https://github.com/jdwininger/BrightEyes`.

--- a/org.jeremy.BrightEyes.yml
+++ b/org.jeremy.BrightEyes.yml
@@ -1,0 +1,155 @@
+app-id: org.jeremy.BrightEyes
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: brighteyes
+finish-args:
+  - --socket=wayland
+  - --socket=x11
+  - --device=dri
+  - --filesystem=home
+  - --share=network
+build-options:
+  cflags: -O2 -g
+  cxxflags: -O2 -g
+modules:
+  # Image I/O helper for tesseract
+  - name: leptonica
+    buildsystem: autotools
+    cleanup:
+      - /bin
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://github.com/DanBloomberg/leptonica.git
+        tag: 1.84.1
+
+  # OCR engine
+  - name: tesseract
+    buildsystem: cmake
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DSTATIC=OFF
+      - -DSW_BUILD=OFF
+      - -DBUILD_TRAINING_TOOLS=OFF
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://github.com/tesseract-ocr/tesseract.git
+        tag: 5.4.0
+
+  # Tesseract language data (fast variant) matching settings menu
+  - name: tessdata
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://github.com/tesseract-ocr/tessdata_fast.git
+        branch: main
+    build-commands:
+      - install -Dm644 eng.traineddata /app/share/tessdata/eng.traineddata
+      - install -Dm644 deu.traineddata /app/share/tessdata/deu.traineddata
+      - install -Dm644 fra.traineddata /app/share/tessdata/fra.traineddata
+      - install -Dm644 spa.traineddata /app/share/tessdata/spa.traineddata
+      - install -Dm644 ita.traineddata /app/share/tessdata/ita.traineddata
+      - install -Dm644 por.traineddata /app/share/tessdata/por.traineddata
+      - install -Dm644 jpn.traineddata /app/share/tessdata/jpn.traineddata
+      - install -Dm644 chi_sim.traineddata /app/share/tessdata/chi_sim.traineddata
+      # Combo languages just need underlying files present
+
+  # GStreamer plugin modules — include a broad set so codecs work inside Flatpak
+  - name: gst-plugins-base
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dintrospection=disabled
+      - -Dtests=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git
+        tag: 1.26.9
+
+  - name: gst-plugins-good
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dintrospection=disabled
+      - -Dtests=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good.git
+        tag: 1.26.9
+
+  - name: gst-plugins-bad
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dintrospection=disabled
+      - -Dtests=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-bad.git
+        tag: 1.26.9
+
+  - name: gst-plugins-ugly
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dintrospection=disabled
+      - -Dtests=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gst-plugins-ugly.git
+        tag: 1.26.9
+
+  - name: ffmpeg
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dstatic=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://github.com/FFmpeg/FFmpeg.git
+        tag: n6.1
+
+  - name: gst-libav
+    buildsystem: meson
+    config-opts:
+      - -Ddefault_library=shared
+      - -Dintrospection=disabled
+      - -Dtests=disabled
+    cleanup:
+      - /share/doc
+      - /share/man
+    sources:
+      - type: git
+        url: https://gitlab.freedesktop.org/gstreamer/gst-libav.git
+        tag: 1.26.9
+
+  # Application
+  - name: brighteyes
+    buildsystem: meson
+    config-opts:
+      - --buildtype=release
+    sources:
+      - type: git
+        url: https://github.com/jdwininger/BrightEyes.git
+        commit: 87188274ac869b4b22a0805409b3a71b26a80e37


### PR DESCRIPTION
Add **BrightEyes** (`org.jeremy.BrightEyes`).

**BrightEyes** is an image viewer and metadata editor with OCR capabilities.

Highlights:
- Bundles GStreamer plugins (`base`, `good`, `bad`, `ugly`) and `gst-libav`/`ffmpeg` for broad codec support.
- Bundles Tesseract + tessdata for OCR features.

Notes for reviewers:
- This manifest bundles GStreamer plugins to ensure consistency and support for formats that might rely on plugins newer than or different from the runtime.
- Source is pulled from the upstream git repository tag/commit.

Verification:
- Flatpak build passes locally.
- Smoke tests verify GStreamer plugins presence.