### PR TITLE
Add io.github.lnxlink.automa

### DIFF
--- a/io.github.lnxlink.automa.yml
+++ b/io.github.lnxlink.automa.yml
@@ -1,0 +1,57 @@
+app-id: io.github.lnxlink.automa
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: automa
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --share=network
+  - --filesystem=home
+  # Controla lnxlink.service via DBus
+  - --talk-name=org.freedesktop.systemd1
+  # Executa systemctl no host via flatpak-spawn
+  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.freedesktop.Notifications
+  - --filesystem=xdg-data/themes:ro
+  - --filesystem=xdg-config/gtk-4.0:ro
+
+modules:
+  - name: python3-ruamel-yaml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation --prefix=/app ruamel.yaml
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/source/r/ruamel.yaml/ruamel.yaml-0.18.6.tar.gz
+        sha256: 8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b
+
+  - name: python3-babel
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation --prefix=/app babel
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/source/B/Babel/Babel-2.14.0.tar.gz
+        sha256: 6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363
+
+  - name: automa
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 bin/automa /app/bin/automa
+      - cp -r . /app/share/automa
+      - install -Dm644 flatpak/io.github.lnxlink.automa.desktop
+          /app/share/applications/io.github.lnxlink.automa.desktop
+      - install -Dm644 flatpak/io.github.lnxlink.automa.metainfo.xml
+          /app/share/metainfo/io.github.lnxlink.automa.metainfo.xml
+      - install -Dm644 flatpak/icons/io.github.lnxlink.automa.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.lnxlink.automa.svg
+      - install -Dm644 flatpak/icons/io.github.lnxlink.automa-symbolic.svg
+          /app/share/icons/hicolor/symbolic/apps/io.github.lnxlink.automa-symbolic.svg
+    sources:
+      - type: git
+        url: https://github.com/ro2342/automa.git
+        tag: v1.0.0
+        commit: 957a581662ce324cbdb7f64a217e7bef8f7ceba5


### PR DESCRIPTION
## New App: Automa

**App ID:** `io.github.lnxlink.automa`
**License:** GPL-3.0-or-later
**Source:** https://github.com/ro2342/automa

### Description

Automa is a GTK4/libadwaita control panel for [LNXlink](https://github.com/bkbilly/lnxlink), the MQTT agent that integrates Linux desktops with Home Assistant. No terminal needed — configure everything from a clean GNOME interface.

### Checklist

- [x] The app ID is in reverse-DNS format and matches a domain I control (GitHub)
- [x] The app has a valid metainfo.xml with screenshots, description and release info
- [x] The app has a proper icon (SVG, scalable)
- [x] No unnecessary permissions in `finish-args`
- [x] The app follows GNOME HIG (GTK4 + libadwaita)
- [x] License is clearly stated (GPL-3.0-or-later)

### Permissions justification

| Permission | Reason |
|---|---|
| `--share=network` | Connect to MQTT broker |
| `--filesystem=home` | Read/write `~/.config/lnxlink/config.yaml` |
| `--talk-name=org.freedesktop.systemd1` | Control `lnxlink.service` via DBus |
| `--talk-name=org.freedesktop.Flatpak` | Run `systemctl` on host via `flatpak-spawn` |
| `--talk-name=org.freedesktop.Notifications` | Desktop notifications from Home Assistant |
| `--filesystem=xdg-data/themes:ro` | Follow system GTK theme |