### PR TITLE
Add SilkTex (app.silktex.SilkTex)

### DIFF
--- a/app.silktex.SilkTex.yml
+++ b/app.silktex.SilkTex.yml
@@ -1,0 +1,76 @@
+# SilkTex - Modern LaTeX Editor
+# Copyright (C) 2026 Bela Georg Barthelmes
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Flathub-ready manifest. The GNOME 49 Platform already provides GTK 4
+# (>= 4.20), libadwaita (>= 1.8), gtksourceview 5 and poppler-glib, so
+# the only module we build is SilkTex itself.
+#
+# NOTE on LaTeX compilation inside the sandbox: SilkTex shells out to
+# pdflatex / bibtex / makeindex / synctex at runtime. Since TeX Live is
+# several GB, we use the host's install via `flatpak-spawn --host` rather
+# than bundling it. That requires `--talk-name=org.freedesktop.Flatpak`,
+# which Flathub reviewers will flag as a sandbox hole. Alternatives if a
+# reviewer objects:
+#   1. Build against the `org.freedesktop.Sdk.Extension.texlive` SDK
+#      extension and use the in-sandbox binaries. Adds a few hundred MB.
+#   2. Ship without compile support and point users at `flatpak override
+#      --user --talk-name=org.freedesktop.Flatpak app.silktex.SilkTex`.
+app-id: app.silktex.SilkTex
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: silktex
+
+finish-args:
+  # Basics for a GUI app.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # Online LaTeX packages, biblatex online lookups, documentation links.
+  - --share=network
+
+  # Users keep .tex projects anywhere on their disk; the editor is
+  # inherently a file-system tool.  `host` is kept here to match the
+  # behaviour of other LaTeX editors on Flathub (TeXstudio, Setzer, Kile).
+  - --filesystem=host
+
+  # Per-user config + cache (snippets.cfg, silktex.ini, compile logs).
+  - --filesystem=xdg-config/silktex:create
+  - --filesystem=xdg-cache/silktex:create
+
+  # Let the user launch the compiled PDF in an external viewer via the
+  # OpenURI portal (no extra filesystem access needed).
+  - --talk-name=org.freedesktop.portal.OpenURI
+
+  # Run host-installed TeX Live. See the note at the top of this file.
+  - --talk-name=org.freedesktop.Flatpak
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/gtk-doc
+  - /share/man
+  - '*.la'
+  - '*.a'
+
+modules:
+  - name: silktex
+    buildsystem: meson
+    config-opts:
+      - --buildtype=release
+      - -Dprefix=/app
+    sources:
+      # Flathub requires reproducible sources. Replace `commit:` with the
+      # exact SHA of the tag you are publishing (CI keeps this in sync,
+      # see the `Update Flathub manifest` workflow in the SilkTex repo).
+      - type: git
+        url: https://github.com/DERK0CHER/SilkTex.git
+        tag: v0.9.1
+        commit: ecc2019deedb42724b1061b7ff27a5c2e8dbb4f0
+        x-checker-data:
+          type: git
+          tag-pattern: '^v([\d.]+)$'

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,5 @@
+{
+  "$comment": "Flathub build-time configuration. See https://docs.flathub.org/docs/for-app-authors/flathub-json",
+  "only-arches": ["x86_64", "aarch64"],
+  "automerge-flathubbot-prs": true
+}


### PR DESCRIPTION
## About the app

**SilkTex** is a modern LaTeX editor for GNOME — a GTK 4 / libadwaita
re-implementation of the classic [Gummi](https://github.com/alexandervdm/gummi)
editor.

- App ID: `app.silktex.SilkTex`
- License: `GPL-3.0-or-later`
- Source: <https://github.com/DERK0CHER/SilkTex>
- Bug tracker: <https://github.com/DERK0CHER/SilkTex/issues>
- Tag / commit this PR pins:
  - `tag: v0.9.1`
  - `commit: ecc2019deedb42724b1061b7ff27a5c2e8dbb4f0`
- Runtime: `org.gnome.Platform//49` (SDK: `org.gnome.Sdk//49`)

### Features

- Live PDF preview with HiDPI / device-scale aware rendering
- Document outline with jump-to-section
- Configurable snippet engine (two global modifier keys + a letter,
  `$1 / $2 / $0` tab placeholders, `$FILENAME / $BASENAME /
  $SELECTED_TEXT` macros)
- SyncTeX forward/inverse sync
- BibTeX / makeindex / build-file cleanup
- libadwaita preferences dialog with editor font, spell-check toggle,
  and a snippet editor

## Sandbox permissions

SilkTex shells out to the host's TeX Live (`pdflatex`, `bibtex`,
`makeindex`, `synctex`) via `flatpak-spawn --host`. The relevant
`finish-args` are:

- `--filesystem=host` — users keep .tex projects anywhere on disk, same
  as other Flathub LaTeX editors (TeXstudio, Setzer, Kile).
- `--talk-name=org.freedesktop.Flatpak` — required for `flatpak-spawn
--host` to invoke the host TeX Live installation.
- `--share=network` — online BibLaTeX / documentation lookups.
- `--talk-name=org.freedesktop.portal.OpenURI` — launching the compiled
  PDF in the user's default viewer.
- Regular GUI args (`wayland`, `fallback-x11`, `dri`, `ipc`) and
  per-app `xdg-config` / `xdg-cache`.

Bundling TeX Live would add several GB to every download, which is why
the host install is used. Happy to discuss tightening the sandbox (e.g.
via `org.freedesktop.Sdk.Extension.texlive`) if reviewers prefer.

## Files in this PR

- `app.silktex.SilkTex.yml` — Flatpak manifest
- `flathub.json` — build options (x86_64 + aarch64, auto-merge bot PRs)

The upstream SilkTex repository also carries:

- a working AppStream metainfo at `data/misc/app.silktex.SilkTex.metainfo.xml.in`
  (validates; screenshots hosted under the upstream repo's `assets`
  branch)
- a `.desktop` file at `data/misc/app.silktex.SilkTex.desktop.in`
- `256x256` + `512x512` PNG icons under `data/icons/`

These are installed by the meson build (`/app/share/...`) so they ship
inside the Flatpak automatically.

## Housekeeping

- Source is pinned via `type: git` + tag + commit, with
  `x-checker-data` for `flatpak-external-data-checker` (`tag-pattern:
'^v([\d.]+)$'`) so FEDC can open automatic update PRs once merged.
- The upstream repo also has a GitHub Actions workflow that bumps the
  manifest here on `release: published`, as a same-minute backup to FEDC.

Thanks for reviewing!
