### PR TITLE
Add com.waystone.browser

### DIFF
--- a/com.waystone.browser.yml
+++ b/com.waystone.browser.yml
@@ -58,5 +58,6 @@ modules:
       - install -Dm644 data/com.waystone.browser.metainfo.xml
           /app/share/metainfo/com.waystone.browser.metainfo.xml
     sources:
-      - type: dir
-        path: .
+      - type: git
+        url: https://github.com/njb1966/waystone-browser.git
+        commit: 51d4f556a4cdf4d041e5ccbbbba11e20676f28f9

--- a/com.waystone.browser.yml
+++ b/com.waystone.browser.yml
@@ -1,0 +1,62 @@
+app-id: com.waystone.browser
+runtime: org.gnome.Platform
+runtime-version: "48"
+sdk: org.gnome.Sdk
+command: waystone
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # User home access for downloads and config
+  - --filesystem=home
+  # Allow user namespaces so WebKit's internal bwrap sandbox works inside Flatpak
+  - --allow=devel
+
+modules:
+  # cffi — C extension needed by cryptography at runtime; not in the GNOME runtime
+  - name: python3-cffi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba
+
+  # cryptography — binary extension, not in the GNOME runtime; use stable ABI wheel
+  - name: python3-cryptography
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308
+
+  # aiosqlite — pure Python, not in the GNOME runtime; use wheel to avoid flit_core dep
+  - name: python3-aiosqlite
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation aiosqlite-0.22.1-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl
+        sha256: 21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb
+
+  # Waystone itself
+  - name: waystone
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation .
+      - install -Dm644 data/com.waystone.browser.desktop
+          /app/share/applications/com.waystone.browser.desktop
+      - install -Dm644 data/com.waystone.browser.svg
+          /app/share/icons/hicolor/scalable/apps/com.waystone.browser.svg
+      - install -Dm644 data/com.waystone.browser.metainfo.xml
+          /app/share/metainfo/com.waystone.browser.metainfo.xml
+    sources:
+      - type: dir
+        path: .

--- a/com.waystone.browser.yml
+++ b/com.waystone.browser.yml
@@ -20,21 +20,39 @@ modules:
   - name: python3-cffi
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi.whl
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
         sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+        dest-filename: cffi.whl
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b
+        dest-filename: cffi.whl
+        only-arches:
+          - aarch64
 
   # cryptography — binary extension, not in the GNOME runtime; use stable ABI wheel
   - name: python3-cryptography
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix=/app --no-deps --no-build-isolation cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cryptography.whl
     sources:
       - type: file
         url: https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
         sha256: 5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308
+        dest-filename: cryptography.whl
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325
+        dest-filename: cryptography.whl
+        only-arches:
+          - aarch64
 
   # aiosqlite — pure Python, not in the GNOME runtime; use wheel to avoid flit_core dep
   - name: python3-aiosqlite
@@ -60,4 +78,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/njb1966/waystone-browser.git
-        commit: 51d4f556a4cdf4d041e5ccbbbba11e20676f28f9
+        commit: 003df6d100aa9c6baebcc754030b2f2ebd8235f1

--- a/com.waystone.browser.yml
+++ b/com.waystone.browser.yml
@@ -10,8 +10,8 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
-  # User home access for downloads and config
-  - --filesystem=home
+  # Downloads folder as default save location; all other file access via portals
+  - --filesystem=xdg-download
   # Allow user namespaces so WebKit's internal bwrap sandbox works inside Flatpak
   - --allow=devel
 
@@ -58,6 +58,5 @@ modules:
       - install -Dm644 data/com.waystone.browser.metainfo.xml
           /app/share/metainfo/com.waystone.browser.metainfo.xml
     sources:
-      - type: git
-        url: https://github.com/njb1966/waystone-browser.git
-        commit: 8cd39fa204ebf6fc65ba5a06a591e94022ac1208
+      - type: dir
+        path: .

--- a/com.waystone.browser.yml
+++ b/com.waystone.browser.yml
@@ -1,6 +1,6 @@
 app-id: com.waystone.browser
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: waystone
 
@@ -20,11 +20,11 @@ modules:
   - name: python3-cffi
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-        sha256: 3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba
+        url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
 
   # cryptography — binary extension, not in the GNOME runtime; use stable ABI wheel
   - name: python3-cryptography
@@ -58,5 +58,6 @@ modules:
       - install -Dm644 data/com.waystone.browser.metainfo.xml
           /app/share/metainfo/com.waystone.browser.metainfo.xml
     sources:
-      - type: dir
-        path: .
+      - type: git
+        url: https://github.com/njb1966/waystone-browser.git
+        commit: 8cd39fa204ebf6fc65ba5a06a591e94022ac1208


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.
  Waystone is a multi-protocol browser for the small web. It supports HTTP/HTTPS (via WebKitGTK), Gemini, Gopher, Spartan, and Titan in a single GTK4/Libadwaita application with tabbed browsing, bookmarks, history, and find-in-page.

- [X] Please attach a video showcasing the application on Linux using the Flatpak.
  https://youtu.be/bVn_otKkkNw

- [X] The Flatpak ID follows all the rules listed in the Application ID requirements.

- [X] I have read and followed all the Submission requirements and the Submission guide and I agree to them.

- [X] I am an author/developer/upstream contributor to the project.