### PR TITLE
Add sdcard formatter newpr

### DIFF
--- a/io.github.sdcardformatter.SDCardFormatter.yaml
+++ b/io.github.sdcardformatter.SDCardFormatter.yaml
@@ -1,6 +1,6 @@
-app-id: org.sdcard.Formatter
+app-id: io.github.sdcardformatter.SDCardFormatter
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 command: sd_formatter_gui.py
 finish-args:
@@ -16,9 +16,9 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm755 sd_formatter_gui.py /app/bin/sd_formatter_gui.py
-      - install -Dm644 sdcard-formatter.desktop /app/share/applications/org.sdcard.Formatter.desktop
-      - install -Dm644 sdcard-formatter.png /app/share/icons/hicolor/256x256/apps/org.sdcard.Formatter.png
-      - install -Dm644 org.sdcard.Formatter.metainfo.xml /app/share/metainfo/org.sdcard.Formatter.metainfo.xml
+      - install -Dm644 sdcard-formatter.desktop /app/share/applications/io.github.sdcardformatter.SDCardFormatter.desktop
+      - install -Dm644 sdcard-formatter.png /app/share/icons/hicolor/256x256/apps/io.github.sdcardformatter.SDCardFormatter.png
+      - install -Dm644 io.github.sdcardformatter.SDCardFormatter.metainfo.xml /app/share/metainfo/io.github.sdcardformatter.SDCardFormatter.metainfo.xml
     sources:
       - type: file
         path: sd_formatter_gui.py
@@ -27,4 +27,4 @@ modules:
       - type: file
         path: sdcard-formatter.png
       - type: file
-        path: org.sdcard.Formatter.metainfo.xml
+        path: io.github.sdcardformatter.SDCardFormatter.metainfo.xml


### PR DESCRIPTION
### Description
README/PR intro)
“SD Card Formatter (Unofficial Community Project) wraps Tuxera’s official SD Card Formatter for Linux in a clean GTK3 interface. It automatically fetches the format_sd binary on first launch, detects removable drives, offers quick or full formatting, and ensures cards are prepared according to the SD Association specs.”

[](https://youtu.be/8MqKPkAOADc)

- Add Flatpak manifest for io.github.sdcardformatter.SDCardFormatter
- Targets Freedesktop Platform 25.08 / org.freedesktop.Sdk
- Includes AppStream metadata, desktop file, icon, and GTK3 GUI launcher
https://youtu.be/8MqKPkAOADc
### Checklist
- [x] Brief description provided
- [x] Video link (https://youtu.be/8MqKPkAOADc)
- [x] Application ID follows requirements
- [x] Submission requirements + guide followed and accepted
- [x] I am the upstream author/maintainer (GitHub org: github.com/3ddruck12)

### Additional info
- Project homepage/bug tracker: https://github.com/3ddruck12/SD-Card-Formatter-Linux-GTK3-GUI-
- Contact: dreiddruck12@t-online.de

