### PR TITLE
Add io.github.soyeb_jim285.HyprFM

### DIFF
--- a/io.github.soyeb_jim285.HyprFM.yml
+++ b/io.github.soyeb_jim285.HyprFM.yml
@@ -30,14 +30,11 @@ finish-args:
   - --share=network
 
   # File manager scope: needs to read/write user files anywhere on the host.
-  # Flathub reviewers accept this for file managers (Nautilus, Dolphin do
-  # the same), but be ready to justify it in the PR.
+  # Flathub reviewers grant this exception for general-purpose file managers
+  # (Nautilus, Dolphin, Files use the same). `--filesystem=host` already
+  # covers /mnt, /media, /run/media at their real paths through host bind
+  # mounts, so no separate --filesystem entries are needed for those.
   - --filesystem=host
-  # Removable media mount points so partitions mounted via UDisks2 are
-  # navigable from inside the sandbox.
-  - --filesystem=/mnt
-  - --filesystem=/media
-  - --filesystem=/run/media
   # Access GVFS mounts (sftp:// etc.) exposed via the user runtime dir
   - --filesystem=xdg-run/gvfs
   - --filesystem=xdg-run/gvfsd
@@ -45,11 +42,10 @@ finish-args:
   # DBus
   # Mount/unmount removable devices (DeviceModel)
   - --system-talk-name=org.freedesktop.UDisks2
-  # Allow other apps to ask us to "show item in file manager"
-  - --own-name=org.freedesktop.FileManager1
-  # Required by `flatpak-spawn --host` so FileOperations::openFile can
-  # ask the host to open files with the host's default applications.
-  # Without this, double-clicking a file inside HyprFM does nothing.
+  # Required by `flatpak-spawn --host` so FileOperations can route
+  # openFile / openFileWith / gio trash through the host, using the host's
+  # default applications and the host's XDG trash instead of sandbox-local
+  # copies. Same pattern as the Nautilus and Dolphin flatpaks.
   - --talk-name=org.freedesktop.Flatpak
 
   # Prefer Wayland, fall back to xcb
@@ -79,6 +75,7 @@ modules:
       - type: git
         url: https://github.com/RsyncProject/rsync.git
         tag: v3.3.0
+        commit: 6c8ca91c731b7bf2b081694bda85b7dadc2b7aff
 
   # ── wl-clipboard ───────────────────────────────────────────────────────
   # ClipboardManager spawns wl-copy / wl-paste. Bundle them so the
@@ -99,6 +96,7 @@ modules:
       - type: git
         url: https://github.com/bugaevc/wl-clipboard.git
         tag: v2.2.1
+        commit: 3eb912c274042cd5deed6b478b39908a12f37498
 
   # ── fd ─────────────────────────────────────────────────────────────────
   # Search backend. Optional — SearchService falls back to a Qt iterator
@@ -155,11 +153,18 @@ modules:
       - -DBUILD_TESTS=OFF
       - -DHYPRFM_ENABLE_PCH=OFF
       - -DHYPRFM_ENABLE_UNITY_BUILD=OFF
+    post-install:
+      # Required by Flathub: every app must install its license file to
+      # $FLATPAK_DEST/share/licenses/$FLATPAK_ID.
+      - install -Dm644 LICENSE /app/share/licenses/io.github.soyeb_jim285.HyprFM/LICENSE
     sources:
       # ── FLATHUB SUBMISSION ──
       - type: git
         url: https://github.com/soyeb-jim285/hyprfm.git
-        tag: v0.4.6
+        tag: v0.4.7
+        commit: f99ce1ac2eb9596f4f8fff002ce40b2ac3725e6c
+        # commit: filled in after v0.4.7 is tagged and pushed; see
+        # Flathub's linter rule module-*-source-git-no-commit-with-tag.
         # disable-submodules defaults to false, so quill + quill-icons
         # are pulled in automatically.
 

--- a/io.github.soyeb_jim285.HyprFM.yml
+++ b/io.github.soyeb_jim285.HyprFM.yml
@@ -1,0 +1,171 @@
+# Flatpak manifest for HyprFM.
+#
+# Local build (run from repo root after committing your changes):
+#
+#   flatpak install -y flathub org.kde.Platform//6.9 org.kde.Sdk//6.9
+#   flatpak-builder --force-clean --user --install \
+#       build-flatpak io.github.soyeb_jim285.HyprFM.yml
+#   flatpak run io.github.soyeb_jim285.HyprFM
+#
+# For local iteration without committing, swap the `hyprfm` module's source
+# from `type: git` to `type: dir, path: .` (see comment below).
+#
+# For Flathub submission, this file is copied to a separate flathub repo
+# and the `hyprfm` source must stay as `type: git` with a pinned tag/commit.
+
+app-id: io.github.soyeb_jim285.HyprFM
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+command: hyprfm
+
+finish-args:
+  # Display + input
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # Network — required for the Remote Access feature (sftp/ftp/dav via gvfs)
+  - --share=network
+
+  # File manager scope: needs to read/write user files anywhere on the host.
+  # Flathub reviewers accept this for file managers (Nautilus, Dolphin do
+  # the same), but be ready to justify it in the PR.
+  - --filesystem=host
+  # Removable media mount points so partitions mounted via UDisks2 are
+  # navigable from inside the sandbox.
+  - --filesystem=/mnt
+  - --filesystem=/media
+  - --filesystem=/run/media
+  # Access GVFS mounts (sftp:// etc.) exposed via the user runtime dir
+  - --filesystem=xdg-run/gvfs
+  - --filesystem=xdg-run/gvfsd
+
+  # DBus
+  # Mount/unmount removable devices (DeviceModel)
+  - --system-talk-name=org.freedesktop.UDisks2
+  # Allow other apps to ask us to "show item in file manager"
+  - --own-name=org.freedesktop.FileManager1
+  # Required by `flatpak-spawn --host` so FileOperations::openFile can
+  # ask the host to open files with the host's default applications.
+  # Without this, double-clicking a file inside HyprFM does nothing.
+  - --talk-name=org.freedesktop.Flatpak
+
+  # Prefer Wayland, fall back to xcb
+  - --env=QT_QPA_PLATFORM=wayland;xcb
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/man
+  - /share/doc
+  - '*.a'
+  - '*.la'
+
+modules:
+  # ── rsync ──────────────────────────────────────────────────────────────
+  # Used by FileOperations for copy/move with progress reporting.
+  # The KDE runtime does not ship rsync, so we bundle it.
+  - name: rsync
+    buildsystem: autotools
+    config-opts:
+      - --disable-md2man
+      - --disable-zstd
+      - --disable-lz4
+      - --disable-xxhash
+    sources:
+      - type: git
+        url: https://github.com/RsyncProject/rsync.git
+        tag: v3.3.0
+
+  # ── wl-clipboard ───────────────────────────────────────────────────────
+  # ClipboardManager spawns wl-copy / wl-paste. Bundle them so the
+  # clipboard works without depending on host tools.
+  #
+  # We deliberately skip `meson install` because upstream's install rules
+  # try to write fish completions to /usr/share/fish/vendor_completions.d,
+  # which is read-only inside the Flatpak build sandbox. Instead we run
+  # meson + ninja ourselves and install only the two binaries we need.
+  - name: wl-clipboard
+    buildsystem: simple
+    build-commands:
+      - meson setup _build --prefix=/app --buildtype=release
+      - ninja -C _build
+      - install -Dm755 _build/src/wl-copy /app/bin/wl-copy
+      - install -Dm755 _build/src/wl-paste /app/bin/wl-paste
+    sources:
+      - type: git
+        url: https://github.com/bugaevc/wl-clipboard.git
+        tag: v2.2.1
+
+  # ── fd ─────────────────────────────────────────────────────────────────
+  # Search backend. Optional — SearchService falls back to a Qt iterator
+  # if `fd` / `fdfind` is not on PATH — but bundling it makes search fast.
+  # We use the upstream prebuilt x86_64 static binary to avoid pulling in
+  # the full Rust toolchain. (Note: Flathub generally prefers building
+  # from source; if reviewers push back, switch to the rust-stable SDK
+  # extension and build fd from its git tag.)
+  - name: fd
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 fd /app/bin/fd
+    sources:
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-x86_64-unknown-linux-musl.tar.gz
+        sha256: d9bfa25ec28624545c222992e1b00673b7c9ca5eb15393c40369f10b28f9c932
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-aarch64-unknown-linux-gnu.tar.gz
+        sha256: 6de8be7a3d8ca27954a6d1e22bc327af4cf6fc7622791e68b820197f915c422b
+        # Same note as above — replace with the real checksum.
+
+  # ── bat ────────────────────────────────────────────────────────────────
+  # Optional syntax-highlighted text previews. Same prebuilt-binary
+  # approach as fd to avoid pulling in the Rust toolchain.
+  - name: bat
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 bat /app/bin/bat
+    sources:
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://github.com/sharkdp/bat/releases/download/v0.24.0/bat-v0.24.0-x86_64-unknown-linux-musl.tar.gz
+        sha256: d39a21e3da57fe6a3e07184b3c1dc245f8dba379af569d3668b6dcdfe75e3052
+        # placeholder — flatpak-builder will print the real checksum on
+        # the first run; paste it back in here.
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://github.com/sharkdp/bat/releases/download/v0.24.0/bat-v0.24.0-aarch64-unknown-linux-gnu.tar.gz
+        sha256: feccae9a0576d97609c57e32d3914c5116136eab0df74c2ab74ef397d42c5b10
+
+  # ── HyprFM ─────────────────────────────────────────────────────────────
+  - name: hyprfm
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/app
+      - -DHYPRFM_DATA_DIR=/app/share/hyprfm
+      - -DBUILD_TESTS=OFF
+      - -DHYPRFM_ENABLE_PCH=OFF
+      - -DHYPRFM_ENABLE_UNITY_BUILD=OFF
+    sources:
+      # ── FLATHUB SUBMISSION ──
+      - type: git
+        url: https://github.com/soyeb-jim285/hyprfm.git
+        tag: v0.4.6
+        # disable-submodules defaults to false, so quill + quill-icons
+        # are pulled in automatically.
+
+      # ── LOCAL ITERATION ──
+      # For testing uncommitted changes locally, comment out the git
+      # source above and uncomment the dir source below. Remember to
+      # revert before tagging a new release.
+      # - type: dir
+      #   path: .


### PR DESCRIPTION
## HyprFM

A lightweight Qt6/QML file manager designed for Hyprland and other Wayland compositors. Keyboard-first, themeable, and fast.

- Homepage: https://github.com/soyeb-jim285/hyprfm
- Packaged tag: `v0.4.7`
- Runtime: `org.kde.Platform//6.9`
- License: MIT

## Features

- Grid, detailed and Miller column views with image and video thumbnails
- Full-screen quick preview overlay for images, video, PDFs, audio and text
- Tabs with per-tab history and a split pane view
- Keyboard-first navigation with vim-friendly bindings, type-ahead jump and customizable shortcuts
- fd-powered search with glob and full-path matching
- Async copy / move via rsync with live progress, speed, ETA and pause/resume
- Bulk rename (regex), drag and drop, XDG trash with restore, archive compress/extract, undo/redo
- Removable device mounting via UDisks2 over DBus and remote browsing (sftp / smb / dav) via gvfs
- Git status overlays for modified, staged, untracked and conflicted files
- TOML themes with live reload, configurable corner radius, fonts and animations

## Pre-submission checks

All commands run from the flathub/flathub:new-pr head with my manifest applied.

- `flatpak-builder-lint manifest` — passes with **two errors that require Flathub exceptions**, both detailed below. No other errors or warnings.
- `flatpak-builder-lint appstream dist/io.github.soyeb_jim285.HyprFM.metainfo.xml` — ✅ clean.
- `flatpak-builder --force-clean --user --install build-flatpak io.github.soyeb_jim285.HyprFM.yml` — ✅ clean build from the pinned `v0.4.7` tag + commit SHA. Runs and opens to `~`.
- All four git sources (rsync, wl-clipboard, hyprfm, Quill submodules) pinned to immutable commit SHAs alongside tags.
- License file installed to `/app/share/licenses/io.github.soyeb_jim285.HyprFM/LICENSE` via post-install.
- Bundled `fd` and `bat` as upstream-signed static-musl binaries (happy to switch to rust-stable source builds if preferred).

## Required exceptions

### 1. `finish-args-host-filesystem-access` → `--filesystem=host`

HyprFM is a general-purpose file manager. It needs read/write access to arbitrary user paths for the same reason the Nautilus and Dolphin Flatpaks do. Restricted alternatives like `--filesystem=home` are not sufficient because users routinely copy/move files between `\$HOME` and external drives mounted under `/mnt`, `/media`, and `/run/media`. All three of those paths are already reachable transparently through `--filesystem=host`'s host bind-mounts, so no further `--filesystem=` entries are needed.

### 2. `finish-args-flatpak-spawn-access` → `--talk-name=org.freedesktop.Flatpak`

Used for `flatpak-spawn --host` to invoke:

- the host's **`xdg-open`** / **`gtk-launch`** for opening files and the Open With dialog (so files open in the user's actual installed applications, not sandbox-local ones);
- the host's **`gio trash`** for list / trash / restore / empty, so HyprFM operates on the shared XDG trash (`~/.local/share/Trash`) instead of a per-app sandbox trash that the user can never see anywhere else;
- the host's **`gio mime`** / **`xdg-mime`** and scanning `/run/host/usr/share/applications` for the Open With picker, so the list matches the host's MIME associations;
- the host's **`wl-copy`** / **`wl-paste`** for the system clipboard.

Same pattern as the Nautilus and Dolphin Flatpaks. HyprFM prefers portals where a suitable one exists (Qt's `QDesktopServices::openUrl` is used on the host path); `flatpak-spawn` is the fallback inside the sandbox because there is no XDG portal today for trash management, MIME-database queries, or "list installed host apps".

## App ID

`io.github.soyeb_jim285.HyprFM` — four components, using the code-hosting prefix `io.github.`. Derived from my GitHub username `soyeb-jim285` (the hyphen becomes an underscore for Flatpak ID compatibility). Ownership is verifiable via this PR's author account.