### PR TITLE
Add org.nylander.vsdview

### DIFF
--- a/org.nylander.vsdview.yml
+++ b/org.nylander.vsdview.yml
@@ -1,0 +1,35 @@
+app-id: org.nylander.vsdview
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: vsdview
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=home:ro
+  - --filesystem=/tmp
+  - --filesystem=xdg-documents
+
+modules:
+  - name: vsdview
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --prefix=/app .
+      - install -Dm644 data/org.nylander.vsdview.desktop /app/share/applications/org.nylander.vsdview.desktop
+      - install -Dm644 data/org.nylander.vsdview.metainfo.xml /app/share/metainfo/org.nylander.vsdview.metainfo.xml
+      - install -Dm644 data/org.nylander.vsdview.mime.xml /app/share/mime/packages/org.nylander.vsdview.mime.xml
+      - install -Dm644 data/icons/hicolor/scalable/apps/org.nylander.vsdview.svg /app/share/icons/hicolor/scalable/apps/org.nylander.vsdview.svg
+      - |
+        for po in po/*.po; do
+          [ -f "$po" ] || continue
+          lang=$(basename "$po" .po)
+          mkdir -p /app/share/locale/$lang/LC_MESSAGES
+          msgfmt -o /app/share/locale/$lang/LC_MESSAGES/vsdview.mo "$po"
+        done
+    sources:
+      - type: archive
+        url: https://github.com/yeager/vsdview/archive/refs/tags/v0.4.0.tar.gz
+        sha256: 33d2da59b194f9ad132472f95677aa9fc4d12bb8486b6c626257cbcca1885f6a


### PR DESCRIPTION
## App Information

**App ID:** org.nylander.vsdview
**App Name:** VSDView
**Homepage:** https://github.com/yeager/vsdview
**License:** GPL-3.0-or-later

## Description

VSDView is a lightweight read-only viewer for Microsoft Visio files (.vsdx, .vsd, .vstx, .vss, .vssx), built with GTK4 and libadwaita. It renders diagrams using a built-in parser with support for shapes, connectors, embedded images, gradients, text, stencils, Visio themes, and multi-page documents.

No LibreOffice or Windows required.

## Checklist

- [x] App ID follows reverse-DNS naming
- [x] .desktop file present with matching app ID
- [x] .metainfo.xml with screenshots, releases, and content rating
- [x] SVG icon in hicolor/scalable
- [x] OARS content rating included
- [x] App builds and runs correctly on Linux