### PR TITLE
Add se.danielnylander.vsdview

### DIFF
--- a/se.danielnylander.vsdview.yml
+++ b/se.danielnylander.vsdview.yml
@@ -1,0 +1,32 @@
+app-id: se.danielnylander.vsdview
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: vsdview
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+
+modules:
+  - name: vsdview
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation --no-deps --ignore-installed --prefix=/app .
+      - install -Dm644 data/se.danielnylander.vsdview.desktop /app/share/applications/se.danielnylander.vsdview.desktop
+      - install -Dm644 data/se.danielnylander.vsdview.metainfo.xml /app/share/metainfo/se.danielnylander.vsdview.metainfo.xml
+      - install -Dm644 data/se.danielnylander.vsdview.mime.xml /app/share/mime/packages/se.danielnylander.vsdview.mime.xml
+      - install -Dm644 data/icons/hicolor/scalable/apps/se.danielnylander.vsdview.svg /app/share/icons/hicolor/scalable/apps/se.danielnylander.vsdview.svg
+      - |
+        for po in po/*.po; do
+          [ -f "$po" ] || continue
+          lang=$(basename "$po" .po)
+          mkdir -p /app/share/locale/$lang/LC_MESSAGES
+          msgfmt -o /app/share/locale/$lang/LC_MESSAGES/vsdview.mo "$po"
+        done
+    sources:
+      - type: archive
+        url: https://github.com/yeager/vsdview/archive/refs/tags/v0.4.1.tar.gz
+        sha256: 6682aa1a8bda794226662b7726859009756bb75bc3943a8a977c15fdce41012c


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. VSDView is a read-only viewer for Microsoft Visio files (.vsdx/.vsd) for the GNOME desktop. It features a built-in .vsdx renderer with geometry parsing, connectors, gradients, theme support, multi-page tabs, text search, PDF/text export, and 11 translated languages. It is the only native Visio file viewer for Linux.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. *(Video will be added shortly — Flatpak builds and runs successfully on Fedora 43)*
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

Additional maintainers: @yeager

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission