### PR TITLE
Add io.github.regwin32.simbuddy

### DIFF
--- a/io.github.regwin32.simbuddy.yaml
+++ b/io.github.regwin32.simbuddy.yaml
@@ -1,0 +1,59 @@
+app-id: io.github.regwin32.simbuddy
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: simbuddy
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+
+  # Input devices — pedals/wheels via evdev (/dev/input/*)
+  - --device=input
+
+  # Steam library (read-only for game list and localconfig.vdf)
+  - --filesystem=~/.local/share/Steam:ro
+  - --filesystem=~/.steam:ro
+
+  # Network access for Steam CDN header image downloads
+  - --share=network
+
+  # Host commands via flatpak-spawn (pkexec for udev, pgrep/steam binary)
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  # ── Python dependencies (vendored via flatpak-pip-generator) ─────────────
+  - python-deps.json
+
+  # ── SimBuddy ─────────────────────────────────────────────────────────────
+  - name: simbuddy
+    buildsystem: simple
+    build-commands:
+      # Install the Python package (deps already installed by python-deps module)
+      - pip3 install --prefix=/app --no-build-isolation .
+
+      # udev rule — shipped in /app for reference; user installs on host manually
+      - install -Dm644 udev/99-simgrade-pedals.rules
+          /app/share/simbuddy/udev/99-simgrade-pedals.rules
+
+      # Locale
+      - install -Dm644 locale/de/LC_MESSAGES/simbuddy.mo
+          /app/share/locale/de/LC_MESSAGES/simbuddy.mo
+
+      # Desktop integration
+      - install -Dm644 data/io.github.regwin32.simbuddy.desktop
+          /app/share/applications/io.github.regwin32.simbuddy.desktop
+      - install -Dm644 data/io.github.regwin32.simbuddy.metainfo.xml
+          /app/share/metainfo/io.github.regwin32.simbuddy.metainfo.xml
+
+      # Icon
+      - install -Dm644 data/icon.png
+          /app/share/icons/hicolor/512x512/apps/io.github.regwin32.simbuddy.png
+
+    sources:
+      - type: git
+        url: https://github.com/RegWin32/simbuddy.git
+        tag: v0.1.0
+        commit: 0406449c347bd6ec3007904b8110ed9d89d36b6a

--- a/io.github.regwin32.simbuddy.yaml
+++ b/io.github.regwin32.simbuddy.yaml
@@ -55,5 +55,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/RegWin32/simbuddy.git
-        tag: v0.1.1
-        commit: a8c40a5739fdc78065a0c1b0fb99cdf957f4349e
+        tag: v0.1.2
+        commit: 20834be2542e216f573bc68c5ad747ea77f83f69

--- a/io.github.regwin32.simbuddy.yaml
+++ b/io.github.regwin32.simbuddy.yaml
@@ -13,9 +13,9 @@ finish-args:
   # Input devices — pedals/wheels via evdev (/dev/input/*)
   - --device=input
 
-  # Steam library (read-only for game list and localconfig.vdf)
-  - --filesystem=~/.local/share/Steam:ro
-  - --filesystem=~/.steam:ro
+  # Steam library — write access needed to update localconfig.vdf launch options
+  - --filesystem=~/.local/share/Steam
+  - --filesystem=~/.steam
 
   # Network access for Steam CDN header image downloads
   - --share=network
@@ -55,5 +55,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/RegWin32/simbuddy.git
-        tag: v0.1.0
-        commit: 0406449c347bd6ec3007904b8110ed9d89d36b6a
+        tag: v0.1.1
+        commit: a8c40a5739fdc78065a0c1b0fb99cdf957f4349e

--- a/python-deps.json
+++ b/python-deps.json
@@ -1,0 +1,49 @@
+{
+    "name": "python-deps",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-evdev",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"evdev==1.9.3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz",
+                    "sha256": "2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9"
+                }
+            ]
+        },
+        {
+            "name": "python3-vdf",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"vdf==3.4\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/96/60/6456b687cf55cf60020dcd01f9bc51561c3cc84f05fd8e0feb71ce60f894/vdf-3.4-py2.py3-none-any.whl",
+                    "sha256": "68c1a125cc49e343d535af2dd25074e9cb0908c6607f073947c4a04bbe234534"
+                }
+            ]
+        },
+        {
+            "name": "python3-PyYAML",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"PyYAML==6.0.2\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz",
+                    "sha256": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
SimBuddy is a configuration and calibration tool for sim racing pedals and controllers on Linux.

**Features:**
- Real-time pedal monitoring via evdev
- Per-axis calibration with deadzone control
- Custom response curve editor with monotone enforcement
- Per-game `PROTON_ENABLE_HIDRAW` toggle written to Steam's `localconfig.vdf`
- Steam integration (installed games, cover art, Steam status)
- Dark/Light/System theme support
- German translation included

**App ID:** `io.github.regwin32.simbuddy`
**License:** GPL-3.0-or-later
**Homepage:** https://github.com/RegWin32/simbuddy