### PR TITLE
Add io.github.AhmadTakkoush.QuranRadio

### DIFF
--- a/io.github.AhmadTakkoush.QuranRadio.yml
+++ b/io.github.AhmadTakkoush.QuranRadio.yml
@@ -1,0 +1,55 @@
+app-id: io.github.AhmadTakkoush.QuranRadio
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+
+command: quran-radio
+
+# Allow the ffmpeg codecs extension for MP3/AAC stream decoding
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    version: '24.08'
+    add-ld-path: .
+    no-autodownload: false
+    autodelete: false
+
+finish-args:
+  - --share=network               # stream audio over the internet
+  - --socket=pulseaudio           # audio output (works with PipeWire-Pulse too)
+  - --talk-name=org.kde.StatusNotifierWatcher   # system tray (SNI protocol)
+
+modules:
+  # Create the ffmpeg extension directory expected by the extension point
+  - name: ffmpeg-dir
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/ffmpeg
+
+  - name: quran-radio
+    buildsystem: simple
+    build-commands:
+      # Main script
+      - install -Dm755 quran_radio.py /app/bin/quran-radio
+
+      # Desktop entry
+      - install -Dm644 io.github.AhmadTakkoush.QuranRadio.desktop
+          /app/share/applications/io.github.AhmadTakkoush.QuranRadio.desktop
+
+      # AppStream metadata
+      - install -Dm644 io.github.AhmadTakkoush.QuranRadio.metainfo.xml
+          /app/share/metainfo/io.github.AhmadTakkoush.QuranRadio.metainfo.xml
+
+      # Icon — 256x256
+      - install -Dm644 icon.png
+          /app/share/icons/hicolor/256x256/apps/io.github.AhmadTakkoush.QuranRadio.png
+
+      # License
+      - install -Dm644 LICENSE
+          /app/share/licenses/io.github.AhmadTakkoush.QuranRadio/LICENSE
+
+    sources:
+      - type: git
+        url: https://github.com/AhmadTakkoush/quranradio.git
+        tag: v1.0.1
+        commit: 920e7f2ec29d346a9eb32dee73aa56ec7661ae19


### PR DESCRIPTION
## New App Submission

**App ID:** `io.github.AhmadTakkoush.QuranRadio`
**Name:** Quran Radio
**Source:** https://github.com/AhmadTakkoush/quranradio
**License:** MIT

## Description

Quran Radio is a lightweight Linux system tray application that lets you stream Quran Karim radio stations directly from the GNOME top bar — no browser or heavy media player required.

**Features:**
- Two built-in stations: Quran Kareem Beirut and Cairo (ERTU 98.2 FM)
- Play, stop, and switch stations from the tray menu
- Volume slider in the controls popup
- Remembers last station and volume across sessions
- Minimal dark-themed UI with Islamic green accents

## Technical Details

- **Runtime:** `org.gnome.Platform//48`
- **Language:** Python 3 with GTK3 (PyGObject)
- **Audio:** GStreamer `playbin` + `org.freedesktop.Platform.ffmpeg-full` extension for MP3/AAC
- **Tray:** AppIndicator3 / StatusNotifierItem (SNI)
- **Permissions:** network, pulseaudio, org.kde.StatusNotifierWatcher

## Checklist

- [x] App ID matches GitHub username (`io.github.AhmadTakkoush`)
- [x] Manifest uses a tagged release with commit hash
- [x] AppStream metainfo included in the build
- [x] Screenshots provided
- [x] OARS content rating set
- [x] MIT license included