### PR TITLE
Add io.github.henriquejsza.FarmModHub

### DIFF
--- a/io.github.henriquejsza.FarmModHub.yml
+++ b/io.github.henriquejsza.FarmModHub.yml
@@ -1,0 +1,35 @@
+app-id: io.github.henriquejsza.FarmModHub
+runtime: org.gnome.Platform
+runtime-version: "48"
+sdk: org.gnome.Sdk
+command: farmmod-hub
+
+cleanup:
+  - /include
+  - /share/man
+  - /share/doc
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --filesystem=home
+
+modules:
+  - name: farmmod-hub
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --no-deps --no-build-isolation --prefix=/app .
+      - install -Dm644 flatpak/io.github.henriquejsza.FarmModHub.desktop /app/share/applications/io.github.henriquejsza.FarmModHub.desktop
+      - install -Dm644 flatpak/io.github.henriquejsza.FarmModHub.metainfo.xml /app/share/metainfo/io.github.henriquejsza.FarmModHub.metainfo.xml
+      - install -Dm644 data/logo/io.github.henriquejsza.FarmModHub.png /app/share/icons/hicolor/512x512/apps/io.github.henriquejsza.FarmModHub.png
+      - install -Dm644 data/logo/io.github.henriquejsza.FarmModHub.png /app/share/icons/hicolor/256x256/apps/io.github.henriquejsza.FarmModHub.png
+      - install -Dm644 data/logo/io.github.henriquejsza.FarmModHub.png /app/share/icons/hicolor/128x128/apps/io.github.henriquejsza.FarmModHub.png
+    sources:
+      - type: git
+        url: https://github.com/henriquejsza/farmmod-hub.git
+        tag: v0.1.0
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
## Summary
- Add a new Flatpak manifest for FarmMod Hub (`io.github.henriquejsza.FarmModHub`).
- Package source from `https://github.com/henriquejsza/farmmod-hub` tag `v0.1.0`.
- Install desktop file, metainfo, and app icon from the source repository.

## Notes
- The app currently requires `--filesystem=home` to access Farming Simulator mod folders under user home paths.
- App supports FS19, FS22 and FS25 profile management and diagnostics.

## Verification
- Local project tests pass (`pytest`) in the source repository.
- AppStream metadata validated in source repo with `appstreamcli validate --pedantic`.