### PR TITLE
Add LightDeck — System monitoring & LED control

### DIFF
--- a/com.lightdeck.LightDeck.yml
+++ b/com.lightdeck.LightDeck.yml
@@ -1,0 +1,33 @@
+app-id: com.lightdeck.LightDeck
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: lightdeck
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=all            # USB HID access for RGB devices
+  - --share=network         # OpenRGB server + Philips Hue
+  - --filesystem=home:ro    # Read config files
+  - --talk-name=org.freedesktop.Notifications
+  - --system-talk-name=org.freedesktop.UDisks2
+
+modules:
+  - name: lightdeck
+    buildsystem: simple
+    build-commands:
+      - install -d /app/share/lightdeck
+      - cp -r *.py drivers/ /app/share/lightdeck/
+      - cp icon.svg /app/share/lightdeck/
+      - install -Dm644 lightdeck.desktop /app/share/applications/com.lightdeck.LightDeck.desktop
+      - install -Dm644 icon.svg /app/share/icons/hicolor/scalable/apps/com.lightdeck.LightDeck.svg
+      - |
+        cat > /app/bin/lightdeck << 'EOF'
+        #!/bin/bash
+        exec python3 /app/share/lightdeck/main.py "$@"
+        EOF
+        chmod +x /app/bin/lightdeck
+    sources:
+      - type: dir
+        path: .


### PR DESCRIPTION
## LightDeck

**App ID:** `com.lightdeck.LightDeck`
**Homepage:** https://github.com/Dirt-Ronin/lightdeck
**License:** PolyForm Noncommercial 1.0

### What it does
System monitoring and RGB LED control for Linux. Real-time hardware gauges, Grafana-style sparkline graphs, gaming overlay, desktop widgets, and LED effect presets from 12 ecosystems.

### Dependencies
- Runtime: org.kde.Platform 6.7
- Python 3, PyQt6

### Features
- 21 hardware sensors (CPU, GPU, fans, RAM, NVMe, battery, network)
- Auto-detects hardware (AMD Ryzen, Intel, NVIDIA, AMD GPU)
- Transparent gaming overlay
- Plugin driver system for RGB devices
- Zero telemetry

### Checklist
- [x] App has appstream metadata
- [x] App has a desktop file
- [x] App has an SVG icon
- [x] Manifest builds successfully
- [x] License file included