### PR TITLE
Add ie.fio.dfakeseeder

### DIFF
--- a/ie.fio.dfakeseeder.json
+++ b/ie.fio.dfakeseeder.json
@@ -127,15 +127,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl",
-                    "sha256": "20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2",
-                    "only-arches": ["x86_64"]
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl",
-                    "sha256": "7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13",
-                    "only-arches": ["aarch64"]
+                    "url": "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz",
+                    "sha256": "9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282"
                 }
             ]
         },
@@ -153,8 +146,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/dmzoneill/DFakeSeeder.git",
-                    "tag": "v1.0.7",
-                    "commit": "76cfd84ed1dc9062edb859337b01029729fdf73a"
+                    "tag": "v1.0.8",
+                    "commit": "eaa089fcb44939e31c665732504cf985de4c0608"
                 }
             ]
         }


### PR DESCRIPTION
its being made against new-pr

### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. 

D' Fake Seeder is a BitTorrent seeding simulator for testing and development purposes. It's a Python GTK4/LibAdwaita desktop application with support for   
  HTTP and UDP tracker protocols, comprehensive peer-to-peer networking (BEP-003), system tray integration via D-Bus IPC, and internationalization for 21  languages. 
  
  More info: https://github.com/dmzoneill/DFakeSeeder  

- [x] Please attach a video showcasing the application on Linux using the Flatpak. 

https://www.youtube.com/embed/HoVV38XEiUE?si=OE4NbbLamTUgH6nB

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

As far as i can see

- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

I can place this if required
[Verification](https://docs.flathub.org/docs/for-app-authors/verification) may require placing a token under https://{domain name}/.well-known/org.flathub.VerifiedApps.txt

- [x] I am an the  author to the project.


<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
