### PR TITLE
Add com.aurivo.mediaplayer

### DIFF
--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,6 +1,6 @@
 app-id: com.aurivo.mediaplayer
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node22

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,7 +1,7 @@
 app-id: com.aurivo.mediaplayer
-runtime: org.gnome.Platform
-runtime-version: "47"
-sdk: org.gnome.Sdk
+runtime: org.freedesktop.Platform
+runtime-version: "24.08"
+sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node22
 command: com.aurivo.mediaplayer
@@ -16,39 +16,22 @@ finish-args:
   - --socket=x11
   - --socket=fallback-x11
   - --socket=pulseaudio
-  - --socket=session-bus
   - --share=network
   - --device=dri
-  - --device=all
-  - --filesystem=xdg-music
-  - --filesystem=xdg-videos
-  - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.kde.StatusNotifierWatcher
-  - --talk-name=org.freedesktop.StatusNotifierWatcher
-  - --talk-name=org.mpris.MediaPlayer2.*
-  - --own-name=org.mpris.MediaPlayer2.*
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --own-name=org.mpris.MediaPlayer2.com.aurivo.mediaplayer
   - --env=TMPDIR=/var/tmp
   - --env=ELECTRON_TRASH=gio
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 
 modules:
-  - name: sdl2-image
-    buildsystem: cmake-ninja
-    builddir: true
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DSDL2IMAGE_AVIF=OFF
-      - -DSDL2IMAGE_WEBP=OFF
-    sources:
-      - type: archive
-        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-2.8.2.tar.gz
-        sha256: 8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc
+  - shared-modules/sdl2/sdl2-image.json
 
   - name: aurivo-media-player
     buildsystem: simple
     build-commands:
-      # Kurulum komutlari... Mevcut yapi Flatpak Flathub standartlarina baslangic asamasidir.
+      # Build and installation commands for Flathub standards
       - install -Dm755 packaging/flatpak/aurivo-wrapper.sh /app/bin/com.aurivo.mediaplayer
       - install -Dm644 packaging/linux/com.aurivo.mediaplayer.desktop /app/share/applications/com.aurivo.mediaplayer.desktop
       - install -Dm644 packaging/appstream/com.aurivo.mediaplayer.metainfo.xml /app/share/metainfo/com.aurivo.mediaplayer.metainfo.xml
@@ -57,4 +40,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux.git
-        branch: main
+        tag: v2.0.30
+        commit: 2022e8d47b0e4549f2b3806a666991039868882b

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,0 +1,60 @@
+app-id: com.aurivo.mediaplayer
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node22
+command: com.aurivo.mediaplayer
+separate-locales: false
+
+build-options:
+  append-path: /usr/lib/sdk/node22/bin
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --socket=session-bus
+  - --share=network
+  - --device=dri
+  - --device=all
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.StatusNotifierWatcher
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --own-name=org.mpris.MediaPlayer2.*
+  - --env=TMPDIR=/var/tmp
+  - --env=ELECTRON_TRASH=gio
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
+modules:
+  - name: sdl2-image
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSDL2IMAGE_AVIF=OFF
+      - -DSDL2IMAGE_WEBP=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-2.8.2.tar.gz
+        sha256: 8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc
+
+  - name: aurivo-media-player
+    buildsystem: simple
+    build-commands:
+      # Kurulum komutlari... Mevcut yapi Flatpak Flathub standartlarina baslangic asamasidir.
+      - install -Dm755 packaging/flatpak/aurivo-wrapper.sh /app/bin/com.aurivo.mediaplayer
+      - install -Dm644 packaging/linux/com.aurivo.mediaplayer.desktop /app/share/applications/com.aurivo.mediaplayer.desktop
+      - install -Dm644 packaging/appstream/com.aurivo.mediaplayer.metainfo.xml /app/share/metainfo/com.aurivo.mediaplayer.metainfo.xml
+      - install -Dm644 icons/aurivo_512.png /app/share/icons/hicolor/512x512/apps/com.aurivo.mediaplayer.png
+      - install -Dm644 icons/aurivo_256.png /app/share/icons/hicolor/256x256/apps/com.aurivo.mediaplayer.png
+    sources:
+      - type: git
+        url: https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux.git
+        branch: main

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -18,8 +18,6 @@ finish-args:
   - --share=network
   - --device=dri
   - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.freedesktop.ScreenSaver
-  - --own-name=org.mpris.MediaPlayer2.com.aurivo.mediaplayer
   - --env=TMPDIR=/var/tmp
   - --env=ELECTRON_TRASH=gio
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,6 +1,6 @@
 app-id: com.aurivo.mediaplayer
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node22

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -23,7 +23,12 @@ finish-args:
   - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
 
 modules:
-  - shared-modules/sdl2/sdl2-image.json
+  - name: sdl2-image
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://www.libsdl.org/projects/SDL_image/release/SDL2_image-2.8.2.tar.gz
+        sha256: 832f0808386121876f9ecfcc5c189280d853e923e3fc301662963d7638848f07
 
   - name: aurivo-media-player
     buildsystem: simple

--- a/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer.yml
@@ -1,6 +1,6 @@
 app-id: com.aurivo.mediaplayer
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.node22
@@ -12,9 +12,8 @@ build-options:
 
 finish-args:
   - --share=ipc
-  - --socket=wayland
-  - --socket=x11
   - --socket=fallback-x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --device=dri
@@ -31,7 +30,6 @@ modules:
   - name: aurivo-media-player
     buildsystem: simple
     build-commands:
-      # Build and installation commands for Flathub standards
       - install -Dm755 packaging/flatpak/aurivo-wrapper.sh /app/bin/com.aurivo.mediaplayer
       - install -Dm644 packaging/linux/com.aurivo.mediaplayer.desktop /app/share/applications/com.aurivo.mediaplayer.desktop
       - install -Dm644 packaging/appstream/com.aurivo.mediaplayer.metainfo.xml /app/share/metainfo/com.aurivo.mediaplayer.metainfo.xml

--- a/com.aurivo.mediaplayer/com.aurivo.mediaplayer.desktop
+++ b/com.aurivo.mediaplayer/com.aurivo.mediaplayer.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Version=1.5
+Name=Aurivo Media Player
+Comment=All-in-one media player for Linux
+Exec=com.aurivo.mediaplayer %U
+Icon=com.aurivo.mediaplayer
+Terminal=false
+Categories=AudioVideo;Player;
+StartupWMClass=com.aurivo.mediaplayer
+MimeType=audio/mpeg;audio/wav;audio/flac;audio/aac;audio/ogg;audio/mp4;audio/x-m4a;audio/opus;audio/aiff;audio/x-ms-wma;video/mp4;video/x-matroska;video/x-msvideo;video/quicktime;video/x-ms-wmv;video/webm;video/x-m4v;
+Keywords=Music;Audio;Video;Player;Aurivo;

--- a/com.aurivo.mediaplayer/com.aurivo.mediaplayer.metainfo.xml
+++ b/com.aurivo.mediaplayer/com.aurivo.mediaplayer.metainfo.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.aurivo.mediaplayer</id>
+  <name>Aurivo Media Player</name>
+  <summary>All-in-one music and video player with advanced DSP effects</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="app.aurivo">
+    <name>Muhammet Dali</name>
+  </developer>
+  <launchable type="desktop-id">com.aurivo.mediaplayer.desktop</launchable>
+
+  <url type="homepage">https://aurivo.app</url>
+  <url type="bugtracker">https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux/issues</url>
+  <url type="vcs-browser">https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux</url>
+  <url type="donation">https://github.com/sponsors/muhammed-aurivo-dev</url>
+
+  <categories>
+    <category>AudioVideo</category>
+    <category>Player</category>
+  </categories>
+
+  <description>
+    <p>Aurivo Media Player is a Linux desktop media app that combines music playback, video playback, web media, downloading workflows, and advanced DSP controls in a single interface.</p>
+    <p>Main features include:</p>
+    <ul>
+      <li>Local music and video playback with playlist management</li>
+      <li>Advanced audio processing including 32-band EQ, compressor, limiter, reverb, and more</li>
+      <li>Song recognition workflow via Aurivo Pulse integration</li>
+      <li>projectM-based real-time visualizer</li>
+      <li>MPRIS integration for desktop media controls</li>
+    </ul>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux/main/screenshots/shot-20260331-222556.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux/main/screenshots/shot-20260331-222611.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux/main/screenshots/shot-20260331-222722.png</image>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1"/>
+
+  <provides>
+    <binary>aurivo</binary>
+  </provides>
+
+  <releases>
+    <release version="2.0.43" date="2026-04-23">
+      <description>
+        <p>Flatpak compatibility groundwork and security hardening updates.</p>
+      </description>
+    </release>
+    <release version="2.0.36" date="2026-04-23"/>
+    <release version="2.0.31" date="2026-04-15"/>
+  </releases>
+</component>

--- a/com.aurivo.mediaplayer/com.aurivo.mediaplayer.yml
+++ b/com.aurivo.mediaplayer/com.aurivo.mediaplayer.yml
@@ -1,0 +1,133 @@
+app-id: com.aurivo.mediaplayer
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node22
+command: com.aurivo.mediaplayer
+separate-locales: false
+
+build-options:
+  append-path: /usr/lib/sdk/node22/bin
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --share=network
+  - --device=dri
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.StatusNotifierWatcher
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --own-name=org.mpris.MediaPlayer2.*
+  - --env=TMPDIR=/var/tmp
+  - --env=ELECTRON_TRASH=gio
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
+modules:
+  - name: sdl2-image
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DSDL2IMAGE_AVIF=OFF
+      - -DSDL2IMAGE_WEBP=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_image/releases/download/release-2.8.2/SDL2_image-2.8.2.tar.gz
+        sha256: 8f486bbfbcf8464dd58c9e5d93394ab0255ce68b51c5a966a918244820a76ddc
+
+  - name: aurivo-media-player
+    buildsystem: simple
+    build-commands:
+      - test -x dist/linux-unpacked/aurivo
+      - node --version
+      - npm --version
+      - npm_config_nodedir=/usr/lib/sdk/node22 npm --prefix native run rebuild
+      - |
+        PROJECTM_LIB="$PWD/dist/linux-unpacked/resources/native-dist/linux/libprojectM-4.so.4"
+        PROJECTM_PLAYLIST_LIB="$PWD/dist/linux-unpacked/resources/native-dist/linux/libprojectM-4-playlist.so.4"
+        test -f "$PROJECTM_LIB"
+        cmake -S visualizer -B build-visualizer-flatpak -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DAURIVO_PROJECTM_C_API_COMPAT=ON \
+          -DAURIVO_PROJECTM_LIB="$PROJECTM_LIB" \
+          -DAURIVO_PROJECTM_PLAYLIST_LIB="$PROJECTM_PLAYLIST_LIB" \
+          -DSDL2IMAGE_INCLUDE_DIR=/app/include/SDL2 \
+          -DSDL2IMAGE_LIBRARY=/app/lib/libSDL2_image.so
+        cmake --build build-visualizer-flatpak --config Release -j"$(nproc)"
+      - install -d /app/aurivo
+      - cp -a dist/linux-unpacked/. /app/aurivo/
+      - |
+        if [ -f /app/aurivo/resources/app.asar.unpacked/Aurivo-Pulse/libs/libchromaprint.so ]; then
+          ln -sf libchromaprint.so /app/aurivo/resources/app.asar.unpacked/Aurivo-Pulse/libs/libchromaprint.so.1
+        fi
+      - install -Dm755 native/build/Release/aurivo_audio.node /app/aurivo/resources/native/build/Release/aurivo_audio.node
+      - |
+        for lib in \
+          libbass.so \
+          libbass_fx.so \
+          libbass_aac.so \
+          libbassape.so \
+          libbassflac.so \
+          libbasswv.so; do
+          install -Dm755 "native/build/Release/$lib" "/app/aurivo/resources/native/build/Release/$lib"
+        done
+      - install -d /app/aurivo/resources/native-dist/linux
+      - install -Dm755 build-visualizer-flatpak/aurivo-projectm-visualizer /app/aurivo/resources/native-dist/linux/aurivo-projectm-visualizer
+      - |
+        # Aurivo-Pulse: native-dist'den kopyala (binary zaten derlenmis olarak geliyor)
+        PULSE_BIN="dist/linux-unpacked/resources/native-dist/linux/aurivo-pulse"
+        if [ -f "$PULSE_BIN" ]; then
+          install -Dm755 "$PULSE_BIN" /app/aurivo/resources/native-dist/linux/aurivo-pulse
+        fi
+      - |
+        # Aurivo-Pulse: libchromaprint soname uyumlulugunu garanti et (.so.1 bekleniyor).
+        CHROMAPRINT_SRC="/app/aurivo/resources/app.asar.unpacked/Aurivo-Pulse/libs/libchromaprint.so"
+        if [ -f "$CHROMAPRINT_SRC" ]; then
+          install -Dm755 "$CHROMAPRINT_SRC" /app/aurivo/resources/native-dist/linux/libchromaprint.so.1
+          ln -sf libchromaprint.so.1 /app/aurivo/resources/native-dist/linux/libchromaprint.so
+          ln -sf libchromaprint.so /app/aurivo/resources/app.asar.unpacked/Aurivo-Pulse/libs/libchromaprint.so.1
+        fi
+      - install -Dm644 assets/fonts/Inter-Regular.ttf /app/aurivo/resources/native-dist/linux/fonts/Inter-Regular.ttf
+      - |
+        for lib in \
+          libavutil.so.60 \
+          libvpl.so.2; do
+          if [ -f "packaging/flatpak/runtime-libs/$lib" ]; then
+            install -Dm755 "packaging/flatpak/runtime-libs/$lib" "/app/aurivo/resources/native-dist/linux/$lib"
+          fi
+        done
+      - |
+        for lib in \
+          libOpenGL.so.0 \
+          libGLX.so.0 \
+          libGL.so.1 \
+          libGLU.so.1 \
+          libGLEW.so.2.2 \
+          libGLEW.so.2.3 \
+          libavutil.so.60 \
+          libvpl.so.2 \
+          libSDL2-2.0.so.0 \
+          libSDL2_image-2.0.so.0 \
+          libX11.so.6; do
+          if [ -f "/usr/lib/$lib" ]; then
+            cp -a "/usr/lib/$lib" "/app/aurivo/resources/native-dist/linux/$lib"
+          elif [ -f "/usr/lib/x86_64-linux-gnu/$lib" ]; then
+            cp -a "/usr/lib/x86_64-linux-gnu/$lib" "/app/aurivo/resources/native-dist/linux/$lib"
+          fi
+        done
+      - install -Dm755 packaging/flatpak/aurivo-wrapper.sh /app/bin/com.aurivo.mediaplayer
+      - install -Dm644 packaging/linux/com.aurivo.mediaplayer.desktop /app/share/applications/com.aurivo.mediaplayer.desktop
+      - install -Dm644 packaging/appstream/com.aurivo.mediaplayer.metainfo.xml /app/share/metainfo/com.aurivo.mediaplayer.metainfo.xml
+      - install -Dm644 icons/aurivo_512.png /app/share/icons/hicolor/512x512/apps/com.aurivo.mediaplayer.png
+      - install -Dm644 icons/aurivo_256.png /app/share/icons/hicolor/256x256/apps/com.aurivo.mediaplayer.png
+    sources:
+      - type: dir
+        path: ../../


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.
Aurivo Media Player is a Linux desktop media player that combines local music/video playback, web media workflows, advanced DSP controls (EQ, limiter, compressor, reverb), and song recognition support in a single interface.

- [x] Please attach a video showcasing the application on Linux using the Flatpak.
Video: https://youtu.be/lsEgsm90bdY?si=S7rhiqfQWxwXdxs8

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
Flatpak ID: `com.aurivo.mediaplayer`

- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][req2] and I agree to them.

- [x] I am an author/developer/upstream contributor to the project.
Upstream repository: https://github.com/muhammed-aurivo-dev/Aurivo-Medya-Player-Linux

- [x] Please mention below the GitHub usernames of any additional maintainers needed (if any).
Additional maintainers: N/A

