### PR TITLE
Add io.github.dyslechtchitect.tfcbm

### DIFF
--- a/io.github.dyslechtchitect.tfcbm.yml
+++ b/io.github.dyslechtchitect.tfcbm.yml
@@ -18,4 +18,4 @@ modules:
       - type: git
         url: https://github.com/dyslechtchitect/tfcbm.git
         tag: v1.0
-        commit: 2707110627fb596e04b8da74368529b83c1da142
+        commit: 018ba961653d6b78df5d99c02bfc3c05e7351043


### PR DESCRIPTION
Supersedes [7497](https://github.com/flathub/flathub/pull/7497) mistakenly closed by me

- [X] Please describe the application briefly. <a clipboard history management tool with search, tags, favorites and secrets, interacts with a **gnome extension that's separately installed by the user** for keybinding and clipboard monitoring>
- [X] Please attach a video showcasing the application on Linux using the Flatpak. <https://github.com/user-attachments/assets/1f321e44-bf89-42f8-880f-960fdc38b2c6>
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][io.github.dyslechtchitect.tfcbm].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am a developer in the project.


[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
