### PR TITLE
Add io.github.MrMiYaGi68.MatrixCalculator

### DIFF
--- a/io.github.MrMiYaGi68.MatrixCalculator.json
+++ b/io.github.MrMiYaGi68.MatrixCalculator.json
@@ -1,0 +1,38 @@
+{
+  "id": "io.github.MrMiYaGi68.MatrixCalculator",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "6.9",
+  "sdk": "org.kde.Sdk",
+  "base": "io.qt.PySide.BaseApp",
+  "base-version": "6.9",
+  "command": "matrix-calculator",
+  "finish-args": [
+    "--share=ipc",
+    "--socket=fallback-x11",
+    "--socket=wayland",
+    "--device=dri"
+  ],
+  "modules": [
+    {
+      "name": "matrix-calculator",
+      "buildsystem": "simple",
+      "build-commands": [
+        "python3 -m pip install --no-build-isolation --no-deps --prefix=/app .",
+        "install -Dm644 io.github.MrMiYaGi68.MatrixCalculator.desktop /app/share/applications/io.github.MrMiYaGi68.MatrixCalculator.desktop",
+        "install -Dm644 io.github.MrMiYaGi68.MatrixCalculator.metainfo.xml /app/share/metainfo/io.github.MrMiYaGi68.MatrixCalculator.metainfo.xml",
+        "install -Dm644 assets/matrix-calculator-icon.svg /app/share/icons/hicolor/scalable/apps/io.github.MrMiYaGi68.MatrixCalculator.svg",
+        "install -Dm644 assets/matrix-calculator-icon.png /app/share/icons/hicolor/256x256/apps/io.github.MrMiYaGi68.MatrixCalculator.png"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/MrMiYaGi68/Matrix-Calculator/releases/download/v1.0.0/matrix_calculator-1.0.0.tar.gz",
+          "sha256": "cc13d3d8857cb8a4fb5fc525ed5253e747a3e9207466b01463cbadc4c97eb7a4"
+        }
+      ]
+    }
+  ],
+  "cleanup-commands": [
+    "/app/cleanup-BaseApp.sh"
+  ]
+}


### PR DESCRIPTION
Title: Add io.github.MrMiYaGi68.MatrixCalculator

## Please confirm the following

- [x] I have read the Flathub submission documentation.
- [x] This is a new app submission targeting the `new-pr` branch.
- [x] The app builds from a public upstream source release.
- [x] The upstream project is maintained by the submitter.

## App summary

Matrix Calculator is a scientific calculator for Linux built with PySide6.
It provides a desktop UI, scientific functions, local natural-language math
handling, history, live previews and optional OpenAI API integration.

Upstream repository:

- https://github.com/MrMiYaGi68/Matrix-Calculator

Upstream release source used by the manifest:

- https://github.com/MrMiYaGi68/Matrix-Calculator/releases/download/v1.0.0/matrix_calculator-1.0.0.tar.gz

## Packaging notes

- Runtime: `org.kde.Platform//6.9`
- BaseApp: `io.qt.PySide.BaseApp//6.9`
- Manifest uses the published source release tarball and matching SHA256
- AppStream metadata validates locally

## Linter note

`flatpak-builder-lint manifest` reports `appid-url-not-reachable`.

Reason:

The Flatpak ID is `io.github.MrMiYaGi68.MatrixCalculator`, while the upstream
GitHub repository is named `Matrix-Calculator`. Flathub's app ID URL check
derives a URL without the hyphen and therefore resolves to a 404, even though
the actual upstream repository is public and reachable.

I am requesting an exception for:

- `appid-url-not-reachable`

## Local validation

Validated on 2026-04-29:

```bash
appstreamcli validate --no-net io.github.MrMiYaGi68.MatrixCalculator.metainfo.xml
flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest io.github.MrMiYaGi68.MatrixCalculator.json
```

The AppStream validation passes. The remaining manifest blocker is the URL
reachability mismatch described above.
