### PR TITLE
Add io.github.karlmh.srcbox

### DIFF
--- a/io.github.karlmh.srcbox.yml
+++ b/io.github.karlmh.srcbox.yml
@@ -1,0 +1,69 @@
+app-id: io.github.karlmh.srcbox
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node20
+base: org.electronjs.Electron2.BaseApp
+base-version: '23.08'
+command: srcbox
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=home
+  - --share=network
+  - --talk-name=org.freedesktop.Notifications
+
+build-options:
+  append-path: /usr/lib/sdk/node20/bin
+  env:
+    npm_config_cache: /run/build/srcbox/.npm
+
+modules:
+  - name: srcbox
+    buildsystem: simple
+    build-options:
+      env:
+        npm_config_offline: 'true'
+        npm_config_cache: /run/build/srcbox/.npm
+    build-commands:
+      # Install pre-fetched npm dependencies
+      - npm install --offline --legacy-peer-deps
+
+      # Build the web app
+      - npm run build
+
+      # Install app files
+      - mkdir -p /app/share/srcbox/electron
+      - cp -r dist /app/share/srcbox/dist
+      - cp electron/main.cjs /app/share/srcbox/electron/
+      - cp electron/preload.cjs /app/share/srcbox/electron/
+      - cp package.json /app/share/srcbox/
+
+      # Launcher script
+      - install -Dm755 flatpak/srcbox.sh /app/bin/srcbox
+
+      # Icon
+      - install -Dm644 public/logo.svg /app/share/icons/hicolor/scalable/apps/io.github.karlmh.srcbox.svg
+
+      # Desktop entry
+      - install -Dm644 build/io.github.karlmh.srcbox.desktop /app/share/applications/io.github.karlmh.srcbox.desktop
+
+      # AppStream metadata
+      - install -Dm644 build/io.github.karlmh.srcbox.metainfo.xml /app/share/metainfo/io.github.karlmh.srcbox.metainfo.xml
+
+    sources:
+      - type: git
+        url: https://github.com/KarlMh/srcbox
+        tag: v1.0.0
+        commit: 73f199683678211b945e64394ea7d1dac09af1b7
+
+      - type: file
+        url: https://github.com/KarlMh/srcbox/releases/download/v1.0.0/generated-sources.json
+        sha256: d6b44794842bd2deaa3f64b03632a0cc38ebb5b1ce8df53fce0711e318c8a8c1
+        dest: .
+        dest-filename: generated-sources.json


### PR DESCRIPTION
## srcbox

A minimal, local-first markdown notes app. Notes are stored as plain `.md` files on the filesystem — no cloud, no accounts, no lock-in.

**Homepage:** https://github.com/KarlMh/srcbox
**License:** MIT

### Features
- Markdown editor with live preview
- Folders (boxes) and tags
- Instant autosave to plain `.md` files
- Syncthing sync support built into Settings
- Light / dark mode
- Electron app for Linux, macOS, Windows

### Build notes
- Electron app using Vite + React + TypeScript
- npm dependencies pre-fetched via `flatpak-node-generator` and hosted as a GitHub release asset
- Electron provided by `org.electronjs.Electron2.BaseApp 23.08`
- Notes stored in user-chosen folder under `--filesystem=home`