### PR TITLE
Add io.github.ro2342.automa

### DIFF
--- a/io.github.ro2342.automa.yml
+++ b/io.github.ro2342.automa.yml
@@ -50,5 +50,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/ro2342/automa.git
-        tag: v1.0.22
-        commit: d3dde37bc9bd4992ce5a5877b2aab4f5a8979694
+        tag: v1.0.23
+        commit: 9b55fe00d308c48771b7d7935e6bc2efcc5ea11f


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.
      Automa is a GTK4/libadwaita control panel for LNXlink, the MQTT agent
      that integrates your Linux desktop with Home Assistant. It lets you start,
      stop and restart the LNXlink service, configure the MQTT broker, enable or
      disable sensors, and create custom commands triggerable from automations —
      all without touching the terminal.

- [X] Please attach a video showcasing the application on Linux using the Flatpak.
      https://github.com/user-attachments/assets/ccbc8836-978b-4b8e-b23d-860e663a364a

- [X] The Flatpak ID follows all the rules listed in the Application ID requirements.

- [X] I have read and followed all the Submission requirements and the Submission
      guide and I agree to them.

- [X] I am the author/developer of the project.

### Permissions justification

| Permission | Reason |
|---|---|
| `--share=network` | Connect to MQTT broker |
| `--filesystem=~/.config/lnxlink:rw` | Read/write LNXlink config file |
| `--filesystem=~/.config/autostart:rw` | Manage app autostart on login |
| `--talk-name=org.freedesktop.systemd1` | Control `lnxlink.service` via DBus |
| `--talk-name=org.freedesktop.Flatpak` | Run `systemctl` on host via `flatpak-spawn` |
| `--talk-name=org.freedesktop.Notifications` | Desktop notifications from Home Assistant |