### PR TITLE
Add io.github.marky_editor.marky

### DIFF
--- a/io.github.marky_editor.marky.yml
+++ b/io.github.marky_editor.marky.yml
@@ -1,0 +1,46 @@
+app-id: io.github.marky_editor.marky
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: marky
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --share=network
+  - --device=dri
+  - --filesystem=home
+  - --talk-name=org.freedesktop.FileManager1
+
+modules:
+  - name: marky
+    buildsystem: simple
+    build-commands:
+      - cp -r . /app/marky
+      - install -Dm755 /dev/stdin /app/bin/marky <<'WRAPPER'
+        #!/bin/bash
+        exec zypak-wrapper /app/marky/marky "$@"
+        WRAPPER
+      - install -Dm644 io.github.marky_editor.marky.desktop /app/share/applications/io.github.marky_editor.marky.desktop
+      - install -Dm644 io.github.marky_editor.marky.metainfo.xml /app/share/metainfo/io.github.marky_editor.marky.metainfo.xml
+      - install -Dm644 icons/256x256.png /app/share/icons/hicolor/256x256/apps/io.github.marky_editor.marky.png
+      - install -Dm644 icons/128x128.png /app/share/icons/hicolor/128x128/apps/io.github.marky_editor.marky.png
+      - install -Dm644 icons/512x512.png /app/share/icons/hicolor/512x512/apps/io.github.marky_editor.marky.png
+    sources:
+      # The unpacked electron-builder output (linux-unpacked directory)
+      # Update the url and sha256 for each release
+      - type: archive
+        url: https://github.com/marky-editor/marky/releases/download/v0.1.0/marky-linux-x64.tar.gz
+        sha256: d9ab694487e0854d48f6dcb31eeb9c9e081927006c4ab8f74170fbb0634ce4ed
+        dest: .
+      - type: file
+        path: io.github.marky_editor.marky.desktop
+      - type: file
+        path: io.github.marky_editor.marky.metainfo.xml
+      - type: dir
+        path: ../build/icons
+        dest: icons


### PR DESCRIPTION
## App Details

- **Name:** Marky
- **App ID:** io.github.marky_editor.marky
- **License:** AGPL-3.0-or-later
- **Homepage:**                              https://github.com/marky-editor/marky
- **Category:** Office / Text Editor

## Description

Marky is a distraction-free, Apostrophe-inspired Markdown editor built 
  with Electron, featuring live preview, Mermaid diagram support, and PDF/HTML export.

## Checklist

- [x] App ID follows naming conventions
- [x] AppStream metainfo
   included with description, releases, and content rating
- [x] Desktop file included
- [x] Icons provided (128x128, 256x256, 512x512)
- [x] App builds and runs 
  successfully
- [x] License is open source