### PR TITLE
Add io.github.crashman79.steam-audio-isolator

### DIFF
--- a/io.github.crashman79.steam-audio-isolator/io.github.crashman79.steam-audio-isolator.yml
+++ b/io.github.crashman79.steam-audio-isolator/io.github.crashman79.steam-audio-isolator.yml
@@ -1,0 +1,84 @@
+app-id: io.github.crashman79.steam-audio-isolator
+branch: stable
+runtime: org.kde.Platform
+runtime-version: '5.15-24.08'
+sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '5.15-24.08'
+command: steam-audio-isolator
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+build-options:
+  env:
+    BASEAPP_REMOVE_WEBENGINE: '1'
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --socket=session-bus
+  - --filesystem=xdg-run/pipewire-0
+  - --filesystem=xdg-config
+  - --filesystem=xdg-cache
+  - --filesystem=xdg-data
+
+modules:
+  - name: pipewire
+    buildsystem: meson
+    config-opts:
+      - -Dsession-managers=[]
+      - -Ddocs=disabled
+      - -Dexamples=disabled
+      - -Dtests=disabled
+      - -Dinstalled_tests=disabled
+      - -Dman=disabled
+      - -Dgstreamer=disabled
+      - -Dffmpeg=disabled
+      - -Dbluez5=disabled
+      - -Djack=disabled
+      - -Dpipewire-jack=disabled
+      - -Dpipewire-alsa=disabled
+      - -Dpipewire-v4l2=disabled
+      - -Dv4l2=disabled
+      - -Dalsa=disabled
+      - -Dlibcamera=disabled
+      - -Droc=disabled
+      - -Dudev=disabled
+      - -Dsystemd-system-service=disabled
+      - -Dsystemd-user-service=disabled
+      - -Dflatpak=enabled
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.2.7/pipewire-1.2.7.tar.bz2
+        sha256: 3c00292f9a419610c9eeb6e45b958d460afb601ecc6894012574a3b9f118616a
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - /share/alsa
+      - '*.a'
+
+  - python3-deps.yml
+
+  - name: steam-audio-isolator
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-build-isolation --prefix=${FLATPAK_DEST} --no-deps .
+      - rm -f ${FLATPAK_DEST}/share/applications/steam-audio-isolator.desktop
+      - install -Dpm644 flatpak/io.github.crashman79.steam-audio-isolator.desktop ${FLATPAK_DEST}/share/applications/io.github.crashman79.steam-audio-isolator.desktop
+      - install -Dpm644 flatpak/io.github.crashman79.steam-audio-isolator.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.crashman79.steam-audio-isolator.metainfo.xml
+      - |
+        for s in 16 24 32 48 64 128 256; do
+          f="steam-audio-isolator-${s}.png"
+          if test -f "$f"; then
+            install -Dpm644 "$f" \
+              "${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/io.github.crashman79.steam-audio-isolator.png"
+          fi
+        done
+    sources:
+      - type: git
+        url: https://github.com/crashman79/steam-audio-isolator.git
+        tag: v0.3.12

--- a/io.github.crashman79.steam-audio-isolator/python3-deps.yml
+++ b/io.github.crashman79.steam-audio-isolator/python3-deps.yml
@@ -1,0 +1,17 @@
+# Pinned wheels (flatpak-pip-generator does not handle PyQt — PyQt comes from PyQt BaseApp).
+name: python3-deps
+buildsystem: simple
+build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+      --prefix=${FLATPAK_DEST} --no-build-isolation "pydbus==0.6.0" "darkdetect==0.8.0"
+      "certifi==2025.11.12"
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/92/56/27148014c2f85ce70332f18612f921f682395c7d4e91ec103783be4fce00/pydbus-0.6.0-py2.py3-none-any.whl
+    sha256: 66b80106352a718d80d6c681dc2a82588048e30b75aab933e4020eb0660bf85e
+  - type: file
+    url: https://files.pythonhosted.org/packages/f2/f2/728f041460f1b9739b85ee23b45fa5a505962ea11fd85bdbe2a02b021373/darkdetect-0.8.0-py3-none-any.whl
+    sha256: a7509ccf517eaad92b31c214f593dbcf138ea8a43b2935406bbd565e15527a85
+  - type: file
+    url: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
+    sha256: 97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b


### PR DESCRIPTION
Upstream: https://github.com/crashman79/steam-audio-isolator

Submitted by the upstream author. PyQt5 via KDE org.kde.Platform + PyQt BaseApp; PipeWire minimal build; pinned pip wheels for pydbus, darkdetect, certifi.