### PR TITLE
Add io.github.c3c4d4.minivmac

### DIFF
--- a/io.github.c3c4d4.minivmac.desktop
+++ b/io.github.c3c4d4.minivmac.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Mini vMac
+GenericName=Macintosh Emulator
+Comment=Run classic Macintosh software in Mini vMac
+Exec=minivmac %F
+Icon=io.github.c3c4d4.minivmac
+Terminal=false
+Categories=System;Emulator;
+Keywords=Macintosh;Emulator;Classic;
+StartupNotify=true

--- a/io.github.c3c4d4.minivmac.metainfo.xml
+++ b/io.github.c3c4d4.minivmac.metainfo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.c3c4d4.minivmac</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  <name>Mini vMac</name>
+  <summary>Emulator for classic black-and-white Macintosh systems</summary>
+  <description>
+    <p>Mini vMac emulates early Motorola 68000 based Macintosh computers with compatibility focused on classic black and white Macintosh software and workflows.</p>
+    <p>This package builds both a Wayland capable SDL2 frontend and an X11 fallback frontend.</p>
+    <p>A compatible Macintosh ROM file and system disk images are required at runtime and are not distributed with this package.</p>
+  </description>
+  <launchable type="desktop-id">io.github.c3c4d4.minivmac.desktop</launchable>
+  <developer id="io.github.minivmac">
+    <name>Mini vMac contributors</name>
+  </developer>
+  <url type="homepage">https://minivmac.github.io/</url>
+  <url type="bugtracker">https://github.com/c3c4d4/minivmac/issues</url>
+  <url type="vcs-browser">https://github.com/c3c4d4/minivmac</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Mini vMac application window.</caption>
+      <image type="source">https://raw.githubusercontent.com/c3c4d4/minivmac/main/packaging/flatpak/screenshots/main.png</image>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="36.04" date="2026-02-27"/>
+  </releases>
+  <provides>
+    <binary>minivmac</binary>
+  </provides>
+</component>

--- a/io.github.c3c4d4.minivmac.svg
+++ b/io.github.c3c4d4.minivmac.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="22" fill="#f4f2ea"/>
+  <rect x="26" y="18" width="76" height="92" rx="7" fill="#d8d4c8" stroke="#2d2d2d" stroke-width="4"/>
+  <rect x="36" y="32" width="56" height="42" rx="3" fill="#a7b6b2" stroke="#2d2d2d" stroke-width="4"/>
+  <rect x="48" y="83" width="32" height="16" rx="3" fill="#ece8dc" stroke="#2d2d2d" stroke-width="4"/>
+  <circle cx="48" cy="56" r="3" fill="#2d2d2d"/>
+  <circle cx="64" cy="56" r="3" fill="#2d2d2d"/>
+  <path d="M73 62c-4 5-10 5-14 0" fill="none" stroke="#2d2d2d" stroke-width="4" stroke-linecap="round"/>
+  <rect x="84" y="78" width="28" height="28" rx="4" fill="#ece8dc" stroke="#2d2d2d" stroke-width="4"/>
+  <rect x="90" y="84" width="16" height="8" rx="1" fill="#b8b4a8"/>
+  <circle cx="102" cy="97" r="2" fill="#2d2d2d"/>
+</svg>

--- a/io.github.c3c4d4.minivmac.yml
+++ b/io.github.c3c4d4.minivmac.yml
@@ -1,0 +1,53 @@
+app-id: io.github.c3c4d4.minivmac
+runtime: org.freedesktop.Platform
+runtime-version: "24.08"
+sdk: org.freedesktop.Sdk
+command: minivmac
+finish-args:
+  - --share=ipc
+  - --device=dri
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+modules:
+  - name: minivmac
+    buildsystem: simple
+    build-commands:
+      - gcc -O2 -o setup/setup_t setup/tool.c
+
+      # Wayland-capable frontend (SDL2)
+      - ./setup/setup_t -t lx64 -api sd2 > setup-wayland.sh
+      - bash setup-wayland.sh
+      - sed -i '/strip --strip-unneeded "minivmac"/d' Makefile
+      - make -j"${FLATPAK_BUILDER_N_JOBS:-4}"
+      - install -Dpm0755 minivmac /app/libexec/minivmac/minivmac-wayland
+
+      # X11 fallback frontend
+      - ./setup/setup_t -t lx64 > setup-x11.sh
+      - bash setup-x11.sh
+      - sed -i '/strip --strip-unneeded "minivmac"/d' Makefile
+      - sed -i 's|$(ObjFiles) -ldl -L/usr/X11R6/lib -lX11|$(ObjFiles) -ldl -lX11|' Makefile
+      - make -j"${FLATPAK_BUILDER_N_JOBS:-4}"
+      - install -Dpm0755 minivmac /app/libexec/minivmac/minivmac-x11
+
+      - install -Dpm0755 minivmac-launcher.sh /app/bin/minivmac
+      - install -Dpm0644 COPYING.txt /app/share/licenses/minivmac/COPYING.txt
+      - install -Dpm0644 io.github.c3c4d4.minivmac.desktop /app/share/applications/io.github.c3c4d4.minivmac.desktop
+      - install -Dpm0644 io.github.c3c4d4.minivmac.metainfo.xml /app/share/metainfo/io.github.c3c4d4.minivmac.metainfo.xml
+      - install -Dpm0644 io.github.c3c4d4.minivmac.svg /app/share/icons/hicolor/scalable/apps/io.github.c3c4d4.minivmac.svg
+
+    sources:
+      - type: archive
+        url: https://minivmac.github.io/gryphel-mirror/d/minivmac/minivmac-36.04/minivmac-36.04.src.tgz
+        sha256: 9b7343cec87723177a203e69ad3baf20f49b4e8f03619e366c4bf2705167dfa4
+      - type: file
+        path: minivmac-launcher.sh
+      - type: file
+        path: io.github.c3c4d4.minivmac.desktop
+      - type: file
+        path: io.github.c3c4d4.minivmac.metainfo.xml
+      - type: file
+        path: io.github.c3c4d4.minivmac.svg

--- a/minivmac-launcher.sh
+++ b/minivmac-launcher.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${MINIVMAC_LIBEXEC_DIR:-}" ]]; then
+  libexec_dir="${MINIVMAC_LIBEXEC_DIR}"
+elif [[ -x /app/libexec/minivmac/minivmac-wayland ]]; then
+  libexec_dir="/app/libexec/minivmac"
+else
+  libexec_dir="/usr/libexec/minivmac"
+fi
+
+wayland_bin="${libexec_dir}/minivmac-wayland"
+x11_bin="${libexec_dir}/minivmac-x11"
+backend="${MINIVMAC_BACKEND:-auto}"
+
+case "${backend}" in
+  wayland)
+    exec env SDL_VIDEODRIVER=wayland "${wayland_bin}" "$@"
+    ;;
+  x11)
+    exec "${x11_bin}" "$@"
+    ;;
+  auto|"")
+    if [[ "${XDG_SESSION_TYPE:-}" == "wayland" || -n "${WAYLAND_DISPLAY:-}" ]]; then
+      exec env SDL_VIDEODRIVER=wayland "${wayland_bin}" "$@"
+    fi
+    exec "${x11_bin}" "$@"
+    ;;
+  *)
+    echo "Invalid MINIVMAC_BACKEND: ${backend} (expected auto, wayland, or x11)" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Add `io.github.c3c4d4.minivmac`

This PR adds Mini vMac as a new Flatpak app.

- App ID: `io.github.c3c4d4.minivmac`
- License: `GPL-2.0-only`
- Upstream source: `https://minivmac.github.io/gryphel-mirror/d/minivmac/minivmac-36.04/minivmac-36.04.src.tgz`

### Runtime behavior

- Builds two frontends:
  - Wayland-capable SDL2 binary (`minivmac-wayland`)
  - X11 fallback binary (`minivmac-x11`)
- Installs a launcher (`minivmac`) that selects Wayland first when available and falls back to X11.

### Permissions rationale

- `--socket=wayland`: native Wayland display support.
- `--socket=fallback-x11`: fallback for non-Wayland sessions or explicit X11 use.
- `--device=dri`: required for working graphics acceleration paths on modern Mesa stacks.
- `--socket=pulseaudio`: emulator audio output.
- `--filesystem=xdg-documents` and `--filesystem=xdg-download`: access to user-provided ROM files and disk images without broad home-directory permission.

### Important runtime note

A compatible Macintosh ROM file and system disk images are required by Mini vMac and are not distributed by this package.

### Validation performed

- `appstreamcli validate --pedantic io.github.c3c4d4.minivmac.metainfo.xml`
- `flatpak-builder --disable-rofiles-fuse --force-clean --repo=repo build-dir io.github.c3c4d4.minivmac.yml`
