### PR TITLE
Add com.github.aliafacan.ZorinDesktopStudio

### DIFF
--- a/com.github.aliafacan.ZorinDesktopStudio.json
+++ b/com.github.aliafacan.ZorinDesktopStudio.json
@@ -1,0 +1,57 @@
+{
+  "app-id": "com.github.aliafacan.ZorinDesktopStudio",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "46",
+  "sdk": "org.gnome.Sdk",
+  "command": "com.github.aliafacan.ZorinDesktopStudio",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri",
+    "--filesystem=xdg-desktop",
+    "--filesystem=xdg-config/zorin-icon-settings:create",
+    "--filesystem=xdg-data/zorin-desktop-studio:create"
+  ],
+  "cleanup": [
+    "*.a",
+    "*.la",
+    "/include"
+  ],
+  "modules": [
+    {
+      "name": "zorin-desktop-studio",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -d /app/bin",
+        "install -d /app/share/zorin-desktop-studio",
+        "install -d /app/share/applications",
+        "install -d /app/share/metainfo",
+        "install -d /app/share/icons/hicolor/scalable/apps",
+        "install -m 644 icon_settings/backend.py /app/share/zorin-desktop-studio/backend.py",
+        "install -m 644 icon_settings/autostart.py /app/share/zorin-desktop-studio/autostart.py",
+        "install -m 644 icon_settings/constants.py /app/share/zorin-desktop-studio/constants.py",
+        "install -m 644 icon_settings/desktop_entries.py /app/share/zorin-desktop-studio/desktop_entries.py",
+        "install -m 644 icon_settings/desktop_layouts.py /app/share/zorin-desktop-studio/desktop_layouts.py",
+        "install -m 644 icon_settings/i18n.py /app/share/zorin-desktop-studio/i18n.py",
+        "install -m 644 icon_settings/layout_store.py /app/share/zorin-desktop-studio/layout_store.py",
+        "install -m 644 icon_settings/main.py /app/share/zorin-desktop-studio/main.py",
+        "install -m 644 icon_settings/preferences.py /app/share/zorin-desktop-studio/preferences.py",
+        "install -m 644 icon_settings/theme.py /app/share/zorin-desktop-studio/theme.py",
+        "install -m 644 icon_settings/ui.py /app/share/zorin-desktop-studio/ui.py",
+        "install -m 644 icon_settings/assets/zorin-desktop-studio.svg /app/share/icons/hicolor/scalable/apps/com.github.aliafacan.ZorinDesktopStudio.svg",
+        "install -m 644 icon_settings/packaging/flatpak/com.github.aliafacan.ZorinDesktopStudio.desktop /app/share/applications/com.github.aliafacan.ZorinDesktopStudio.desktop",
+        "install -m 644 icon_settings/packaging/flatpak/com.github.aliafacan.ZorinDesktopStudio.metainfo.xml /app/share/metainfo/com.github.aliafacan.ZorinDesktopStudio.metainfo.xml",
+        "cat > /app/bin/com.github.aliafacan.ZorinDesktopStudio << 'EOF'\n#!/bin/sh\nexec /usr/bin/python3 /app/share/zorin-desktop-studio/main.py \"$@\"\nEOF",
+        "chmod 755 /app/bin/com.github.aliafacan.ZorinDesktopStudio"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/aliafacan/zorin-desktop-studio/archive/refs/tags/v2.0.1.tar.gz",
+          "sha256": "9e714b57dd1d78fc6a8d23456b145731938c84274a0b6b004c84ba63a14bff5b"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Add com.github.aliafacan.ZorinDesktopStudio

Zorin Desktop Studio is a GTK application for Zorin OS desktop management.

### Features
- Live icon size/spacing tuning
- Desktop launcher editor for existing `.desktop` files
- Desktop layout save/restore
- Optional auto-load layout at login
- Turkish and English UI

### Upstream
- Repository: https://github.com/aliafacan/zorin-desktop-studio
- License: MIT
- Source tag: v2.0.1

### Notes
- AppStream metadata and screenshots are provided in upstream packaging files.
- I can quickly address any review feedback on permissions/metadata.

### Checklist

- [x] Please describe the application briefly
- [x] I have read the submission guidelines
- [x] This application builds and runs without errors
- [x] I have tested this locally
- [x] The app has a working icon and metadata
- [x] The permissions are justified