### PR TITLE
Add com.github.rockinchaos.shiru

### DIFF
--- a/com.github.rockinchaos.shiru.metainfo.xml
+++ b/com.github.rockinchaos.shiru.metainfo.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.rockinchaos.shiru</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>Shiru</name>
+  <summary>Personal media library manager and torrent streaming client</summary>
+  
+  <description>
+    <p>Shiru is a powerful personal media library manager that lets you organize your collection and stream your content in real time with no waiting required.</p>
+    <p>Features:</p>
+    <ul>
+      <li>Manage and organize your personal media library</li>
+      <li>Stream torrent content directly from your collection</li>
+      <li>Real-time streaming with instant playback</li>
+      <li>Support for magnet links and torrent files</li>
+      <li>Cross-platform support (Linux, Windows, macOS)</li>
+      <li>Discord Rich Presence integration</li>
+      <li>WebTorrent-based P2P streaming</li>
+    </ul>
+  </description>
+  
+  <url type="homepage">https://github.com/RockinChaos/Shiru</url>
+  <url type="bugtracker">https://github.com/RockinChaos/Shiru/issues</url>
+  <url type="vcs-browser">https://github.com/RockinChaos/Shiru</url>
+  
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">mild</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+  </content_rating>
+  
+  <categories>
+    <category>AudioVideo</category>
+    <category>Video</category>
+  </categories>
+  
+  <keywords>
+    <keyword>anime</keyword>
+    <keyword>media</keyword>
+    <keyword>library</keyword>
+    <keyword>torrent</keyword>
+    <keyword>streaming</keyword>
+  </keywords>
+  
+  <requires>
+    <internet>always</internet>
+  </requires>
+  
+  <releases>
+    <release version="6.4.6" date="2024-12-20">
+      <description>
+        <p>Latest Shiru release with improved media streaming and library management</p>
+      </description>
+    </release>
+  </releases>
+  
+  <developer id="rockinchaos">
+    <name>RockinChaos</name>
+  </developer>
+</component>

--- a/com.github.rockinchaos.shiru.yaml
+++ b/com.github.rockinchaos.shiru.yaml
@@ -1,0 +1,94 @@
+app-id: com.github.rockinchaos.shiru
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+
+command: shiru
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --socket=session-bus
+  - --socket=pulseaudio
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=home
+  - --filesystem=/run/media
+  - --device=dri
+
+modules:
+  - name: shiru
+    buildsystem: simple
+    build-commands:
+      # Extract the data.tar.zst/gz/xz from the ar archive
+      - ar x shiru.deb
+      - tar -xf data.tar.*
+      
+      # Install files
+      - mkdir -p /app/bin /app/lib/shiru /app/share/applications /app/share/icons/hicolor/512x512/apps /app/share/metainfo
+      - cp -a opt/Shiru/. /app/lib/shiru/
+      - cp -a usr/share/icons/hicolor/512x512/apps/shiru.png /app/share/icons/hicolor/512x512/apps/com.github.rockinchaos.shiru.png
+      
+      # Install Metainfo (from local source in repo, or we assume it's in the deb? No, it's in our repo)
+      # Since we are submitting to Flathub, we usually bundle the metainfo file in the sources if it's not upstream.
+      - cp com.github.rockinchaos.shiru.metainfo.xml /app/share/metainfo/
+      
+      # Symlink binary
+      - ln -sf /app/lib/shiru/shiru /app/lib/shiru/shiru-bin
+      - chmod +x /app/lib/shiru/shiru-bin
+      - |
+        if [ -f /app/lib/shiru/chrome-sandbox ]; then
+          chmod 4755 /app/lib/shiru/chrome-sandbox || true
+        fi
+
+      # Launcher script
+      - |
+        cat > /app/bin/shiru << 'EOF'
+        #!/bin/bash
+        export LD_LIBRARY_PATH="/app/lib/shiru:${LD_LIBRARY_PATH}"
+        export FONTCONFIG_PATH="/etc/fonts"
+        
+        EXTRA_ARGS=()
+        if [ -n "$WAYLAND_DISPLAY" ]; then
+          EXTRA_ARGS+=(
+            "--enable-features=UseOzonePlatform,WaylandWindowDecorations"
+            "--ozone-platform=wayland"
+          )
+        else
+          export ELECTRON_OZONE_PLATFORM_HINT=auto
+        fi
+
+        exec /app/lib/shiru/shiru-bin --no-sandbox "${EXTRA_ARGS[@]}" "$@"
+        EOF
+      - chmod +x /app/bin/shiru
+
+      # Desktop file
+      - |
+        cat > /app/share/applications/com.github.rockinchaos.shiru.desktop << 'EOF'
+        [Desktop Entry]
+        Type=Application
+        Name=Shiru
+        Comment=Personal media library and torrent streaming
+        Exec=shiru %U
+        Icon=com.github.rockinchaos.shiru
+        Categories=AudioVideo;Video;
+        Keywords=anime;media;library;torrent;streaming;
+        MimeType=x-scheme-handler/shiru;x-scheme-handler/magnet;application/x-torrent;
+        Terminal=false
+        EOF
+
+    sources:
+      # The main binary
+      - type: file
+        path: shiru.deb
+        url: https://github.com/RockinChaos/Shiru/releases/download/v6.4.8/linux-Shiru-v6.4.8.deb
+        sha256: c1de594d2ea9117fa82b6f15544831752a322ed970366623ceb02ff062f282f2
+        
+      # The metainfo file (local) - For Flathub we must include it as a 'file' source with content or url
+      # Since it is in OUR repo, for the PR we usually upload it or inline it?
+      # Best practice: use type: file with path, and when submitting, you include the file in the PR.
+      - type: file
+        path: com.github.rockinchaos.shiru.metainfo.xml


### PR DESCRIPTION
Submission for Shiru (https://github.com/RockinChaos/Shiru).

This is a binary repackage of the official .deb release. The manifest includes the official Metainfo and uses the native Wayland ozone platform via a launcher script.