### PR TITLE
Add io.lamco.rdp-server

### DIFF
--- a/io.lamco.rdp-server/io.lamco.rdp-server.metainfo.xml
+++ b/io.lamco.rdp-server/io.lamco.rdp-server.metainfo.xml
@@ -1,87 +1,156 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="console-application">
+<!-- Copyright 2025 Lamco Development -->
+<component type="desktop-application">
   <id>io.lamco.rdp-server</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-proprietary=https://mariadb.com/bsl11/</project_license>
+  <project_license>BUSL-1.1</project_license>
 
-  <name>lamco RDP Server</name>
-  <summary>Remote access to your Linux desktop via RDP</summary>
-
-  <description>
-    <p>
-      lamco RDP Server provides remote access to your existing Linux desktop session
-      via the industry-standard Remote Desktop Protocol (RDP). Built specifically for
-      Wayland compositors, it delivers hardware-accelerated H.264 video encoding,
-      full keyboard and mouse support, and clipboard synchronization.
-    </p>
-    <p>
-      Perfect for remote work, system administration, or accessing your Linux desktop
-      from Windows, macOS, or other Linux machines. Works with GNOME, KDE Plasma,
-      Sway, and Hyprland through XDG Desktop Portals and PipeWire integration.
-    </p>
-    <p>
-      <strong>Licensing:</strong> Free for personal use, non-profits, and small businesses
-      (≤3 employees OR &lt;$1M revenue). Commercial use requires license from office@lamco.io.
-      Business Source License converts to Apache-2.0 on December 31, 2028.
-    </p>
-    <p>
-      Visit https://lamco.ai for licensing details and commercial options.
-    </p>
-  </description>
-
-  <launchable type="desktop-id">io.lamco.rdp-server.desktop</launchable>
-
-  <url type="homepage">https://lamco.ai/products/lamco-rdp-server/</url>
-  <url type="bugtracker">https://github.com/lamco-admin/lamco-rdp-server/issues</url>
-  <url type="help">https://github.com/lamco-admin/lamco-rdp-server/blob/main/README.md</url>
-  <url type="vcs-browser">https://github.com/lamco-admin/lamco-rdp-server</url>
-  <url type="contact">https://lamco.ai/contact/</url>
-
-  <provides>
-    <binary>lamco-rdp-server</binary>
-  </provides>
-
-  <releases>
-    <release version="0.9.0" date="2026-01-18">
-      <description>
-        <p>Initial public release with core remote desktop functionality.</p>
-        <ul>
-          <li>Wayland-native screen capture via XDG Desktop Portals</li>
-          <li>H.264 video encoding (AVC420, AVC444)</li>
-          <li>Full keyboard and mouse input via Portal RemoteDesktop</li>
-          <li>Bidirectional clipboard synchronization</li>
-          <li>Multi-monitor support</li>
-          <li>Adaptive frame rate (5-60 FPS)</li>
-          <li>Runtime service discovery (18 Wayland services)</li>
-          <li>Multi-strategy session persistence architecture</li>
-          <li>TLS 1.3 encryption</li>
-          <li>Tested on GNOME (Ubuntu 24.04, RHEL 9)</li>
-        </ul>
-      </description>
-      <url>https://github.com/lamco-admin/lamco-rdp-server/releases/tag/v0.9.0</url>
-    </release>
-  </releases>
-
-  <content_rating type="oars-1.1">
-    <content_attribute id="social-info">moderate</content_attribute>
-  </content_rating>
+  <name>Lamco RDP Server</name>
+  <summary>Remote desktop server for Wayland with graphical configuration</summary>
 
   <developer id="io.lamco">
     <name>Lamco Development</name>
   </developer>
 
-  <update_contact>office@lamco.io</update_contact>
+  <description>
+    <p>
+      Lamco RDP Server provides remote access to your Linux desktop session
+      via the Remote Desktop Protocol (RDP). Built for Wayland compositors,
+      it delivers hardware-accelerated H.264 video encoding, full keyboard
+      and mouse support, bidirectional clipboard, and audio streaming.
+    </p>
+    <p>
+      Includes a graphical configuration interface for easy setup and
+      management of server settings, TLS certificates, and live monitoring.
+    </p>
+    <p>
+      Works with GNOME, KDE Plasma, Sway, and Hyprland through XDG Desktop
+      Portals and PipeWire. Connect from Windows, macOS, or Linux using any
+      standard RDP client.
+    </p>
+    <p>
+      Free for personal use, non-profits, and small businesses (3 or fewer
+      employees AND less than $1M revenue). Commercial use requires a license.
+      Converts to Apache-2.0 on December 31, 2028.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.lamco.rdp-server.desktop</launchable>
+
+  <icon type="remote" width="256" height="256">https://lamco.ai/assets/icons/io.lamco.rdp-server-256.png</icon>
 
   <categories>
     <category>Network</category>
     <category>RemoteAccess</category>
   </categories>
 
+  <screenshots>
+    <screenshot type="default">
+      <caption>Server configuration with professional dark theme</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-server.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Security settings and TLS certificate management</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-security.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Video encoding and codec configuration</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-video.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>EGFX graphics pipeline settings</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-egfx.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Performance tuning and adaptive quality</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-performance.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Advanced options and damage tracking</caption>
+      <image type="source" width="1280" height="800">https://lamco.ai/assets/screenshots/lamco-rdp-server-gui-advanced.png</image>
+    </screenshot>
+  </screenshots>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#0EA5E9</color>
+    <color type="primary" scheme_preference="dark">#00BFD8</color>
+  </branding>
+
+  <url type="homepage">https://lamco.ai/products/lamco-rdp-server/</url>
+  <url type="bugtracker">https://github.com/lamco-admin/lamco-rdp-server/issues</url>
+  <url type="help">https://lamco.ai/products/lamco-rdp-server/docs/v1</url>
+  <url type="faq">https://lamco.ai/products/lamco-rdp-server/faq</url>
+  <url type="vcs-browser">https://github.com/lamco-admin/lamco-rdp-server</url>
+  <url type="contribute">https://github.com/lamco-admin/lamco-rdp-server/blob/main/CONTRIBUTING.md</url>
+  <url type="contact">https://lamco.ai/contact/</url>
+
+  <provides>
+    <binary>lamco-rdp-server</binary>
+    <binary>lamco-rdp-server-gui</binary>
+  </provides>
+
+  <!-- GUI requires minimum display size -->
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <!-- Recommended for full GUI interaction -->
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </recommends>
+
+  <!-- Additional input methods supported -->
+  <supports>
+    <control>touch</control>
+  </supports>
+
+  <releases>
+    <release version="1.2.0" date="2026-01-21">
+      <url type="details">https://github.com/lamco-admin/lamco-rdp-server/releases/tag/v1.2.0</url>
+      <description>
+        <p>Audio streaming and GUI enhancements.</p>
+        <ul>
+          <li>RDPSND audio channel with OPUS, AAC, and PCM codecs</li>
+          <li>Audio configuration tab in GUI</li>
+          <li>PipeWire audio capture integration</li>
+          <li>Improved capability detection with JSON output</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.9.0" date="2026-01-21">
+      <url type="details">https://github.com/lamco-admin/lamco-rdp-server/releases/tag/v0.9.0</url>
+      <description>
+        <p>Initial release with core remote desktop functionality.</p>
+        <ul>
+          <li>Wayland-native screen capture via XDG Desktop Portals</li>
+          <li>H.264 video encoding (AVC420, AVC444)</li>
+          <li>Full keyboard and mouse input</li>
+          <li>Bidirectional clipboard synchronization</li>
+          <li>Multi-monitor support</li>
+          <li>TLS 1.3 encryption</li>
+          <li>10-tab graphical configuration interface</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+
   <keywords>
-    <keyword>rdp</keyword>
+    <keyword>RDP</keyword>
+    <keyword>Wayland</keyword>
     <keyword>remote desktop</keyword>
-    <keyword>wayland</keyword>
+    <keyword>remote access</keyword>
     <keyword>screen sharing</keyword>
-    <keyword>server</keyword>
+    <keyword>desktop sharing</keyword>
+    <keyword>vnc alternative</keyword>
+    <keyword>linux remote access</keyword>
+    <keyword>h264</keyword>
+    <keyword>pipewire</keyword>
+    <keyword>mstsc</keyword>
+    <keyword>remmina</keyword>
   </keywords>
+
+  <update_contact>office_at_lamco.io</update_contact>
 </component>

--- a/io.lamco.rdp-server/io.lamco.rdp-server.yml
+++ b/io.lamco.rdp-server/io.lamco.rdp-server.yml
@@ -6,7 +6,7 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
   - org.freedesktop.Sdk.Extension.llvm18
 
-command: lamco-rdp-server
+command: lamco-rdp-server-gui
 
 finish-args:
   # Wayland/X11 access
@@ -14,36 +14,31 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
 
-  # Network access for RDP
+  # Network access for RDP server
   - --share=network
 
-  # PipeWire access for screen capture
+  # PipeWire access for screen capture and audio
   - --socket=pulseaudio
   - --filesystem=xdg-run/pipewire-0
 
-  # Portal access
+  # Portal access for screen capture and remote input
   - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.portal.ScreenCast
   - --talk-name=org.freedesktop.portal.RemoteDesktop
 
-  # D-Bus access
+  # D-Bus session bus
   - --socket=session-bus
 
   # Config directory
   - --filesystem=~/.config/lamco-rdp-server:create
 
-  # File clipboard: read access to home directory for file transfer
+  # Clipboard file transfer
   - --filesystem=home:ro
-  # Downloads directory: write access for saving pasted files from clipboard
   - --filesystem=xdg-download:rw
-
-  # FUSE support for clipboard virtual filesystem
-  # Note: FUSE mounts are limited in Flatpak sandbox; falls back to staging mode
-  - --filesystem=xdg-run/wrd-clipboard-fuse:create
   - --filesystem=/tmp:rw
 
 modules:
-  # FUSE3 library for clipboard file transfer (drive redirection)
+  # FUSE3 for clipboard virtual filesystem
   - name: libfuse3
     buildsystem: meson
     config-opts:
@@ -65,26 +60,63 @@ modules:
         RUST_BACKTRACE: '1'
         LIBCLANG_PATH: /usr/lib/sdk/llvm18/lib
     build-commands:
-      # Note: vaapi disabled (incomplete color space API), pam-auth disabled (not sandboxable)
-      # Features: h264 (video encoding), libei (Flatpak-compatible wlroots input via Portal+EIS)
-      # wayland feature excluded (wlr-direct requires direct Wayland socket, blocked by Flatpak sandbox)
-      - cargo --offline build --release --no-default-features --features "h264,libei"
+      # Build with H.264 encoding, libei input, and GUI
+      - cargo --offline build --release --no-default-features --features "h264,libei,gui"
       - install -Dm755 target/release/lamco-rdp-server /app/bin/lamco-rdp-server
+      - install -Dm755 target/release/lamco-rdp-server-gui /app/bin/lamco-rdp-server-gui
 
-      # Install MetaInfo
-      - install -Dm644 packaging/io.lamco.rdp-server.metainfo.xml /app/share/metainfo/io.lamco.rdp-server.metainfo.xml
+      # Install MetaInfo (from inline source)
+      - install -Dm644 io.lamco.rdp-server.metainfo.xml /app/share/metainfo/io.lamco.rdp-server.metainfo.xml
 
-      # Install desktop file
-      - install -Dm644 packaging/io.lamco.rdp-server.desktop /app/share/applications/io.lamco.rdp-server.desktop
+      # Install desktop file (from inline source)
+      - install -Dm644 io.lamco.rdp-server.desktop /app/share/applications/io.lamco.rdp-server.desktop
 
-      # Install icons
-      - install -Dm644 packaging/icons/io.lamco.rdp-server.svg /app/share/icons/hicolor/scalable/apps/io.lamco.rdp-server.svg
-      - install -Dm644 packaging/icons/io.lamco.rdp-server-256.png /app/share/icons/hicolor/256x256/apps/io.lamco.rdp-server.png
-      - install -Dm644 packaging/icons/io.lamco.rdp-server-128.png /app/share/icons/hicolor/128x128/apps/io.lamco.rdp-server.png
-      - install -Dm644 packaging/icons/io.lamco.rdp-server-64.png /app/share/icons/hicolor/64x64/apps/io.lamco.rdp-server.png
-      - install -Dm644 packaging/icons/io.lamco.rdp-server-48.png /app/share/icons/hicolor/48x48/apps/io.lamco.rdp-server.png
-      - install -Dm644 packaging/icons/io.lamco.rdp-server-32.png /app/share/icons/hicolor/32x32/apps/io.lamco.rdp-server.png
+      # Install icons (PNG only - no SVG due to rendering issues)
+      - install -Dm644 io.lamco.rdp-server-256.png /app/share/icons/hicolor/256x256/apps/io.lamco.rdp-server.png
+      - install -Dm644 io.lamco.rdp-server-128.png /app/share/icons/hicolor/128x128/apps/io.lamco.rdp-server.png
+      - install -Dm644 io.lamco.rdp-server-64.png /app/share/icons/hicolor/64x64/apps/io.lamco.rdp-server.png
+      - install -Dm644 io.lamco.rdp-server-48.png /app/share/icons/hicolor/48x48/apps/io.lamco.rdp-server.png
+      - install -Dm644 io.lamco.rdp-server-32.png /app/share/icons/hicolor/32x32/apps/io.lamco.rdp-server.png
+
     sources:
+      # Source tarball with vendored dependencies
       - type: archive
-        url: https://github.com/lamco-admin/lamco-rdp-server/releases/download/v0.9.0/lamco-rdp-server-0.9.0-final.tar.xz
-        sha256: ad4f532f7438361bff368ed836b0a67fc620baf73eb011b149a8aad53b0b8a66
+        url: https://github.com/lamco-admin/lamco-rdp-server/releases/download/v1.2.0/lamco-rdp-server-1.2.0.tar.xz
+        sha256: 0522d46f94a66854f53439af1668f609e37be0a936171b234611a531ef6c9e01
+
+      # Icons from lamco.ai (PNG only - no SVG due to rendering issues)
+      - type: file
+        url: https://lamco.ai/assets/icons/io.lamco.rdp-server-256.png
+        dest-filename: io.lamco.rdp-server-256.png
+      - type: file
+        url: https://lamco.ai/assets/icons/io.lamco.rdp-server-128.png
+        dest-filename: io.lamco.rdp-server-128.png
+      - type: file
+        url: https://lamco.ai/assets/icons/io.lamco.rdp-server-64.png
+        dest-filename: io.lamco.rdp-server-64.png
+      - type: file
+        url: https://lamco.ai/assets/icons/io.lamco.rdp-server-48.png
+        dest-filename: io.lamco.rdp-server-48.png
+      - type: file
+        url: https://lamco.ai/assets/icons/io.lamco.rdp-server-32.png
+        dest-filename: io.lamco.rdp-server-32.png
+
+      # MetaInfo file (inline)
+      - type: file
+        path: io.lamco.rdp-server.metainfo.xml
+
+      # Desktop file (inline)
+      - type: inline
+        dest-filename: io.lamco.rdp-server.desktop
+        contents: |
+          [Desktop Entry]
+          Name=Lamco RDP Server
+          GenericName=Remote Desktop Server
+          Comment=Remote desktop server for Wayland with graphical configuration
+          Exec=lamco-rdp-server-gui
+          Icon=io.lamco.rdp-server
+          Terminal=false
+          Type=Application
+          Categories=Network;RemoteAccess;
+          Keywords=rdp;remote;desktop;wayland;screen;sharing;
+          StartupNotify=true


### PR DESCRIPTION
## New App Submission: Lamco RDP Server

**App ID:** `io.lamco.rdp-server`

**Description:** Native RDP server for Linux Wayland desktops with graphical configuration interface.

**Features:**
- PipeWire-based screen capture via Portal API
- H.264 video encoding (software + VA-API hardware)
- Audio streaming (RDPSND with OPUS/PCM/ADPCM codecs)
- Native Wayland input injection via libei
- GTK4/Adwaita configuration GUI
- Clipboard sync with file transfer support

**Upstream:** https://github.com/lamco-admin/lamco-rdp-server
**Homepage:** https://lamco.ai/products/lamco-rdp-server

**License:** Lamco Source Available License (converts to Apache-2.0 on 2028-12-31)

**Checklist:**
- [x] App ID follows reverse-DNS naming
- [x] MetaInfo file with OARS, releases, screenshots
- [x] Desktop file with required keys
- [x] Icons in multiple sizes (32-256px PNG)
- [x] Builds with Freedesktop SDK 24.08
- [x] finish-args follow least-privilege principle