### PR TITLE
Add org.ferrum_lang.ferrumc

### DIFF
--- a/org.ferrum_lang.ferrumc/org.ferrum_lang.ferrumc.appdata.xml
+++ b/org.ferrum_lang.ferrumc/org.ferrum_lang.ferrumc.appdata.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>org.ferrum_lang.ferrumc</id>
+  <name>ferrumc</name>
+  <summary>Ferrum-language compiler with compile-time memory safety</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-only</project_license>
+  <description>
+    <p>
+      Ferrum-language is a systems programming language with C syntax and
+      compile-time memory safety via a borrow checker and ownership model.
+      Compiled to native code through LLVM 18.
+    </p>
+    <ul>
+      <li>Ownership and move semantics</li>
+      <li>Immutable and mutable borrows enforced at compile time</li>
+      <li>Opt-in unsafe blocks for raw pointer arithmetic and FFI</li>
+      <li>C interoperability via #include</li>
+      <li>Zero runtime overhead — no garbage collector, no reference counting</li>
+    </ul>
+  </description>
+  <url type="homepage">https://ferrum-language.github.io/Ferrum/</url>
+  <url type="bugtracker">https://github.com/Ferrum-Language/Ferrum/issues</url>
+  <releases>
+    <release version="0.3.0" date="2026-03-23"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/org.ferrum_lang.ferrumc/org.ferrum_lang.ferrumc.yml
+++ b/org.ferrum_lang.ferrumc/org.ferrum_lang.ferrumc.yml
@@ -1,0 +1,27 @@
+app-id: org.ferrum_lang.ferrumc
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: ferrumc
+
+finish-args:
+  - --share=network
+  - --filesystem=home
+  - --filesystem=/tmp
+
+modules:
+  - name: ferrumc
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 ferrumc /app/bin/ferrumc
+    sources:
+      - type: archive
+        url: https://github.com/Ferrum-Language/Ferrum/releases/download/v0.3.0/ferrumc-v0.3.0-linux-x86_64.tar.gz
+        sha256: 2735cf702ff9c3f3bf9ad95140bde211f3e642590e9222800f81969727ea6029
+        only-arches:
+          - x86_64
+      - type: archive
+        url: https://github.com/Ferrum-Language/Ferrum/releases/download/v0.3.0/ferrumc-v0.3.0-linux-aarch64.tar.gz
+        sha256: 4324815376c13b8038705864805c4d5b0e44910b6cc52c3111ec311afcc4cf9c
+        only-arches:
+          - aarch64


### PR DESCRIPTION
## New app submission: ferrumc (Ferrum-language compiler)

**App ID:** `org.ferrum_lang.ferrumc`
**License:** GPL-3.0-only
**Homepage:** https://ferrum-language.github.io/Ferrum/
**Source:** https://github.com/Ferrum-Language/Ferrum

Ferrum-language is a systems programming language with C syntax and compile-time memory safety via a borrow checker and ownership model, compiled to native code through LLVM 18.

- [x] Open source (GPL-3.0)
- [x] AppStream metainfo included
- [x] SHA256 verified
- [x] Supports x86_64 and aarch64