### PR TITLE
Add io.github.ulitus.Lunday

### DIFF
--- a/io.github.ulitus.Lunday/flathub.json
+++ b/io.github.ulitus.Lunday/flathub.json
@@ -1,0 +1,3 @@
+{
+  "only-arches": ["x86_64", "aarch64"]
+}

--- a/io.github.ulitus.Lunday/io.github.ulitus.Lunday.yml
+++ b/io.github.ulitus.Lunday/io.github.ulitus.Lunday.yml
@@ -1,0 +1,40 @@
+app-id: io.github.ulitus.Lunday
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: lunday
+finish-args:
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.secrets
+  - --filesystem=xdg-download:rw
+modules:
+  - name: lunday
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 lunday.py /app/bin/lunday
+      - install -Dm644 io.github.ulitus.Lunday.desktop /app/share/applications/io.github.ulitus.Lunday.desktop
+      - install -Dm644 io.github.ulitus.Lunday.metainfo.xml /app/share/metainfo/io.github.ulitus.Lunday.metainfo.xml
+      - install -Dm644 io.github.ulitus.Lunday.svg /app/share/icons/hicolor/scalable/apps/io.github.ulitus.Lunday.svg
+      - install -Dm644 notify.wav /app/share/sounds/notify.wav
+    sources:
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/71a5442e8608c570f63ded2945b585c71526d263/assets/lunday.py
+        sha256: caa0f722be5e30593ede6e90b023b1dc2b75a16168b69b2fdeb39a28205e915a
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/71a5442e8608c570f63ded2945b585c71526d263/assets/io.github.ulitus.Lunday.desktop
+        sha256: 839eb2e8f1a08c7e0de61b71c9129d8fb186062e0f401d588278b7f121e10737
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/71a5442e8608c570f63ded2945b585c71526d263/assets/io.github.ulitus.Lunday.metainfo.xml
+        sha256: afbf95dfda330fd19a3e53e531e7e285e46896e72ca57aba7a1cc2de4a5f0228
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/71a5442e8608c570f63ded2945b585c71526d263/assets/io.github.ulitus.Lunday.svg
+        sha256: d09e8843006fad7c8c3c0533936675e3f150d447ff2188167dcf31d5bf9c4efe
+      - type: file
+        url: https://raw.githubusercontent.com/ulitus/lunday/71a5442e8608c570f63ded2945b585c71526d263/assets/notify.wav
+        sha256: 551c9e9a322d29efb24582b7465d8c5605338bd263d5c84eb93c148cf0648d48


### PR DESCRIPTION
## New App: Lunday

Lunday is an unofficial Linux desktop wrapper for monday.com using GTK and WebKit.

- **App ID**: `io.github.ulitus.Lunday`
- **Source**: https://github.com/ulitus/lunday
- **License**: MIT
- **Runtime**: org.gnome.Platform 50

### Checklist
- [x] Manifest uses pinned commit SHA with verified sha256 hashes
- [x] App ID follows reverse-DNS format matching source repo URL
- [x] Metainfo XML included with OARS rating
- [x] Desktop file included
- [x] Icon (SVG) included
- [x] flathub.json with arch restrictions (x86_64, aarch64)