### PR TITLE
Add Argus Overview

### DIFF
--- a/io.github.aretedriver.ArgusOverview.yml
+++ b/io.github.aretedriver.ArgusOverview.yml
@@ -1,0 +1,117 @@
+# Argus Overview Flatpak Manifest for Flathub
+# Uses KDE runtime (includes PySide6/Qt)
+# Builds wmctrl and xdotool from source for X11 window management
+
+app-id: io.github.aretedriver.ArgusOverview
+runtime: org.kde.Platform
+runtime-version: '6.8'
+sdk: org.kde.Sdk
+command: argus-overview
+
+finish-args:
+  # X11 and Wayland display access
+  - --share=ipc
+  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
+  # GPU acceleration for Qt
+  - --device=dri
+  # Network for updates/notifications
+  - --share=network
+  # Desktop notifications
+  - --talk-name=org.freedesktop.Notifications
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.StatusNotifierWatcher
+  # Access to EVE settings and app config
+  - --filesystem=home:ro
+  - --filesystem=~/.config/argus-overview:create
+  - --filesystem=~/.local/share/argus-overview:create
+  - --filesystem=~/.local/share/Steam:ro
+  # Environment for Qt
+  - --env=QT_QPA_PLATFORM=xcb
+
+modules:
+  # libXmu - required by wmctrl
+  - name: libXmu
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://xorg.freedesktop.org/releases/individual/lib/libXmu-1.2.1.tar.xz
+        sha256: fcb27793248a39e5fcc5b9c4aec40cc0734b3ca76aac3d7d1c264e7f7e14e8b2
+
+  # wmctrl - window management CLI
+  - name: wmctrl
+    buildsystem: simple
+    build-commands:
+      - |
+        export CFLAGS="$(pkg-config --cflags glib-2.0 x11 xmu)"
+        export LIBS="$(pkg-config --libs glib-2.0 x11 xmu)"
+        ./configure --prefix=/app
+        make CFLAGS="$CFLAGS" LIBS="$LIBS"
+        make install
+    sources:
+      - type: archive
+        url: http://archive.ubuntu.com/ubuntu/pool/universe/w/wmctrl/wmctrl_1.07.orig.tar.gz
+        sha256: d78a1efdb62f18674298ad039c5cbdb1edb6e8e149bb3a8e3a01a4750aa3cca9
+
+  # xdotool - X11 automation tool
+  - name: xdotool
+    buildsystem: simple
+    build-commands:
+      - make PREFIX=/app
+      - make PREFIX=/app install
+    sources:
+      - type: archive
+        url: https://github.com/jordansissel/xdotool/releases/download/v3.20211022.1/xdotool-3.20211022.1.tar.gz
+        sha256: 96f0facfde6d78eacad35b91b0f46fecd0b35e474c03e00e30da3fdd345f9ada
+
+  # Python dependencies (not in KDE runtime)
+  - name: python-xlib
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps python_xlib-0.33-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl
+        sha256: c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398
+
+  - name: python-pynput
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps pynput-1.7.7-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ef/1d/fdef3fdc9dc8dedc65898c8ad0e8922a914bb89c5308887e45f9aafaec36/pynput-1.7.7-py2.py3-none-any.whl
+        sha256: afc43f651684c98818de048abc76adf9f2d3d797083cb07c1f82be764a2d44cb
+
+  - name: python-watchdog
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl
+        sha256: 20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2
+
+  # Argus Overview application (from PyPI)
+  - name: argus-overview
+    buildsystem: simple
+    build-commands:
+      # Install application from PyPI wheel
+      - pip3 install --prefix=/app --no-deps argus_overview-2.8.2-py3-none-any.whl
+      # Install desktop file
+      - install -Dm644 flatpak/io.github.aretedriver.ArgusOverview.desktop /app/share/applications/io.github.aretedriver.ArgusOverview.desktop
+      # Install icons
+      - install -Dm644 assets/icon_256.png /app/share/icons/hicolor/256x256/apps/io.github.aretedriver.ArgusOverview.png
+      - install -Dm644 assets/icon_128.png /app/share/icons/hicolor/128x128/apps/io.github.aretedriver.ArgusOverview.png
+      - install -Dm644 assets/icon_48.png /app/share/icons/hicolor/48x48/apps/io.github.aretedriver.ArgusOverview.png
+      # Install metainfo
+      - install -Dm644 flatpak/io.github.aretedriver.ArgusOverview.metainfo.xml /app/share/metainfo/io.github.aretedriver.ArgusOverview.metainfo.xml
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/df/0a/2b7a722dda8b24ba300bc016d0f8e03dbe3280c55b1aa06d4469a9da1a17/argus_overview-2.8.2-py3-none-any.whl
+        sha256: a27579f8ac32fdcf581b37aae138c127eeabef7686a4b123df38f18a237166df
+      - type: git
+        url: https://github.com/AreteDriver/Argus_Overview.git
+        commit: 8874d467519acd7590fd77d6ab41f137b9102576


### PR DESCRIPTION
Argus Overview - Professional multi-boxing tool for EVE Online on Linux.

## Features
- Live window previews at configurable FPS (1-60)
- Broadcast hotkeys - send keystrokes to all EVE windows
- Preview filter - quick search by character name
- Keyboard window control (1-9 keys)
- System tray integration with minimize-to-tray
- One-click import of all EVE windows
- Character and team management
- Layout presets with auto-tiling
- Visual activity alerts
- EVE settings synchronization
- Multi-monitor support

## Links
- Homepage: https://github.com/AreteDriver/Argus_Overview
- PyPI: https://pypi.org/project/argus-overview/
- License: MIT

## Checklist
- [x] App builds and runs locally with flatpak-builder
- [x] Metainfo with releases (2.7.0 - 2.8.2)
- [x] Desktop file included
- [x] Icons (256/128/48 PNG)
- [x] Screenshot in metainfo
- [x] Offline build (no network during build)
- [x] Content rating (OARS 1.1)
- [x] Categories and keywords
- [x] Uses KDE runtime 6.8 for PySide6/Qt support
- [x] Builds wmctrl and xdotool from source for X11 window management