### PR TITLE
Add com.lunday.Lunday

### DIFF
--- a/com.lunday.Lunday/com.lunday.Lunday.yml
+++ b/com.lunday.Lunday/com.lunday.Lunday.yml
@@ -1,0 +1,41 @@
+app-id: com.lunday.Lunday
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: lunday
+finish-args:
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.secrets
+  - --filesystem=xdg-download:rw
+  - --filesystem=home:ro
+modules:
+  - name: monday
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 lunday.py /app/bin/lunday
+      - install -Dm644 com.lunday.Lunday.desktop /app/share/applications/com.lunday.Lunday.desktop
+      - install -Dm644 com.lunday.Lunday.metainfo.xml /app/share/metainfo/com.lunday.Lunday.metainfo.xml
+      - install -Dm644 com.lunday.Lunday.svg /app/share/icons/hicolor/scalable/apps/com.lunday.Lunday.svg
+      - install -Dm644 notify.wav /app/share/sounds/notify.wav
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/11c2a3021fba3138f87ea474415c30d02eeff445/assets/lunday.py
+        sha256: caa0f722be5e30593ede6e90b023b1dc2b75a16168b69b2fdeb39a28205e915a
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/11c2a3021fba3138f87ea474415c30d02eeff445/assets/com.lunday.Lunday.desktop
+        sha256: c4877aeffb6cb580d983ebe05350274d231f880dccc79755efe8b5ddefdf32ef
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/11c2a3021fba3138f87ea474415c30d02eeff445/assets/com.lunday.Lunday.metainfo.xml
+        sha256: ed141cf8d242e78760a477d444281aa9a717acbc0d415da4d922c956a0a6db76
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/11c2a3021fba3138f87ea474415c30d02eeff445/assets/com.lunday.Lunday.svg
+        sha256: d09e8843006fad7c8c3c0533936675e3f150d447ff2188167dcf31d5bf9c4efe
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/11c2a3021fba3138f87ea474415c30d02eeff445/assets/notify.wav
+        sha256: 551c9e9a322d29efb24582b7465d8c5605338bd263d5c84eb93c148cf0648d48


### PR DESCRIPTION
New app submission for com.lunday.Lunday (unofficial Monday.com desktop client for Linux).\n\nSource repo: https://github.com/ulitus/lunday\nManifest uses immutable commit-pinned source URLs and checksums.\n\nPlease let me know if any manifest adjustments are required.