### PR TITLE
Add com.nxtai.stowit

### DIFF
--- a/com.nxtai.stowit.desktop
+++ b/com.nxtai.stowit.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=StowIt
+Comment=The universal drop buffer
+Exec=stowit
+Icon=com.nxtai.stowit
+Terminal=false
+Type=Application
+Categories=Utility;
+Keywords=clipboard;buffer;drop;drag;transfer;
+StartupWMClass=StowIt

--- a/com.nxtai.stowit.metainfo.xml
+++ b/com.nxtai.stowit.metainfo.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.nxtai.stowit</id>
+  <name>StowIt</name>
+  <summary>The universal drop buffer — drop anything, pin what matters, everything expires</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <developer id="com.nxtai">
+    <name>NXTAI</name>
+  </developer>
+  <description>
+    <p>StowIt is a lightweight, always-on drop zone that sits at the edge of your screen. Drag files, text, images, or links into it — or just copy to your clipboard and it captures automatically.</p>
+    <p>Items expire after 10 minutes unless you pin them. No clutter, no cleanup, no thinking required.</p>
+    <p>Features include automatic clipboard capture, drag and drop, QR code sharing to mobile, auto-expiring items with pin to keep, LAN Zones for team sharing, REST API for automation, and integrations with Slack, Discord, and Obsidian.</p>
+    <p>No account required. No cloud. No tracking. 100% local-first.</p>
+  </description>
+  <url type="homepage">https://zamfir70.github.io/stowit-site/</url>
+  <url type="bugtracker">https://zamfir70.github.io/stowit-site/contact.html</url>
+  <url type="help">https://zamfir70.github.io/stowit-site/contact.html</url>
+  <launchable type="desktop-id">com.nxtai.stowit.desktop</launchable>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <keywords>
+    <keyword>clipboard</keyword>
+    <keyword>buffer</keyword>
+    <keyword>drop zone</keyword>
+    <keyword>drag and drop</keyword>
+    <keyword>file transfer</keyword>
+  </keywords>
+  <releases>
+    <release version="4.1.0" date="2026-02-15">
+      <description>
+        <p>Polish pass: drag-and-drop fix, zone persistence, zone picker, pin limits, improved window resizing.</p>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1" />
+</component>

--- a/com.nxtai.stowit.yml
+++ b/com.nxtai.stowit.yml
@@ -1,0 +1,35 @@
+app-id: com.nxtai.stowit
+runtime: org.gnome.Platform
+runtime-version: '45'
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node20
+command: stowit
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --share=network
+  - --device=dri
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --filesystem=home
+
+modules:
+  - name: stowit
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin
+      env:
+        CARGO_HOME: /run/build/stowit/cargo
+        npm_config_nodedir: /usr/lib/sdk/node20
+    build-commands:
+      - npm install
+      - npx tauri build --bundles none
+      - install -Dm755 src-tauri/target/release/stowit /app/bin/stowit
+      - install -Dm644 src-tauri/icons/icon.png /app/share/icons/hicolor/512x512/apps/com.nxtai.stowit.png
+      - install -Dm644 flatpak/com.nxtai.stowit.desktop /app/share/applications/com.nxtai.stowit.desktop
+      - install -Dm644 flatpak/com.nxtai.stowit.metainfo.xml /app/share/metainfo/com.nxtai.stowit.metainfo.xml
+    sources:
+      - type: dir
+        path: ..


### PR DESCRIPTION
## New App: StowIt

**App ID:** com.nxtai.stowit
**Homepage:** https://zamfir70.github.io/stowit-site/
**Category:** Utility

StowIt is a lightweight, always-on drop zone — a universal clipboard buffer. Drag files, text, images, or links into it, or copy to clipboard and it captures automatically. Items auto-expire after 10 minutes unless pinned.

- Desktop file included
- AppStream metainfo included
- Icon: 512x512 PNG