### PR TITLE
Add com.molvicstudios.DosMundos

### DIFF
--- a/com.molvicstudios.DosMundos/com.molvicstudios.DosMundos.yml
+++ b/com.molvicstudios.DosMundos/com.molvicstudios.DosMundos.yml
@@ -1,0 +1,33 @@
+app-id: com.molvicstudios.DosMundos
+runtime: org.gnome.Platform
+runtime-version: "48"
+sdk: org.gnome.Sdk
+command: com.molvicstudios.DosMundos
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+modules:
+  - name: dosmundos
+    buildsystem: simple
+    build-commands:
+      - install -d /app/share/dosmundos
+      - cp -r assets /app/share/dosmundos/
+      - install -Dm644 index.html /app/share/dosmundos/index.html
+      - install -Dm644 game.js /app/share/dosmundos/game.js
+      - install -Dm644 scenes.js /app/share/dosmundos/scenes.js
+      - install -Dm644 characters.js /app/share/dosmundos/characters.js
+      - install -Dm644 style.css /app/share/dosmundos/style.css
+      - install -Dm755 flatpak/com.molvicstudios.DosMundos /app/bin/com.molvicstudios.DosMundos
+      - install -Dm755 flatpak/com.molvicstudios.DosMundos.js /app/bin/com.molvicstudios.DosMundos.js
+      - install -Dm644 flatpak/com.molvicstudios.DosMundos.desktop /app/share/applications/com.molvicstudios.DosMundos.desktop
+      - install -Dm644 flatpak/com.molvicstudios.DosMundos.metainfo.xml /app/share/metainfo/com.molvicstudios.DosMundos.metainfo.xml
+      - install -Dm644 flatpak/com.molvicstudios.DosMundos.svg /app/share/icons/hicolor/scalable/apps/com.molvicstudios.DosMundos.svg
+    sources:
+      # Para Flathub, reemplaza URL/tag por una version publicada e inmutable.
+      - type: git
+        url: https://github.com/MolvicStudios/dosmundos.git
+        tag: v1.0.1


### PR DESCRIPTION
## New App Submission: com.molvicstudios.DosMundos

### App Summary
Dos Mundos is a sci-fi interactive narrative game with branching decisions, puzzle sequences, and card-based combat.

### Upstream Project
- Repo: https://github.com/MolvicStudios/dosmundos
- Homepage: https://dosmundos.space/
- License: Proprietary (`LicenseRef-proprietary` in AppStream)

### Runtime
- `org.gnome.Platform//48`
- `org.gnome.Sdk//48`

### Technical Notes
The app uses a GTK + WebKitGTK launcher to run packaged static game files.

### Permission Rationale
- `--share=network`: game connectivity and online resource compatibility.
- `--socket=wayland`, `--socket=fallback-x11`: desktop display backends.
- `--socket=pulseaudio`: audio playback.
- `--device=dri`: hardware acceleration.
- `--share=ipc`: GUI compatibility.

### QA
- AppStream metadata validated.
- Local Flatpak build succeeds.