### PR TITLE
Add io.lamco.rdp-server

### DIFF
--- a/io.lamco.rdp-server/io.lamco.rdp-server.metainfo.xml
+++ b/io.lamco.rdp-server/io.lamco.rdp-server.metainfo.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.lamco.rdp-server</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://mariadb.com/bsl11/</project_license>
+
+  <name>lamco RDP Server</name>
+  <summary>Remote access to your Linux desktop via RDP</summary>
+
+  <description>
+    <p>
+      lamco RDP Server provides remote access to your existing Linux desktop session
+      via the industry-standard Remote Desktop Protocol (RDP). Built specifically for
+      Wayland compositors, it delivers hardware-accelerated H.264 video encoding,
+      full keyboard and mouse support, and clipboard synchronization.
+    </p>
+    <p>
+      Perfect for remote work, system administration, or accessing your Linux desktop
+      from Windows, macOS, or other Linux machines. Works with GNOME, KDE Plasma,
+      Sway, and Hyprland through XDG Desktop Portals and PipeWire integration.
+    </p>
+    <p>
+      <strong>Licensing:</strong> Free for personal use, non-profits, and small businesses
+      (≤3 employees OR &lt;$1M revenue). Commercial use requires license from office@lamco.io.
+      Business Source License converts to Apache-2.0 on December 31, 2028.
+    </p>
+    <p>
+      Visit https://lamco.ai for licensing details and commercial options.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.lamco.rdp-server.desktop</launchable>
+
+  <url type="homepage">https://lamco.ai/products/lamco-rdp-server/</url>
+  <url type="bugtracker">https://github.com/lamco-admin/lamco-rdp-server/issues</url>
+  <url type="help">https://github.com/lamco-admin/lamco-rdp-server/blob/main/README.md</url>
+  <url type="vcs-browser">https://github.com/lamco-admin/lamco-rdp-server</url>
+  <url type="contact">https://lamco.ai/contact/</url>
+
+  <provides>
+    <binary>lamco-rdp-server</binary>
+  </provides>
+
+  <releases>
+    <release version="0.9.0" date="2026-01-18">
+      <description>
+        <p>Initial public release with core remote desktop functionality.</p>
+        <ul>
+          <li>Wayland-native screen capture via XDG Desktop Portals</li>
+          <li>H.264 video encoding (AVC420, AVC444)</li>
+          <li>Full keyboard and mouse input via Portal RemoteDesktop</li>
+          <li>Bidirectional clipboard synchronization</li>
+          <li>Multi-monitor support</li>
+          <li>Adaptive frame rate (5-60 FPS)</li>
+          <li>Runtime service discovery (18 Wayland services)</li>
+          <li>Multi-strategy session persistence architecture</li>
+          <li>TLS 1.3 encryption</li>
+          <li>Tested on GNOME (Ubuntu 24.04, RHEL 9)</li>
+        </ul>
+      </description>
+      <url>https://github.com/lamco-admin/lamco-rdp-server/releases/tag/v0.9.0</url>
+    </release>
+  </releases>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+
+  <developer id="io.lamco">
+    <name>Lamco Development</name>
+  </developer>
+
+  <update_contact>office@lamco.io</update_contact>
+
+  <categories>
+    <category>Network</category>
+    <category>RemoteAccess</category>
+  </categories>
+
+  <keywords>
+    <keyword>rdp</keyword>
+    <keyword>remote desktop</keyword>
+    <keyword>wayland</keyword>
+    <keyword>screen sharing</keyword>
+    <keyword>server</keyword>
+  </keywords>
+</component>

--- a/io.lamco.rdp-server/io.lamco.rdp-server.yml
+++ b/io.lamco.rdp-server/io.lamco.rdp-server.yml
@@ -1,0 +1,90 @@
+app-id: io.lamco.rdp-server
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.llvm18
+
+command: lamco-rdp-server
+
+finish-args:
+  # Wayland/X11 access
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+
+  # Network access for RDP
+  - --share=network
+
+  # PipeWire access for screen capture
+  - --socket=pulseaudio
+  - --filesystem=xdg-run/pipewire-0
+
+  # Portal access
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.portal.ScreenCast
+  - --talk-name=org.freedesktop.portal.RemoteDesktop
+
+  # D-Bus access
+  - --socket=session-bus
+
+  # Config directory
+  - --filesystem=~/.config/lamco-rdp-server:create
+
+  # File clipboard: read access to home directory for file transfer
+  - --filesystem=home:ro
+  # Downloads directory: write access for saving pasted files from clipboard
+  - --filesystem=xdg-download:rw
+
+  # FUSE support for clipboard virtual filesystem
+  # Note: FUSE mounts are limited in Flatpak sandbox; falls back to staging mode
+  - --filesystem=xdg-run/wrd-clipboard-fuse:create
+  - --filesystem=/tmp:rw
+
+modules:
+  # FUSE3 library for clipboard file transfer (drive redirection)
+  - name: libfuse3
+    buildsystem: meson
+    config-opts:
+      - -Dexamples=false
+      - -Duseroot=false
+      - -Dtests=false
+      - -Dudevrulesdir=/app/lib/udev/rules.d
+    sources:
+      - type: archive
+        url: https://github.com/libfuse/libfuse/releases/download/fuse-3.16.2/fuse-3.16.2.tar.gz
+        sha256: f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87
+
+  - name: lamco-rdp-server
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin
+      env:
+        CARGO_HOME: /run/build/lamco-rdp-server/cargo
+        RUST_BACKTRACE: '1'
+        LIBCLANG_PATH: /usr/lib/sdk/llvm18/lib
+    build-commands:
+      # Note: vaapi disabled (incomplete color space API), pam-auth disabled (not sandboxable)
+      # Features: h264 (video encoding), libei (Flatpak-compatible wlroots input via Portal+EIS)
+      # wayland feature excluded (wlr-direct requires direct Wayland socket, blocked by Flatpak sandbox)
+      - cargo --offline build --release --no-default-features --features "h264,libei"
+      - install -Dm755 target/release/lamco-rdp-server /app/bin/lamco-rdp-server
+
+      # Install MetaInfo
+      - install -Dm644 packaging/io.lamco.rdp-server.metainfo.xml /app/share/metainfo/io.lamco.rdp-server.metainfo.xml
+
+      # Install desktop file
+      - install -Dm644 packaging/io.lamco.rdp-server.desktop /app/share/applications/io.lamco.rdp-server.desktop
+
+      # Install icons
+      - install -Dm644 packaging/icons/io.lamco.rdp-server.svg /app/share/icons/hicolor/scalable/apps/io.lamco.rdp-server.svg
+      - install -Dm644 packaging/icons/io.lamco.rdp-server-256.png /app/share/icons/hicolor/256x256/apps/io.lamco.rdp-server.png
+      - install -Dm644 packaging/icons/io.lamco.rdp-server-128.png /app/share/icons/hicolor/128x128/apps/io.lamco.rdp-server.png
+      - install -Dm644 packaging/icons/io.lamco.rdp-server-64.png /app/share/icons/hicolor/64x64/apps/io.lamco.rdp-server.png
+      - install -Dm644 packaging/icons/io.lamco.rdp-server-48.png /app/share/icons/hicolor/48x48/apps/io.lamco.rdp-server.png
+      - install -Dm644 packaging/icons/io.lamco.rdp-server-32.png /app/share/icons/hicolor/32x32/apps/io.lamco.rdp-server.png
+    sources:
+      - type: archive
+        url: https://github.com/lamco-admin/lamco-rdp-server/releases/download/v0.9.0/lamco-rdp-server-0.9.0-final.tar.xz
+        sha256: ad4f532f7438361bff368ed836b0a67fc620baf73eb011b149a8aad53b0b8a66


### PR DESCRIPTION
This PR adds lamco RDP Server, a Wayland-native RDP server for Linux.

**Application Details:**
- **Name:** lamco RDP Server  
- **App ID:** io.lamco.rdp-server
- **Category:** Network, Remote Access
- **License:** Business Source License 1.1 (proprietary, source-available)
- **Free Use:** Personal, non-profit, small businesses (≤3 employees OR <$1M revenue)
- **Commercial Use:** Requires license from office@lamco.io
- **Future:** Converts to Apache-2.0 on December 31, 2028

**Description:**
Remote desktop server for Linux with native Wayland integration. Enables remote access to GNOME, KDE, and wlroots desktop sessions via RDP. Uses XDG Desktop Portals for screen capture and input injection, PipeWire for video streaming, and H.264 encoding for efficient bandwidth usage.

**Testing:**
- Built and tested locally on Fedora 42
- Manifest validated with appstream-util
- MetaInfo XML validated  
- Desktop file validated
- Application tested on Ubuntu 24.04 (GNOME 46) and RHEL 9 (GNOME 40)

**Homepage:** https://lamco.ai/products/lamco-rdp-server/  
**Source:** https://github.com/lamco-admin/lamco-rdp-server  
**Documentation:** https://github.com/lamco-admin/lamco-rdp-server/blob/main/README.md

**BSL License Note:**
This application uses Business Source License 1.1, which allows free redistribution and use for non-production purposes. Flathub guidelines permit proprietary licenses that allow redistribution. The license will convert to Apache-2.0 (fully open source) on December 31, 2028.

**Organization:** Lamco Development  
**Contact:** greg@lamco.io