### PR TITLE
Add io.github.saleguas.librewolfprofiles

### DIFF
--- a/io.github.saleguas.librewolfprofiles.yml
+++ b/io.github.saleguas.librewolfprofiles.yml
@@ -1,0 +1,20 @@
+app-id: io.github.saleguas.librewolfprofiles
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: io.github.saleguas.librewolfprofiles
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  - name: librewolf-profiles
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/saleguas/LibrewolfProfiles.git
+        tag: v0.1.0
+        commit: a62ee8ec421da03bba69e32338dd58a6dcc4e210


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. LibreWolf Profiles is an independent companion app for launching, annotating, and creating LibreWolf profiles. It is intended for keeping multiple accounts, workspaces, or browsing contexts separate while continuing to use LibreWolf.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. N/A: this is a small profile-launcher utility; AppStream metadata includes a screenshot, and the Flatpak was built and launched locally for validation.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

Additional maintainers: N/A

Submission notes:

LibreWolf must already be installed. The app auto-detects the LibreWolf Flatpak and its profiles.ini path, stores profile notes in its own config directory, and does not edit LibreWolf profile data directly.

Permission rationale:

- The app requests org.freedesktop.Flatpak access so it can call flatpak-spawn --host.
- This is needed to launch the user's installed LibreWolf Flatpak with profile-specific arguments such as -P <profile>, -CreateProfile, and --ProfileManager.
- I am not aware of a portal that can launch another installed Flatpak app with these browser profile arguments.
- Without this permission the app can list saved metadata only, but cannot perform its core launch/create/profile-manager actions.

Local validation performed:

- Built and installed successfully with org.flatpak.Builder/flathub-build using org.gnome.Platform//50 and org.gnome.Sdk//50.
- App command is callable after install.
- appstreamcli validation passes in the upstream app repo.
- desktop-file-validate passes in the upstream app repo.
- Backend unit tests pass upstream.

Known linter exception requested:

- finish-args-flatpak-spawn-access, for the org.freedesktop.Flatpak permission described above.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
