### PR TITLE
Add Razer Control Center

### DIFF
--- a/com.github.AreteDriver.RazerControls.yml
+++ b/com.github.AreteDriver.RazerControls.yml
@@ -1,0 +1,186 @@
+app-id: com.github.AreteDriver.RazerControls
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: '6.9'
+command: razer-control-center
+
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+finish-args:
+  # X11 + Wayland
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # D-Bus for OpenRazer and system services
+  - --socket=session-bus
+  - --socket=system-bus
+  # Device access for evdev input devices
+  - --device=all
+  # Home directory for config
+  - --filesystem=~/.config/razer-control-center:create
+  # For systemd user services
+  - --filesystem=~/.config/systemd/user:create
+  - --filesystem=~/.local/bin:create
+  # Talk to OpenRazer daemon
+  - --talk-name=org.razer
+
+modules:
+  # Python evdev
+  - name: python3-evdev
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} evdev --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/63/fe/a17c106a1f4061ce83f04d14bcedcfb2c38c7793ea56bfb906a6fadae8cb/evdev-1.9.2.tar.gz
+        sha256: 5d3278892ce1f92a74d6bf888cc8525d9f68af85dbe336c95d1c87fb8f423069
+
+  # Python pydbus
+  - name: python3-pydbus
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} pydbus --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/58/56/3e84f2c1f2e39b9ea132460183f123af41e3b9c8befe222a35636baa6a5a/pydbus-0.6.0.tar.gz
+        sha256: 4207162eff54223822c185da06c1ba8a34137a9602f3da5a528eedf3f78d0f2c
+
+  # Python python-xlib (required by pynput on Linux)
+  - name: python3-xlib
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} python-xlib --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl
+        sha256: c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398
+
+  # Python pynput
+  - name: python3-pynput
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} pynput --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/59/4f/ac3fa906ae8a375a536b12794128c5efacade9eaa917a35dfd27ce0c7400/pynput-1.8.1-py2.py3-none-any.whl
+        sha256: 42dfcf27404459ca16ca889c8fb8ffe42a9fe54f722fd1a3e130728e59e768d2
+
+  # Python typing-extensions (pydantic dependency)
+  - name: python3-typing-extensions
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} typing_extensions --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+        sha256: f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+
+  # Python annotated-types (pydantic dependency)
+  - name: python3-annotated-types
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} annotated_types --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+        sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+
+  # Python pydantic-core (pydantic dependency)
+  - name: python3-pydantic-core
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} pydantic_core --no-build-isolation
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+        sha256: e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69
+
+  # Python typing-inspection (pydantic dependency)
+  - name: python3-typing-inspection
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} typing_inspection --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
+        sha256: 4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7
+
+  # Python pydantic
+  - name: python3-pydantic
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} pydantic --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+        sha256: e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
+
+  # Python PyYAML
+  - name: python3-pyyaml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} PyYAML --no-build-isolation
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+        sha256: ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28
+
+  # Python packaging (setuptools build dependency)
+  - name: python3-packaging
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} packaging --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl
+        sha256: 09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759
+
+  # Main application
+  - name: razer-control-center
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} razer_control_center --no-build-isolation --no-deps
+      # Copy data directories for device layouts and images
+      - cp -r data ${FLATPAK_DEST}/lib/python3.12/site-packages/
+      - install -Dm644 packaging/flatpak/com.github.AreteDriver.RazerControls.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/com.github.AreteDriver.RazerControls.metainfo.xml
+      - install -Dm644 packaging/flatpak/com.github.AreteDriver.RazerControls.desktop
+        ${FLATPAK_DEST}/share/applications/com.github.AreteDriver.RazerControls.desktop
+      - install -Dm644 packaging/flatpak/icons/hicolor/scalable/apps/com.github.AreteDriver.RazerControls.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/com.github.AreteDriver.RazerControls.svg
+    sources:
+      - type: file
+        url: https://github.com/AreteDriver/Razer_Controls/raw/main/packaging/flatpak/wheels/razer_control_center-1.9.8-py3-none-any.whl
+        sha256: 71852d96bc647bb757c035646e6970e55e67a8fcdb68620bcf2a424a74daf107
+      - type: git
+        url: https://github.com/AreteDriver/Razer_Controls.git
+        commit: 370aea7d2903ec73153bc639293d34dc2e3f9b4c


### PR DESCRIPTION
Razer Control Center - A Synapse-like control center for Razer devices on Linux.

## Features
- Button remapping for mice and keyboards
- Macro support with recording and playback
- RGB lighting control via OpenRazer
- Profile management with per-application switching
- System tray integration
- Global hotkeys for profile switching

## Links
- Homepage: https://github.com/AreteDriver/Razer_Controls
- License: MIT

## Checklist
- [x] App builds and runs locally
- [x] Metainfo with releases (1.5.0 - 1.9.8)
- [x] Desktop file
- [x] Icon (SVG)
- [ ] Screenshot (will add shortly)
- [x] Offline build (no network during build)
- [x] Multi-arch support (x86_64 + aarch64)