### PR TITLE
feat: add io.github.weversonl.GnomeQuickShare

### DIFF
--- a/io.github.weversonl.GnomeQuickShare/io.github.weversonl.GnomeQuickShare.json
+++ b/io.github.weversonl.GnomeQuickShare/io.github.weversonl.GnomeQuickShare.json
@@ -1,0 +1,61 @@
+{
+  "app-id": "io.github.weversonl.GnomeQuickShare",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "47",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/rust-stable/bin",
+    "env": {
+      "CARGO_HOME": "/run/build/gnomeqs/.cargo-home"
+    }
+  },
+  "command": "gnomeqs",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--device=dri",
+    "--system-talk-name=org.bluez",
+    "--talk-name=org.freedesktop.Notifications",
+    "--filesystem=xdg-download"
+  ],
+  "modules": [
+    {
+      "name": "gnomeqs",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p .cargo",
+        "printf \"[source.crates-io]\\nreplace-with = 'vendored-sources'\\n\\n[source.\\\"git+https://github.com/Martichou/mdns-sd?branch=unsolicited\\\"]\\ngit = 'https://github.com/Martichou/mdns-sd'\\nbranch = 'unsolicited'\\nreplace-with = 'vendored-sources'\\n\\n[source.vendored-sources]\\ndirectory = '/run/build/gnomeqs/vendor'\\n\" > .cargo/config.toml",
+        "cargo build --offline --release -p gnomeqs",
+        "install -Dm755 target/release/gnomeqs /app/bin/gnomeqs",
+        "install -Dm644 app/gtk/data/io.github.weversonl.GnomeQuickShare.desktop /app/share/applications/io.github.weversonl.GnomeQuickShare.desktop",
+        "install -Dm644 app/gtk/data/io.github.weversonl.GnomeQuickShare.metainfo.xml /app/share/metainfo/io.github.weversonl.GnomeQuickShare.metainfo.xml",
+        "install -Dm644 app/gtk/data/io.github.weversonl.GnomeQuickShare.gschema.xml /app/share/glib-2.0/schemas/io.github.weversonl.GnomeQuickShare.gschema.xml",
+        "install -Dm644 app/gtk/data/icons/32x32.png /app/share/icons/hicolor/32x32/apps/io.github.weversonl.GnomeQuickShare.png",
+        "install -Dm644 app/gtk/data/icons/128x128.png /app/share/icons/hicolor/128x128/apps/io.github.weversonl.GnomeQuickShare.png",
+        "install -Dm644 app/gtk/data/icons/128x128@2x.png /app/share/icons/hicolor/256x256@2/apps/io.github.weversonl.GnomeQuickShare.png",
+        "install -Dm644 app/gtk/data/icons/tray_mono.png /app/share/icons/hicolor/32x32/apps/io.github.weversonl.GnomeQuickShare-symbolic.png",
+        "install -Dm644 app/gtk/data/icons/hicolor/scalable/actions/io.github.weversonl.GnomeQuickShare-airdrop-symbolic.svg /app/share/icons/hicolor/scalable/actions/io.github.weversonl.GnomeQuickShare-airdrop-symbolic.svg",
+        "install -Dm644 app/gtk/data/icons/hicolor/scalable/status/io.github.weversonl.GnomeQuickShare-tray-symbolic.svg /app/share/icons/hicolor/scalable/status/io.github.weversonl.GnomeQuickShare-tray-symbolic.svg",
+        "install -dm755 /app/share/locale/pt_BR/LC_MESSAGES",
+        "msgfmt -o /app/share/locale/pt_BR/LC_MESSAGES/gnomeqs.mo app/gtk/po/pt_BR.po",
+        "glib-compile-schemas /app/share/glib-2.0/schemas"
+      ],
+      "sources": [
+        {
+          "type": "dir",
+          "path": "../.."
+        },
+        {
+          "type": "dir",
+          "path": "vendor",
+          "dest": "vendor"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. < GNOME Quick Share is a GNOME-first Quick Share client for Linux, built with Rust, GTK4, and libadwaita. It focuses on nearby device discovery and local file sharing with a native GNOME experience. >
- [X] Please attach a video showcasing the application on Linux using the Flatpak. < https://github.com/user-attachments/assets/4ea935da-a58a-4428-8421-b2cff7b81d9d >
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements](https://docs.flathub.org/docs/for-app-authors/requirements#application-id)
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer/upstream contributor to the project.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission