### PR TITLE
Add com.cosmic.browser

### DIFF
--- a/com.cosmic.browser/com.cosmic.browser.yml
+++ b/com.cosmic.browser/com.cosmic.browser.yml
@@ -1,0 +1,36 @@
+id: com.cosmic.browser
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: cosmic-browser
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin
+  build-args:
+    - --share=network
+  env:
+    CARGO_HOME: /run/build/cosmic-browser/cargo
+finish-args:
+  - --socket=wayland
+  - --share=ipc
+  - --share=network
+  - --device=all
+  - --filesystem=home
+  - --env=GDK_BACKEND=wayland
+modules:
+  - name: cosmic-browser
+    buildsystem: simple
+    build-commands:
+      # O --frozen impede que o cargo tente acessar a rede no servidor do Flathub
+      - cargo build --release --frozen
+      - install -Dm755 target/release/cosmic-browser /app/bin/cosmic-browser
+      - install -Dm644 com.cosmic.browser.desktop /app/share/applications/com.cosmic.browser.desktop
+      - mkdir -p /app/share/icons/hicolor/512x512/apps/
+      - install -Dm644 com.cosmic.browser.png /app/share/icons/hicolor/512x512/apps/com.cosmic.browser.png
+      - install -Dm644 com.cosmic.browser.metainfo.xml /app/share/metainfo/com.cosmic.browser.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/ubportsbr-hub/COSMIC-Browser.git
+        branch: main
+      - generated-sources.json


### PR DESCRIPTION
### Description
This PR adds **COSMIC Browser**, a web browser built for the COSMIC Desktop environment using Rust and GTK4/WPE. 

The application is being developed to provide a native, fast, and integrated browsing experience for the COSMIC ecosystem. This submission includes the Flatpak manifest and necessary metadata.

### Checklist
- [x] I am the upstream developer of this application.
- [x] The application ID matches the one in the manifest.
- [x] Metadata (metainfo) is included and valid.
- [x] Screenshots are provided in the metainfo file.

I have tested the build locally using `flatpak-builder` and it completes successfully.
---
[appid]: com.cosmic.browser
[metadata]: https://github.com/ubportsbr-hub/COSMIC-Browser/raw/main/com.cosmic.browser.metainfo.xml