### PR TITLE
Add Flatpak configuration for Aurivo Media Player

### DIFF
--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,0 +1,60 @@
+app-id: com.aurivo.mediaplayer
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node22
+command: com.aurivo.mediaplayer
+separate-locales: false
+
+build-options:
+  append-path: /usr/lib/sdk/node22/bin
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --socket=session-bus
+  - --share=network
+  - --device=dri
+  - --device=all
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.StatusNotifierWatcher
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --own-name=org.mpris.MediaPlayer2.*
+  - --env=TMPDIR=/var/tmp
+  - --env=ELECTRON_TRASH=gio
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
+modules:
+  - name: sdl2-image
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSDL2IMAGE_AVIF=OFF
+      - -DSDL2IMAGE_WEBP=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-2.8.2.tar.gz
+        sha256: 8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc
+
+  - name: aurivo-media-player
+    buildsystem: simple
+    build-commands:
+      # Kurulum komutlari... Mevcut yapi Flatpak Flathub standartlarina baslangic asamasidir.
+      - install -Dm755 packaging/flatpak/aurivo-wrapper.sh /app/bin/com.aurivo.mediaplayer
+      - install -Dm644 packaging/linux/com.aurivo.mediaplayer.desktop /app/share/applications/com.aurivo.mediaplayer.desktop
+      - install -Dm644 packaging/appstream/com.aurivo.mediaplayer.metainfo.xml /app/share/metainfo/com.aurivo.mediaplayer.metainfo.xml
+      - install -Dm644 icons/aurivo_512.png /app/share/icons/hicolor/512x512/apps/com.aurivo.mediaplayer.png
+      - install -Dm644 icons/aurivo_256.png /app/share/icons/hicolor/256x256/apps/com.aurivo.mediaplayer.png
+    sources:
+      - type: git
+        url: https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux.git
+        branch: main


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. 
**Aurivo Media Player** is a premium, all-in-one Linux media application designed for a first-class desktop experience. It seamlessly combines music and video playback with an advanced, robust DSP audio control pipeline. Above all, it features an industry-leading integrated background song recognition engine (Shazam/AcoustID hybrid) capable of intercepting and identifying system audio dynamically. Written entirely by upstream to offer an uncompromisingly native, hardware-accelerated experience on modern Wayland/X11 compositors.

- [x] Please attach a video showcasing the application on Linux using the Flatpak. 
**Demo Video:** https://youtu.be/lsEgsm90bdY

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
App ID: `com.aurivo.mediaplayer`

- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [x] I am an author/developer/upstream contributor to the project.
If not, I contacted upstream developers about this submission. 

<!-- ⚠️⚠️ Please DO NOT modify anything below this line ⚠️⚠️ -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
