### PR TITLE
Add com.netxms.NetXMSClient61

### DIFF
--- a/com.netxms.NetXMSClient61.yaml
+++ b/com.netxms.NetXMSClient61.yaml
@@ -1,0 +1,49 @@
+app-id: com.netxms.NetXMSClient61
+runtime: org.freedesktop.Sdk
+runtime-version: "25.08"
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk17
+command: netxms-client.sh
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --share=network
+  - --persist=.nxmc4
+  - --persist=.swt
+modules:
+  - name: openjdk-17
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk17/install.sh
+  - name: netxms-client
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 netxms-client.sh /app/bin/netxms-client.sh
+      - install -Dm644 nxmc.jar /app/bin/nxmc.jar
+      - install -T -Dm644 netxms.svg /app/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - install -t /app/share/applications/ -Dm644 ${FLATPAK_ID}.desktop
+      - install -t /app/share/metainfo/ -Dm644 ${FLATPAK_ID}.metainfo.xml
+    sources:
+      - type: file
+        url: https://netxms.org/download/releases/6.1/nxmc-6.1.0-standalone.jar
+        sha256: b3f45c3d97fdf6b46916adc8a36b8f2c5357b6670737f2d4e96b525806f154c6
+        dest-filename: nxmc.jar
+        x-checker-data:
+          type: html
+          url: https://netxms.com/downloads/
+          version-pattern: "NetXMS Version [0-9.]+"
+          url-template: >-
+            https://netxms.com/download/releases/$major.$minor/nxmc-$version-standalone.jar
+      - type: file
+        path: netxms-client.sh
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/def0a45eccdbc9b76d06edf2814c0cd9717fac27/6.1/com.netxms.NetXMSClient61.desktop
+        sha256: 430e983a23e1f4be0f3b42707af313c3b80c8996556aa043980a35990375ee45
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/a8acbc591bea0291ab6edf24d09749d955bc89b7/6.1/com.netxms.NetXMSClient61.metainfo.xml
+        sha256: a5fe2c89d4635ceb36b332018e1cd0a6bb76c89d93ebd9b807fa000b73f2649c
+      - type: file
+        url: https://raw.githubusercontent.com/netxms/appstream/def0a45eccdbc9b76d06edf2814c0cd9717fac27/6.1/netxms-icon.svg
+        sha256: 2be6744ec2dfad5dbfd76c66eb161136bb7294736ebb053dc8f901881c5409bc
+        dest-filename: netxms.svg

--- a/netxms-client.sh
+++ b/netxms-client.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# workaround for https://github.com/eclipse-platform/eclipse.platform.swt/issues/568
+if [ ! -f ~/.swt/trims.prefs ]; then
+    mkdir -p ~/.swt
+    cat > ~/.swt/trims.prefs <<_END
+trimWidths=0 4 6 0 6 0
+trimHeights=0 4 6 0 29 23
+_END
+fi
+
+exec /app/jre/bin/java -jar /app/bin/nxmc.jar "$@"


### PR DESCRIPTION
This package is a rich client for network monitoring system NetXMS. Client is Java (SWT) based and depends on Java17+. Package is build from release version which we publish on our site.

This particular package is for 6.1.x branch. We keep protocol compatibility between server and client across major.minor releases, but some users need to access different versions of the server at the same time (e.g. during test deployment/upgrade).

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.
- [X] Please attach a video showcasing the application on Linux using the Flatpak. https://youtu.be/ADEF3wrMFM0
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author. https://netxms.com/about-us

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
