### PR TITLE
Add ca.vtrlx.Telepipe

### DIFF
--- a/ca.vtrlx.Telepipe.json
+++ b/ca.vtrlx.Telepipe.json
@@ -40,7 +40,7 @@
 		"sources": [{
 			"type": "git",
 			"url": "https://github.com/vtrlx/telepipe",
-			"commit": "089e74f96500b33f3b11fc566c2467581772b632"
+			"commit": "3509576e0eaafcf1ed27ec701da03a61a220613a"
 		}]
 	}]
 }


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. **Telepipe allows the user to run command-lines smoothly. It is an alternative to the terminal for running command-line software.**
- [x] Please attach a video showcasing the application on Linux using the Flatpak. [Telepipe demo](https://github.com/user-attachments/assets/b817c141-2498-4e5b-94e0-5019a1ce73b8)
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
  - **Note:** Flatpak's linter has warned me that the app has lax sandbox permissions, so I'll address them here: The permission to enable `flatpak-spawn` is needed to be able to run programs on the host machine, and the read/write permission to the host filesystem is needed for the filename insertion feature to be able to calculate relative paths using GIO. I consider the latter permission to be a moot point given the app's reliance on `flatpak-spawn`.
- [x] I am the author of the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
