### PR TITLE
Add GitHub Puller (io.github.alihaydarsucu.GitHubPuller)

### DIFF
--- a/io.github.alihaydarsucu.GitHubPuller/io.github.alihaydarsucu.GitHubPuller.json
+++ b/io.github.alihaydarsucu.GitHubPuller/io.github.alihaydarsucu.GitHubPuller.json
@@ -1,0 +1,48 @@
+{
+  "id": "io.github.alihaydarsucu.GitHubPuller",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "45",
+  "sdk": "org.gnome.Sdk",
+  "command": "github-puller",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--filesystem=home",
+    "--talk-name=org.gtk.vfs.*",
+    "--talk-name=org.freedesktop.FileManager1"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/pkgconfig",
+    "/man",
+    "/share/doc",
+    "/share/gtk-doc",
+    "/share/man",
+    "/share/pkgconfig",
+    "*.la",
+    "*.a"
+  ],
+  "modules": [
+    {
+      "name": "github-puller",
+      "buildsystem": "simple", 
+      "build-commands": [
+        "python3 setup.py install --prefix=${FLATPAK_DEST} --root=/ --optimize=1",
+        "install -D io.github.alihaydarsucu.GitHubPuller.desktop ${FLATPAK_DEST}/share/applications/io.github.alihaydarsucu.GitHubPuller.desktop",
+        "install -D icons/io.github.alihaydarsucu.GitHubPuller.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.alihaydarsucu.GitHubPuller.svg",
+        "install -D io.github.alihaydarsucu.GitHubPuller.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.alihaydarsucu.GitHubPuller.metainfo.xml"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/alihaydarsucu/GitHubPuller/archive/v1.0.1.tar.gz",
+          "sha256": "a6260e0ed848ab6d4d700729b6bf6a0f038f8cdade54b56ead075cb8d38a772a",
+          "strip-components": 1
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add GitHub Puller to Flathub.

GitHub Puller is a GTK4 application for managing GitHub repositories. It allows users to download and organize repositories from their GitHub account.

- **App ID**: io.github.alihaydarsucu.GitHubPuller  
- **GitHub**: https://github.com/alihaydarsucu/GitHubPuller
- **Release**: v1.0.1

**Build Status**: ✅ Tested and working on GNOME Platform 45

The manifest has been tested with local Flatpak builds and all desktop integration files are properly configured.