### PR TITLE
Add page.codeberg.pare.Kino

### DIFF
--- a/page.codeberg.pare.Kino.yml
+++ b/page.codeberg.pare.Kino.yml
@@ -1,0 +1,33 @@
+app-id: page.codeberg.pare.Kino
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: '6.10'
+command: kino
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  - python3-requests.json
+
+  - name: kino
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-build-isolation --prefix=/app .
+      - install -Dm644 page.codeberg.pare.Kino.desktop /app/share/applications/page.codeberg.pare.Kino.desktop
+      - install -Dm644 page.codeberg.pare.Kino.metainfo.xml /app/share/metainfo/page.codeberg.pare.Kino.metainfo.xml
+      - install -Dm644 page.codeberg.pare.Kino.svg /app/share/icons/hicolor/scalable/apps/page.codeberg.pare.Kino.svg
+    sources:
+      - type: git
+        url: https://codeberg.org/pare/kino.git
+        commit: 59d8b0553f2f21a24e1eeced49fe5bbd29e76f3f

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -1,0 +1,34 @@
+{
+    "name": "python3-requests",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl",
+            "sha256": "9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz",
+            "sha256": "94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl",
+            "sha256": "771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl",
+            "sha256": "2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl",
+            "sha256": "bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"
+        }
+    ]
+}


### PR DESCRIPTION
Kino is a movie and TV show browser built with PySide6 and Kirigami. It uses the TorBox API to search for content and stream via an external player (Haruna).

It needs `--talk-name=org.freedesktop.Flatpak` to launch Haruna on the host through `flatpak-spawn`, since there's no portal for opening arbitrary desktop apps.