### PR TITLE
Add io.github.turutupa.yames

### DIFF
--- a/io.github.turutupa.yames.yml
+++ b/io.github.turutupa.yames.yml
@@ -1,0 +1,32 @@
+app-id: io.github.turutupa.yames
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: yames
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+modules:
+  - name: yames
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 yames -t /app/bin/
+      - install -Dm644 yames.desktop -t /app/share/applications/
+      - install -Dm644 icon-128.png /app/share/icons/hicolor/128x128/apps/io.github.turutupa.yames.png
+      - install -Dm644 icon-256.png /app/share/icons/hicolor/256x256/apps/io.github.turutupa.yames.png
+    sources:
+      - type: file
+        url: https://github.com/turutupa/yames/releases/download/v0.4.1/yames_0.4.1_amd64.deb
+        sha256: cbef85a97ebac9132a3c31ccee0f39e20973973564cf35a271f4df953e9c91c2
+        dest-filename: yames.deb
+      - type: shell
+        commands:
+          - ar x yames.deb
+          - tar xf data.tar.*
+          - mv usr/bin/yames yames
+          - mv usr/share/applications/yames.desktop yames.desktop || true
+          - mv usr/share/icons/hicolor/128x128/apps/*.png icon-128.png || true
+          - mv usr/share/icons/hicolor/256x256/apps/*.png icon-256.png || true


### PR DESCRIPTION
## New app submission: Yames  - App ID: io.github.turutupa.yames - Homepage: https://turutupa.github.io/yames/ - Source: https://github.com/turutupa/yames  ### Description  Yames (Yet Another Metronome Everyone Skips) is a free, open-source desktop metronome for musicians. Features include:  - Always-on-top floating widget - Sub-millisecond audio precision - Zen mode with immersive visuals - Drill practice mode with auto-BPM increment - Tap tempo - 10 beautiful themes  Built with Rust + Tauri v2.  ### License  MIT  ### Categories  Audio, Music