### PR TITLE
Add com.base76.Claunux — native Linux desktop app for Claude AI

### DIFF
--- a/com.base76.Claunux/com.base76.Claunux.metainfo.xml
+++ b/com.base76.Claunux/com.base76.Claunux.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.base76.Claunux</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>Claunux</name>
+  <summary>Native Linux desktop app for Claude AI</summary>
+  <description>
+    <p>Claunux brings Claude AI to Linux as a native desktop application. Built with Tauri (Rust + Svelte), it offers a lightweight (~10 MB) alternative to browser tabs, with MCP server integration and system tray support.</p>
+  </description>
+  <developer_name>Base76 Research Lab</developer_name>
+  <url type="homepage">https://github.com/base76-research-lab/claunux</url>
+  <launchable type="desktop-id">com.base76.Claunux.desktop</launchable>
+  <provides>
+    <binary>claunux</binary>
+  </provides>
+  <categories>
+    <category>Network</category>
+    <category>Chat</category>
+  </categories>
+  <release version="0.1.0" date="2026-03-03">
+    <description>Initial MVP release</description>
+  </release>
+</component>

--- a/com.base76.Claunux/com.base76.Claunux.yml
+++ b/com.base76.Claunux/com.base76.Claunux.yml
@@ -1,0 +1,30 @@
+app-id: com.base76.Claunux
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+sdk-version: '46'
+command: claunux
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node20
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin
+modules:
+  - name: claunux
+    buildsystem: simple
+    build-commands:
+      - npm ci
+      - npm run build
+      - cargo build --release
+      - install -Dm755 src-tauri/target/release/claunux /app/bin/claunux
+    sources:
+      - type: git
+        url: https://github.com/base76-research-lab/claunux.git
+        branch: main


### PR DESCRIPTION
## New App Submission: Claunux

**App ID:** com.base76.Claunux  
**Name:** Claunux  
**Category:** Network; Chat  
**License:** MIT  
**Developer:** Base76 Research Lab  
**Homepage:** https://github.com/base76-research-lab/claunux

### Description

Claunux brings Claude AI to Linux as a native desktop application. Built with Tauri 2 (Rust + Svelte), it offers a lightweight (~5MB) alternative to browser tabs, with MCP server integration and system tray support.

Anthropic ships official desktop apps for Mac and Windows but not Linux. Claunux fills that gap.

### Technical details

- **Runtime:** org.gnome.Platform//46
- **SDK:** org.gnome.Sdk//46
- **Build system:** Rust (cargo) + Node.js (npm/vite)
- **Binary size:** ~17MB uncompressed, ~5MB AppImage

### Checklist

- [x] App ID follows reverse-DNS format
- [x] Manifest builds from source (git)
- [x] AppStream metainfo included
- [x] MIT license
- [x] finish-args are minimal and justified