### PR TITLE
Add app.pastetools.Tools

### DIFF
--- a/app.pastetools.Tools.json
+++ b/app.pastetools.Tools.json
@@ -1,0 +1,30 @@
+{
+  "app-id": "app.pastetools.Tools",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.15-24.08",
+  "sdk": "org.kde.Sdk",
+  "command": "app.pastetools.Tools",
+  "finish-args": [
+    "--socket=fallback-x11",
+    "--socket=wayland"
+  ],
+  "cleanup": [
+    "/include",
+    "/lib/cmake",
+    "/lib/pkgconfig",
+    "/share/pkgconfig"
+  ],
+  "modules": [
+    {
+      "name": "app.pastetools.Tools",
+      "buildsystem": "cmake-ninja",
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/macsplit/it-tools-kirigami.git",
+          "commit": "aa543716b2090cf722244d94dc22a96c7528b224"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- ⚠⚠  Submission pull request MUST be made against the `new-pr` **base branch** ⚠⚠  -->
  <!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

  ### Please confirm your submission meets all the criteria

  - [X] Please describe the application briefly. Tools is a Linux desktop utility app built with Qt and
    Kirigami. It provides a collection of small developer-focused tools including formatters, converters,
    generators, networking helpers, and text utilities in a single desktop application.
  - [X] Please attach a video showcasing the application on Linux using the Flatpak. [tools.mp4](https://github.com/user-attachments/assets/8bba103a-6f6a-4e5b-86b4-93ef485dd64a)
  - [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
  - [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2]
    and I agree to them.
  - [X] I am an author/developer/upstream contributor to the project.
    If not, I contacted upstream developers about this submission. Link: N/A

  Additional context:

  - Upstream repository: https://github.com/macsplit/it-tools-kirigami
  - Website: https://pastetools.app
  - Application ID: app.pastetools.Tools
  - The app builds successfully locally as a Flatpak from the submitted manifest.
  - Domain verification file: https://pastetools.app/.well-known/org.flathub.VerifiedApps.txt
