### PR TITLE
Add com.kernelerror.cm2016

### DIFF
--- a/com.kernelerror.cm2016.yml
+++ b/com.kernelerror.cm2016.yml
@@ -1,0 +1,74 @@
+app-id: com.kernelerror.cm2016
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: cm2016
+
+finish-args:
+  # Serial port access for USB charger (no finer-grained option available)
+  - --device=all
+  # Display
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+
+modules:
+  # et-xmlfile (openpyxl dependency, must come first)
+  - name: python3-et-xmlfile
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "et-xmlfile" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+        sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+
+  # Python pyserial
+  - name: python3-pyserial
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pyserial>=3.5" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl
+        sha256: c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0
+
+  # Python openpyxl
+  - name: python3-openpyxl
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "openpyxl>=3.1" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
+        sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+
+  # The application
+  - name: cm2016
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} . --no-build-isolation
+      # Install icon
+      - install -Dm644 data/icons/hicolor/scalable/apps/com.kernelerror.cm2016.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/com.kernelerror.cm2016.svg
+      # Install desktop file
+      - install -Dm644 data/com.kernelerror.cm2016.desktop
+        ${FLATPAK_DEST}/share/applications/com.kernelerror.cm2016.desktop
+      # Install metainfo
+      - install -Dm644 data/com.kernelerror.cm2016.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/com.kernelerror.cm2016.metainfo.xml
+      # Install translations
+      - for lang in de fr nl it es pl; do
+          mkdir -p ${FLATPAK_DEST}/share/locale/${lang}/LC_MESSAGES;
+          msgfmt -o ${FLATPAK_DEST}/share/locale/${lang}/LC_MESSAGES/cm2016.mo
+            po/${lang}.po;
+        done
+    sources:
+      - type: git
+        url: https://github.com/Kernel-Error/voltcraft-cm2016.git
+        tag: v0.1.0
+        commit: 57edeef8c7c9b9dbe5d8a720d9839877cf4e7986


### PR DESCRIPTION
## New App Submission

**App ID:** com.kernelerror.cm2016
**Name:** CM 2016 Manager
**License:** MIT
**Homepage:** https://github.com/Kernel-Error/voltcraft-cm2016

### Description

Open-source Linux GTK4/libadwaita desktop application for monitoring and logging
data from the Voltcraft Charge Manager CM 2016 battery charger. Replaces the
Windows-only CM2016 Logger V2.10 software.

### Checklist

- [x] App follows the [quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines)
- [x] App ID follows reverse-DNS convention with 3+ components
- [x] AppStream metainfo with screenshots, branding, content rating, release notes
- [x] Desktop file with proper categories
- [x] SVG app icon (128x128+)
- [x] Manifest uses tagged release with pinned commit hash
- [x] finish-args follow least-privilege (`--device=all` needed for USB serial access)
- [x] No `--filesystem=home` (uses file chooser portal for save/load/export)
- [x] Build tested locally with `flatpak-builder`

### Notes

- `--device=all` is required because the app communicates with a USB serial device
  (Silicon Labs CP210x). There is no finer-grained Flatpak permission for serial ports.
- The app has been tested on Linux Mint with a real Voltcraft CM 2016 device.