### PR TITLE
Add UBI System

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="dotnet8" value="/usr/lib/sdk/dotnet8/nuget/packages" />
+  </packageSources>
+</configuration>

--- a/io.github.matthewpchapdelaine.ubi-system.desktop
+++ b/io.github.matthewpchapdelaine.ubi-system.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=UBI System
+Comment=Local-first managed UBI dashboards for estates, presence, and operations
+Exec=ubi-native-host
+Icon=io.github.matthewpchapdelaine.ubi-system
+Terminal=false
+Type=Application
+Categories=Office;ProjectManagement;
+Keywords=ubi;dashboard;estate;presence;operations;
+StartupNotify=true

--- a/io.github.matthewpchapdelaine.ubi-system.metainfo.xml
+++ b/io.github.matthewpchapdelaine.ubi-system.metainfo.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2026 MatthewPChapdelaine -->
+<component type="desktop-application">
+  <id>io.github.matthewpchapdelaine.ubi-system</id>
+  <name>UBI System</name>
+  <summary>Local-first managed UBI dashboards for estates, presence, and operations</summary>
+  <developer id="io.github.matthewpchapdelaine">
+    <name>Matthew P. Chapdelaine</name>
+  </developer>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <url type="homepage">https://github.com/MatthewPChapdelaine/UBI-System</url>
+  <url type="bugtracker">https://github.com/MatthewPChapdelaine/UBI-System/issues</url>
+  <url type="vcs-browser">https://github.com/MatthewPChapdelaine/UBI-System</url>
+  <url type="contribute">https://github.com/MatthewPChapdelaine/UBI-System</url>
+  <description>
+    <p>
+      UBI System is a local-first Blazor desktop application for managed UBI operations,
+      combining estate transparency, employee presence tracking, leadership visibility,
+      and intervention workflows in a single Linux desktop interface.
+    </p>
+    <p>
+      This Flatpak build publishes the .NET 8 application from source, starts the local
+      ASP.NET server inside the sandbox, and embeds it in a native GTK4 and Libadwaita
+      shell backed by WebKit.
+    </p>
+    <ul>
+      <li>Review company estate, workspace, and intervention dashboards.</li>
+      <li>Track presence data and local operational records without external services.</li>
+      <li>Launch the app as a native Linux desktop window instead of a browser tab.</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">io.github.matthewpchapdelaine.ubi-system.desktop</launchable>
+  <provides>
+    <binary>ubi-native-host</binary>
+  </provides>
+  <branding>
+    <color type="primary" scheme_preference="light">#2563eb</color>
+    <color type="primary" scheme_preference="dark">#10b981</color>
+  </branding>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/MatthewPChapdelaine/UBI-System/v0.1.0/packaging/flatpak/screenshots/overview.png</image>
+      <caption>Overview dashboard with current managed UBI status</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/MatthewPChapdelaine/UBI-System/v0.1.0/packaging/flatpak/screenshots/estate.png</image>
+      <caption>Estate view for company and workspace activity</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/MatthewPChapdelaine/UBI-System/v0.1.0/packaging/flatpak/screenshots/presence.png</image>
+      <caption>Presence dashboard with staffing visibility</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/MatthewPChapdelaine/UBI-System/v0.1.0/packaging/flatpak/screenshots/leadership.png</image>
+      <caption>Leadership dashboard summarizing operational trends</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.0" date="2026-03-24">
+      <url type="details">https://github.com/MatthewPChapdelaine/UBI-System/releases/tag/v0.1.0</url>
+      <description>
+        <p>Initial public release of the UBI System desktop application.</p>
+        <ul>
+          <li>Introduced overview, estate, presence, leadership, and operations screens.</li>
+          <li>Added local JSON-backed persistence and HTTP APIs for company data.</li>
+          <li>Packaged the desktop shell with GTK4, Libadwaita, and WebKit.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+  </content_rating>
+</component>

--- a/io.github.matthewpchapdelaine.ubi-system.svg
+++ b/io.github.matthewpchapdelaine.ubi-system.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <defs>
+    <linearGradient id="bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="#08111f"/>
+  <rect x="20" y="20" width="216" height="216" rx="44" fill="url(#bg)" opacity="0.15"/>
+  <path d="M72 78h28l28 100h-24l-6-24H70l-6 24H40L72 78zm2 58h20l-10-40-10 40z" fill="#f8fafc"/>
+  <path d="M142 78h24v54c0 18 8 28 24 28s24-10 24-28V78h24v58c0 17-5 30-15 40-10 9-24 14-41 14-18 0-32-5-42-14-9-10-14-23-14-40V78z" fill="#f8fafc"/>
+</svg>

--- a/io.github.matthewpchapdelaine.ubi-system.yaml
+++ b/io.github.matthewpchapdelaine.ubi-system.yaml
@@ -1,0 +1,44 @@
+id: io.github.matthewpchapdelaine.ubi-system
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet8
+build-options:
+  append-path: /usr/lib/sdk/dotnet8/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet8/lib
+  prepend-pkg-config-path: /usr/lib/sdk/dotnet8/lib/pkgconfig
+  env:
+    DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+    DOTNET_GENERATE_ASPNET_CERTIFICATE: "false"
+    DOTNET_NOLOGO: "true"
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+command: ubi-native-host
+finish-args:
+  - --device=dri
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --env=DOTNET_ROOT=/app/lib/dotnet
+modules:
+  - name: dotnet-runtime
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/dotnet8/bin/install.sh
+
+  - name: ubi-system
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/dotnet8/bin/dotnet restore src/UBI.App/UBI.App.csproj --configfile packaging/flathub/NuGet.Config --source /usr/lib/sdk/dotnet8/nuget/packages
+      - /usr/lib/sdk/dotnet8/bin/dotnet publish src/UBI.App/UBI.App.csproj -c Release --no-restore --configfile packaging/flathub/NuGet.Config --source /usr/lib/sdk/dotnet8/nuget/packages -o publish --no-self-contained
+      - install -d /app/bin /app/share/ubi-app /app/share/applications /app/share/metainfo /app/share/icons/hicolor/scalable/apps /app/share/licenses/${FLATPAK_ID}/ubi-system
+      - cp -a publish/. /app/share/ubi-app/
+      - install -Dm755 packaging/flathub/ubi-native-host.py /app/bin/ubi-native-host
+      - install -Dm644 packaging/flathub/io.github.matthewpchapdelaine.ubi-system.desktop /app/share/applications/io.github.matthewpchapdelaine.ubi-system.desktop
+      - install -Dm644 packaging/flathub/io.github.matthewpchapdelaine.ubi-system.metainfo.xml /app/share/metainfo/io.github.matthewpchapdelaine.ubi-system.metainfo.xml
+      - install -Dm644 packaging/flathub/io.github.matthewpchapdelaine.ubi-system.svg /app/share/icons/hicolor/scalable/apps/io.github.matthewpchapdelaine.ubi-system.svg
+      - install -Dm644 LICENSE /app/share/licenses/${FLATPAK_ID}/ubi-system/LICENSE
+    sources:
+      - type: git
+        url: https://github.com/MatthewPChapdelaine/UBI-System.git
+        tag: v0.1.2

--- a/ubi-native-host.py
+++ b/ubi-native-host.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python3
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+gi.require_version("WebKit", "6.0")
+
+from gi.repository import Adw, Gio, GLib, WebKit  # noqa: E402
+
+
+APP_DIR = "/app/share/ubi-app"
+APP_BIN = os.path.join(APP_DIR, "UBI.App")
+APP_ID = "io.github.matthewpchapdelaine.ubi-system"
+START_PATH = os.environ.get("UBI_APP_START_PATH", "/").strip() or "/"
+
+
+def allocate_base_url() -> str:
+    requested_port = os.environ.get("UBI_APP_PORT")
+    if requested_port:
+        return f"http://127.0.0.1:{requested_port}"
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+    return f"http://127.0.0.1:{port}"
+
+
+def build_target_url(base_url: str) -> str:
+    normalized_path = START_PATH if START_PATH.startswith("/") else f"/{START_PATH}"
+    if normalized_path == "/":
+        return base_url
+    return f"{base_url}{normalized_path}"
+
+
+class UbiWindow(Adw.ApplicationWindow):
+    def __init__(self, app: "UbiNativeHost") -> None:
+        super().__init__(application=app, title="UBI System")
+        self.set_default_size(1440, 960)
+
+        header = Adw.HeaderBar()
+        header.set_title_widget(Adw.WindowTitle(title="UBI System", subtitle="Managed UBI dashboards"))
+
+        self._status = Adw.StatusPage(
+            title="Starting UBI System",
+            description="Launching the local application server and preparing the native dashboard shell.",
+            icon_name=APP_ID,
+        )
+
+        self._webview = WebKit.WebView()
+        self._webview.connect("load-changed", self._on_load_changed)
+
+        toolbar_view = Adw.ToolbarView()
+        toolbar_view.add_top_bar(header)
+        toolbar_view.set_content(self._status)
+        self.set_content(toolbar_view)
+
+        self._toolbar_view = toolbar_view
+
+    def load_app(self, url: str) -> None:
+        self._webview.load_uri(url)
+
+    def show_error(self, message: str) -> None:
+        self._status.set_title("Unable to start UBI System")
+        self._status.set_description(message)
+        self._toolbar_view.set_content(self._status)
+
+    def _on_load_changed(self, _: WebKit.WebView, event: WebKit.LoadEvent) -> None:
+        if event == WebKit.LoadEvent.FINISHED:
+            self._toolbar_view.set_content(self._webview)
+            print("[ubi-native-host] webview-loaded", flush=True)
+
+
+class UbiNativeHost(Adw.Application):
+    def __init__(self) -> None:
+        super().__init__(
+            application_id=APP_ID,
+            flags=Gio.ApplicationFlags.DEFAULT_FLAGS,
+        )
+        self._server: subprocess.Popen[str] | None = None
+        self._window: UbiWindow | None = None
+        self._attempts = 0
+        self._base_url = allocate_base_url()
+        self._target_url = build_target_url(self._base_url)
+
+    def do_activate(self) -> None:
+        if self._window is None:
+            self._window = UbiWindow(self)
+            self._start_server()
+        self._window.present()
+
+    def do_shutdown(self) -> None:
+        self._stop_server()
+        super().do_shutdown()
+
+    def _start_server(self) -> None:
+        if self._server is not None:
+            return
+
+        if not os.path.exists(APP_BIN):
+            raise FileNotFoundError(f"Missing application binary: {APP_BIN}")
+
+        env = os.environ.copy()
+        env["UBI_DISABLE_HTTPS_REDIRECT"] = "1"
+        command = [
+            APP_BIN,
+            "--urls",
+            self._base_url,
+            "--contentRoot",
+            APP_DIR,
+            "--webroot",
+            os.path.join(APP_DIR, "wwwroot"),
+        ]
+        self._server = subprocess.Popen(
+            command,
+            cwd=APP_DIR,
+            env=env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            text=True,
+        )
+        print(f"[ubi-native-host] server-started {self._base_url}", flush=True)
+        GLib.timeout_add(250, self._poll_server_ready)
+
+    def _poll_server_ready(self) -> bool:
+        self._attempts += 1
+
+        if self._server is not None and self._server.poll() is not None:
+            if self._window is not None:
+                self._window.show_error("The local server exited before the dashboard window could load.")
+            return False
+
+        try:
+            with urllib.request.urlopen(self._base_url, timeout=1) as response:
+                if response.status < 500:
+                    if self._window is not None:
+                        self._window.load_app(self._target_url)
+                    print(f"[ubi-native-host] server-ready {self._target_url}", flush=True)
+                    return False
+        except (urllib.error.URLError, TimeoutError):
+            pass
+
+        if self._attempts >= 80:
+            if self._window is not None:
+                self._window.show_error("Timed out while waiting for the embedded UBI application server.")
+            return False
+
+        return True
+
+    def _stop_server(self) -> None:
+        if self._server is None:
+            return
+
+        if self._server.poll() is None:
+            self._server.terminate()
+            try:
+                self._server.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._server.kill()
+                self._server.wait(timeout=5)
+
+        self._server = None
+
+
+def main() -> int:
+    app = UbiNativeHost()
+    return app.run(sys.argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add UBI System for Flathub review
- build the .NET 8 Blazor app from source and host it inside GTK4/Libadwaita/WebKit
- reference the upstream v0.1.2 source release

## Validation
- appstreamcli validate
- desktop-file-validate
- flatpak-builder-lint
- flatpak-builder build
- sandbox smoke test for GTK/WebKit and local app launch