### PR TITLE
Add OpenMetaverseKit

### DIFF
--- a/com.matthew.OpenMetaverseKit.yaml
+++ b/com.matthew.OpenMetaverseKit.yaml
@@ -1,0 +1,56 @@
+app-id: com.matthew.openmetaversekit
+runtime: org.freedesktop.Platform
+runtime-version: "24.08"
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: "24.08"
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node24
+command: openmetaversekit
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --device=dri
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --env=ELECTRON_TRASH=gio
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+build-options:
+  append-path: /usr/lib/sdk/node24/bin
+  env:
+    NPM_CONFIG_LOGLEVEL: info
+modules:
+  - name: openmetaversekit
+    buildsystem: simple
+    subdir: main
+    build-options:
+      env:
+        XDG_CACHE_HOME: /run/build/openmetaversekit/flatpak-node/cache
+        npm_config_cache: /run/build/openmetaversekit/flatpak-node/npm-cache
+        npm_config_nodedir: /usr/lib/sdk/node24
+        npm_config_offline: "true"
+        npm_config_update_notifier: "false"
+        npm_config_audit: "false"
+        ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+    build-commands:
+      - jq '.desktopName = "com.matthew.openmetaversekit.desktop" | .build.appId = "com.matthew.openmetaversekit"' package.json > package.json.flatpak && mv package.json.flatpak package.json
+      - npm install --offline
+      - npm run build
+      - install -d /app/bin /app/share/openmetaversekit /app/share/applications /app/share/metainfo /app/share/licenses/OpenMetaverseKit
+      - cp -a desktop dist /app/share/openmetaversekit/
+      - install -Dm644 package.json /app/share/openmetaversekit/package.json
+      - install -Dm755 packaging/flathub/openmetaversekit.sh /app/bin/openmetaversekit
+      - install -Dm644 packaging/flathub/com.matthew.openmetaversekit.desktop /app/share/applications/com.matthew.openmetaversekit.desktop
+      - install -Dm644 packaging/flathub/com.matthew.openmetaversekit.metainfo.xml /app/share/metainfo/com.matthew.openmetaversekit.metainfo.xml
+      - install -Dm644 assets/icons/64x64.png /app/share/icons/hicolor/64x64/apps/com.matthew.openmetaversekit.png
+      - install -Dm644 assets/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.matthew.openmetaversekit.png
+      - install -Dm644 assets/icons/256x256.png /app/share/icons/hicolor/256x256/apps/com.matthew.openmetaversekit.png
+      - install -Dm644 assets/icons/512x512.png /app/share/icons/hicolor/512x512/apps/com.matthew.openmetaversekit.png
+      - install -Dm644 LICENSE /app/share/licenses/OpenMetaverseKit/LICENSE
+    sources:
+      - type: git
+        url: https://github.com/MatthewPChapdelaine/OpenMetaverseKit.git
+        tag: v0.1.1
+        dest: main
+      - npm-sources.json

--- a/com.matthew.openmetaversekit.desktop
+++ b/com.matthew.openmetaversekit.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=OpenMetaverseKit
+Comment=Open-source social VR metaverse toolkit
+Exec=openmetaversekit
+Icon=com.matthew.openmetaversekit
+Terminal=false
+Categories=Game;Graphics;Network;
+Keywords=metaverse;vr;webxr;social;3d;open-source;
+StartupWMClass=OpenMetaverseKit

--- a/com.matthew.openmetaversekit.metainfo.xml
+++ b/com.matthew.openmetaversekit.metainfo.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.matthew.openmetaversekit</id>
+  <name>OpenMetaverseKit</name>
+  <summary>Open-source social VR metaverse toolkit</summary>
+  <developer id="com.matthew">
+    <name>Matthew</name>
+  </developer>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <launchable type="desktop-id">com.matthew.openmetaversekit.desktop</launchable>
+  <description>
+    <p>
+      OpenMetaverseKit is a free Linux desktop application for generating locally hosted metaverse spaces with
+      multiplayer rooms, Blender asset import, desktop social locomotion, avatar emotes, sit/stand interactions,
+      and WebXR controller support.
+    </p>
+    <p>
+      This Flatpak build packages the Electron desktop shell from source and keeps the existing local Flatpak
+      packaging isolated under packaging/flatpak/ for developer-side binary testing.
+    </p>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>Graphics</category>
+    <category>Network</category>
+  </categories>
+  <keywords>
+    <keyword>metaverse</keyword>
+    <keyword>vr</keyword>
+    <keyword>webxr</keyword>
+    <keyword>social</keyword>
+    <keyword>3d</keyword>
+    <keyword>open source</keyword>
+  </keywords>
+  <url type="homepage">https://github.com/MatthewPChapdelaine/OpenMetaverseKit</url>
+  <url type="bugtracker">https://github.com/MatthewPChapdelaine/OpenMetaverseKit/issues</url>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.1.0" date="2026-03-24">
+      <description>
+        <ul>
+          <li>Initial Linux desktop release with local metaverse generation and multiplayer rooms.</li>
+          <li>Added Blender asset import, emotes, social seating, and VR controller mappings.</li>
+          <li>Prepared an Electron BaseApp Flatpak path for Flathub-style source builds.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/npm-sources.json
+++ b/npm-sources.json
@@ -1,0 +1,2732 @@
+[
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+    "sha512": "d1ca783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a",
+    "dest-filename": "783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/ca"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+    "sha512": "8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+    "dest-filename": "eb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+    "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "dest-filename": "0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+    "sha512": "424ce9836b3d1a7555d88d818d192c522e375397bafb369031c8e8272d02f82e68c5a2a5f9f99c9060d016d469669655d0d41e92e659fad1b3ec403d4d59d0b5",
+    "dest-filename": "e9836b3d1a7555d88d818d192c522e375397bafb369031c8e8272d02f82e68c5a2a5f9f99c9060d016d469669655d0d41e92e659fad1b3ec403d4d59d0b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+    "sha512": "17e9ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+    "dest-filename": "ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/e9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+    "sha512": "8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
+    "dest-filename": "fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/d4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+    "sha512": "299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+    "dest-filename": "26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/9f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.3.tgz",
+    "sha512": "bbdbe94c744c90e602b3fd452e249500567b15b8ec5caf9b42ecef88965afa51bb047665d67cf9dbf21c1afc1adec93cd3f7dcde596eb4191b0aad74561f1640",
+    "dest-filename": "e94c744c90e602b3fd452e249500567b15b8ec5caf9b42ecef88965afa51bb047665d67cf9dbf21c1afc1adec93cd3f7dcde596eb4191b0aad74561f1640",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/db"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+    "sha512": "5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+    "dest-filename": "6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+    "sha512": "75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+    "dest-filename": "5ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/f6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+    "sha512": "d520e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+    "dest-filename": "e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+    "sha512": "bc23efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+    "dest-filename": "efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+    "sha512": "734b97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+    "dest-filename": "97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+    "sha512": "0fb68f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+    "dest-filename": "8f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+    "sha512": "0f0a97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+    "dest-filename": "97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+    "sha512": "b1efc98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+    "dest-filename": "c98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+    "sha512": "e49711c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+    "dest-filename": "11c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+    "sha512": "27de643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+    "dest-filename": "643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+    "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+    "dest-filename": "f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/f6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+    "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+    "dest-filename": "af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+    "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+    "dest-filename": "d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+    "sha512": "b877f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+    "dest-filename": "f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+    "sha512": "21a8ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+    "dest-filename": "ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+    "sha512": "d611d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+    "dest-filename": "d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+    "sha512": "d877570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+    "dest-filename": "570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+    "sha512": "ceeb39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+    "dest-filename": "39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+    "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+    "dest-filename": "1d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+    "sha512": "5a88b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+    "dest-filename": "b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+    "sha512": "1cb34dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+    "dest-filename": "4dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+    "sha512": "ebe823985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+    "dest-filename": "23985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+    "sha512": "67480e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+    "dest-filename": "0e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+    "sha512": "4965c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+    "dest-filename": "c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+    "sha512": "b5077fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+    "dest-filename": "7fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+    "sha512": "3bc8dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+    "dest-filename": "dc8da6d76a578e1bd0d0d3e0115d66414df9cfe16340ab3ba224aee5978e009b118abff2763384cf8f18d8df39c109fbc15c5cee726d6dc1dc85c9b16a10",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+    "sha512": "c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
+    "dest-filename": "bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+    "sha512": "d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
+    "dest-filename": "4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/3a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+    "sha512": "f503ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
+    "dest-filename": "ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+    "sha512": "4bbf4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5",
+    "dest-filename": "4d74480341dfcd1826b2e930a85735d28fbe2c9116482897292630b994eab7e12673c88e8caad8a25a88955a856b4dc1a335e0b88a96e1d552079697c5e5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+    "sha512": "ff11a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1",
+    "dest-filename": "a57b323ac5f18ef4dc2e2659f0cff2b5e2a0f59024801ad69c0479c6cde008b8919acdca78e4a3f936ec80457a0a6fb730ba5006595b1b792c5d1bf71bd1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+    "sha512": "fb55648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+    "dest-filename": "648dd0f44012cfa1d1ab2547aa6ab1fc54022f40e0c86f087d5e93f94b28ac7fb628420b0928f345a2aa8b425bbe550fed552b21311ea5a0f327f14f9d3e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
+    "sha512": "58e84d5bd2bc6d1de47f8ccbc5b7e0e8fc6edb26ce51b0760233031d2431f3a2c8178ac7e05b7bbe633036dd25a0ed1ea2782548dcb87290f730a5d7290bb4fc",
+    "dest-filename": "4d5bd2bc6d1de47f8ccbc5b7e0e8fc6edb26ce51b0760233031d2431f3a2c8178ac7e05b7bbe633036dd25a0ed1ea2782548dcb87290f730a5d7290bb4fc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
+    "sha512": "bba2472e597940a46f8dc884efc6d05c39aa46a36ce4cff7195a9978cc2f9a368d38326287f588ac99455448a1bd5d0c89816677e6723ebf70c4e55b3c01b623",
+    "dest-filename": "472e597940a46f8dc884efc6d05c39aa46a36ce4cff7195a9978cc2f9a368d38326287f588ac99455448a1bd5d0c89816677e6723ebf70c4e55b3c01b623",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/a2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
+    "sha512": "a8417b0ac28acd245cdb40a2bb6670d7046b073e20e7a17baffbd1c18e37d143e9fe7b75c76d50fdfa49f4de65e3b596bc99643423c9cf7411570d34f1f8bbc8",
+    "dest-filename": "7b0ac28acd245cdb40a2bb6670d7046b073e20e7a17baffbd1c18e37d143e9fe7b75c76d50fdfa49f4de65e3b596bc99643423c9cf7411570d34f1f8bbc8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
+    "sha512": "5800d8a332784029d7087e303c1fb716e1a60cfa05b1e54252b00d980e4b5b01a60ba14bd780560bba5cabe16cb4e66fddb6865fae6d677efcb93e961bcca74f",
+    "dest-filename": "d8a332784029d7087e303c1fb716e1a60cfa05b1e54252b00d980e4b5b01a60ba14bd780560bba5cabe16cb4e66fddb6865fae6d677efcb93e961bcca74f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
+    "sha512": "e9bf301872650eb19e484dda1f99863470630344d39317683478a4e4492f3c70addf9d579e2800e294bb5ac8ff128f58f11054e9fdf972337d498982141b73c7",
+    "dest-filename": "301872650eb19e484dda1f99863470630344d39317683478a4e4492f3c70addf9d579e2800e294bb5ac8ff128f58f11054e9fdf972337d498982141b73c7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
+    "sha512": "876e466b4b788daca5301f0cfc9280cabbef7f11918e73d0211f259c26b2cb312310ec7610922522231b8695b10d1286285f236cd1f4d4d9cdebaddd1fadfc98",
+    "dest-filename": "466b4b788daca5301f0cfc9280cabbef7f11918e73d0211f259c26b2cb312310ec7610922522231b8695b10d1286285f236cd1f4d4d9cdebaddd1fadfc98",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/87/6e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
+    "sha512": "473781c2fd01deab55056b5cb8006d4ae0b34e8a3620400842b73207f6f6cccbc15956e3a3c6d90e30025299da69f6b1853c365be8a641b3f6043d6eb1ab0ae2",
+    "dest-filename": "81c2fd01deab55056b5cb8006d4ae0b34e8a3620400842b73207f6f6cccbc15956e3a3c6d90e30025299da69f6b1853c365be8a641b3f6043d6eb1ab0ae2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
+    "sha512": "49fef3bac348d82214d472f3baef53739606007119b392eeecdd6cb091b84e4c3a7b4304b0decd7635030df18d1f2d8853e10dc964fe2f6a1b8168a0b9689b59",
+    "dest-filename": "f3bac348d82214d472f3baef53739606007119b392eeecdd6cb091b84e4c3a7b4304b0decd7635030df18d1f2d8853e10dc964fe2f6a1b8168a0b9689b59",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
+    "sha512": "0d7db1ec231cac9cec13dd6aeff3b4d88250e7f68b915b5816bcaa0a376e26151f18a1bac8957c8716b0f2965af7794b1293d33ffa2174de30173ef2a7faf2f4",
+    "dest-filename": "b1ec231cac9cec13dd6aeff3b4d88250e7f68b915b5816bcaa0a376e26151f18a1bac8957c8716b0f2965af7794b1293d33ffa2174de30173ef2a7faf2f4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
+    "sha512": "d3d10bfb21556c966585c41f4a1a6cc30459d1183ecff0ac4842c50a73edde22be8aac06b08e3386ddec79c8f9bcb12cf79ed0bc51579f3013d0514f2314ab91",
+    "dest-filename": "0bfb21556c966585c41f4a1a6cc30459d1183ecff0ac4842c50a73edde22be8aac06b08e3386ddec79c8f9bcb12cf79ed0bc51579f3013d0514f2314ab91",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
+    "sha512": "8bd21c08c3ebdc45e6f04420e639e36b4672735885c498d95a56f8c2bed4d96c7f1ab75d3ae11a7f145d30f45855a5e381b86fa9a969ea7a74ee1375c3d9002b",
+    "dest-filename": "1c08c3ebdc45e6f04420e639e36b4672735885c498d95a56f8c2bed4d96c7f1ab75d3ae11a7f145d30f45855a5e381b86fa9a969ea7a74ee1375c3d9002b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
+    "sha512": "0c6cdd24af64c89f81efc3029167869e95c9f75b4afe2280e87c07c45e130253c863b19712f31ef2104546076b47d2f2e2a79b47fee07d4b3dcb6228695132a2",
+    "dest-filename": "dd24af64c89f81efc3029167869e95c9f75b4afe2280e87c07c45e130253c863b19712f31ef2104546076b47d2f2e2a79b47fee07d4b3dcb6228695132a2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
+    "sha512": "470a672eca82f2a6d2f33d47d40c410351faaa49d1e18a4f47dc365d7d2fa364b3d749a2bb9ecf90d7271d569991bab2c3f91459f28c23bde38667e2f4144c51",
+    "dest-filename": "672eca82f2a6d2f33d47d40c410351faaa49d1e18a4f47dc365d7d2fa364b3d749a2bb9ecf90d7271d569991bab2c3f91459f28c23bde38667e2f4144c51",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
+    "sha512": "67ca4f7f9e0bcb76aab5d582dc6e2b16281980dbddfaa265384e767e6928dca493f52a067c0752442c32a321b4e6ad47aeb01b94b6e4d7f3d2215fbcd3fa712e",
+    "dest-filename": "4f7f9e0bcb76aab5d582dc6e2b16281980dbddfaa265384e767e6928dca493f52a067c0752442c32a321b4e6ad47aeb01b94b6e4d7f3d2215fbcd3fa712e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/ca"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
+    "sha512": "ddadea42eb2da7708e086be73f84afacc1e73d0f5dd6fcc26a44154539626b3f1c229ff050b1a3886a5b72aae4bf45ab1d3129f1b403fc1dc7063cee8d558b38",
+    "dest-filename": "ea42eb2da7708e086be73f84afacc1e73d0f5dd6fcc26a44154539626b3f1c229ff050b1a3886a5b72aae4bf45ab1d3129f1b403fc1dc7063cee8d558b38",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
+    "sha512": "a63643b151ffd55b2084c276fe401ac6de9d2f4a6c4fa65ec5056b8a373339ff8f78fd8152a4c761e8e4de5e9394f47276080834e78d461be92dad0062909649",
+    "dest-filename": "43b151ffd55b2084c276fe401ac6de9d2f4a6c4fa65ec5056b8a373339ff8f78fd8152a4c761e8e4de5e9394f47276080834e78d461be92dad0062909649",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
+    "sha512": "dce6d0b34061bcf82251566b37b82a092be616e316bd6bec8c6e5ac89dcbadaaaffb62a13aca7ea546e282a6de5aab9e188b279fed3d1c1c36eeb27e8182b855",
+    "dest-filename": "d0b34061bcf82251566b37b82a092be616e316bd6bec8c6e5ac89dcbadaaaffb62a13aca7ea546e282a6de5aab9e188b279fed3d1c1c36eeb27e8182b855",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/e6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
+    "sha512": "12dca5a6b0ed40f752e6b5ef01acab343628261233d7fbf33767c4b9ba37c8b13bb5f030fbde3c74ed20e0cd2f91354584aa239c5fa7e82f1b0cd7be80345d4e",
+    "dest-filename": "a5a6b0ed40f752e6b5ef01acab343628261233d7fbf33767c4b9ba37c8b13bb5f030fbde3c74ed20e0cd2f91354584aa239c5fa7e82f1b0cd7be80345d4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
+    "sha512": "934f688910a2fdb1d4f54545a83d7baf778947d6e7d374f22ab682ae5cf950b14919d2468bb54e9a6f63978e2f389bd127a3fb5ae062fecd80f7b2f1c4718877",
+    "dest-filename": "688910a2fdb1d4f54545a83d7baf778947d6e7d374f22ab682ae5cf950b14919d2468bb54e9a6f63978e2f389bd127a3fb5ae062fecd80f7b2f1c4718877",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/4f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
+    "sha512": "d68ff4fe9221a33a126832680dc79cf8854b6e746d4261f03d5ef7d3e00e0f6f651c4128e05e41114076e07d0e05d85b0410f020e4ae7fbbe0834630c5d7e28b",
+    "dest-filename": "f4fe9221a33a126832680dc79cf8854b6e746d4261f03d5ef7d3e00e0f6f651c4128e05e41114076e07d0e05d85b0410f020e4ae7fbbe0834630c5d7e28b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
+    "sha512": "a44483928b3f3c3cd8c2dcb3079a7f528354ffc7c9a3af2f71733d656d95d248d86b28f529a6947e2d4d993513529327e14854e204ee2bc8086853b8506b8c6c",
+    "dest-filename": "83928b3f3c3cd8c2dcb3079a7f528354ffc7c9a3af2f71733d656d95d248d86b28f529a6947e2d4d993513529327e14854e204ee2bc8086853b8506b8c6c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/44"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
+    "sha512": "863d70152b43ec1d5805e626bd8fa559767b7b2ef76063dc5623128588a4a8a4f51adb2d20a400b5f508eb2af33e3032fceee93b454b5c69945565d031a6204d",
+    "dest-filename": "70152b43ec1d5805e626bd8fa559767b7b2ef76063dc5623128588a4a8a4f51adb2d20a400b5f508eb2af33e3032fceee93b454b5c69945565d031a6204d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/3d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
+    "sha512": "4b26883c5a319943e5343ab91079136e22b3992126abf80e60523fdc71c9f224bfbf599bba055aedd5d4cdc24641fa32b69f432452e11c7e14dff793cb606ae3",
+    "dest-filename": "883c5a319943e5343ab91079136e22b3992126abf80e60523fdc71c9f224bfbf599bba055aedd5d4cdc24641fa32b69f432452e11c7e14dff793cb606ae3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
+    "sha512": "45d72bc847f366bfa502be64466dae70df5a5650826b640dab88577a56716fc186d0d2526b3ab8e19dcf08273cc08491b825671acd25409557e55a7a7ca03e20",
+    "dest-filename": "2bc847f366bfa502be64466dae70df5a5650826b640dab88577a56716fc186d0d2526b3ab8e19dcf08273cc08491b825671acd25409557e55a7a7ca03e20",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
+    "sha512": "3ebb16350f01b84d343b75ecc7700b8760dff1f023f7e72fbd7f40200ea8e0aa404d1f7c73d9ae7785ed0d656fb04bb289ae54e2d5524caca06b0c899239bad3",
+    "dest-filename": "16350f01b84d343b75ecc7700b8760dff1f023f7e72fbd7f40200ea8e0aa404d1f7c73d9ae7785ed0d656fb04bb289ae54e2d5524caca06b0c899239bad3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3e/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+    "sha512": "b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
+    "dest-filename": "6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/4f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+    "sha512": "e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
+    "dest-filename": "1f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/10"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+    "sha512": "210dc46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab",
+    "dest-filename": "c46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+    "sha512": "2925609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b",
+    "dest-filename": "609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+    "sha512": "7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+    "dest-filename": "f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/61"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+    "sha512": "9c49f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4",
+    "dest-filename": "f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+    "sha512": "2f72e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1",
+    "dest-filename": "e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/72"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+    "sha512": "050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
+    "dest-filename": "5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/0e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+    "sha512": "1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+    "dest-filename": "822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
+    "sha512": "1980f1b198b70a1826724453f473d4d1612128b3f4f1ebff61f72ad80b2d8eb0c048e6024977b28c3b07838bf9b788ce8fb7320d7def9a9ada7ca956206f4c5d",
+    "dest-filename": "f1b198b70a1826724453f473d4d1612128b3f4f1ebff61f72ad80b2d8eb0c048e6024977b28c3b07838bf9b788ce8fb7320d7def9a9ada7ca956206f4c5d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/80"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+    "sha512": "13a3826919807b858399636c2fff5132a7649330c26357adbad91f95693873e01c8c3534ecf733d5f4304d7d13433f8fc6a9fd8b82f54d4dd41698e7adc0e0c4",
+    "dest-filename": "826919807b858399636c2fff5132a7649330c26357adbad91f95693873e01c8c3534ecf733d5f4304d7d13433f8fc6a9fd8b82f54d4dd41698e7adc0e0c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/a3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+    "sha512": "1fff8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb",
+    "dest-filename": "8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+    "sha512": "4650e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6",
+    "dest-filename": "e6f4aefea39b2dbf40a8f22f19446c436eb4f1849b608ea8c5c9587fb5743297fad8b532a59d3bd9f3ca124de611116babc31db426ce244ee282b05914b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+    "sha512": "a09a1fb6fd0b4ae683644dcb7b80db297f8a4bd1b7e8dcce7926a9f745082b4c8c03f36128986a9521ad3433913516886d07f38d70eb41ad32b49ea63511b3fd",
+    "dest-filename": "1fb6fd0b4ae683644dcb7b80db297f8a4bd1b7e8dcce7926a9f745082b4c8c03f36128986a9521ad3433913516886d07f38d70eb41ad32b49ea63511b3fd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+    "sha512": "710cd60ad3ba0bc4d0898975aee28d9f653a028e28e1604171b2fad72265f38c7e8f9b0e596154f57ec3a4d0fc5d91b775a0e9a52b2280c75f008976ba940147",
+    "dest-filename": "d60ad3ba0bc4d0898975aee28d9f653a028e28e1604171b2fad72265f38c7e8f9b0e596154f57ec3a4d0fc5d91b775a0e9a52b2280c75f008976ba940147",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/0c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+    "sha512": "ba44cf561a86e2337332ba36a80f4748249254937768deed95bfa17ea602b77111d325aba1e036551dfc30dace1cb43f7158fe0da20c69dd24142b565a8c21fc",
+    "dest-filename": "cf561a86e2337332ba36a80f4748249254937768deed95bfa17ea602b77111d325aba1e036551dfc30dace1cb43f7158fe0da20c69dd24142b565a8c21fc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/44"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+    "sha512": "00ed9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282",
+    "dest-filename": "9a73aa63441dd2266189a3ebf9fda2ba3a6820a7a7ec2ebb3ac0df5b777e6e96ee1c0b068053dfbb6615e37aa1d591a1d384bbb31f49d9af462908387282",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+    "sha512": "32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest-filename": "3e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+    "sha512": "e69e964cdd03753195424e958dc123bb5f4881a1ee75a95c7da6c3ef284319e03a6dc42798bf82a6f78b26aff786f7f07756a87fa2f7f3a3ae824c7a45fc8c21",
+    "dest-filename": "964cdd03753195424e958dc123bb5f4881a1ee75a95c7da6c3ef284319e03a6dc42798bf82a6f78b26aff786f7f07756a87fa2f7f3a3ae824c7a45fc8c21",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/9e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+    "sha512": "216ae8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417",
+    "dest-filename": "e8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+    "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest-filename": "505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+    "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+    "dest-filename": "d2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+    "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+    "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+    "dest-filename": "fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
+    "sha512": "8fcee8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb",
+    "dest-filename": "e8d23e8ba8f2f7411afcca277a73e4ede600bbc4d7d8a3ab90210928ac00ba32979ac95319ac40f32a6249fc796fec49ce4296919b9de4ea4b43619c81eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ce"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
+    "sha512": "a74226fc3c790b8b66cfc404135627e0c92e3c2f0fae79519de3215898fb0415d07cd4c952c84cfdba7796eb1d12c0dbbef7c96695d69d87ac8122efc2d33667",
+    "dest-filename": "26fc3c790b8b66cfc404135627e0c92e3c2f0fae79519de3215898fb0415d07cd4c952c84cfdba7796eb1d12c0dbbef7c96695d69d87ac8122efc2d33667",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+    "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+    "dest-filename": "56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+    "sha512": "35f27853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
+    "dest-filename": "7853304271018b0e542aee71f11feb6fde4c99d211d0a85e413ba27bb4d25e3f9768d6594fafc759f331e89df840bb43c701d3244a8fbca34c3183d9595b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/f2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+    "sha512": "67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
+    "dest-filename": "4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+    "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+    "dest-filename": "9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+    "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+    "dest-filename": "940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+    "sha512": "39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest-filename": "bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+    "sha512": "faafedec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa",
+    "dest-filename": "edec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+    "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest-filename": "9e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+    "sha512": "04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+    "dest-filename": "e011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+    "sha512": "00aa5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
+    "dest-filename": "5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+    "sha512": "d56d3b70cf604ba0dc2e97ab65f1528fe6d62ed68f1923875a13e21b35e6bd525b44b746f36b07fca9fc12d5b556a595039e0029fda1e64e416e721bc05de1eb",
+    "dest-filename": "3b70cf604ba0dc2e97ab65f1528fe6d62ed68f1923875a13e21b35e6bd525b44b746f36b07fca9fc12d5b556a595039e0029fda1e64e416e721bc05de1eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+    "sha512": "774208fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
+    "dest-filename": "08fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+    "sha512": "f53f548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
+    "dest-filename": "548d6debd145b973543b193c25969b57c21bd8984cc587331f67d1fb1505adfae65e3e364f8c13ff5b5644c99d6dc065a89b9ff9e9317894f72a8e70c772",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+    "sha512": "26dd2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
+    "dest-filename": "2f1f233e8e6501aa88c1ec4d4d21869db74bc8d10c63c5dd9312b5bde300f3f84d8b026e6f28c5d7c20e996414c73ee5250e0407297be318175f705d590d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+    "sha512": "87e0c49e956fc667d579f6b88c56c27f91dd1f960c0d746c98a7e5a5fd6920b6564459536c9a71794e799c99784a6b791d0686ce0d68e911c53c968eaa79810e",
+    "dest-filename": "c49e956fc667d579f6b88c56c27f91dd1f960c0d746c98a7e5a5fd6920b6564459536c9a71794e799c99784a6b791d0686ce0d68e911c53c968eaa79810e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/87/e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+    "sha512": "54ef47b7ffa9dd237b48a5aa72b804ce319b4522584f1f90d694d00b4c2b5aa1f1d2fa49ada43a1ad1f1f2dbdc835ae52b56f2854e6071cc603a08fb0744c391",
+    "dest-filename": "47b7ffa9dd237b48a5aa72b804ce319b4522584f1f90d694d00b4c2b5aa1f1d2fa49ada43a1ad1f1f2dbdc835ae52b56f2854e6071cc603a08fb0744c391",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+    "sha512": "13e5d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+    "dest-filename": "d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+    "sha512": "10773220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
+    "dest-filename": "3220f050e0148696f8c1d7a9392a0009dbb088b0763fd8906609145ea38f32f6b43731a533597dca56505ae14eccc97d361dd563d0aec2dd6681de3bbb15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+    "sha512": "aade35b4c7e01d39658517aca8ce437271f20c858d8331efb98da30dc60ff62686a645b14d4cd5e864230de2e7951d7f0ed76572c5906c0eec0723299891532d",
+    "dest-filename": "35b4c7e01d39658517aca8ce437271f20c858d8331efb98da30dc60ff62686a645b14d4cd5e864230de2e7951d7f0ed76572c5906c0eec0723299891532d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.8.1.tgz",
+    "sha512": "a66d654d86c6c9cf740c78020ceedea3c465e04a8a2dc89ac8d6d9a86ce2aa71fd8eb94a7bc640346762b722d953ea49875e9d7f38c0c76c50abd31cb883c4b7",
+    "dest-filename": "654d86c6c9cf740c78020ceedea3c465e04a8a2dc89ac8d6d9a86ce2aa71fd8eb94a7bc640346762b722d953ea49875e9d7f38c0c76c50abd31cb883c4b7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+    "sha512": "85db14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015",
+    "dest-filename": "14c6e9570a2e524c877bf2f455604b43023abdf48080524b4b4de4d8b0ba1313a67c752d1cf2958d0b1c1dae4f587c97a86c365cd98d7cea10ffe5942015",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/db"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+    "sha512": "dbf90db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980",
+    "dest-filename": "0db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+    "sha512": "bfea7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72",
+    "dest-filename": "7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+    "sha512": "4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest-filename": "5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+    "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest-filename": "db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/a9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+    "sha512": "f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
+    "dest-filename": "7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/8c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+    "sha512": "d51e45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b",
+    "dest-filename": "45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+    "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+    "dest-filename": "b6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+    "sha512": "efb3d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+    "dest-filename": "d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+    "sha512": "23fcc7030b0a7fd16a1a85cce16591002a1bf7e48dba465377de03585e7b138b68a2e46e95b0b171487a44a5043909584c7267ce43ccc92bcf35a6922cd7cb67",
+    "dest-filename": "c7030b0a7fd16a1a85cce16591002a1bf7e48dba465377de03585e7b138b68a2e46e95b0b171487a44a5043909584c7267ce43ccc92bcf35a6922cd7cb67",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/fc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+    "sha512": "cb0a95fb9326c8be04ef26d780acace03ba065b5f4142e8b9f0ae18eeca42239caf64f0e41a710edac462a78c35d63619ecd31a2dddb648e61e791fcca8f5c26",
+    "dest-filename": "95fb9326c8be04ef26d780acace03ba065b5f4142e8b9f0ae18eeca42239caf64f0e41a710edac462a78c35d63619ecd31a2dddb648e61e791fcca8f5c26",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cb/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+    "sha512": "9fc7ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6",
+    "dest-filename": "ce8b1c030fa6ff39b8a7cd3ae9d59285cdb82f299beecff4ef7a39cb9f56907c2eabe765c4c7ce459ae0bedc723e24cedca0145752f36a114d8f1d5ac7a6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+    "sha512": "05278d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest-filename": "8d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/27"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+    "sha512": "44ea0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0",
+    "dest-filename": "0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+    "sha512": "2501d9d90316ea5dda1ff8fac42a904e163ff4e1f80fff65b37e1c8245018847a87114d4d38b477ca3c1b142b53ea64251033b1a20342085c94ae5c723ae0a6e",
+    "dest-filename": "d9d90316ea5dda1ff8fac42a904e163ff4e1f80fff65b37e1c8245018847a87114d4d38b477ca3c1b142b53ea64251033b1a20342085c94ae5c723ae0a6e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+    "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+    "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+    "sha512": "1503783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest-filename": "783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+    "sha512": "3f40b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
+    "dest-filename": "b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+    "sha512": "291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+    "dest-filename": "3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/1b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+    "sha512": "a490e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8",
+    "dest-filename": "e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+    "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+    "sha512": "de5ab3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69",
+    "dest-filename": "b3e588d64d89d6e9d9436b94cb69309c4a17daaf57b8d2b99c255c020490ba996945ba3d1e0872049661b5839932b89fc60fef169f814509ccf88093df69",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/5a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+    "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
+    "dest-filename": "e67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+    "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+    "dest-filename": "3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+    "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest-filename": "903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+    "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest-filename": "305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+    "sha512": "696df9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+    "dest-filename": "f9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+    "sha512": "785b9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0",
+    "dest-filename": "9a2e8cbf4716a5bf692bfa5a8c9549eb0d657ede3e299633882602c8848d39f0841f589eef5e1c84207bbe1ed0bbdfc9251802d8c4e2833b46d03f7b60f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/78/5b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+    "sha512": "e2dbedb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e",
+    "dest-filename": "edb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/db"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+    "sha512": "ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest-filename": "2f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+    "sha512": "f109902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest-filename": "902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+    "sha512": "672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest-filename": "83ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+    "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest-filename": "f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+    "sha512": "4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+    "dest-filename": "48b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/43"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+    "sha512": "db130298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+    "dest-filename": "0298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.8.1.tgz",
+    "sha512": "8253098274eb7a8f0214836e8ed0210a037de9002a0290cc67c565d6bf1fd104fc429aef0b550296d57809c5a3db46282322d9c7a214b24689674355f1fa2472",
+    "dest-filename": "098274eb7a8f0214836e8ed0210a037de9002a0290cc67c565d6bf1fd104fc429aef0b550296d57809c5a3db46282322d9c7a214b24689674355f1fa2472",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/53"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+    "sha512": "65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9",
+    "dest-filename": "e6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+    "sha512": "cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+    "dest-filename": "f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/81"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+    "sha512": "b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+    "dest-filename": "b87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+    "sha512": "28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest-filename": "7f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+    "sha512": "23cf1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+    "dest-filename": "1361959cf578981d1438ff7739ae38df8248e12f25b696e18885e18445b350e8e63bc93c9b6a74a90d765af32ed550ff589837186be7b2ab871aee22ea58",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+    "sha512": "51e26615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
+    "dest-filename": "6615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
+    "sha512": "a36f3c7c87603cb1c0efa783ac50031cfa28ed5c869030986cb5751b39dd68c480541a19ac6bccf66d887a175c54ccdd019276795f5b8328acb105c7bf9b46cc",
+    "dest-filename": "3c7c87603cb1c0efa783ac50031cfa28ed5c869030986cb5751b39dd68c480541a19ac6bccf66d887a175c54ccdd019276795f5b8328acb105c7bf9b46cc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.8.1.tgz",
+    "sha512": "b96871d6bef8346a426a01b450bb3f3fd36abf69eca28fbb7a8e1f2d4381f0bf0c75696dabda1d5bfbae2d73050831a73da7e49d82d9823357d1920547339003",
+    "dest-filename": "71d6bef8346a426a01b450bb3f3fd36abf69eca28fbb7a8e1f2d4381f0bf0c75696dabda1d5bfbae2d73050831a73da7e49d82d9823357d1920547339003",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/68"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.8.1.tgz",
+    "sha512": "abe8eb493221fc2bf878665aee8551fa0ac4268fc5a0b3180409d22f9182b6ac14a6bd53f9580a07f767d699f3c48c6a0fc4bf8cfd728a54fd56bc02a88351e3",
+    "dest-filename": "eb493221fc2bf878665aee8551fa0ac4268fc5a0b3180409d22f9182b6ac14a6bd53f9580a07f767d699f3c48c6a0fc4bf8cfd728a54fd56bc02a88351e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+    "sha512": "6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+    "dest-filename": "f2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron/-/electron-41.0.3.tgz",
+    "sha512": "2038f1f25896d6afabefe30e8a9e56d44a3578cc09cd539b998addf72cf674f0a44bb5e580bab7a8f54c47cd13a6244e169ef7898df4913ccc76903a7c456cdc",
+    "dest-filename": "f1f25896d6afabefe30e8a9e56d44a3578cc09cd539b998addf72cf674f0a44bb5e580bab7a8f54c47cd13a6244e169ef7898df4913ccc76903a7c456cdc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+    "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest-filename": "d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+    "sha512": "2f5f03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
+    "dest-filename": "03689b17494936fb8da9bfc98bb398c94f686a164144e23db5c0e9a06d4aac67684bef636c514efce60f515e0a37b3464d815978d93887a7766d3affd5ca",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/5f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+    "sha512": "11305aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc",
+    "dest-filename": "5aba8c354f7e58fd664c922a3d8e2334679c631c7989e179a364eab597f757cf796bdac467f3b9c9cb6d11ba9a928751769b71c73d2a7c4a120f409ac9dc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/30"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+    "sha512": "a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
+    "dest-filename": "0673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/81"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+    "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+    "dest-filename": "6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+    "sha512": "d9b9a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
+    "dest-filename": "a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+    "sha512": "7b79d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest-filename": "d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+    "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest-filename": "47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+    "sha512": "146807da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c",
+    "dest-filename": "07da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/68"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+    "sha512": "8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest-filename": "d6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+    "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
+    "dest-filename": "fe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+    "sha512": "9a0dce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+    "dest-filename": "ce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+    "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+    "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest-filename": "5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/da"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+    "sha512": "66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+    "dest-filename": "1e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+    "sha512": "183854f67b70b8ac865dd6415204c87bebd79d68f47e9a5412d3032f4fa275de52b5af131a91ecb27fdebac03d9ab3ebf6a343ca6e92c406198cdbc29fff5106",
+    "dest-filename": "54f67b70b8ac865dd6415204c87bebd79d68f47e9a5412d3032f4fa275de52b5af131a91ecb27fdebac03d9ab3ebf6a343ca6e92c406198cdbc29fff5106",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+    "sha512": "5ab937e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30",
+    "dest-filename": "37e5ef327422838ff02b0a5a3556b3d598df33a61e55e00b47c08b8786f317b0a7fbdd44f704e0fe6b30485bedf0389e058441fbcf2689085bc286362f30",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+    "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest-filename": "90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+    "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+    "dest-filename": "7fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+    "sha512": "704d6ab01fd5c32428cd9faad5d1b147c2c160d65ea1f84475434648c6d00f71b0da50335fd65bdee214e846dcfc59b28e8f405967e79f4014087aad7afb3ff2",
+    "dest-filename": "6ab01fd5c32428cd9faad5d1b147c2c160d65ea1f84475434648c6d00f71b0da50335fd65bdee214e846dcfc59b28e8f405967e79f4014087aad7afb3ff2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/4d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+    "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest-filename": "d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+    "sha512": "e608b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4",
+    "dest-filename": "b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+    "sha512": "8085e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3",
+    "dest-filename": "e32aab45b96120cc544903d58241e4892d90e380950e302333c6dbc5abfdfb2a88ccd41146b9faac0b2d2be2a4909982ec65831ec91ab321638cba9d37b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+    "sha512": "f118a944ba25dfb6cdb366e1a15ebb7e24c4bdd4eb6cc5187054e2cb7fb0bae3a75288364011c26565c34628d641f0248418f651fe549d56a25b0039bdd77cdb",
+    "dest-filename": "a944ba25dfb6cdb366e1a15ebb7e24c4bdd4eb6cc5187054e2cb7fb0bae3a75288364011c26565c34628d641f0248418f651fe549d56a25b0039bdd77cdb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+    "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+    "dest-filename": "c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+    "sha512": "0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+    "dest-filename": "ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/35"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+    "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+    "dest-filename": "da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+    "sha512": "ca1950800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2",
+    "dest-filename": "50800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/19"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+    "sha512": "85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+    "dest-filename": "376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+    "sha512": "5d4040f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f",
+    "dest-filename": "40f570a51db9c95927c1ce3926e91bcfb32837b2bc99b74e81110a17705ec42bfc6919a41826040a0c94941f948667be98ee9171d500675f3d3dad4e456f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+    "sha512": "38ed291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest-filename": "291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+    "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest-filename": "037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+    "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest-filename": "cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+    "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest-filename": "4fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/21"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+    "sha512": "f5f4a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest-filename": "a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+    "sha512": "b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest-filename": "9f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/34"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+    "sha512": "9c117e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
+    "dest-filename": "7e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+    "sha512": "0df5cdf037e127b347dce7bb7059aedcd0aed7029b911789f13a2bcd20056d22ab94d69048a7c8cea62a558f3395bb3634b05b5a9462539d865f63db68154d92",
+    "dest-filename": "cdf037e127b347dce7bb7059aedcd0aed7029b911789f13a2bcd20056d22ab94d69048a7c8cea62a558f3395bb3634b05b5a9462539d865f63db68154d92",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+    "sha512": "9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest-filename": "74ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/54"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+    "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+    "dest-filename": "9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/3e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+    "sha512": "0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest-filename": "ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+    "sha512": "65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest-filename": "9187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+    "sha512": "ead7d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2",
+    "dest-filename": "d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+    "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+    "dest-filename": "79fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+    "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+    "sha512": "e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest-filename": "4d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+    "sha512": "d5c0cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest-filename": "cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+    "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest-filename": "0307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+    "sha512": "d21254f5208fbe633320175916a34f5d66ba76a87b59d1f470823dcbe0b24bcac6de72f8f01725adaf4798a8555541f23d6347e58ef10f0001edb7e04a391431",
+    "dest-filename": "54f5208fbe633320175916a34f5d66ba76a87b59d1f470823dcbe0b24bcac6de72f8f01725adaf4798a8555541f23d6347e58ef10f0001edb7e04a391431",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+    "sha512": "9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+    "dest-filename": "ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+    "sha512": "753c5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41",
+    "dest-filename": "5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+    "sha512": "4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest-filename": "240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/58"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+    "sha512": "57edb7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
+    "dest-filename": "b7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+    "sha512": "bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest-filename": "4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+    "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
+    "dest-filename": "2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+    "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+    "dest-filename": "a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+    "sha512": "75ccaa843bd7d42e3a95765c56a0a92be16d31141574830debf0dfe63b36ce8b94b2a1bb23ab05c62b480beeca60adbd29d5ce2c776ef732f8b059e85509ea68",
+    "dest-filename": "aa843bd7d42e3a95765c56a0a92be16d31141574830debf0dfe63b36ce8b94b2a1bb23ab05c62b480beeca60adbd29d5ce2c776ef732f8b059e85509ea68",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/cc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+    "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+    "dest-filename": "cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+    "sha512": "93dd88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest-filename": "88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+    "sha512": "93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest-filename": "c6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/fb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+    "sha512": "5d70031f15e6bd3f7e091c615e0e7a2c9a2f13e6e65a711607bf0b07cdd5653a6b29399a0b941faee5e8731cd36762a5d033702ae05d9488632fc2de63c49ff1",
+    "dest-filename": "031f15e6bd3f7e091c615e0e7a2c9a2f13e6e65a711607bf0b07cdd5653a6b29399a0b941faee5e8731cd36762a5d033702ae05d9488632fc2de63c49ff1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+    "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest-filename": "a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+    "sha512": "d87bc810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb",
+    "dest-filename": "c810a468a92eb682e102faa063a6f46e6dd5fdd7458232e25367e23dcafa8a536ff5d9e48be78f47330b5a6dbe28ba9763dac30fe7493e5c97c1ffc244eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+    "sha512": "927c46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
+    "dest-filename": "46daae140b7bbcb2d446c8054908e771166bf90d989171d94868041701b49f2726be3a1a29368b4b42bb2d061aaeaaee19a6e29b0dcffc4ba9a05e03c53f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+    "sha512": "887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb",
+    "dest-filename": "ea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+    "sha512": "827583d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61",
+    "dest-filename": "83d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+    "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest-filename": "4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+    "sha512": "e81ded2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3",
+    "dest-filename": "ed2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+    "sha512": "386959429cf6c9f6a103f45dd58f0277d48812caaf5e42d5a12c3f720c219e114c0dbb1015e658a0927b6c86414bd05c6a6516f7a6acabf9e93d6ba033e45007",
+    "dest-filename": "59429cf6c9f6a103f45dd58f0277d48812caaf5e42d5a12c3f720c219e114c0dbb1015e658a0927b6c86414bd05c6a6516f7a6acabf9e93d6ba033e45007",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/69"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+    "sha512": "c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+    "dest-filename": "d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+    "sha512": "7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85",
+    "dest-filename": "a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+    "sha512": "a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+    "dest-filename": "93e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/02"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+    "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+    "dest-filename": "7905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+    "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+    "dest-filename": "c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+    "sha512": "642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
+    "dest-filename": "60e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+    "sha512": "5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+    "dest-filename": "967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/63"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+    "sha512": "9ba175477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6",
+    "dest-filename": "75477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/a1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+    "sha512": "146b8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502",
+    "dest-filename": "8fc37d0074e2144d1302d8e311b5057e8e4563d9c7cfa927965efd4d100275a99e736f55facf598585b7ce07f8b2decb09083fb72ae67cafc0b7b9516502",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/6b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+    "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+    "dest-filename": "4790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+    "sha512": "d3f06718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
+    "dest-filename": "6718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+    "sha512": "60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
+    "dest-filename": "ff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+    "sha512": "473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
+    "dest-filename": "86f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+    "sha512": "53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
+    "dest-filename": "2c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+    "sha512": "2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
+    "dest-filename": "e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+    "sha512": "c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
+    "dest-filename": "e79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+    "sha512": "d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
+    "dest-filename": "ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+    "sha512": "529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
+    "dest-filename": "24a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/94"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+    "sha512": "57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
+    "dest-filename": "2be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/b4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+    "sha512": "6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
+    "dest-filename": "0ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/87"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+    "sha512": "f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
+    "dest-filename": "c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+    "sha512": "026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
+    "dest-filename": "bd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+    "sha512": "357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
+    "dest-filename": "01ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+    "sha512": "2e055332942d228a428bbf5225e0e23f44df5a2e4234473f2ff691753877c88be66574e785e5a92a3499867bcc97c8976c2d6d160f607471c330ba15ec29c6fb",
+    "dest-filename": "5332942d228a428bbf5225e0e23f44df5a2e4234473f2ff691753877c88be66574e785e5a92a3499867bcc97c8976c2d6d160f607471c330ba15ec29c6fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/05"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+    "sha512": "f173efa4003cbb285fb5ebbca48bd0c69259ed2618769522bd9a46cbab05b01b8a458ffbad019abde75e07c68af99932ababa930554bffd016eaf398cdf4722e",
+    "dest-filename": "efa4003cbb285fb5ebbca48bd0c69259ed2618769522bd9a46cbab05b01b8a458ffbad019abde75e07c68af99932ababa930554bffd016eaf398cdf4722e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/73"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+    "sha512": "b6a357ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798",
+    "dest-filename": "57ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/a3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+    "sha512": "24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+    "dest-filename": "3365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+    "sha512": "268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
+    "dest-filename": "9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+    "sha512": "40c8c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5",
+    "dest-filename": "c66c54cfd1b963f7b11e89d1b9864fd084a4374f82027244062e0cf7f1017b5606e4e9ee854c044df0a84ac7205b5a7f11d0753e6e7c3c692a053c3e2ab5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+    "sha512": "3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
+    "dest-filename": "8368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+    "sha512": "fc85ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest-filename": "ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+    "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest-filename": "38b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+    "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest-filename": "3e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+    "sha512": "5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+    "dest-filename": "e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+    "sha512": "3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
+    "dest-filename": "ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+    "sha512": "8f911cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5",
+    "dest-filename": "1cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+    "sha512": "cf4c9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+    "dest-filename": "9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+    "sha512": "a118d3c3ff7b69304dd111db60276d1753107efbac488050334219120ce5eb8dbafbc8d20b49c5d5afc69a754ba5f07dcb2afa83a153a96aa26556f1aed68222",
+    "dest-filename": "d3c3ff7b69304dd111db60276d1753107efbac488050334219120ce5eb8dbafbc8d20b49c5d5afc69a754ba5f07dcb2afa83a153a96aa26556f1aed68222",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+    "sha512": "5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest-filename": "d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+    "sha512": "ee8d70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617",
+    "dest-filename": "70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/8d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+    "sha512": "381c0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+    "dest-filename": "0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/1c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+    "sha512": "db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest-filename": "8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+    "sha512": "0fb57c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b",
+    "dest-filename": "7c3cef686b3ecf5862db0800ae235a843acabb50a7cba2dc7f0b401eb78ddf09407fc1f43b0d87aada847fb2f1491980c73ebdfc48701379a8ff6682872b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+    "sha512": "8fb535d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81",
+    "dest-filename": "35d42e475e2815baeb7179b15a7686016dded549d65682049eeb835576f58d06a1808973cbd905427a18e6c3b958d6817d80e96561b39187e8623607cf81",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+    "sha512": "266412618a4f52a5f92729f5997691c0e75ad6e43c1cfe4a013fe80d22c2cedd41611850534fe10edb01d6e7d97c4133319f5a0159ac070f3e156b085e50a55b",
+    "dest-filename": "12618a4f52a5f92729f5997691c0e75ad6e43c1cfe4a013fe80d22c2cedd41611850534fe10edb01d6e7d97c4133319f5a0159ac070f3e156b085e50a55b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/64"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+    "sha512": "c6e22aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec",
+    "dest-filename": "2aedc20eb74f513d1275f60762e1bf9188dbc31587b9247fa080dbc1a86aa941772bbb73dc466399b8704a58ad53c5ff7e710f8731537877acf8e8b64fec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+    "sha512": "31b9104360938813250360e6ff9718fbd49614437ca73cce5e2eab94ce57c6ad18a9b75ae59432f6c53be5aebbdc513d64ad19b1bafa63988feaef6792d7e0da",
+    "dest-filename": "104360938813250360e6ff9718fbd49614437ca73cce5e2eab94ce57c6ad18a9b75ae59432f6c53be5aebbdc513d64ad19b1bafa63988feaef6792d7e0da",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+    "sha512": "0f188d89dc5210afad1c6eb3388925bcd3b09b786f0ab6d4addb7363be14e87293271bc80df3942f95b93f61a17770d392184a3d81aa78d508879a9c3386017f",
+    "dest-filename": "8d89dc5210afad1c6eb3388925bcd3b09b786f0ab6d4addb7363be14e87293271bc80df3942f95b93f61a17770d392184a3d81aa78d508879a9c3386017f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+    "sha512": "b44047a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+    "dest-filename": "47a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+    "sha512": "299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
+    "dest-filename": "58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+    "sha512": "14ffa9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027",
+    "dest-filename": "a9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+    "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest-filename": "73b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+    "sha512": "37c4a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb",
+    "dest-filename": "a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+    "sha512": "f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+    "dest-filename": "ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
+    "sha512": "41fa795d92f57090ce69b393f07e609ea31398ce0d8ef6331e9e08fcab7f4a5efa39590e0411d11653eca46574858bcca2a42cca91634ff629eca9b46de5d6f6",
+    "dest-filename": "795d92f57090ce69b393f07e609ea31398ce0d8ef6331e9e08fcab7f4a5efa39590e0411d11653eca46574858bcca2a42cca91634ff629eca9b46de5d6f6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/fa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+    "sha512": "89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce",
+    "dest-filename": "cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+    "sha512": "db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+    "dest-filename": "ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
+    "sha512": "adaecabe58719f957d4a5caeb34ca031ada1f94a84c4fa942247e4ecf73c4132d3f79e892d2cb9d6e585c07b48632d2f23c701e010e173f4b4dfef3cd0ccbf2d",
+    "dest-filename": "cabe58719f957d4a5caeb34ca031ada1f94a84c4fa942247e4ecf73c4132d3f79e892d2cb9d6e585c07b48632d2f23c701e010e173f4b4dfef3cd0ccbf2d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+    "sha512": "89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec",
+    "dest-filename": "aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/e1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+    "sha512": "0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+    "dest-filename": "fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+    "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest-filename": "0449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest-filename": "89808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+    "sha512": "91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
+    "dest-filename": "5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+    "sha512": "e5be98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
+    "dest-filename": "98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/be"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+    "sha512": "0593abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2",
+    "dest-filename": "abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+    "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+    "dest-filename": "9a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+    "sha512": "b64010130f32b0cce6921830f24fb553f88f856361ca42a74a4e11779ccba0f242b8968644fa3a629a2cad981ac472b30c774359666f13f4a4ee1b0bd97fc2a5",
+    "dest-filename": "10130f32b0cce6921830f24fb553f88f856361ca42a74a4e11779ccba0f242b8968644fa3a629a2cad981ac472b30c774359666f13f4a4ee1b0bd97fc2a5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+    "sha512": "5046484b7fdbcb8382f2f2f73f67535d1113a5e6cb236362239bc8ae3683ff952dae4157fed35bc234d2440182ffeec2028da921c05a4605a670104772c68223",
+    "dest-filename": "484b7fdbcb8382f2f2f73f67535d1113a5e6cb236362239bc8ae3683ff952dae4157fed35bc234d2440182ffeec2028da921c05a4605a670104772c68223",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/46"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+    "sha512": "0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest-filename": "f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+    "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+    "sha512": "5dae0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
+    "dest-filename": "0dc35ec54bd02940527dba62e2252e28ac68e6ed9cf052bc1a99c190b874b30f2b61f5ba0a0dac9c61d0dc643baa6004d7c381c55e06aa59372d5bfbf51c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+    "sha512": "791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+    "dest-filename": "81e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+    "sha512": "1776acbf8d94b97721773b7ec57a9f5b538695505efa6c5ada6a88d29839c801d93ef16663763a76b49ffc643503ce9681610df4ace1fd6ae029aea219c1d72e",
+    "dest-filename": "acbf8d94b97721773b7ec57a9f5b538695505efa6c5ada6a88d29839c801d93ef16663763a76b49ffc643503ce9681610df4ace1fd6ae029aea219c1d72e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+    "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest-filename": "87dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+    "sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+    "dest-filename": "3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+    "sha512": "bb2b2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
+    "dest-filename": "2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+    "sha512": "396feb5fc3bf8d79e6f36132d64e38a4e6cfb5d6e57e2b969eb77c5fb189ede9889823acb6e9c66d7529a7b1dd06b1505faac9ce7dec3d3dfded6a79682c021e",
+    "dest-filename": "eb5fc3bf8d79e6f36132d64e38a4e6cfb5d6e57e2b969eb77c5fb189ede9889823acb6e9c66d7529a7b1dd06b1505faac9ce7dec3d3dfded6a79682c021e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+    "sha512": "6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+    "dest-filename": "1bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+    "sha512": "033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d",
+    "dest-filename": "33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/03/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+    "sha512": "ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
+    "dest-filename": "87b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+    "sha512": "cbe58a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde",
+    "dest-filename": "8a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cb/e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+    "sha512": "4e334f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68",
+    "dest-filename": "4f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+    "sha512": "552eec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
+    "dest-filename": "ec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+    "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "dest-filename": "7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+    "sha512": "5aec802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+    "dest-filename": "802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+    "sha512": "04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
+    "dest-filename": "3d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+    "sha512": "f6efec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
+    "dest-filename": "ec9e20ab6370f959db04447cc71381b66025eaa06e454c7522082e1221bafa5dc2d9058d39c9af442a361e93d3b9c4e0308c6abed497460404bb43d49ca0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+    "sha512": "7c6c4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest-filename": "4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+    "sha512": "bc78dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+    "dest-filename": "dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/78"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+    "sha512": "d1ad45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa",
+    "dest-filename": "45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+    "sha512": "e20974df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787",
+    "dest-filename": "74df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+    "sha512": "97eb1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc",
+    "dest-filename": "1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+    "sha512": "f4b9224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3",
+    "dest-filename": "224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+    "sha512": "9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+    "dest-filename": "9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+    "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
+    "dest-filename": "4f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/78"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
+    "sha512": "caa8f1aee306050276806e07b6366d01f5c0ac7a266b30c7a05c05166659974afb3dda3ba822172aa28765cf327a8320cc927ea4eea91041daf95eeecd696b01",
+    "dest-filename": "f1aee306050276806e07b6366d01f5c0ac7a266b30c7a05c05166659974afb3dda3ba822172aa28765cf327a8320cc927ea4eea91041daf95eeecd696b01",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+    "sha512": "ae9dd2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d",
+    "dest-filename": "d2a34eca71d9a629b1af81a37141226bedb1954959394bd12ad45fa9a5b468ef4f9879a0f1930e4377c34f37e183e9b8e7626d95b8fb825e6a6e62f9825d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ae/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+    "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+    "dest-filename": "372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+    "sha512": "f59c88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512",
+    "dest-filename": "88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+    "sha512": "e91dc9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc",
+    "dest-filename": "c9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+    "sha512": "60cdff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3",
+    "dest-filename": "ff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+    "sha512": "701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+    "dest-filename": "e79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/1c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+    "sha512": "051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+    "dest-filename": "d5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+    "sha512": "bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+    "dest-filename": "82d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+    "sha512": "f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
+    "dest-filename": "138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+    "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest-filename": "6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+    "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+    "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest-filename": "f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+    "sha512": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+    "dest-filename": "99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+    "sha512": "6b607d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
+    "dest-filename": "7d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/60"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+    "sha512": "a52cafedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9",
+    "dest-filename": "afedb4930bb8a0f437206f0f40b913546f993957aa03b9d8d9a0c052af5deaa4b046eed07ece00a40118eaef121481dcf93f541ef2efab486768b8e388c9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+    "sha512": "f7884ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a",
+    "dest-filename": "4ad0787cacfa90976c577371ec681a0e5ca576d0c4e83e4717bf06c84962c4b3eeb8b01ab9905827da42431dbd4faf2f72acfd1dc6b088f5145c8bb4572a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+    "sha512": "1de84212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327",
+    "dest-filename": "4212ca2d16a6cf5bdb09f1655807a51b98832fee4514391205d8d9dcab8550bc17cd04b89b5bd619479765602494870703eb6f29465966ee7f84f984f327",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+    "sha512": "1cba6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0",
+    "dest-filename": "6dfae2f2fe9c41f9bba6ffd0f302088a4bc097d44bdb5b1238ce59a01821312262dd89a776882c174f967873d73712af2b3f6df5f263d6d9cf906ed8caf0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+    "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest-filename": "8c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+    "sha512": "b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+    "dest-filename": "d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+    "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest-filename": "1aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+    "sha512": "3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+    "dest-filename": "b4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+    "sha512": "4bb886368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01",
+    "dest-filename": "86368b1ea71f5169d5fcda88a6524bebd02b7b22325b11bb38989713c6cb7cba6f79277b03614d510443af76eea82f559e9363832398b8300c3e759e9c01",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/b8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+    "sha512": "8c7f4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2",
+    "dest-filename": "4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+    "sha512": "864457f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
+    "dest-filename": "57f14d568c915df0bb03276c90ff0596c5aa2912c0015355df90cf00fa3d3ef392401a9a6dd7a72bd56860e8a21b6f8a2453a32a97a04e8febaea7fc0a78",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/44"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+    "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest-filename": "90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/ac"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+    "sha512": "1e72ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+    "dest-filename": "ce091def8dc63c6dea0d2ed723679fe7c67d9a7e6304ea586b0eb79ba24a8c6a9f976de5bc9fd4d7a4f0cea9d18ae6a708de84f418a4d6eb00bb10c895a8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/72"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+    "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest-filename": "153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+    "sha512": "c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+    "dest-filename": "cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+    "sha512": "32f8d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe",
+    "dest-filename": "d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+    "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest-filename": "80bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+    "sha512": "b4e1bfec6c97a457af857561f2338f26b9ad469393b18a9422455d568a196094bfcfc5a17d0517f112482e67ae24d8a7180312bb5bde06be1ab121c5b79fe19e",
+    "dest-filename": "bfec6c97a457af857561f2338f26b9ad469393b18a9422455d568a196094bfcfc5a17d0517f112482e67ae24d8a7180312bb5bde06be1ab121c5b79fe19e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/e1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+    "sha512": "0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
+    "dest-filename": "63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+    "sha512": "c98aebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+    "dest-filename": "ebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/8a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+    "sha512": "762dc1b0bd85110d4f03b1dcbe7e1fc893a5c514601580693137323a093024868339d24c79b1053c0fadf7c12f8ee9630f1e2136e9401b017a2888edc08e6381",
+    "dest-filename": "c1b0bd85110d4f03b1dcbe7e1fc893a5c514601580693137323a093024868339d24c79b1053c0fadf7c12f8ee9630f1e2136e9401b017a2888edc08e6381",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/2d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+    "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+    "dest-filename": "00c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+    "sha512": "8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
+    "dest-filename": "6ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/66"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+    "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+    "dest-filename": "3b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+    "sha512": "be8cb3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3",
+    "dest-filename": "b3e8c0296b5ad0194c53dc4f812bbfd139ef22b44c7bbc3f3f1c4bede31c17b9cbd0e46e687848879261d926e04edb546939ff98626f4c3a2be3ef4f63a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/8c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+    "sha512": "f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
+    "dest-filename": "eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+    "sha512": "df847b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732",
+    "dest-filename": "7b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+    "sha512": "673f9a6564a3f0b13ace8c43fb1ae387855f9081bc61ae8bbd8919aad5101893d98d8979df2a42694c16aa8ede234c7ae8a046791a3e9a504490c49e499dfc37",
+    "dest-filename": "9a6564a3f0b13ace8c43fb1ae387855f9081bc61ae8bbd8919aad5101893d98d8979df2a42694c16aa8ede234c7ae8a046791a3e9a504490c49e499dfc37",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+    "sha512": "5d29c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535",
+    "dest-filename": "c47b05e643ebde3fbc57d9d4b9438c9902f3b8d1c04dd8c5a427b0ffeac5b80e0eb060137033556b9f3d45847e4075e2c89545d123d7b6f33d58662ef535",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+    "sha512": "f4e75aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e",
+    "dest-filename": "5aa8ee64c2a47ed645601c086ca79bcf354d219f145adbaac114d7cd80ceccea936d8337819f7b3fc5bc8240bddd723cce6ad71e7fa5141e907fe8c6844e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+    "sha512": "ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+    "dest-filename": "5e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+    "sha512": "829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+    "dest-filename": "4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+    "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+    "dest-filename": "94cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+    "sha512": "5e7d30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c",
+    "dest-filename": "30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+    "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+    "dest-filename": "f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+    "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
+    "dest-filename": "9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+    "sha512": "a396bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+    "dest-filename": "bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/96"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+    "sha512": "5c73c4c12d2ae936b172f1bce7ef046246e20aec765ed586da691ce3b360d80efb050bbdf83a8838995d493e0780f92e79aeddbca4a3e55817dcfd5de2b5bc4e",
+    "dest-filename": "c4c12d2ae936b172f1bce7ef046246e20aec765ed586da691ce3b360d80efb050bbdf83a8838995d493e0780f92e79aeddbca4a3e55817dcfd5de2b5bc4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5c/73"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+    "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+    "sha512": "244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+    "dest-filename": "46cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+    "sha512": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest-filename": "888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+    "sha512": "b22ed0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+    "dest-filename": "d0588eb350cab9e9b11216f6a0b66ccc7463ada317d1f927b3d753286df73bb66f9591472493d6d6d9479f7d319551b3a4b31992c34000da0b3c83bd4d09",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest-filename": "a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+    "sha512": "b00b7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54",
+    "dest-filename": "7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/0b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+    "sha512": "c8ca8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
+    "dest-filename": "8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/ca"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+    "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest-filename": "c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+    "sha512": "df074689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec",
+    "dest-filename": "4689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+    "sha512": "620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+    "dest-filename": "d44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/0b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+    "sha512": "b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest-filename": "6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/5a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+    "sha512": "edd4b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
+    "dest-filename": "b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/d4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+    "sha512": "a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde",
+    "dest-filename": "bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+    "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "dest-filename": "2cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/59"
+  }
+]

--- a/openmetaversekit.sh
+++ b/openmetaversekit.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+
+export TMPDIR="${XDG_RUNTIME_DIR}/app/${FLATPAK_ID}"
+mkdir -p "${TMPDIR}"
+export OPEN_METAVERSE_APP_URL="file:///app/share/openmetaversekit/dist/index.html"
+export OPEN_METAVERSE_DESKTOP_NAME="com.matthew.openmetaversekit.desktop"
+
+exec zypak-wrapper.sh /app/bin/electron /app/share/openmetaversekit "$@"


### PR DESCRIPTION
## Summary
- add OpenMetaverseKit for Flathub review
- build the Electron desktop app from source with the Electron BaseApp
- reference the upstream v0.1.1 source release

## Validation
- npm run build
- appstreamcli validate --pedantic
- flatpak-builder source build
- flatpak build-export / build-bundle

## Note
- screenshots still need to be expanded in the metainfo for a stronger store listing, but the submission packaging is now in place