### PR TITLE
Add io.github.gnome-sticky-notes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/io.github.gnome-sticky-notes.yml
+++ b/io.github.gnome-sticky-notes.yml
@@ -1,0 +1,22 @@
+app-id: io.github.gnome-sticky-notes
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: gnome-sticky-notes
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+modules:
+  - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
+
+  - name: gnome-sticky-notes
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/hybrid811/gnome-sticky-notes.git
+        tag: v0.2.0
+        commit: 909abbafba9160a7f1567a93ebc8bceea4dd8ec9


### PR DESCRIPTION
## New App Submission

**App ID:** `io.github.gnome-sticky-notes`
**Homepage:** https://github.com/hybrid811/gnome-sticky-notes
**License:** MIT

### Description

A simple, lightweight sticky notes app for the GNOME desktop built with Python + GTK4.

### Features
- Classic post-it style notes that stay on your desktop
- 5 color presets (yellow, pink, blue, green, purple)
- Auto-save on every edit
- System tray integration (via AyatanaAppIndicator)
- Right-click context menu for note management

### Checklist
- [x] App builds and runs
- [x] AppStream metainfo included and validated (`appstreamcli validate` passes)
- [x] Desktop file included
- [x] App icon (SVG) included
- [x] Uses flathub shared-modules for libayatana-appindicator
- [x] Local `flatpak-builder` test passes