### PR TITLE
Add io.github.kriouscodes.wormshare

### DIFF
--- a/io.github.kriouscodes.wormshare/io.github.kriouscodes.wormshare.yml
+++ b/io.github.kriouscodes.wormshare/io.github.kriouscodes.wormshare.yml
@@ -1,0 +1,21 @@
+app-id: io.github.kriouscodes.wormshare
+runtime: org.gnome.Platform
+runtime-version: "46"
+sdk: org.gnome.Sdk
+command: wormshare
+finish-args:
+  - --share=network
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.portal.Desktop
+modules:
+  - python-deps.json
+  - name: wormshare
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 src/main.py /app/bin/wormshare
+      - install -Dm644 io.github.kriouscodes.wormshare.desktop /app/share/applications/io.github.kriouscodes.wormshare.desktop
+      - install -Dm644 io.github.kriouscodes.wormshare.metainfo.xml /app/share/metainfo/io.github.kriouscodes.wormshare.metainfo.xml
+      - install -Dm644 icons/hicolor/256x256/apps/io.github.kriouscodes.wormshare.png /app/share/icons/hicolor/256x256/apps/io.github.kriouscodes.wormshare.png
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
Submitting WormShare for Flathub.

- App: WormShare - Secure file sharing via Magic-Wormhole
- Repo: https://github.com/KriousCodes/Wormshare
- Runtime: GNOME 46 (GTK 4 + Adwaita)
- License: MIT