### PR TITLE
Add dev.inkwell.Inkwell

### DIFF
--- a/dev.inkwell.Inkwell.yml
+++ b/dev.inkwell.Inkwell.yml
@@ -1,0 +1,29 @@
+id: dev.inkwell.Inkwell
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: inkwell
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+
+modules:
+  - name: inkwell
+    buildsystem: simple
+    build-commands:
+      - cc -std=c99 -Wall -Wextra -Werror -I core/include core/src/inkwell_core.c shells/linux-gtk-native/main.c $(pkg-config --cflags --libs gtk+-3.0) -o inkwell
+      - install -Dm755 inkwell /app/bin/inkwell
+      - install -Dm644 packaging/linux/dev.inkwell.Inkwell.desktop /app/share/applications/dev.inkwell.Inkwell.desktop
+      - install -Dm644 packaging/linux/dev.inkwell.Inkwell.metainfo.xml /app/share/metainfo/dev.inkwell.Inkwell.metainfo.xml
+      - install -Dm644 app/assets/icons/inkwell-64.png /app/share/icons/hicolor/64x64/apps/dev.inkwell.Inkwell.png
+      - install -Dm644 app/assets/icons/inkwell-128.png /app/share/icons/hicolor/128x128/apps/dev.inkwell.Inkwell.png
+      - install -Dm644 app/assets/icons/inkwell-256.png /app/share/icons/hicolor/256x256/apps/dev.inkwell.Inkwell.png
+      - install -Dm644 app/assets/icons/inkwell-512.png /app/share/icons/hicolor/512x512/apps/dev.inkwell.Inkwell.png
+      - install -Dm644 LICENSE /app/share/licenses/dev.inkwell.Inkwell/LICENSE
+    sources:
+      - type: git
+        url: https://github.com/VendorBuyMVP/Inkwell.git
+        tag: v0.2.5
+        commit: 4999781541bf0a167bb06ac7fd15c1c4b6839fff


### PR DESCRIPTION
Adds Inkwell, a local-first Markdown editor with a minimal Flatpak permission posture.

Validation performed locally:
- Built from public Inkwell tag v0.2.5 / commit 4999781541bf0a167bb06ac7fd15c1c4b6839fff.
- Ran flatpak-builder-lint manifest on dev.inkwell.Inkwell.yml.
- Built the Flatpak with org.gnome.Platform//50 and org.gnome.Sdk//50.
- Ran flatpak-builder-lint repo on the generated OSTree repo.
- Installed local Flatpak and audited permissions: shared=ipc; sockets=x11;wayland;fallback-x11; no network and no filesystem grants.

Upstream: https://github.com/VendorBuyMVP/Inkwell
Release: https://github.com/VendorBuyMVP/Inkwell/releases/tag/v0.2.5