### PR TITLE
Add ch.stockmonitor.StockMonitor (Stock Monitor)

### DIFF
--- a/ch.stockmonitor.StockMonitor.yml
+++ b/ch.stockmonitor.StockMonitor.yml
@@ -12,7 +12,6 @@ finish-args:
   - --share=ipc
   - --device=dri
   - --share=network
-  - --filesystem=home
   - --talk-name=org.freedesktop.portal.Desktop
   - --talk-name=org.freedesktop.portal.FileChooser
   - --talk-name=org.freedesktop.portal.OpenURI

--- a/ch.stockmonitor.StockMonitor.yml
+++ b/ch.stockmonitor.StockMonitor.yml
@@ -1,0 +1,229 @@
+app-id: ch.stockmonitor.StockMonitor
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '6.10'
+command: stock-monitor
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --share=network
+  - --filesystem=home
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.portal.FileChooser
+  - --talk-name=org.freedesktop.portal.OpenURI
+
+cleanup-commands:
+  - chmod +x /app/cleanup-BaseApp.sh && /app/cleanup-BaseApp.sh || true
+
+modules:
+
+  - name: python3-wheels
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links=. --prefix=/app --ignore-installed \
+          beautifulsoup4-4.14.3-py3-none-any.whl \
+          certifi-2026.2.25-py3-none-any.whl \
+          cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl \
+          contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
+          cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          cycler-0.12.1-py3-none-any.whl \
+          defusedxml-0.7.1-py2.py3-none-any.whl \
+          et_xmlfile-2.0.0-py3-none-any.whl \
+          fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          frozendict-2.4.7-py3-none-any.whl \
+          idna-3.11-py3-none-any.whl \
+          kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          markdown_it_py-4.0.0-py3-none-any.whl \
+          matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          mdurl-0.1.2-py3-none-any.whl \
+          multitasking-0.0.11-py3-none-any.whl \
+          numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
+          openpyxl-3.1.5-py2.py3-none-any.whl \
+          packaging-26.0-py3-none-any.whl \
+          pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl \
+          peewee-4.0.4-py3-none-any.whl \
+          pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl \
+          platformdirs-4.9.4-py3-none-any.whl \
+          protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl \
+          pycparser-3.0-py3-none-any.whl \
+          pygments-2.20.0-py3-none-any.whl \
+          pyparsing-3.3.2-py3-none-any.whl \
+          pyqtgraph-0.13.7-py3-none-any.whl \
+          python_dateutil-2.9.0.post0-py2.py3-none-any.whl \
+          pytz-2026.1.post1-py2.py3-none-any.whl \
+          reportlab-4.4.10-py3-none-any.whl \
+          requests-2.33.1-py3-none-any.whl \
+          rich-15.0.0-py3-none-any.whl \
+          six-1.17.0-py2.py3-none-any.whl \
+          soupsieve-2.8.3-py3-none-any.whl \
+          typing_extensions-4.15.0-py3-none-any.whl \
+          tzdata-2026.1-py2.py3-none-any.whl \
+          urllib3-2.6.3-py3-none-any.whl \
+          websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl \
+          yfinance-1.2.2-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl"
+        sha256: 0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb
+      - type: file
+        url: "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl"
+        sha256: 027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa
+      - type: file
+        url: "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+      - type: file
+        url: "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl"
+        sha256: e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd
+      - type: file
+        url: "https://files.pythonhosted.org/packages/c8/65/5245ce8c548a8422236c13ffcdcdada6a2a812c361e9e0c70548bb40b661/contourpy-1.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        sha256: 434f0adf84911c924519d2b08fc10491dd282b20bdd3fa8f60fd816ea0b48841
+      - type: file
+        url: "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: 9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a
+      - type: file
+        url: "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: 2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc
+      - type: file
+        url: "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl"
+        sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+      - type: file
+        url: "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl"
+        sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+      - type: file
+        url: "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl"
+        sha256: 7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa
+      - type: file
+        url: "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: 6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1
+      - type: file
+        url: "https://files.pythonhosted.org/packages/38/74/f94141b38a51a553efef7f510fc213894161ae49b88bffd037f8d2a7cb2f/frozendict-2.4.7-py3-none-any.whl"
+        sha256: 972af65924ea25cf5b4d9326d549e69a9a4918d8a76a9d3a7cd174d98b237550
+      - type: file
+        url: "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl"
+        sha256: 771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea
+      - type: file
+        url: "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: 332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3
+      - type: file
+        url: "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl"
+        sha256: 87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147
+      - type: file
+        url: "https://files.pythonhosted.org/packages/75/97/a471f1c3eb1fd6f6c24a31a5858f443891d5127e63a7788678d14e249aea/matplotlib-3.10.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: a0a7f52498f72f13d4a25ea70f35f4cb60642b466cbb0a9be951b5bc3f45a486
+      - type: file
+        url: "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+        sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+      - type: file
+        url: "https://files.pythonhosted.org/packages/3e/8a/bb3160e76e844db9e69a413f055818969c8acade64e1a9ac5ce9dfdcf6c1/multitasking-0.0.11-py3-none-any.whl"
+        sha256: 1e5b37a5f8fc1e6cfaafd1a82b6b1cc6d2ed20037d3b89c25a84f499bd7b3dd4
+      - type: file
+        url: "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        sha256: 1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f
+      - type: file
+        url: "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl"
+        sha256: 5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2
+      - type: file
+        url: "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl"
+        sha256: b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
+      - type: file
+        url: "https://files.pythonhosted.org/packages/8f/52/0634adaace9be2d8cac9ef78f05c47f3a675882e068438b9d7ec7ef0c13f/pandas-2.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+        sha256: 4ac8c320bded4718b298281339c1a50fb00a6ba78cb2a63521c39bec95b0209b
+      - type: file
+        url: "https://files.pythonhosted.org/packages/c0/9b/bee274b72adc7c692bf7cb8d6b0cd4071acf2957e82dace45d3f2770470e/peewee-4.0.4-py3-none-any.whl"
+        sha256: 37ccd3f89e523c7b42eed023cd90b48d088753ddff1d74e854a9c6445e7bd797
+      - type: file
+        url: "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+        sha256: 03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9
+      - type: file
+        url: "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl"
+        sha256: 68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868
+      - type: file
+        url: "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl"
+        sha256: 8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4
+      - type: file
+        url: "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl"
+        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+      - type: file
+        url: "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl"
+        sha256: 81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
+      - type: file
+        url: "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl"
+        sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
+      - type: file
+        url: "https://files.pythonhosted.org/packages/7b/34/5702b3b7cafe99be1d94b42f100e8cc5e6957b761fcb1cf5f72d492851da/pyqtgraph-0.13.7-py3-none-any.whl"
+        sha256: 7754edbefb6c367fa0dfb176e2d0610da3ada20aa7a5318516c74af5fb72bf7a
+      - type: file
+        url: "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl"
+        sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+      - type: file
+        url: "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl"
+        sha256: f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a
+      - type: file
+        url: "https://files.pythonhosted.org/packages/8a/2e/e1798b8b248e1517e74c6cdf10dd6edd485044e7edf46b5f11ffcc5a0add/reportlab-4.4.10-py3-none-any.whl"
+        sha256: 5abc815746ae2bc44e7ff25db96814f921349ca814c992c7eac3c26029bf7c24
+      - type: file
+        url: "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl"
+        sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+      - type: file
+        url: "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl"
+        sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+      - type: file
+        url: "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl"
+        sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+      - type: file
+        url: "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl"
+        sha256: ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
+      - type: file
+        url: "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl"
+        sha256: f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+      - type: file
+        url: "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl"
+        sha256: 4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9
+      - type: file
+        url: "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl"
+        sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+      - type: file
+        url: "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl"
+        sha256: 95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5
+      - type: file
+        url: "https://files.pythonhosted.org/packages/f7/db/c26791912c20b07c52849a651837e639eccfeb62a764f51cb6707901c601/yfinance-1.2.2-py2.py3-none-any.whl"
+        sha256: 3b292f609e5ff27a8c2d850f5a3c6f10d7290f3b403346705d8d33524ff5745b
+
+  - name: python3-odfpy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links=. --no-build-isolation
+          --ignore-installed --prefix=/app odfpy-1.4.1.tar.gz
+    sources:
+      - type: file
+        url: "https://files.pythonhosted.org/packages/97/73/8ade73f6749177003f7ce3304f524774adda96e6aaab30ea79fd8fda7934/odfpy-1.4.1.tar.gz"
+        sha256: db766a6e59c5103212f3cc92ec8dd50a0f3a02790233ed0b52148b70d3c438ec
+
+  - name: stock-monitor
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 stock-monitor-5.0.1/stock_monitor.py    /app/lib/stock-monitor/stock_monitor.py
+      - install -Dm644 stock-monitor-5.0.1/tax_module.py       /app/lib/stock-monitor/tax_module.py
+      - install -Dm644 stock-monitor-5.0.1/translations.py     /app/lib/stock-monitor/translations.py
+      - install -Dm644 stock-monitor-5.0.1/tax_translations.py /app/lib/stock-monitor/tax_translations.py
+      - install -Dm644 stock-monitor-5.0.1/help_texts.py       /app/lib/stock-monitor/help_texts.py
+      - install -Dm644 stock-monitor-5.0.1/world_map.py        /app/lib/stock-monitor/world_map.py
+      - install -Dm644 stock-monitor-5.0.1/config.py           /app/lib/stock-monitor/config.py
+      - install -Dm644 stock-monitor-5.0.1/market_data.py      /app/lib/stock-monitor/market_data.py
+      - install -Dm644 stock-monitor-5.0.1/portfolio_db.py     /app/lib/stock-monitor/portfolio_db.py
+      - install -Dm644 stock-monitor-5.0.1/dividend_lists.json /app/lib/stock-monitor/dividend_lists.json
+      - install -Dm644 stock-monitor-5.0.1/stock-monitor-256.png /app/share/icons/hicolor/256x256/apps/ch.stockmonitor.StockMonitor.png
+      - install -Dm755 stock-monitor-5.0.1/stock-monitor.sh    /app/bin/stock-monitor
+      - install -Dm644 stock-monitor-5.0.1/ch.stock-monitor.StockMonitor.desktop /app/share/applications/ch.stockmonitor.StockMonitor.desktop
+      - install -Dm644 stock-monitor-5.0.1/ch.stock-monitor.StockMonitor.metainfo.xml /app/share/metainfo/ch.stockmonitor.StockMonitor.metainfo.xml
+    sources:
+      - type: archive
+        url: "https://github.com/StockMonitorCH/stock-monitor/releases/download/v5.0.1/stock-monitor-5.0.1-app.tar.gz"
+        sha256: 9ca3fb3a945ed483966118061f2d13c9278a90a20946a3d303c450fa61f0b40b


### PR DESCRIPTION
## New app submission: Stock Monitor

**App ID:** ch.stockmonitor.StockMonitor  
**Homepage:** https://www.stock-monitor.ch  
**Source repo:** https://github.com/StockMonitorCH/stock-monitor  
**Manifest repo:** https://github.com/StockMonitorCH/ch.stockmonitor.StockMonitor  
**License:** MIT  

### Description

Stock Monitor is a free, open-source desktop application for managing and analysing investment portfolios. Track stocks, ETFs, cryptocurrencies and commodities across all major global exchanges — no cloud, no subscription, all data stays local.

**Features:**
- Up to 16 simultaneous live charts (MA 20/50/200, RSI, Bollinger Bands, Candlestick)
- Real-time price data via Yahoo Finance
- AES-256-GCM encrypted portfolio files
- Monte Carlo simulation, Sharpe Ratio, Alpha, Beta analysis
- AI Balance — rebalancing weighted by analyst consensus and news sentiment
- Tax reports for CH / DE / AT / UK / US
- Interactive world map of holdings
- Import from Swissquote and Generic CSV
- PDF, XLSX and ODS export
- Available in German and English

### Technical details

- Runtime: `org.kde.Platform 6.10` + `com.riverbankcomputing.PyQt.BaseApp 6.10`
- Language: Python 3 / PyQt6
- All Python dependencies bundled as wheels from PyPI (with SHA256 checksums)
- No proprietary blobs, no vendored binaries

### Checklist

- [x] App ID follows reverse-DNS format
- [x] All sources reference remote URLs with SHA256 checksums
- [x] Metainfo file included with screenshots, description, releases
- [x] Desktop file included
- [x] Icon (256×256 PNG) included
- [x] License: MIT
- [x] No `--talk-name=org.freedesktop.Flatpak`