### PR TITLE
Add io.github.jye16.OrbitTrack

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": true
+}

--- a/io.github.jye16.OrbitTrack.yml
+++ b/io.github.jye16.OrbitTrack.yml
@@ -1,0 +1,35 @@
+app-id: io.github.jye16.OrbitTrack
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: orbittrack
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=network
+  - --persist=.config/orbittrack
+
+build-options:
+  env:
+    PIP_DISABLE_PIP_VERSION_CHECK: "1"
+
+modules:
+  - python3-deps.yaml
+
+  - name: orbittrack
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation --no-deps --prefix=${FLATPAK_DEST} .
+      - install -Dm644 io.github.jye16.OrbitTrack.desktop
+            ${FLATPAK_DEST}/share/applications/io.github.jye16.OrbitTrack.desktop
+      - install -Dm644 io.github.jye16.OrbitTrack.metainfo.xml
+            ${FLATPAK_DEST}/share/metainfo/io.github.jye16.OrbitTrack.metainfo.xml
+      - install -Dm644 data/io.github.jye16.OrbitTrack.svg
+            ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.jye16.OrbitTrack.svg
+    sources:
+      - type: git
+        url: https://github.com/JYe16/OrbitTrack.git
+        tag: v1.0.0
+        commit: bc08ba1a13c5aa4fb1e10b4be0d024ea13dd1d87

--- a/python3-deps.yaml
+++ b/python3-deps.yaml
@@ -1,0 +1,92 @@
+# Generated with flatpak-pip-generator --runtime org.gnome.Sdk//49 --yaml --output python3-deps caldav<2 vobject requests lxml
+build-commands: []
+buildsystem: simple
+modules:
+  - name: python3-caldav
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "caldav<2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/8d/8a/b30d53c02ab508287a46cc7c3c1ce88624db003376a435d30806439f8f5d/caldav-1.6.0-py3-none-any.whl
+        sha256: 077ab30726036e80d75ba6da4bcd0134f475189ee0e161aab08062adbf59f099
+      - &id004
+        type: file
+        url: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
+        sha256: 027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
+      - &id005
+        type: file
+        url: https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz
+        sha256: 94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
+        sha256: 981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6
+      - type: file
+        url: https://files.pythonhosted.org/packages/62/ab/e0d44b1de0beb703bbc507ca064300b34046f9f9628f052d1a97ffa61b95/icalendar-7.0.2-py3-none-any.whl
+        sha256: ad31a5825b39522a30b073c6ced3ffcdf6c02cbb7dab69ba2e4de32ddbf77cc9
+      - &id006
+        type: file
+        url: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+        sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+      - &id009
+        type: file
+        url: https://files.pythonhosted.org/packages/aa/88/262177de60548e5a2bfc46ad28232c9e9cbde697bd94132aeb80364675cb/lxml-6.0.2.tar.gz
+        sha256: cd79f3367bd74b317dda655dc8fcfa304d9eb6e4fb06b7168c5cf27f96e0cd62
+      - &id001
+        type: file
+        url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+        sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+      - &id002
+        type: file
+        url: https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl
+        sha256: 5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00
+      - type: file
+        url: https://files.pythonhosted.org/packages/14/67/4d4aead359164de68d30ee67efcdbe3784063cb21535c85b9a9a03dd2ebb/recurring_ical_events-3.8.1-py3-none-any.whl
+        sha256: 3bb3aaa0c87a4d3ab5951360480686bd69f1512945f478be6a2c0f141da0bf78
+      - &id007
+        type: file
+        url: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+        sha256: 2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6
+      - type: file
+        url: https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl
+        sha256: 06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1
+      - &id008
+        type: file
+        url: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+        sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+      - &id003
+        type: file
+        url: https://files.pythonhosted.org/packages/68/20/6bba813bbd498c28edbbcf8253a6398cf4266ecf7bfa6129835c0a2bfbb1/vobject-0.9.9-py2.py3-none-any.whl
+        sha256: 0fbdb982065cf4d1843a5d5950c88510041c6de026bda49c3502721de1c6ac3d
+      - type: file
+        url: https://files.pythonhosted.org/packages/0f/b7/4bac35b4079b76c07d8faddf89467e9891b1610cfe8d03b0ebb5610e4423/x_wr_timezone-2.0.1-py3-none-any.whl
+        sha256: e74a53b9f4f7def8138455c240e65e47c224778bce3c024fcd6da2cbe91ca038
+  - name: python3-vobject
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "vobject" --no-build-isolation
+    sources:
+      - *id001
+      - *id002
+      - *id003
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
+    sources:
+      - *id004
+      - *id005
+      - *id006
+      - *id007
+      - *id008
+  - name: python3-lxml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "lxml" --no-build-isolation
+    sources:
+      - *id009
+name: python3-deps


### PR DESCRIPTION
## App Summary

**Name:** OrbitTrack
**App ID:** `io.github.jye16.OrbitTrack`
**License:** GPL-3.0-or-later
**Homepage:** https://github.com/JYe16/OrbitTrack

### Description

OrbitTrack is a native GNOME (GTK4/Libadwaita) application that connects to your CalDAV server (e.g. Nextcloud) and lets you track time spent on tasks using a stopwatch or Pomodoro technique. Completed time entries are saved back to your calendar as events.

### Features
- Browse tasks grouped by calendar
- Create, edit and complete tasks
- Start a stopwatch or Pomodoro timer per task
- Automatically saves time entries as calendar events

### Checklist
- [x] App ID matches GitHub username (`io.github.jye16`)
- [x] Manifest uses `type: git` source with tag + commit
- [x] `metainfo.xml` passes appstreamcli validation
- [x] Desktop file included
- [x] Icon (SVG) included
- [x] Screenshots with URLs in metainfo
- [x] License: GPL-3.0-or-later
- [x] Release info in metainfo
- [x] Content rating (OARS 1.1) included
