### PR TITLE
Add com.obsproject.Studio.Plugin.OBSPWVideo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+OBS PipeWire Video plugin
+=========================
+
+This is a plugin for OBS Studio that allows you to add generic PipeWire video input streams to your scenes.
+
+To use this plugin you also need an application that supports PipeWire video output. To enable PipeWire video output for Windows applications running under Wine/Proton, see [Spout2PW](https://github.com/hoshinolina/spout2pw).
+
+Installation
+------------
+
+This flatpak is an extension for OBS Studio and is therefore not listed on the Flathub website.
+
+To install this plugin you need to run this command in a terminal:
+
+```
+flatpak install com.obsproject.Studio.Plugin.OBSPWVideo
+```

--- a/com.obsproject.Studio.Plugin.OBSPWVideo.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.OBSPWVideo.metainfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.OBSPWVideo</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>OBS PipeWire Video</name>
+  <summary>Add generic PipeWire video streams as sources</summary>
+  <url type="homepage">https://github.com/hoshinolina/obs-pwvideo</url>
+  <url type="bugtracker">https://github.com/hoshinolina/obs-pwvideo/issues</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+  <releases>
+    <release version="0.1.1" date="2026-02-01"/>
+    <release version="0.1.0" date="2026-01-31"/>
+  </releases>
+  <developer id="net.hoshinolina">
+    <name>Hoshino Lina</name>
+  </developer>
+</component>

--- a/com.obsproject.Studio.Plugin.OBSPWVideo.yml
+++ b/com.obsproject.Studio.Plugin.OBSPWVideo.yml
@@ -1,0 +1,29 @@
+id: com.obsproject.Studio.Plugin.OBSPWVideo
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.kde.Sdk//6.8
+build-extension: true
+separate-locales: false
+build-options:
+  prefix: /app/plugins/OBSPWVideo
+  strip: true
+
+modules:
+  - name: obs-pwvideo-plugin
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    post-install:
+      - install -Dpm0644 -t ${FLATPAK_DEST}/share/metainfo ../${FLATPAK_ID}.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/hoshinolina/obs-pwvideo.git
+        tag: 0.1.1
+        commit: 05edbfdf94d61752683f6993a535831940a600c5
+        x-checker-data:
+          type: git
+          is-main-source: true
+          tag-pattern: ^([\d.]+)$
+      - type: file
+        path: com.obsproject.Studio.Plugin.OBSPWVideo.metainfo.xml

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+	"only-arches": [ "x86_64" ],
+	"skip-icons-check": true,
+	"disable-external-data-checker": true
+}


### PR DESCRIPTION
This is a plugin for OBS Studio that allows you to add generic PipeWire video input streams to your scenes.

Manifest based on flathub/com.obsproject.Studio.Plugin.OBSVkCapture

Notes:
* This implements functionality analogous to Spout2 (on Windows) and Syphon (on macOS), which are widely used by OBS users streaming video from other applications (e.g. for VTubing and professional video mixing productions). In particular, it allows video to be captured without on-screen overlays/menus and with an alpha channel (see demo below). This is currently a major blocker for these users moving to Linux. While the plugin can be installed standalone with standalone OBS, a large fraction of users are using Flatpak (e.g. with immutable distros such as Bazzite), and a Flatpak extension build is required for them.
* The PipeWire socket permission from the OBS Flatpak package is used. OBS uses this for the JACK input source, which is analogously doing a direct connection to PipeWire (the upstream JACK input plugin is analogous to this plugin, but for audio). Once a suitable portal solution exists for [app-to-app media sharing](https://github.com/flatpak/xdg-desktop-portal/discussions/1141), this code will be updated to use it (and likely merged into upstream OBS at a later point).

### Please confirm your submission meets all the criteria
- [x] Please describe the application briefly.
      OBS-PWVideo is an OBS plugin that allows adding generic PipeWire video input streams to OBS scenes.
- [x] Please attach a video showcasing the application on Linux using the Flatpak.
      Demo showing VTube Studio's Spout2 output, bridged through [spout2pw](https://github.com/hoshinolina/spout2pw) into PipeWire, and then into OBS using this plugin. Note the alpha transparency and lack of on-screen menu overlays in the composited video feed, which is currently impossible on Linux with any other solution.

https://github.com/user-attachments/assets/0b997ba3-45ba-4b89-b3d5-744b9a9b8e3b

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am the author of the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
