### PR TITLE
Add com.github.souren.BetterNotes

### DIFF
--- a/com.github.souren.BetterNotes.json
+++ b/com.github.souren.BetterNotes.json
@@ -1,0 +1,37 @@
+{
+    "app-id": "com.github.souren.BetterNotes",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "46",
+    "sdk": "org.gnome.Sdk",
+    "command": "betternotes",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "betternotes",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/0xpaperhead/betternotes.git",
+                    "tag": "v0.1.1",
+                    "commit": "7a2c1091588ac74f3f72b8111de42f3d3088b8f5",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## New App Submission: BetterNotes

**App ID:** `com.github.souren.BetterNotes`
**Homepage:** https://github.com/0xpaperhead/betternotes
**License:** GPL-3.0-or-later

### Description
BetterNotes is a sticky notes application for GNOME built with GTK4 and Libadwaita. Features include 8 note colors, rich text editing, full-text search (SQLite FTS5), tags, trash with restore, always-on-top windows, and dark mode.

### Checklist
- [x] App has a valid metainfo file with screenshots
- [x] App uses a stable release tag (`v0.1.1`)
- [x] Manifest includes `x-checker-data` for automated updates
- [x] App ID follows reverse-DNS naming
- [x] License is FOSS (GPL-3.0-or-later)