### PR TITLE
Add io.github.haliskoc.MediaHarbor

### DIFF
--- a/io.github.haliskoc.MediaHarbor.yaml
+++ b/io.github.haliskoc.MediaHarbor.yaml
@@ -1,0 +1,62 @@
+app-id: io.github.haliskoc.MediaHarbor
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: mediaharbor
+finish-args:
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.secrets
+  - --env=MEDIAHARBOR_APP_ID=io.github.haliskoc.MediaHarbor
+modules:
+  - name: python3-deps
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-index --find-links=. keyring==25.7.0 yt-dlp==2025.9.23
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
+        sha256: be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f
+      - type: file
+        url: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+        sha256: 0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137
+      - type: file
+        url: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+        sha256: 97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl
+        sha256: f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790
+      - type: file
+        url: https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl
+        sha256: bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535
+      - type: file
+        url: https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl
+        sha256: 9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176
+      - type: file
+        url: https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl
+        sha256: 42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+      - type: file
+        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+      - type: file
+        url: https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl
+        sha256: 6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/b7/723a4061d7efac4bbb86eddef9ceec0fc1e85415c7d665c2e5e1879759bb/yt_dlp-2025.9.23-py3-none-any.whl
+        sha256: 84e36acf2dfbadb307d734a590dd937923173b13c57cf45a662f40c93e746302
+  - name: mediaharbor
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation .
+      - install -Dm644 data/io.github.haliskoc.MediaHarbor.desktop /app/share/applications/io.github.haliskoc.MediaHarbor.desktop
+      - install -Dm644 data/io.github.haliskoc.MediaHarbor.metainfo.xml /app/share/metainfo/io.github.haliskoc.MediaHarbor.metainfo.xml
+      - install -Dm644 data/io.github.haliskoc.MediaHarbor.svg /app/share/icons/hicolor/scalable/apps/io.github.haliskoc.MediaHarbor.svg
+    sources:
+      - type: git
+        url: https://github.com/haliskoc/ytdlp_for_gnome.git
+        commit: df1dd13665f7210ed706d423a8bd4228de873ebf


### PR DESCRIPTION
### Please confirm these before merge

- [x] I have read the [App Requirements](https://github.com/flathub/flathub/wiki/App-Requirements).
- [x] The app has a valid AppStream metainfo file and desktop entry.
- [x] Sources are pinned (git commit + sha256 for wheel files).

### Notes

- App ID: `io.github.haliskoc.MediaHarbor`
- Runtime: `org.gnome.Platform//49`
- Python dependencies are pinned with `sha256` URLs.
- Upstream source is pinned to commit `df1dd13665f7210ed706d423a8bd4228de873ebf`.

This is an initial Flathub submission for MediaHarbor, a GNOME frontend for yt-dlp.