### PR TITLE
Add io.magma.terminal

### DIFF
--- a/io.magma.terminal.json
+++ b/io.magma.terminal.json
@@ -1,0 +1,56 @@
+{
+  "app-id": "io.magma.terminal",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "48",
+  "sdk": "org.gnome.Sdk",
+  "sdk-extensions": [
+    "org.freedesktop.Sdk.Extension.rust-stable"
+  ],
+  "command": "magma",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--share=network",
+    "--talk-name=org.freedesktop.notifications",
+    "--filesystem=host"
+  ],
+  "build-options": {
+    "append-path": "/usr/lib/sdk/rust-stable/bin",
+    "env": {
+      "CARGO_HOME": "/run/build/magma/cargo",
+      "RUST_BACKTRACE": "1"
+    }
+  },
+  "modules": [
+    {
+      "name": "magma",
+      "buildsystem": "simple",
+      "build-commands": [
+        "cargo --offline fetch --manifest-path Cargo.toml --verbose",
+        "cargo --offline build --release --manifest-path Cargo.toml",
+        "install -Dm755 target/release/magma /app/bin/magma",
+        "install -Dm644 assets/io.magma.terminal.desktop /app/share/applications/io.magma.terminal.desktop",
+        "install -Dm644 assets/io.magma.terminal.metainfo.xml /app/share/metainfo/io.magma.terminal.metainfo.xml",
+        "install -Dm644 assets/icons/hicolor/48x48/apps/io.magma.terminal.png /app/share/icons/hicolor/48x48/apps/io.magma.terminal.png",
+        "install -Dm644 assets/icons/hicolor/64x64/apps/io.magma.terminal.png /app/share/icons/hicolor/64x64/apps/io.magma.terminal.png",
+        "install -Dm644 assets/icons/hicolor/128x128/apps/io.magma.terminal.png /app/share/icons/hicolor/128x128/apps/io.magma.terminal.png",
+        "install -Dm644 assets/icons/hicolor/256x256/apps/io.magma.terminal.png /app/share/icons/hicolor/256x256/apps/io.magma.terminal.png",
+        "install -Dm644 assets/icons/hicolor/512x512/apps/io.magma.terminal.png /app/share/icons/hicolor/512x512/apps/io.magma.terminal.png"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/WilliamSamson/magma/archive/refs/tags/v0.1.1.tar.gz",
+          "sha256": "bc7fff43b73aeb50a480f8890db665e0277d1d083d9bb12c43a70d02ce743d9f"
+        }
+      ]
+    }
+  ],
+  "x-flathub": {
+    "linter-exceptions": {
+      "finish-args-host-filesystem-access": "Terminal emulator requires host filesystem access to function as a shell"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Magma is a GPU-accelerated terminal workspace written in Rust. It combines a custom shell with a built-in structured JSON log viewer, file browser, and web browser pane — built on GTK4, VTE4, and WebKitGTK.

- **Homepage:** https://github.com/WilliamSamson/magma
- **License:** GPL-3.0-only
- **Runtime:** org.gnome.Platform 48

## Linter notes

The manifest requests `--filesystem=host` which is standard for terminal emulators (similar to BlackBox, GNOME Terminal). A linter exception is included in the manifest.

## Checklist

- [x] Application builds from source
- [x] Valid AppStream metainfo with screenshots
- [x] `.desktop` file included
- [x] Icons in hicolor (48, 64, 128, 256, 512)
- [x] License allows redistribution (GPL-3.0-only)