### PR TITLE
Add com.talkye.scriber

### DIFF
--- a/com.talkye.scriber.desktop
+++ b/com.talkye.scriber.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Talkye Scriber
+Comment=Voice-to-text dictation tool
+Exec=talkye-scriber
+Icon=com.talkye.scriber
+Terminal=false
+StartupWMClass=com.talkye.scriber
+Categories=Utility;Accessibility;Audio;

--- a/com.talkye.scriber.metainfo.xml
+++ b/com.talkye.scriber.metainfo.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2026 Olivetty -->
+<component type="desktop-application">
+  <id>com.talkye.scriber</id>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <name>Talkye Scriber</name>
+  <summary>Voice-to-text dictation for your desktop</summary>
+
+  <developer id="com.talkye">
+    <name>Olivetty</name>
+  </developer>
+
+  <description>
+    <p>
+      Hold a key, speak, release — text appears at your cursor. Talkye Scriber
+      is a system-wide voice dictation tool that works in any application.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Push-to-talk dictation with configurable trigger key</li>
+      <li>Works system-wide in any text field</li>
+      <li>Offline speech recognition powered by whisper.cpp (no cloud required)</li>
+      <li>Supports 30+ languages with automatic detection</li>
+      <li>Voice commands: say "enter", "delete", "undo" and more</li>
+      <li>Optional AI-powered grammar correction and translation</li>
+      <li>Customizable sound themes for recording feedback</li>
+      <li>Lightweight system tray integration</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/olivetty/Talkye-Scriber</url>
+  <url type="bugtracker">https://github.com/olivetty/Talkye-Scriber/issues</url>
+
+  <launchable type="desktop-id">com.talkye.scriber.desktop</launchable>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#e8f0fe</color>
+    <color type="primary" scheme_preference="dark">#1a1a2e</color>
+  </branding>
+
+  <content_rating type="oars-1.1" />
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/olivetty/Talkye-Scriber/main/screenshots/screenshot-1.png</image>
+      <caption>Talkye Scriber main dictation interface</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/olivetty/Talkye-Scriber/main/screenshots/screenshot-2.png</image>
+      <caption>Voice-to-text dictation in action</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.6.4" date="2026-03-12">
+      <description>
+        <p>System tray updates menu, persistent language selection, window focus improvements, .deb sidecar fix.</p>
+      </description>
+    </release>
+  </releases>
+
+  <requires>
+    <display_length compare="ge">800</display_length>
+  </requires>
+
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </supports>
+</component>

--- a/com.talkye.scriber.yml
+++ b/com.talkye.scriber.yml
@@ -1,0 +1,114 @@
+app-id: com.talkye.scriber
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: talkye-scriber
+
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
+  # Audio (recording + playback)
+  - --socket=pulseaudio
+  # Input devices (evdev for push-to-talk key capture)
+  - --device=input
+  # Network (for update checks, optional Groq API)
+  - --share=network
+  # Filesystem access for config
+  - --filesystem=xdg-config/talkye:create
+  # xdotool / xdg for typing into other apps
+  - --talk-name=org.freedesktop.Flatpak
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
+  # GPU (whisper.cpp can use GPU acceleration)
+  - --device=dri
+
+modules:
+  # xdotool for typing text into other applications
+  - name: xdotool
+    buildsystem: simple
+    build-commands:
+      - make PREFIX=/app
+      - make PREFIX=/app install
+    sources:
+      - type: git
+        url: https://github.com/jordansissel/xdotool.git
+        tag: v3.20211022.1
+
+  # xclip for clipboard operations
+  - name: xclip
+    buildsystem: autotools
+    sources:
+      - type: git
+        url: https://github.com/astrand/xclip.git
+        tag: '0.13'
+
+  # Main application bundle (pre-built from GitHub release)
+  - name: talkye-scriber
+    buildsystem: simple
+    build-commands:
+      # Extract AppImage
+      - chmod +x TalkyeScriber-x86_64.AppImage
+      - ./TalkyeScriber-x86_64.AppImage --appimage-extract
+
+      # Install Flutter app binary + libs
+      - install -Dm755 squashfs-root/usr/bin/talkye_app /app/bin/talkye_app
+      - cp -r squashfs-root/usr/bin/lib /app/bin/lib
+      - cp -r squashfs-root/usr/bin/data /app/bin/data
+
+      # Install sidecar
+      - mkdir -p /app/sidecar
+      - cp -r squashfs-root/usr/sidecar/* /app/sidecar/
+
+      # Install bundled Python
+      - cp -r squashfs-root/usr/python /app/python
+
+      # Install whisper-cli
+      - install -Dm755 squashfs-root/usr/whisper/whisper-cli /app/whisper/whisper-cli
+
+      # Install sox
+      - mkdir -p /app/sox/lib
+      - install -Dm755 squashfs-root/usr/sox/sox /app/sox/sox
+      - cp -r squashfs-root/usr/sox/lib/* /app/sox/lib/ || true
+
+      # Install icon
+      - install -Dm644 squashfs-root/talkye-scriber.png /app/share/icons/hicolor/256x256/apps/com.talkye.scriber.png
+
+      # Install desktop file
+      - install -Dm644 com.talkye.scriber.desktop /app/share/applications/com.talkye.scriber.desktop
+
+      # Install metainfo
+      - install -Dm644 com.talkye.scriber.metainfo.xml /app/share/metainfo/com.talkye.scriber.metainfo.xml
+
+      # Install launcher script
+      - install -Dm755 talkye-scriber.sh /app/bin/talkye-scriber
+
+    sources:
+      - type: file
+        url: https://github.com/olivetty/Talkye-Scriber/releases/download/v0.6.4/TalkyeScriber-x86_64.AppImage
+        sha256: 2f122bf5a6eda61bb9ab4ff0458c37d512c17ad91b9b90b5763bd9ef4447ec4b
+        dest-filename: TalkyeScriber-x86_64.AppImage
+
+      - type: file
+        path: com.talkye.scriber.desktop
+
+      - type: file
+        path: com.talkye.scriber.metainfo.xml
+
+      - type: inline
+        dest-filename: talkye-scriber.sh
+        contents: |
+          #!/usr/bin/env bash
+          APP_DIR="$(dirname "$(readlink -f "$0")")/.."
+
+          export LD_LIBRARY_PATH="$APP_DIR/bin/lib:$APP_DIR/sox/lib:${LD_LIBRARY_PATH:-}"
+          export TALKYE_WHISPER_BIN="$APP_DIR/whisper/whisper-cli"
+          export TALKYE_SIDECAR_DIR="$APP_DIR/sidecar"
+          export TALKYE_PYTHON="$APP_DIR/python/bin/python3"
+          export TALKYE_SOX="$APP_DIR/sox/sox"
+          export TALKYE_INSTALL_TYPE="flatpak"
+
+          exec "$APP_DIR/bin/talkye_app" "$@"


### PR DESCRIPTION
## App Details

**Name:** Talkye Scriber
**Summary:** Voice-to-text dictation for Linux. Hold a key, speak, release — text appears at your cursor.
**Homepage:** https://github.com/olivetty/Talkye-Scriber
**License:** MIT

## Description

Talkye Scriber is a system-wide push-to-talk voice dictation tool. It works in any application — browser, terminal, IDE, chat apps. Speech recognition runs 100% locally via whisper.cpp (no cloud dependency). Supports 30+ languages.

## Technical Details

- Flutter desktop app (UI) + Python sidecar (audio/STT/keyboard)
- Bundles whisper.cpp, standalone Python, sox, xdotool, xclip
- The manifest extracts a pre-built AppImage from GitHub Releases
- Screenshots included in metainfo XML

## Checklist

- [x] App ID follows reverse-DNS convention
- [x] MetaInfo file with description, screenshots, releases, content rating
- [x] Desktop file included
- [x] Icon included (256x256)
- [x] App is freely available (MIT license)
- [x] No trademark issues