### PR TITLE
Add com.anthropic.claude-desktop

### DIFF
--- a/claude-desktop.sh
+++ b/claude-desktop.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Launcher script for Claude Desktop Flatpak
+
+export ELECTRON_OZONE_PLATFORM_HINT="${ELECTRON_OZONE_PLATFORM_HINT:-auto}"
+
+# Use zypak for proper Flatpak sandbox integration with Electron
+exec zypak-wrapper /app/lib/claude-desktop/electron /app/lib/claude-desktop/resources/app.asar "$@"

--- a/com.anthropic.claude-desktop.desktop
+++ b/com.anthropic.claude-desktop.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Claude
+Comment=Claude AI Desktop Application
+Exec=claude-desktop %u
+Icon=com.anthropic.claude-desktop
+Type=Application
+Terminal=false
+Categories=Office;Utility;Chat;
+MimeType=x-scheme-handler/claude;
+StartupWMClass=Claude

--- a/com.anthropic.claude-desktop.metainfo.xml
+++ b/com.anthropic.claude-desktop.metainfo.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.anthropic.claude-desktop</id>
+  <name>Claude</name>
+  <summary>Claude AI Desktop Application</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://www.anthropic.com/terms</project_license>
+  <developer id="com.anthropic">
+    <name>Anthropic</name>
+  </developer>
+  <description>
+    <p>
+      Claude is an AI assistant created by Anthropic to be helpful, harmless, and honest.
+      This desktop application provides native access to Claude with features including:
+    </p>
+    <ul>
+      <li>Conversational AI assistance</li>
+      <li>Code generation and analysis</li>
+      <li>Document understanding</li>
+      <li>Quick Entry for fast access</li>
+      <li>System tray integration</li>
+    </ul>
+    <p>
+      Note: This is an unofficial Linux port of the official Claude Desktop application.
+      Requires an Anthropic account to use.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.anthropic.claude-desktop.desktop</launchable>
+  <url type="homepage">https://claude.ai</url>
+  <url type="bugtracker">https://github.com/patrickjaja/claude-desktop-bin/issues</url>
+  <url type="help">https://support.anthropic.com</url>
+  <categories>
+    <category>Office</category>
+    <category>Utility</category>
+    <category>Chat</category>
+  </categories>
+  <requires>
+    <internet>always</internet>
+  </requires>
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="1.1.381" date="2026-01-20">
+      <description>
+        <p>Update to Claude Desktop version 1.1.381</p>
+      </description>
+    </release>
+  </releases>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Claude Desktop main interface</caption>
+      <image>https://raw.githubusercontent.com/patrickjaja/claude-desktop-bin/master/cc.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/com.anthropic.claude-desktop.yml
+++ b/com.anthropic.claude-desktop.yml
@@ -1,0 +1,93 @@
+# Flatpak manifest for Claude Desktop
+# Submitted to Flathub for distribution
+#
+# Auto-updates are handled by Flathub's external-data-checker bot
+# which monitors the x-checker-data annotations below
+
+app-id: com.anthropic.claude-desktop
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: claude-desktop
+separate-locales: false
+
+finish-args:
+  # X11 + Wayland
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  # GPU acceleration
+  - --device=dri
+  # Network access (required for Claude API)
+  - --share=network
+  # Audio (for potential future features)
+  - --socket=pulseaudio
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=com.canonical.AppMenu.Registrar
+  # File access for uploads/downloads
+  - --filesystem=home
+  - --filesystem=xdg-download
+  # Required for Electron
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
+modules:
+  # Electron runtime - bundled for sandbox compatibility
+  - name: electron
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/electron/electron/releases/download/v33.2.1/electron-v33.2.1-linux-x64.zip
+        sha256: 51ab902b76a95bb97a6e40a21c4aeb34d7bc44d8bf498e3c13772ba8d0bc650f
+        dest: electron
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/electron/electron/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: .assets[] | select(.name == "electron-" + $version + "-linux-x64.zip") | .browser_download_url
+    build-commands:
+      - install -d /app/lib/claude-desktop
+      - cp -r electron/* /app/lib/claude-desktop/
+      - chmod +x /app/lib/claude-desktop/electron
+
+  # Claude Desktop application (pre-patched for Linux)
+  - name: claude-desktop
+    buildsystem: simple
+    sources:
+      - type: archive
+        url: https://github.com/patrickjaja/claude-desktop-bin/releases/download/v1.1.381/claude-desktop-1.1.381-linux.tar.gz
+        sha256: 2ceafdc4a56207b2bf13d184d7b64350b2f028ce152cf1a9fd7985a64d418008
+        dest: tarball
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/patrickjaja/claude-desktop-bin/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: .assets[] | select(.name | test("claude-desktop-.*-linux.tar.gz")) | .browser_download_url
+      - type: file
+        path: claude-desktop.sh
+      - type: file
+        path: com.anthropic.claude-desktop.desktop
+      - type: file
+        path: com.anthropic.claude-desktop.metainfo.xml
+    build-commands:
+      # Create resources directory for app.asar
+      - mkdir -p /app/lib/claude-desktop/resources
+
+      # Install application files
+      - cp -r tarball/app/* /app/lib/claude-desktop/resources/
+
+      # Install launcher script
+      - install -Dm755 claude-desktop.sh /app/bin/claude-desktop
+
+      # Install desktop file
+      - install -Dm644 com.anthropic.claude-desktop.desktop /app/share/applications/com.anthropic.claude-desktop.desktop
+
+      # Install metainfo
+      - install -Dm644 com.anthropic.claude-desktop.metainfo.xml /app/share/metainfo/com.anthropic.claude-desktop.metainfo.xml
+
+      # Install icon
+      - install -Dm644 tarball/icons/claude-desktop.png /app/share/icons/hicolor/256x256/apps/com.anthropic.claude-desktop.png


### PR DESCRIPTION
## New App Submission: Claude Desktop for Linux

### App Information
- **App ID:** `com.anthropic.claude-desktop`
- **Name:** Claude
- **Summary:** Claude AI Desktop Application
- **Homepage:** https://claude.ai
- **Source Repository:** https://github.com/patrickjaja/claude-desktop-bin

### Description
Claude is an AI assistant created by Anthropic. This is an unofficial Linux port of the official Claude Desktop application, providing native desktop access with features including:
- Conversational AI assistance
- Code generation and analysis
- Document understanding
- Quick Entry for fast access
- System tray integration

### Technical Details
- Uses Electron runtime (bundled)
- Downloads pre-patched application files from GitHub Releases
- Includes `x-checker-data` for automatic updates via external-data-checker

### Checklist
- [x] App ID follows [naming conventions](https://docs.flathub.org/docs/for-app-authors/requirements#application-id)
- [x] Manifest validates with `flatpak-builder`
- [x] Desktop file included
- [x] MetaInfo/AppStream file included with:
  - [x] App description
  - [x] Screenshots
  - [x] Release information
  - [x] Content rating
- [x] Icon included (256x256)
- [x] `x-checker-data` configured for auto-updates

### Notes
This application requires an Anthropic account to use. The upstream Windows application is repackaged with Linux-compatible patches applied.