### PR TITLE
Add com.buxjr.box

### DIFF
--- a/com.buxjr.box.yaml
+++ b/com.buxjr.box.yaml
@@ -1,0 +1,62 @@
+app-id: com.buxjr.box
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: box
+
+separate-locales: false
+
+finish-args:
+  # Display
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # Network — IMAP, SMTP, OAuth2
+  - --share=network
+
+  # Audio — send/receive notification sounds
+  - --socket=pulseaudio
+
+  # Filesystem — broad access for arbitrary attachment paths
+  - --filesystem=home
+  - --persist=.config/Box
+
+  # Host's /usr read-only — needed so the sandbox can see the user's system
+  # cursor theme at /run/host/usr/share/icons (Yaru on Ubuntu, Adwaita on
+  # Fedora, Breeze on KDE, etc.). Flatpak refuses to mount /usr/share/icons
+  # directly ("Path /usr is reserved") and the freedesktop runtime ships
+  # zero cursor themes, so without this Chromium has nothing to draw from.
+  - --filesystem=host-os:ro
+
+  # D-Bus
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # Electron sandbox helper needs writable tmp
+  - --env=TMPDIR=/var/tmp
+
+modules:
+  - name: box
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 packaging/apply_extra.sh /app/bin/apply_extra
+      - install -Dm755 packaging/box.sh /app/bin/box
+      - install -Dm644 packaging/com.buxjr.box.desktop /app/share/applications/com.buxjr.box.desktop
+      - install -Dm644 packaging/com.buxjr.box.metainfo.xml /app/share/metainfo/com.buxjr.box.metainfo.xml
+      - install -Dm644 packaging/icon.png /app/share/icons/hicolor/512x512/apps/com.buxjr.box.png
+    sources:
+      - type: extra-data
+        url: https://github.com/buxjr311/box-app/releases/download/v1.1.170/box_1.1.170_x64.tar.gz
+        sha256: 4572ababb25c28c4189e40c8f2add80f47298842b7c5d14b734197d7104a887a
+        size: 126404160
+        filename: box.tar.gz
+      - type: archive
+        url: https://github.com/buxjr311/box-app/releases/download/v1.1.170/box_1.1.170_packaging.tar.gz
+        sha256: 92500306a620c9998c992b588d75ee8a2a85ffb0324992df2b0cbccb8b2fd38a
+        strip-components: 0
+        dest: packaging


### PR DESCRIPTION
## Box — desktop email client for Linux

Box is a desktop email client built specifically for Linux, with privacy-first architecture: direct IMAP/SMTP, OS-keyring credentials (libsecret), local SQLite, zero telemetry. Smart email rendering with per-message dark mode, contrast auditing, and tracking-pixel neutralization.

- **Homepage:** https://box.buxjr.com
- **Source / issue tracker:** https://github.com/buxjr311/box-app
- **License:** Proprietary (free for one account, $10 one-time for unlimited). See https://box.buxjr.com/eula
- **Upstream contact:** box@buxjr.com (also the maintainer of this submission)

### Packaging notes for reviewers

- **Two-tarball release pair.** Box ships closed-source binaries; per Flathub's proprietary-app guidance the binary is fetched at install time via `extra-data` from the upstream's GitHub Release. Packaging assets (`apply_extra.sh`, `box.sh`, `.desktop`, metainfo, icon) are shipped in a separate flat tarball alongside the binary in the same Release, fetched at build time via `type: archive`. Both content-addressed by sha256.
- **`apply_extra.sh`** strips `chrome-sandbox` (suid wrapper that can't run inside the Flatpak sandbox); `box.sh` launches with `--no-sandbox` — same approach as Flathub's existing Electron-based proprietary apps (Slack, Discord, Bitwarden, etc.).
- **`org.electronjs.Electron2.BaseApp//24.08`** as base, per Flathub's [Electron packaging guide](https://docs.flathub.org/docs/for-app-authors/requirements#electron-apps).

### Permissions justification — exception requests

The linter flags two permissions as needing exceptions; both are essential to this app and follow established precedent:

| Permission | Justification |
|---|---|
| `--filesystem=home` | Email clients need broad attachment access for arbitrary user files. `~/Projects/contract.pdf`, `~/work/`, `~/Downloads/` — narrowing to `xdg-*` portals would break all of these. Same precedent as `org.mozilla.Thunderbird`, `org.gnome.Evolution`, `org.gnome.Geary`. |
| `--filesystem=host-os:ro` | Cursor-theme bridging. The `org.freedesktop.Platform//24.08` runtime ships zero cursor themes (`hicolor` only, no cursor data), and Flatpak refuses `/usr/share/icons` mounts (`/usr` is reserved). `host-os:ro` exposes host's `/usr` read-only at `/run/host/usr/` so Box can find Yaru on Ubuntu, Adwaita on Fedora, Breeze on KDE, etc. without bundling 50+ MB of cursor data. `flatpak/box.sh` reads `XCURSOR_PATH` / `XCURSOR_THEME` / `XCURSOR_SIZE` from the host's `gsettings` accordingly. |

Other permissions:

| Permission | Why |
|---|---|
| `--share=network` | IMAP/SMTP/OAuth2 — fundamental to an email client |
| `--persist=.config/Box` | SQLite database, cached message bodies, settings |
| `--socket=pulseaudio` | New-mail and send-confirmation sounds |
| `--talk-name=org.freedesktop.secrets` | Email account credentials in OS keyring |
| `--talk-name=org.freedesktop.Notifications` | Desktop notifications for new mail |
| `--talk-name=org.kde.StatusNotifierWatcher` | Cross-DE compatibility (Box has no tray, but the talk-name is harmless and matches the Electron BaseApp default set) |

### Verification checklist

- [x] AppStream metainfo validates with `appstreamcli validate --strict`
- [x] Manifest passes `flatpak-builder-lint manifest` (only the two exception-eligible filesystem errors remain)
- [x] Built repo passes `flatpak-builder-lint repo` (same two errors plus the expected `appstream-external-screenshot-url` / `appstream-screenshots-not-mirrored-in-ostree` artifacts that resolve automatically once Flathub's buildbot mirrors screenshots)
- [x] Local build with this exact manifest installs and runs successfully (Wayland + X11) — verified against the v1.1.170 binary tarball pulled from GitHub Releases
- [x] All four screenshot URLs return HTTP 200
- [x] OARS content rating present
- [x] `<release version="1.1.170" date="2026-05-05">` present in metainfo

Happy to address any review feedback — thanks for considering Box for Flathub!