### PR TITLE
Add io.github.meehow.Receiver

### DIFF
--- a/io.github.meehow.Receiver.yml
+++ b/io.github.meehow.Receiver.yml
@@ -10,7 +10,6 @@ finish-args:
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --own-name=org.mpris.MediaPlayer2.receiver
 
 modules:
   - name: receiver
@@ -19,5 +18,5 @@ modules:
       - --buildtype=release
     sources:
       - type: archive
-        url: https://github.com/meehow/receiver/archive/refs/tags/v0.3.3.tar.gz
-        sha256: 70bb50ff924f1d45aabbc313f07c4852b00fe9db93b7d5952b94104ca1d89e26
+        url: https://github.com/meehow/receiver/archive/refs/tags/v0.3.4.tar.gz
+        sha256: fa5dcbdd8c89e79ee1498a45116bb0b7f018329b542b87430291505f65f450e8


### PR DESCRIPTION
- [x] Please describe the application briefly. < Receiver is a modern internet radio player for GNOME, featuring a curated collection of over 30,000 stations from around the world. >
- [x] Please attach a video showcasing the application on Linux using the Flatpak.

https://github.com/user-attachments/assets/0398db50-f91b-4cff-a718-0ca495622a79

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
