### PR TITLE
Add com.canarybuilds.VertexWrite

### DIFF
--- a/com.canarybuilds.VertexWrite.desktop
+++ b/com.canarybuilds.VertexWrite.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=VertexWrite
+GenericName=Markdown Editor
+Comment=Markdown editor with local and SSH/SFTP file browsing
+Exec=vertexwrite %F
+Icon=com.canarybuilds.VertexWrite
+Terminal=false
+Categories=Utility;TextEditor;GTK;
+MimeType=text/markdown;text/x-markdown;
+Keywords=markdown;md;editor;notes;ssh;sftp;
+StartupNotify=true

--- a/com.canarybuilds.VertexWrite.metainfo.xml
+++ b/com.canarybuilds.VertexWrite.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.canarybuilds.VertexWrite</id>
+  <name>VertexWrite</name>
+  <summary>Markdown editor with local and SSH/SFTP file browsing</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="com.canarybuilds">
+    <name>Canary Builds</name>
+  </developer>
+  <launchable type="desktop-id">com.canarybuilds.VertexWrite.desktop</launchable>
+  <url type="homepage">https://github.com/Canary-Builds/vertexwrite</url>
+  <url type="bugtracker">https://github.com/Canary-Builds/vertexwrite/issues</url>
+  <description>
+    <p>VertexWrite is a lightweight GTK markdown editor with live preview.</p>
+    <p>It focuses on fast startup, clean reading, local and SSH/SFTP file browsing, and practical writing workflows on Linux.</p>
+    <ul>
+      <li>Live preview while editing Markdown</li>
+      <li>Syntax-highlighted editor with useful defaults</li>
+      <li>Local and remote file browsing through the sidebar</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/Canary-Builds/vertexwrite/v0.7.3/docs/screenshots/02-split-view.png</image>
+      <caption>Split editor and live preview layout</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.7.3" date="2026-05-01" />
+    <release version="0.7.2" date="2026-05-01" />
+    <release version="0.7.1" date="2026-05-01" />
+    <release version="0.7.0" date="2026-05-01" />
+    <release version="0.6.9" date="2026-05-01" />
+    <release version="0.6.8" date="2026-05-01" />
+    <release version="0.6.7" date="2026-05-01" />
+    <release version="0.6.6" date="2026-05-01" />
+    <release version="0.6.5" date="2026-05-01" />
+    <release version="0.6.4" date="2026-05-01" />
+    <release version="0.6.3" date="2026-05-01" />
+  </releases>
+</component>

--- a/com.canarybuilds.VertexWrite.yml
+++ b/com.canarybuilds.VertexWrite.yml
@@ -1,0 +1,76 @@
+app-id: com.canarybuilds.VertexWrite
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: vertexwrite
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --share=network
+  - --filesystem=home
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+modules:
+  - name: python3-vertexwrite-deps
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --ignore-installed --no-deps Markdown-3.7-py3-none-any.whl pygments-2.18.0-py3-none-any.whl html2text-2025.4.15-py3-none-any.whl paramiko-4.0.0-py3-none-any.whl bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl invoke-3.0.3-py3-none-any.whl pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl pycparser-3.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/3f/08/83871f3c50fc983b88547c196d11cf8c3340e37c32d2e9d6152abe2c61f7/Markdown-3.7-py3-none-any.whl
+        sha256: 7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
+      - type: file
+        url: https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl
+        sha256: b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a
+      - type: file
+        url: https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl
+        sha256: 00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc
+      - type: file
+        url: https://files.pythonhosted.org/packages/a9/90/a744336f5af32c433bd09af7854599682a383b37cfd78f7de263de6ad6cb/paramiko-4.0.0-py3-none-any.whl
+        sha256: 0e20e00ac666503bf0b4eda3b6d833465a2b7aff2e2b3d79a8bba5ef144ee3b9
+      - type: file
+        url: https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl
+        sha256: 611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a
+      - type: file
+        url: https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
+        sha256: 4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+      - type: file
+        url: https://files.pythonhosted.org/packages/5a/de/bbc12563bbf979618d17625a4e753ff7a078523e28d870d3626daa97261a/invoke-3.0.3-py3-none-any.whl
+        sha256: f11327165e5cbb89b2ad1d88d3292b5113332c43b8553b494da435d6ec6f5053
+      - type: file
+        url: https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl
+        sha256: c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6
+      - type: file
+        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+
+  - name: vertexwrite
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 vertexwrite.py /app/lib/vertexwrite/vertexwrite.py
+      - install -Dm644 vertexwrite_core.py /app/lib/vertexwrite/vertexwrite_core.py
+      - install -Dm644 vertexwrite_files.py /app/lib/vertexwrite/vertexwrite_files.py
+      - install -Dm755 vertexwrite-wrapper /app/bin/vertexwrite
+      - install -Dm644 style.css /app/lib/vertexwrite/style.css
+      - install -Dm644 CHANGELOG.md /app/lib/vertexwrite/CHANGELOG.md
+      - install -Dm644 icon.png /app/lib/vertexwrite/icon.png
+      - install -Dm644 com.canarybuilds.VertexWrite.desktop /app/share/applications/com.canarybuilds.VertexWrite.desktop
+      - install -Dm644 com.canarybuilds.VertexWrite.metainfo.xml /app/share/metainfo/com.canarybuilds.VertexWrite.metainfo.xml
+      - install -Dm644 icon-256.png /app/share/icons/hicolor/256x256/apps/com.canarybuilds.VertexWrite.png
+    sources:
+      - type: git
+        url: https://github.com/Canary-Builds/vertexwrite.git
+        tag: v0.7.3
+      - type: file
+        path: vertexwrite-wrapper
+      - type: file
+        path: com.canarybuilds.VertexWrite.desktop
+      - type: file
+        path: com.canarybuilds.VertexWrite.metainfo.xml

--- a/vertexwrite-wrapper
+++ b/vertexwrite-wrapper
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec python3 /app/lib/vertexwrite/vertexwrite.py "$@"


### PR DESCRIPTION
Adds VertexWrite, a GTK/WebKit markdown editor with local and SSH/SFTP file browsing.\n\nValidation performed locally:\n- appstreamcli validate --no-net com.canarybuilds.VertexWrite.metainfo.xml\n- flatpak-builder --user --force-clean --repo=repo-flatpak build-flatpak flatpak/com.canarybuilds.VertexWrite.yml\n\nRelease source is pinned to v0.7.3 and screenshot metadata is pinned to the v0.7.3 tag.