### PR TITLE
Add io.github.gregfelice.DailyDriver

### DIFF
--- a/io.github.gregfelice.DailyDriver.yml
+++ b/io.github.gregfelice.DailyDriver.yml
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# Flatpak manifest for Daily Driver
+# Flathub submission
+
+app-id: io.github.gregfelice.DailyDriver
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: dailydriver
+
+finish-args:
+  # GUI access
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+
+  # GSettings/dconf access - required to read and write GNOME keyboard shortcuts
+  # The app's core functionality is modifying GSettings for keybindings
+  - --talk-name=ca.desrt.dconf
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:rw
+  - --own-name=ca.desrt.dconf.Writer
+
+  # Portal access for system settings
+  - --talk-name=org.freedesktop.portal.Settings
+  - --talk-name=org.freedesktop.portal.Desktop
+
+  # Access host GSettings schemas (required to read/write shortcuts for
+  # org.gnome.desktop.wm.keybindings, org.gnome.shell.keybindings,
+  # org.gnome.settings-daemon.plugins.media-keys, and extensions)
+  - --env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas
+
+  # Read-only host access for detecting installed GNOME Shell extensions
+  # (e.g., Tiling Assistant) to show their shortcuts
+  - --filesystem=host-os:ro
+
+  # Hardware detection for keyboard identification (Mac keyboards, etc.)
+  - --filesystem=/sys/class/input:ro
+  - --filesystem=/sys/module/hid_apple:ro
+
+  # PolicyKit for hid-apple kernel module configuration (Mac keyboard fn key behavior)
+  - --system-talk-name=org.freedesktop.PolicyKit1
+
+  # User profile storage
+  - --filesystem=xdg-config/dailydriver
+
+  # GNOME Shell DBus for shortcut grab functionality
+  - --talk-name=org.gnome.Shell
+
+modules:
+  # dconf GIO module for GSettings backend
+  - name: dconf
+    buildsystem: meson
+    config-opts:
+      - -Dbash_completion=false
+      - -Dman=false
+      - -Dvapi=false
+    cleanup:
+      - /libexec
+      - /share/dbus-1
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/dconf/0.40/dconf-0.40.0.tar.xz
+        sha256: cf7f22a4c9200421d8d3325c5c1b8b93a36843650c9f95d6451e20f0bcb24533
+
+  # Python dependencies
+  - name: python3-typing-extensions
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/python3.12/site-packages
+      - unzip -o *.whl -d /app/lib/python3.12/site-packages
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl
+        sha256: 04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d
+
+  - name: python3-annotated-types
+    buildsystem: simple
+    build-commands:
+      - unzip -o *.whl -d /app/lib/python3.12/site-packages
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
+        sha256: 1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53
+
+  - name: python3-pydantic-core
+    buildsystem: simple
+    build-commands:
+      - unzip -o pydantic_core-*.whl -d /app/lib/python3.12/site-packages
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256: 6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2
+
+  - name: python3-pydantic
+    buildsystem: simple
+    build-commands:
+      - unzip -o *.whl -d /app/lib/python3.12/site-packages
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/58/26/82663c79010b28eddf29dcdd0ea723439535fa917fce5905885c0e9ba562/pydantic-2.10.5-py3-none-any.whl
+        sha256: 4dd4e322dbe55472cb7ca7e73f4b63574eecccf2835ffa2af9021ce113c83c53
+
+  - name: python3-tomli-w
+    buildsystem: simple
+    build-commands:
+      - unzip -o *.whl -d /app/lib/python3.12/site-packages
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c4/ac/ce90573ba446a9bbe65838ded066a805234d159b4446ae9f8ec5bbd36cbd/tomli_w-1.1.0-py3-none-any.whl
+        sha256: 1403179c78193e3184bfaade390ddbd071cba48a32a2e62ba11aae47490c63f7
+
+  # Main application
+  - name: dailydriver
+    buildsystem: meson
+    builddir: true
+    sources:
+      - type: git
+        url: https://github.com/gregfelice/dailydriver.git
+        tag: v0.1.0
+        # commit: f3fe96f5fdc2c42eaeeb6688f77f41aae6131e37


### PR DESCRIPTION
## App Summary

**Daily Driver** is a visual keyboard shortcut configuration tool for GNOME. It provides a videogame-like options UI for customizing keyboard shortcuts, with a visual keyboard overlay showing which keys are bound to which actions.

**Homepage:** https://github.com/gregfelice/dailydriver
**License:** GPL-3.0-or-later

## Features

- Visual keyboard display with real-time shortcut overlay
- Built-in presets (Vanilla GNOME, GNOME + Tiling, Hyprland-style)
- Profile system for saving and sharing configurations
- Mac keyboard support (hid-apple fn key configuration)
- Tiling Assistant extension integration
- Conflict detection and resolution

## Screenshots

Screenshots are included in the AppStream metadata and visible at:
https://github.com/gregfelice/dailydriver/tree/main/data/screenshots

## Permission Justifications

### dconf/GSettings Access
```
--talk-name=ca.desrt.dconf
--filesystem=xdg-run/dconf
--filesystem=~/.config/dconf:rw
--own-name=ca.desrt.dconf.Writer
--env=GSETTINGS_SCHEMA_DIR=/run/host/usr/share/glib-2.0/schemas
```
**Justification:** The app's core functionality is reading and writing GNOME keyboard shortcuts, which are stored in GSettings/dconf. This includes:
- `org.gnome.desktop.wm.keybindings` (window manager shortcuts)
- `org.gnome.shell.keybindings` (shell shortcuts)
- `org.gnome.settings-daemon.plugins.media-keys` (media keys and custom shortcuts)
- `org.gnome.mutter.keybindings` (compositor shortcuts)
- `org.gnome.shell.extensions.*` (extension shortcuts like Tiling Assistant)

The `--own-name=ca.desrt.dconf.Writer` is needed to write changes back to dconf from within the Flatpak sandbox.

### Host Filesystem (Read-Only)
```
--filesystem=host-os:ro
```
**Justification:** Required to detect installed GNOME Shell extensions (located in `/usr/share/gnome-shell/extensions/` and `~/.local/share/gnome-shell/extensions/`). The app shows shortcuts for extensions like Tiling Assistant when detected.

### Hardware Access
```
--filesystem=/sys/class/input:ro
--filesystem=/sys/module/hid_apple:ro
--system-talk-name=org.freedesktop.PolicyKit1
```
**Justification:** The app detects connected keyboards to identify Mac keyboards and configure the `hid-apple` kernel module (fn key behavior, Option/Command swap). PolicyKit is required to write to `/sys/module/hid_apple/parameters/` with proper authorization.

### GNOME Shell DBus
```
--talk-name=org.gnome.Shell
```
**Justification:** Used for the keyboard shortcut grabber functionality, allowing users to press a key combination to set a shortcut (similar to GNOME Settings).

### Portal Access
```
--talk-name=org.freedesktop.portal.Settings
--talk-name=org.freedesktop.portal.Desktop
```
**Justification:** Standard portal access for system settings and desktop integration.

## Checklist

- [x] App builds and runs correctly
- [x] AppStream metadata validates
- [x] Desktop file present
- [x] Icon present (scalable SVG + symbolic)
- [x] Screenshots included
- [x] Release notes for v0.1.0
- [x] Content rating (OARS-1.1) present
- [x] Appropriate categories (Settings, HardwareSettings)

## Testing

The app has been tested on:
- Fedora 39/40/41 (GNOME 45/46/47)
- Ubuntu 24.04 (GNOME 46)

## Notes

This is the initial submission. The app is fully functional for its core use case (configuring GNOME keyboard shortcuts visually). Future releases will add KDE Plasma support.