### PR TITLE
Add org.freedesktop.Sdk.Extension.qt611

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# SDK Extension for Qt 6.11
+
+This extension contains the [Qt](https://www.qt.io/) 6.11 libraries and development tools, providing a comprehensive cross-platform application framework for building modern desktop and embedded applications.
+
+Included modules: QtBase, QtDeclarative (QML/Quick), QtWayland, QtMultimedia, QtSvg, QtImageFormats, QtTools, QtShaderTools, Qt5Compat, QtWebSockets, QtWebChannel, QtPositioning, QtLocation, QtConnectivity, QtSerialPort, QtSerialBus, QtSensors, QtSCXML, QtRemoteObjects, QtCharts, QtNetworkAuth, QtHttpServer, QtQuickTimeline, QtQuick3D, QtQuick3DPhysics, QtGrpc, QtSpeech, QtVirtualKeyboard, QtLottie, Qt3D, QtGraphs, and more.
+
+**QtWebEngine is NOT included** due to its extreme build size (Chromium). Use a separate extension or the system WebEngine if needed.
+
+## Usage
+
+### Build
+
+In order to build your app with Qt 6.11 provided by this extension you have to set the following variables in your app manifest:
+
+```json
+{
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.qt611"],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/qt611/bin",
+    "prepend-ld-library-path": "/usr/lib/sdk/qt611/lib",
+    "env": {
+      "QTDIR": "/usr/lib/sdk/qt611",
+      "QT_PLUGIN_PATH": "/usr/lib/sdk/qt611/lib/plugins"
+    }
+  }
+}
+```
+
+Example:
+```json
+{
+  "id": "org.example.MyApp",
+  "runtime": "org.freedesktop.Platform",
+  "runtime-version": "25.08",
+  "sdk": "org.freedesktop.Sdk",
+  "sdk-extensions": ["org.freedesktop.Sdk.Extension.qt611"],
+  "modules": [
+    {
+      "name": "MyApp",
+      "buildsystem": "cmake-ninja",
+      "build-options": {
+        "append-path": "/usr/lib/sdk/qt611/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/qt611/lib",
+        "env": {
+          "QTDIR": "/usr/lib/sdk/qt611",
+          "QT_PLUGIN_PATH": "/usr/lib/sdk/qt611/lib/plugins"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Debugging/Development
+
+In order to use this extension in a Flatpak SDK environment you may add all provided tools to your PATH by executing:
+```
+source /usr/lib/sdk/qt611/enable.sh
+```

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+  "only-arches": ["x86_64", "aarch64"],
+  "skip-appstream-check": true,
+  "skip-icons-check": true
+}

--- a/org.freedesktop.Sdk.Extension.qt611.json
+++ b/org.freedesktop.Sdk.Extension.qt611.json
@@ -1,0 +1,732 @@
+{
+  "id": "org.freedesktop.Sdk.Extension.qt611",
+  "branch": "25.08",
+  "runtime": "org.freedesktop.Sdk",
+  "runtime-version": "25.08",
+  "sdk": "org.freedesktop.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.llvm22"
+  ],
+  "build-extension": true,
+  "separate-locales": false,
+  "build-options": {
+    "prefix": "/usr/lib/sdk/qt611",
+    "prepend-path": "/usr/lib/sdk/qt611/bin:/usr/lib/sdk/llvm22/bin",
+    "prepend-pkg-config-path": "/usr/lib/sdk/qt611/lib/pkgconfig",
+    "prepend-ld-library-path": "/usr/lib/sdk/qt611/lib:/usr/lib/sdk/llvm22/lib",
+    "cflags": "-g0",
+    "cxxflags": "-g0",
+    "env": {
+      "CMAKE_PREFIX_PATH": "/usr/lib/sdk/qt611"
+    }
+  },
+  "modules": [
+    {
+      "name": "qtbase",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF",
+        "-DINSTALL_ARCHDATADIR=lib",
+        "-DINSTALL_DATADIR=share",
+        "-DINSTALL_DOCDIR=share/doc/qt6",
+        "-DINSTALL_EXAMPLESDIR=share/doc/qt6/examples",
+        "-DINSTALL_INCLUDEDIR=include/qt6",
+        "-DINSTALL_MKSPECSDIR=lib/mkspecs",
+        "-DINPUT_openssl=linked",
+        "-DQT_FEATURE_journald=OFF",
+        "-DQT_FEATURE_openssl_linked=ON",
+        "-DQT_FEATURE_reduce_relocations=OFF",
+        "-DQT_FEATURE_rpath=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtbase-everywhere-src-6.11.0.tar.xz",
+          "sha512": "79db424fcab4870684717871886f4c0933f8b394f2706cafb76c6b07589083c56d7af18f8b589bdd17d8e263c43cc5c1f4da77a6adc2c56206957629bbc8b5f3"
+        }
+      ]
+    },
+    {
+      "name": "qtshadertools",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtshadertools-everywhere-src-6.11.0.tar.xz",
+          "sha512": "36fae98a78df8f1fef39628a7f8946e9e1d9d94c7e5cbf10c0ee7eac5439e5e8941fe59324c720f1a430ef75bb70efd63fef61858e0dd88e703e652f16bc29de"
+        }
+      ]
+    },
+    {
+      "name": "qtsvg",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtsvg-everywhere-src-6.11.0.tar.xz",
+          "sha512": "b2cf14dc00e033f0f2361b84f8b954379b67d03fc1bdb9f0f3d191218677d98fb3827484a69540297157ac4ca47a6ef50b233ec347d0a814f054ffb029670e9e"
+        }
+      ]
+    },
+    {
+      "name": "qtimageformats",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtimageformats-everywhere-src-6.11.0.tar.xz",
+          "sha512": "07534cf1d3506a8821f0fc985db84b7ea6513a3b23861c1410bdcbe16f74f13ab1633ece1058750f4ffcf9b76be2b3754d14ddba7cd43d24fdb93011fa4c4cf4"
+        }
+      ]
+    },
+    {
+      "name": "qtlanguageserver",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtlanguageserver-everywhere-src-6.11.0.tar.xz",
+          "sha512": "43dee77d2405858ffa85e59cb148349594e16575b4166f1f4dc91d12b7f1529eaf1ff15fe131db57f58534395dd712f634c0a8ea1a13fb465793fc40ca88fe23"
+        }
+      ]
+    },
+    {
+      "name": "qtdeclarative",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtdeclarative-everywhere-src-6.11.0.tar.xz",
+          "sha512": "0ac6b06a1d19505def7be46529627de45dcda1ad17145a64b5525a43562b8e1bba3fadf25ad555bab985a2d9071375448d8c9f3cf750d5b9b2bec5965d55789d"
+        }
+      ]
+    },
+    {
+      "name": "qttools",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qttools-everywhere-src-6.11.0.tar.xz",
+          "sha512": "0db48ac38ac8f0a6637477e182c96d28e42b7f24aef9832882ac0398e536edd1fece12f5b1fa6588863ac04cbe201d77f4bb45b1c15cf7c6d991d072e2e9d696"
+        }
+      ]
+    },
+    {
+      "name": "qtwayland",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtwayland-everywhere-src-6.11.0.tar.xz",
+          "sha512": "ae1728e67d21d28aadbc90a6abe1cd9812fbd99c791deb8f01bbfd074fb3b7160521464d8f3da2f1c0c5661d3d50d3b5ea5cfb953d9fa12d0fff4b385914ae3a"
+        }
+      ]
+    },
+    {
+      "name": "qtmultimedia",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtmultimedia-everywhere-src-6.11.0.tar.xz",
+          "sha512": "8d9fae3b8c7d1a67cce8fc53d7808230d201ea5498849926c88ac1853f7b11560e1b18a7930832269fa2422cf00a360c2861b0049cf5b0a5fb000bed24bbdc44"
+        }
+      ]
+    },
+    {
+      "name": "qt5compat",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qt5compat-everywhere-src-6.11.0.tar.xz",
+          "sha512": "3271515532c18c95a556cd5477f37591b527b318094b8a4813ad381db63b77b7b1b4537042504fe23b70dc2672da302e056e3f1817b413e4899a2112b6fed060"
+        }
+      ]
+    },
+    {
+      "name": "qtwebsockets",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtwebsockets-everywhere-src-6.11.0.tar.xz",
+          "sha512": "142d95bd1ed4d84c83544b3b8dc9afc344690525ae6533973aec5232563efb68c2b3d85c4e29638824e1b388589f73c0e0290b9afc564edea631f405da648dd9"
+        }
+      ]
+    },
+    {
+      "name": "qtwebchannel",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtwebchannel-everywhere-src-6.11.0.tar.xz",
+          "sha512": "40e95da636a2399a66131d7985cbf692653a52200893c59be9d9441d4a8c561b8074cce78c9fa9dbbdfa87f4bb3892dc267cbb563da9f81eba7687e7dc091e5f"
+        }
+      ]
+    },
+    {
+      "name": "qtpositioning",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtpositioning-everywhere-src-6.11.0.tar.xz",
+          "sha512": "de31a3c09f0db36ba643a102bffcd197e14c1c872a8caef66f7650dd98d7eab8ace142dc3801f870e8b7454ea95639f96b692cb763e2eff2ff27691bd52c7948"
+        }
+      ]
+    },
+    {
+      "name": "qtlocation",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtlocation-everywhere-src-6.11.0.tar.xz",
+          "sha512": "ea779e98ac516dc67117e8324512815233b86f5f2a3416b3f1b1a110cd9736ea1be248195107447dc7feabf3905a9ed11eb5777d087d0281c2e408465d32e053"
+        }
+      ]
+    },
+    {
+      "name": "qtconnectivity",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtconnectivity-everywhere-src-6.11.0.tar.xz",
+          "sha512": "a0d85d324c503d7ed24631581da14fdd4c71e2b23ae66078149ac736c7131407712a93f901b9caf254f2beb7c698b9d935a9d6f41696757c7a0bd21701c85aee"
+        }
+      ]
+    },
+    {
+      "name": "qtserialport",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtserialport-everywhere-src-6.11.0.tar.xz",
+          "sha512": "2136bf94e398593abfa4703a5a2234acf92439b36023549c8d85999e9cb154d0fdc1a6b3eb1167613edff32712ae547a217818ba309b928250a88a65f6253377"
+        }
+      ]
+    },
+    {
+      "name": "qtserialbus",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtserialbus-everywhere-src-6.11.0.tar.xz",
+          "sha512": "1b718bb74a7a1bc85572a115373df81bf1249141a5632c9cc2467b139021743cba561ad5fd0171caabbcc3a06b11725b38754c2ca937ce5af2dc48f809c775d4"
+        }
+      ]
+    },
+    {
+      "name": "qtsensors",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtsensors-everywhere-src-6.11.0.tar.xz",
+          "sha512": "2efb5d37e4fef8345d13c40b1c179277032c91193376d1c048d80f38223b59de716fc56b10f904ceb717291d7d66a6059aa82d96b8709bbb995b24562fbc7597"
+        }
+      ]
+    },
+    {
+      "name": "qtscxml",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtscxml-everywhere-src-6.11.0.tar.xz",
+          "sha512": "5f8fdb9d710f2c0b811a9a409b6043f7e1e22291fb0192ddde997d8589c7d179d65d223300015486ae8c5e40e93bc46f15953f08f03a2d1e7606935c45576b9d"
+        }
+      ]
+    },
+    {
+      "name": "qtremoteobjects",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtremoteobjects-everywhere-src-6.11.0.tar.xz",
+          "sha512": "5ddf78a43e06677fa302da4f231ab24de59547ad56f8fd01a3d8836c6c8f29de84ef2fd62086744c9649538b46091b8382fe7958cd8484dd957ce818e143789d"
+        }
+      ]
+    },
+    {
+      "name": "qtcharts",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtcharts-everywhere-src-6.11.0.tar.xz",
+          "sha512": "af2fe927ccc661f08f2179b2aa60ead3c94d3a21face1152e9ffdee6df12b34bbd1073f20b12410a2851b111f30fa101929ae6d9044cede8acee59e489313f88"
+        }
+      ]
+    },
+    {
+      "name": "qtnetworkauth",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtnetworkauth-everywhere-src-6.11.0.tar.xz",
+          "sha512": "d285386d81bec778cdf917e5561f4de953b3d2d993d189f639822de3ecf752ce0a883b1ad8895b297b3516e3787de66e745f3afadf8dd920982446ae49e8e9f9"
+        }
+      ]
+    },
+    {
+      "name": "qthttpserver",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qthttpserver-everywhere-src-6.11.0.tar.xz",
+          "sha512": "89bd0fe2b61f5f9dec4b58721ef3041443eac567ce64e1e861065ca220b618bfb05fec85bb424e5b1a0391018f4d0704e9972417d1f59a150d8f1f48a97f75b6"
+        }
+      ]
+    },
+    {
+      "name": "qtquicktimeline",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtquicktimeline-everywhere-src-6.11.0.tar.xz",
+          "sha512": "0272615261792374f81b984f925511282ee990c7e358198b79bdb7dccd14a3a18dc95551e4116ee087addb8dadbd52b2c39fe5b1883c682e7712d29414132e66"
+        }
+      ]
+    },
+    {
+      "name": "qtquick3d",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtquick3d-everywhere-src-6.11.0.tar.xz",
+          "sha512": "2387e679f503899bd59a6a99b8ff1c23fa98cf24ee9a30a02f5c3890d0c5ddad964ee23beb3f89e9cbacf65258b00ac6b68598dde3ee6c8526f5b8e452080640"
+        }
+      ]
+    },
+    {
+      "name": "qtquick3dphysics",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtquick3dphysics-everywhere-src-6.11.0.tar.xz",
+          "sha512": "28d390e5d630c6705608c85266918e7a6c0ea402fcd30a6e4214ccbb5a57b09e9cc9a8b5b05a98c0637cc0fdf44abae65cad473125a5684835d5f77ac49959d5"
+        }
+      ]
+    },
+    {
+      "name": "qtquickeffectmaker",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtquickeffectmaker-everywhere-src-6.11.0.tar.xz",
+          "sha512": "4fba30bfd6d1d16c45b3017a66eeb2370d543dde21274a0ed12182d2a4a74a486de38a555d250113f2c431270da66442df6cdcfc67df3a0083c377742e392c6c"
+        }
+      ]
+    },
+    {
+      "name": "qt3d",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qt3d-everywhere-src-6.11.0.tar.xz",
+          "sha512": "4bf5c17a66f5f64d3707f1e70808d813a63a1507d56200b7f9dddce35eb1897d35e2e923019c9358c2b43de7bf4f204114cb76494e0d2e8d10a6f05c3a8638c5"
+        }
+      ]
+    },
+    {
+      "name": "qtdatavis3d",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtdatavis3d-everywhere-src-6.11.0.tar.xz",
+          "sha512": "3f9f63f197888b9dda75716f63bb9e5ed8b6f2d71df905e4352f78894fb364e7805cff8934f4bcfe67a7ca5386ce864506a0e2ff3d28e1fa8728ee4c404ed9b9"
+        }
+      ]
+    },
+    {
+      "name": "qtgraphs",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtgraphs-everywhere-src-6.11.0.tar.xz",
+          "sha512": "ed2c2b5bc143076c77ac370f6ec549627a72462ae6a11b1ede829a89692fa5ef0fdb89437eac8305d24dd2e6672bdb6e50121598ac42a7241ecd7bbd55ce83a3"
+        }
+      ]
+    },
+    {
+      "name": "qtgrpc",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtgrpc-everywhere-src-6.11.0.tar.xz",
+          "sha512": "6f99b42afafd380d0483a84157cf2441d7ddbb98975c04999c0e3fcf0c665f8d6d0e535dce9800d5a189b93c17248c89255512938abb393cfda71f1a28dd029a"
+        }
+      ]
+    },
+    {
+      "name": "qtspeech",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtspeech-everywhere-src-6.11.0.tar.xz",
+          "sha512": "05072484ab1c28e1d3ec6861da3917485314e0ba4cf0cdeab900673881ed3645d531d6d3b91333fd3e69be2158d66a67394b6ec97a71150d18db6ac33379034e"
+        }
+      ]
+    },
+    {
+      "name": "qtvirtualkeyboard",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtvirtualkeyboard-everywhere-src-6.11.0.tar.xz",
+          "sha512": "fb1f10ebcad503779dc8363afd02062db82153ba075177c8f89d6868ab91228fa62076f59eba9de4a8d869a0604177bd69be24826379f08f4f73984c8fd4a95c"
+        }
+      ]
+    },
+    {
+      "name": "qtlottie",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtlottie-everywhere-src-6.11.0.tar.xz",
+          "sha512": "55a6c09e12d89b5db5e718f6dbf33aba37dfc5bb4cbaace583d214609b7051c3f85532903510b4129c51a03a686af92634839ad5c656dcb671a242cca2677052"
+        }
+      ]
+    },
+    {
+      "name": "qtcanvaspainter",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtcanvaspainter-everywhere-src-6.11.0.tar.xz",
+          "sha512": "98851d4929d64d4edb94171f53a8cb85d36ccdb5989764ff6fed4da9561814e1fcd323600858c3716346cb5855442dee6b137355b143d8c4d9b1565644ef9acf"
+        }
+      ]
+    },
+    {
+      "name": "qtopenapi",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtopenapi-everywhere-src-6.11.0.tar.xz",
+          "sha512": "d7d20ca08a050a74d28b3fb8470c020accd55d306d4ba8311b9ffac2fda219f1ae14419c8da7f122769f30ed58c69f631f544aaf7b1e07487a477cbb55bcc3df"
+        }
+      ]
+    },
+    {
+      "name": "qttasktree",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qttasktree-everywhere-src-6.11.0.tar.xz",
+          "sha512": "b52d700a294a693b63eaf7530e4b2220183c534f81213b343d11e32832febc2aaa2360975c9504c14b3d7f13c18597e6ee72a5ecfaf36b8abf6f2648292f1099"
+        }
+      ]
+    },
+    {
+      "name": "qttranslations",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qttranslations-everywhere-src-6.11.0.tar.xz",
+          "sha512": "9711e56b844118374b62ce99efcab81bc8e692657529e97a211c1c0ed227aa98cd060ff15fbe3cff74134efc557218ee7ad48a916a1a0f40cfe46f385e810e51"
+        }
+      ]
+    },
+    {
+      "name": "qtwebview",
+      "buildsystem": "cmake-ninja",
+      "builddir": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DQT_BUILD_EXAMPLES=OFF",
+        "-DQT_BUILD_TESTS=OFF"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qt/6.11/6.11.0/submodules/qtwebview-everywhere-src-6.11.0.tar.xz",
+          "sha512": "79331399d177c7906f45b34088db3a5d8004810df18dae786768f84ae13ee3bd82d6b0e3416114ba6c93f095412300b3cc914317c1053582ae46f3fdf1cb446c"
+        }
+      ]
+    },
+    {
+      "name": "scripts",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cp enable.sh /usr/lib/sdk/qt611/"
+      ],
+      "sources": [
+        {
+          "type": "script",
+          "commands": [
+            "export PATH=/usr/lib/sdk/qt611/bin:$PATH",
+            "export LD_LIBRARY_PATH=/usr/lib/sdk/qt611/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}",
+            "export PKG_CONFIG_PATH=/usr/lib/sdk/qt611/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}",
+            "export CMAKE_PREFIX_PATH=/usr/lib/sdk/qt611${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}",
+            "export QT_PLUGIN_PATH=/usr/lib/sdk/qt611/lib/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}",
+            "export QML2_IMPORT_PATH=/usr/lib/sdk/qt611/lib/qml${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}"
+          ],
+          "dest-filename": "enable.sh"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm0644 -t ${FLATPAK_DEST}/share/metainfo/ ${FLATPAK_ID}.metainfo.xml"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "org.freedesktop.Sdk.Extension.qt611.metainfo.xml"
+        }
+      ]
+    }
+  ]
+}

--- a/org.freedesktop.Sdk.Extension.qt611.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.qt611.metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="runtime">
+  <id>org.freedesktop.Sdk.Extension.qt611</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-3.0-only AND GPL-3.0-only AND GPL-2.0-only WITH Qt-GPL-exception-1.0</project_license>
+  <developer id="org.qt-project">
+    <name>The Qt Project</name>
+  </developer>
+  <name>Qt 6.11</name>
+  <summary>Qt 6.11 development framework</summary>
+  <description>
+    <p>This extension contains the Qt 6.11 libraries and development tools, providing a comprehensive cross-platform application framework for building modern desktop and embedded applications.</p>
+    <p>Included modules: QtBase, QtDeclarative (QML/Quick), QtWayland, QtMultimedia,
+       QtSvg, QtImageFormats, QtTools, QtShaderTools, Qt5Compat, QtWebSockets,
+       QtWebChannel, QtPositioning, QtLocation, QtConnectivity, QtSerialPort,
+       QtSerialBus, QtSensors, QtSCXML, QtRemoteObjects, QtCharts, QtNetworkAuth,
+       QtHttpServer, QtQuickTimeline, QtQuick3D, QtQuick3DPhysics, QtGrpc,
+       QtSpeech, QtVirtualKeyboard, QtLottie, Qt3D, QtGraphs, and more.</p>
+    <p>QtWebEngine is NOT included due to its extreme build size (Chromium). Use a
+       separate extension or the system WebEngine if needed.</p>
+  </description>
+  <url type="homepage">https://www.qt.io/</url>
+  <url type="bugtracker">https://bugreports.qt.io/</url>
+  <releases>
+    <release version="6.11.0" date="2026-03-23"/>
+  </releases>
+</component>


### PR DESCRIPTION
Qt 6.11.0 SDK extension for org.freedesktop.Sdk 25.08, providing 39 Qt submodules built from source as a composable SDK extension.

Depends on org.freedesktop.Sdk.Extension.llvm22 for shader toolchain (qtshadertools) and other LLVM-dependent modules.

QtWebEngine is excluded due to extreme build size (Chromium).

Builds for x86_64 and aarch64.

- [X] Please describe the application briefly.
      This is an SDK extension (not an application). It provides Qt 6.11.0
      libraries and development tools for building Qt-based Flatpak
      applications on the org.freedesktop.Sdk 25.08 runtime. 39 Qt submodules
      are built from source (cmake-ninja), with all source archives fetched
      from download.qt.io with SHA-512 verification. QtWebEngine is excluded.
- [X] Please attach a video showcasing the application on Linux using the
      Flatpak. N/A — This is an SDK extension, not a GUI application.
      It has no user-facing interface.
- [X] The Flatpak ID follows all the rules listed in the Application ID
      requirements. The ID `org.freedesktop.Sdk.Extension.qt611` follows the
      org.freedesktop.Sdk extension point naming convention, which is exempt
      from the reverse-DNS domain ownership requirement.
- [X] I have read and followed all the Submission requirements and the
      Submission guide and I agree to them.
- [X] I am a packager/maintainer of this SDK extension manifest.