### PR TITLE
Add io.github.athanor_dev.athanor-launcher

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,6 @@
+{
+    "only-arches": [
+        "x86_64"
+    ],
+    "disable-external-data-checker": true
+}

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -1,6 +1,6 @@
 app-id: io.github.athanor_dev.athanor-launcher
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: athanor
 
@@ -21,12 +21,13 @@ modules:
       - cp -r * /app/nwjs
     sources:
       - type: archive
-        url: https://dl.nwjs.io/v0.106.0/nwjs-sdk-v0.106.0-linux-x64.tar.gz
-        sha256: "17512bfcce4777a306185fb6929fd5829ce1a474c28fb941d29b2329bf039b85"
+        url: https://dl.nwjs.io/v0.110.1/nwjs-sdk-v0.110.1-linux-x64.tar.gz
+        sha256: "4f82bfdc6102a5a9a224e8f26ab586c2e6f7202c774aad621d067becdba0d402"
 
   - name: athanor
     buildsystem: meson
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: d959da101432425942244dc7be0f7f67a263a653
+        tag: v0.2.1
+        commit: 9be535da747a7fdad5ff7039e11fa2fcf8c2b5ec

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -30,4 +30,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: f311b1463adb8fa261143b5e95181842128ce041
+        commit: 26dcf064043a6c81d75b9a2ee9372ae66c649110

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -29,5 +29,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        tag: v0.2.1
-        commit: 9be535da747a7fdad5ff7039e11fa2fcf8c2b5ec
+        tag: v0.2.2
+        commit: 19fb16d149df1a7298ea0d00c05bb21be6e5b3cb

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -30,4 +30,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: ba3ae7dcdf89a0fdf7e023d95f22b38e4e41a886
+        commit: f311b1463adb8fa261143b5e95181842128ce041

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -12,7 +12,6 @@ finish-args:
   - --socket=pulseaudio
   - --device=dri
   - --socket=fallback-x11
-  - --env=NWJS_DIR=/app/nwjs/
 
 modules:
   - name: nwjs
@@ -30,4 +29,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: 26dcf064043a6c81d75b9a2ee9372ae66c649110
+        commit: d959da101432425942244dc7be0f7f67a263a653

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -30,4 +30,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: 62b24922410a61f2469041fea18a856ce9db2589
+        commit: ba3ae7dcdf89a0fdf7e023d95f22b38e4e41a886

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -1,4 +1,4 @@
-app-id: io.github.athanor_dev.athanor_launcher
+app-id: io.github.athanor_dev.athanor-launcher
 runtime: org.gnome.Platform
 runtime-version: '49'
 sdk: org.gnome.Sdk
@@ -12,6 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --device=dri
   - --filesystem=home
+  - --socket=fallback-x11
   - --env=NWJS_DIR=/app/nwjs/
 
 modules:
@@ -30,4 +31,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: 3876e3bc8c9dbcb1fdf159b91dbb5a47d5921aba
+        commit: d4b88e85679f4f40ea27f013c972d1bac1636d74

--- a/io.github.athanor_dev.athanor-launcher.yaml
+++ b/io.github.athanor_dev.athanor-launcher.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --device=dri
-  - --filesystem=home
   - --socket=fallback-x11
   - --env=NWJS_DIR=/app/nwjs/
 
@@ -31,4 +30,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: d4b88e85679f4f40ea27f013c972d1bac1636d74
+        commit: 62b24922410a61f2469041fea18a856ce9db2589

--- a/io.github.athanor_dev.athanor_launcher.yaml
+++ b/io.github.athanor_dev.athanor_launcher.yaml
@@ -1,0 +1,32 @@
+app-id: io.github.athanor_dev.athanor_launcher
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: athanor
+
+
+finish-args:
+  - --socket=wayland
+  - --share=ipc
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=home
+  - --env=NWJS_DIR=/app/nwjs/
+
+modules:
+  - name: nwjs
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/nwjs
+      - cp -r * /app/nwjs
+    sources:
+      - type: archive
+        url: https://dl.nwjs.io/v0.106.0/nwjs-sdk-v0.106.0-linux-x64.tar.gz
+        sha256: "17512bfcce4777a306185fb6929fd5829ce1a474c28fb941d29b2329bf039b85"
+
+  - name: athanor
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/athanor-dev/athanor-launcher.git
+        commit: b778238c71f69a5e336622372d24b4a648e4714d

--- a/io.github.athanor_dev.athanor_launcher.yaml
+++ b/io.github.athanor_dev.athanor_launcher.yaml
@@ -8,6 +8,7 @@ command: athanor
 finish-args:
   - --socket=wayland
   - --share=ipc
+  - --share=network
   - --socket=pulseaudio
   - --device=dri
   - --filesystem=home

--- a/io.github.athanor_dev.athanor_launcher.yaml
+++ b/io.github.athanor_dev.athanor_launcher.yaml
@@ -29,4 +29,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/athanor-dev/athanor-launcher.git
-        commit: b778238c71f69a5e336622372d24b4a648e4714d
+        commit: 3876e3bc8c9dbcb1fdf159b91dbb5a47d5921aba


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly.



[Athanor](https://github.com/athanor-dev/athanor-launcher) 是一个开源的 rpgmaker mv/mz 游戏启动器，使用原生的 nwjs 运行时，在子沙箱中运行游戏

[Athanor](https://github.com/athanor-dev/athanor-launcher) is an open-source RPG Maker MV/MZ game launcher that uses a native NW.js runtime to run games within a child sandbox.

## 关于 app 权限

## About App Permissions

### `--filesystem=home`

由于`flatpak-spawn --sandbox`子沙箱的兼容性问题，athanor 需要申请用户主目录的访问权限以便在子沙箱中正常启动游戏

Due to compatibility issues with the `flatpak-spawn --sandbox` mechanism, Athanor requires access permissions for the user's home directory to launch games correctly within the child sandbox.

#### `xdg-portal`+`FileChooser` 有什么问题？

#### What is the issue with `xdg-portal` + `FileChooser`?

`xdg-portal`+`FileChooser`申请的权限无法继承给子沙箱，如果 app 通过这种方式直接申请目录的访问权限，即使用户通过文件选择器选择，子沙箱也无法访问游戏的目录

Permissions granted via `xdg-portal` + `FileChooser` cannot be inherited by the child sandbox. If the app requests directory access via this method, the child sandbox remains unable to access the game directory, even if the user selects it through the file chooser.

#### 为什么需要整个`--filesystem=home`而不是更窄的权限？

#### Why is the full `--filesystem=home` required instead of narrower permissions?

不管用户将游戏放到哪里，我们都希望用户能方便的运行它们。如果我们申请更窄的权限，没有覆盖用户存放游戏的位置，游戏将无法运行，这不符合用户的预期

We want users to be able to run their games easily, regardless of where they are stored. If we request restricted permissions that do not cover the user's game storage location, the game will fail to launch, which goes against user expectations.

#### 如何保护用户的数据

#### How user data is protected

除非用户主动选择目录，athanor 不会访问任何用户文件，athanor 也不会联网上传任何数据

Athanor does not access any user files unless the user actively selects a directory. Furthermore, Athanor does not connect to the internet to upload any data.

对于用户运行的游戏，athanor 通过子沙箱技术限制其目录访问，只允许游戏访问用户提供的游戏目录；并且，除非用户启用，游戏无法访问网络

For games launched by the user, Athanor uses child sandbox technology to restrict directory access, allowing the game to access *only* the specific game directory provided by the user. Additionally, games cannot access the network unless explicitly enabled by the user.

### `--share=network`

athanor 包含为游戏开启网络的选项，所以需要为整个 app 申请网络权限，该选项由用户控制并且默认关闭

Athanor includes an option to enable network access for games; therefore, network permission must be requested for the host application. This option is user-controlled and disabled by default.



这个申请使用中文编写并由 AI 工具翻译为英文，希望您能理解

This request was written in Chinese and translated into English by an AI tool. Thank you for your understanding.


- [x] Please attach a video showcasing the application on Linux using the Flatpak.

[https://github.com/athanor-dev/assets/tree/main/video](https://github.com/athanor-dev/assets/tree/main/video)
 
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author to the project.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
