### PR TITLE
Add com.github.remotex.RemoteX

### DIFF
--- a/com.github.remotex.RemoteX.yml
+++ b/com.github.remotex.RemoteX.yml
@@ -1,0 +1,159 @@
+id: com.github.remotex.RemoteX
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: remotex
+
+finish-args:
+  # Display — prefer Wayland, fall back to X11
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  # GPU access — avoids "amdgpu_get_auth failed" / "egl: failed to create dri2 screen"
+  # and prevents GTK4 software-rendering fallback
+  - --device=dri
+  # Network — license validation and link rows (docs, purchase)
+  - --share=network
+  # Home access — RemoteX is a shell command launcher; buttons typically reference
+  # files and dirs in the user's home tree (scripts, logs, project dirs, etc.)
+  - --filesystem=home
+  # App config directory (buttons.toml, license.key, .trial, .mcp_enabled)
+  - --filesystem=~/.config/remotex:create
+  # Autostart — writes ~/.config/autostart/remotex.desktop
+  - --filesystem=~/.config/autostart:create
+  # Open URLs in system browser (docs, purchase link)
+  - --talk-name=org.freedesktop.portal.OpenURI
+  - --talk-name=org.freedesktop.portal.Desktop
+  # Background portal — register autostart entry
+  - --talk-name=org.freedesktop.portal.Background
+  # Host shell — RemoteX uses flatpak-spawn --host to run user commands on the
+  # real host shell instead of inside the sandbox. This is the core feature of
+  # the app; without it only trivial sandbox-side commands would work.
+  - --talk-name=org.freedesktop.Flatpak
+  # GSettings / dconf
+  - --metadata=X-DConf=migrate-path=/com/github/remotex/RemoteX/
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - '*.la'
+  - '*.a'
+
+modules:
+
+  # ── tomli_w — TOML config writer ─────────────────────────────────────────────
+  - name: python3-tomli-w
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps tomli_w-1.2.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
+        sha256: 188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90
+
+  # ── cairosvg + deps — Bootstrap SVG icon rendering ───────────────────────────
+  # Imported inside a try/except — app degrades gracefully if absent.
+
+  - name: python3-pycparser
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps pycparser-*.tar.gz
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz
+        sha256: 491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6
+
+  - name: python3-cffi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps --no-build-isolation cffi-*.tar.gz
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
+        sha256: 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
+
+  - name: python3-webencodings
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps webencodings-0.5.1-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
+        sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
+
+  # Pure-Python wheels — Flatpak build sandbox has no network; pip's PEP 517
+  # build isolation would try to fetch flit_core from PyPI. Prebuilt wheels avoid that.
+  - name: python3-tinycss2
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps tinycss2-1.5.1-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl
+        sha256: 3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661
+
+  - name: python3-cssselect2
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps cssselect2-0.9.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl
+        sha256: 6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563
+
+  - name: python3-defusedxml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps defusedxml-0.7.1-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl
+        sha256: a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61
+
+  - name: python3-cairocffi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps cairocffi-1.7.1-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/93/d8/ba13451aa6b745c49536e87b6bf8f629b950e84bd0e8308f7dc6883b67e2/cairocffi-1.7.1-py3-none-any.whl
+        sha256: 9803a0e11f6c962f3b0ae2ec8ba6ae45e957a146a004697a1ac1bbf16b073b3f
+
+  # Pillow — runtime dep of cairosvg 2.9+ for raster image handling.
+  - name: python3-pillow
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps pillow-*.whl
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: 03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987
+
+  - name: python3-cairosvg
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps cairosvg-2.9.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/bf/e0/5011747466414c12cac8a8df77aa235068669a6a5a5df301a96209db6054/cairosvg-2.9.0-py3-none-any.whl
+        sha256: 4b82d07d145377dffdfc19d9791bd5fb65539bb4da0adecf0bdbd9cd4ffd7c68
+
+  # ── RemoteX application ───────────────────────────────────────────────────────
+
+  - name: remotex
+    buildsystem: meson
+    config-opts:
+      - -Dpro=false
+    post-install:
+      - glib-compile-schemas /app/share/glib-2.0/schemas
+    sources:
+      - type: git
+        url: https://github.com/neurocontrarian/remotex.git
+        tag: v1.7.0
+        commit: 5be8cc7f57ec779957fd70618c396791f92ea6e5


### PR DESCRIPTION
## App information

**Name:** RemoteX  
**App ID:** `com.github.remotex.RemoteX`  
**License:** MIT  
**Homepage:** https://neurocontrarian.github.io/remotex  
**Source:** https://github.com/neurocontrarian/remotex (tag `v1.7.0`)

## Description

RemoteX is a visual button grid (Stream Deck-style) for launching local shell commands and SSH commands on remote servers — without a terminal. Users create labeled buttons, click to run, see output in a dialog. Targets beginner to intermediate Linux users who want to avoid repetitive terminal work.

The Flatpak build ships the **free tier** (local command execution, up to 3 custom buttons, default Linux Essentials + Development commands, 11 UI languages). Pro features (SSH machines, unlimited buttons, MCP/AI integration) are distributed separately.

## Permission justification

### `--talk-name=org.freedesktop.Flatpak`
RemoteX's core feature is running arbitrary shell commands on the **host system**, not inside the sandbox. Without `flatpak-spawn --host`, commands would execute inside the Flatpak runtime with no access to the user's tools, PATH, or home directory — making the app useless. This permission is used exclusively to dispatch user-configured commands to the host shell.

### `--filesystem=home`
The button grid allows users to reference files and directories in their home tree (scripts, logs, project directories). Many default commands — disk usage, file search, log viewers — also operate on `~`. Read/write access to the home directory is part of the app's core value proposition.

### `--filesystem=~/.config/autostart:create`
Writes `~/.config/autostart/remotex.desktop` when the user enables "Launch at login" in Preferences.

## Build notes

- Runtime: GNOME 47
- Python dependencies bundled as wheels (no network needed at build time)
- `cairosvg` + `Pillow` for Bootstrap SVG icon rendering (graceful fallback if absent)
- `tomli_w` for TOML config writes (`tomllib` read support is in stdlib since Python 3.11)
- All dependency wheels pinned with sha256 checksums