### PR TITLE
Add org.kde.glaxnimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Glaxnimate
+
+See: <https://flathub.org/apps/org.kde.glaxnimate>
+
+This app was published with a different app id (org.mattbas.Glaxnimate) before. Since the 0.6.0 release, the app is part of KDE and hence changed its id.

--- a/fix-appstream-metainfo.patch
+++ b/fix-appstream-metainfo.patch
@@ -1,0 +1,37 @@
+From fc564e35bc3e36f60d115a0a7b5b6ed60a86c067 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Julius=20K=C3=BCnzel?= <julius.kuenzel@kde.org>
+Date: Tue, 3 Mar 2026 22:17:21 +0100
+Subject: [PATCH] [appstream metainfo] Add some fields required by Flathub
+
+---
+ deploy/org.kde.glaxnimate.metainfo.xml | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/deploy/org.kde.glaxnimate.metainfo.xml b/deploy/org.kde.glaxnimate.metainfo.xml
+index df5c3ce4..1070659c 100644
+--- a/deploy/org.kde.glaxnimate.metainfo.xml
++++ b/deploy/org.kde.glaxnimate.metainfo.xml
+@@ -7,6 +7,12 @@
+   </replaces>
+   <metadata_license>CC-BY-SA-4.0</metadata_license>
+   <project_license>GPL-3.0+</project_license>
++  <developer_name translate="no">KDE</developer_name>
++  <project_group>KDE</project_group>
++  <branding>
++    <color type="primary" scheme_preference="light">#abbae7</color>
++    <color type="primary" scheme_preference="dark">#889ddd</color>
++  </branding>
+   <name>Glaxnimate</name>
+   <name xml:lang="ar">غلاكسنيمَيْت</name>
+   <name xml:lang="ca">Glaxnimate</name>
+@@ -511,6 +517,7 @@
+   <url type="bugtracker">https://bugs.kde.org/enter_bug.cgi?product=glaxnimate</url>
+   <url type="help">https://docs.glaxnimate.org/</url>
+   <url type="donation">https://www.kde.org/community/donations/?app=glaxnimate&amp;source=appdata</url>
++  <url type="vcs-browser">https://invent.kde.org/graphics/glaxnimate</url>
+   <!-- url type=contribute is not recognized but it should be valid o_O -->
+   <!--     <url type="contribute">https://glaxnimate.org/contributing/</url> -->
+   <screenshots>
+-- 
+GitLab
+

--- a/org.kde.glaxnimate.yml
+++ b/org.kde.glaxnimate.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: None
+# SPDX-License-Identifier: CC0-1.0
+
+app-id: org.kde.glaxnimate
+runtime: org.kde.Platform
+runtime-version: "6.10"
+sdk: org.kde.Sdk
+command: glaxnimate
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=host
+  - --device=dri
+modules:
+  - name: potrace
+    builddir: true
+    config-opts:
+      - --with-libpotrace
+    sources:
+      - type: archive
+        url: https://potrace.sourceforge.net/download/1.16/potrace-1.16.tar.gz
+        sha256: be8248a17dedd6ccbaab2fcc45835bb0502d062e40fbded3bc56028ce5eb7acc
+        x-checker-data:
+          - type: anitya
+            project-id: 3691
+            stable-only: true
+            url-template: https://potrace.sourceforge.net/download/$version/potrace-$version.tar.gz
+  - name: glaxnimate
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+      - -DQT_MAJOR_VERSION=6
+    post-install:
+      - |
+        DEST="$FLATPAK_DEST/share/licenses/$FLATPAK_ID/glaxnimate"
+        mkdir -p "$DEST"
+        mv ../LICENSES/* "$DEST"
+    sources:
+      - type: archive
+        url: https://download.kde.org/stable/glaxnimate/0.6.0/glaxnimate-0.6.0.tar.xz
+        sha256: 4fe5e4d48124d499aab318c932884e3e98da2fd279399c3ba3c6a4d1e07de94a
+        x-checker-data:
+          - type: anitya
+            project-id: 142485
+            stable-only: true
+            url-template: https://download.kde.org/stable/glaxnimate/$version/src/glaxnimate-$version.tar.xz
+      - type: patch
+        path: fix-appstream-metainfo.patch


### PR DESCRIPTION
This is a resubmission of [`org.mattbas.Glaxnimate`](https://github.com/flathub/org.mattbas.Glaxnimate) after app id has been changed for the recent 0.6.0 release because glaxnimate joined the KDE Community.

`replaces` and `provides` tags in the Metainfo file have been set accordingly. We will EOL the old app after this submission has been accepted.

<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly. Glaxnimate is an open-source vector animation and motion design desktop application.
- [x] Please attach a video showcasing the application on Linux using the Flatpak. 
[Screenrecording.webm](https://github.com/user-attachments/assets/b2170138-3d42-4b36-abe9-683eef2891c0)
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am a developer to the project. @mbasaglia is the original author and still active in the project.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->
Please grant access to this app for @mbasaglia, me (@jlskuz) and the KDE Flathub team

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
