### PR TITLE
Add io.github.Rockykln.Refrain

### DIFF
--- a/io.github.Rockykln.Refrain.desktop
+++ b/io.github.Rockykln.Refrain.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Type=Application
+Name=Refrain
+GenericName=Apple Music Discord RPC
+GenericName[de_DE]=Apple Music Discord-Status
+Comment=Discord Rich Presence for Apple Music
+Comment[de_DE]=Discord-Status für Apple Music
+Exec=refrain
+Icon=io.github.Rockykln.Refrain
+Terminal=false
+Categories=Audio;Music;Network;
+Keywords=apple;music;discord;rpc;rich;presence;
+StartupNotify=true
+StartupWMClass=io.github.Rockykln.Refrain

--- a/io.github.Rockykln.Refrain.metainfo.xml
+++ b/io.github.Rockykln.Refrain.metainfo.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.Rockykln.Refrain</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-RefrainUseOnly</project_license>
+
+  <name>Refrain</name>
+  <summary>Discord Rich Presence for Apple Music on Linux</summary>
+
+  <description>
+    <p>
+      Refrain shows what you are listening to on Apple Music as your Discord
+      status — whether the audio is playing in your browser
+      (music.apple.com) or streaming from your iPhone over Bluetooth.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Reads playback metadata from MPRIS (Apple Music in any major Linux browser)</li>
+      <li>Reads playback metadata from BlueZ AVRCP (any AVRCP-capable Bluetooth source)</li>
+      <li>Forwards track info plus iTunes-resolved cover art to Discord</li>
+      <li>System-tray icon with Play / Pause / Next / Previous controls</li>
+      <li>Settings window for sources, privacy mode, autostart and Bluetooth device picker</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">io.github.Rockykln.Refrain.desktop</launchable>
+
+  <url type="homepage">https://github.com/Rockykln/refrain</url>
+  <url type="bugtracker">https://github.com/Rockykln/refrain/issues</url>
+  <url type="vcs-browser">https://github.com/Rockykln/refrain</url>
+
+  <developer id="io.github.Rockykln">
+    <name>Rockykln</name>
+  </developer>
+
+  <categories>
+    <category>Audio</category>
+    <category>Music</category>
+    <category>Network</category>
+  </categories>
+
+  <keywords>
+    <keyword>apple music</keyword>
+    <keyword>discord</keyword>
+    <keyword>rich presence</keyword>
+    <keyword>rpc</keyword>
+    <keyword>mpris</keyword>
+    <keyword>bluetooth</keyword>
+  </keywords>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.1.4" date="2026-05-06">
+      <description>
+        <p>
+          Same-day follow-up to v0.1.3 fixing the two issues v0.1.3
+          shipped with: AppImage filename was rendered as
+          "Refrain-.version.-x86_64.AppImage" because of a broken
+          {version} placeholder, and the AppImage icon wasn't bundled
+          because the icon_bundler walks XDG icon paths but the recipe
+          used files.include. Both fixed. Plus AUR refrain and
+          refrain-git are now live, and the Flatpak manifest is
+          validated locally end-to-end against KDE 6.10 + the PySide
+          BaseApp.
+        </p>
+      </description>
+    </release>
+    <release version="0.1.3" date="2026-05-06">
+      <description>
+        <p>
+          Start-on-Login now works for venv / pipx / pip --user installs
+          (the autostart .desktop no longer assumes `refrain` is on $PATH
+          at session-startup time). The noisy Qt XDG-portal warning is
+          suppressed in the live log. PyPI publishing is wired into the
+          release workflow via Trusted Publishers, so installs via
+          `pip install refrain` now Just Work.
+        </p>
+      </description>
+    </release>
+    <release version="0.1.2" date="2026-05-05">
+      <description>
+        <p>
+          More production-readiness: empty Discord client_id no longer
+          spams reconnect attempts, the cover-art toggle is now actually
+          honored by the desktop notification, AppImage restart uses
+          $APPIMAGE explicitly, the AppImage build recipe was fixed,
+          and the tray menu shows a Discord connection indicator.
+          Reset-to-defaults and Open-log-folder buttons added to
+          Settings → Advanced.
+        </p>
+      </description>
+    </release>
+    <release version="0.1.1" date="2026-05-05">
+      <description>
+        <p>
+          Reliability fixes for desktop notifications, in-app Restart
+          (tray + Settings), CodeQL false-positive suppressions, and
+          minor dead-code cleanup.
+        </p>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-05-05">
+      <description>
+        <p>Initial public release.</p>
+      </description>
+    </release>
+  </releases>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">560</display_length>
+  </requires>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#FFB347</color>
+    <color type="primary" scheme_preference="dark">#E85D04</color>
+  </branding>
+</component>

--- a/io.github.Rockykln.Refrain.yaml
+++ b/io.github.Rockykln.Refrain.yaml
@@ -1,0 +1,94 @@
+# Flatpak manifest for Refrain — Flathub submission target.
+#
+# Local build / test:
+#   flatpak install -y flathub org.kde.Platform//6.10 org.kde.Sdk//6.10
+#   flatpak-builder --user --install --force-clean build-dir io.github.Rockykln.Refrain.yaml
+#   flatpak run io.github.Rockykln.Refrain
+#
+# Refresh the bundled Python deps when pinning a new release:
+#   cd packaging/flatpak
+#   flatpak-pip-generator --runtime org.kde.Sdk//6.10 \
+#       --requirements-file=../../requirements.txt -o python-deps
+#   git add python-deps.json
+#
+# When bumping `tag:` below, also bump the matching <release/> entry in
+# io.github.Rockykln.Refrain.metainfo.xml — Flathub's CI fails the build
+# without it.
+
+id: io.github.Rockykln.Refrain
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+# PySide6 is huge and Flathub-policy says use the official BaseApp instead
+# of vendoring it as a Python wheel. The BaseApp's branch must match the
+# runtime branch (6.10 → 6.10). Cleanup= drops headers / pyc files we
+# inherit from the BaseApp but don't need at runtime.
+base: io.qt.PySide.BaseApp
+base-version: '6.10'
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+command: refrain
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Network for the iTunes Search cover-art lookup + Discord IPC fallback
+  - --share=network
+  # Bluetooth metadata via the system bus
+  - --system-talk-name=org.bluez
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+  # MPRIS metadata from any media player on the session bus
+  - --talk-name=org.mpris.MediaPlayer2.*
+  # Discord IPC sockets (Discord may use any of 0..9)
+  - --filesystem=xdg-run/discord-ipc-0
+  - --filesystem=xdg-run/discord-ipc-1
+  - --filesystem=xdg-run/discord-ipc-2
+  - --filesystem=xdg-run/discord-ipc-3
+  - --filesystem=xdg-run/discord-ipc-4
+  - --filesystem=xdg-run/discord-ipc-5
+  - --filesystem=xdg-run/discord-ipc-6
+  - --filesystem=xdg-run/discord-ipc-7
+  - --filesystem=xdg-run/discord-ipc-8
+  - --filesystem=xdg-run/discord-ipc-9
+  # XDG-style config / state / cache
+  - --filesystem=xdg-config/refrain:create
+  - --filesystem=xdg-cache/refrain:create
+  - --filesystem=xdg-data/refrain:create
+
+modules:
+  # patchelf is a build-time dependency of meson-python (the PEP 517 backend
+  # used by dbus-python). The KDE SDK doesn't ship it, so we build it once
+  # here and clean it up before the final image.
+  - name: patchelf
+    buildsystem: autotools
+    cleanup:
+      - '*'
+    sources:
+      - type: archive
+        url: https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0.tar.gz
+        sha256: 64de10e4c6b8b8379db7e87f58030f336ea747c0515f381132e810dbf84a86e7
+
+  # Python deps that aren't part of the KDE Platform runtime, vendored as
+  # individual file: sources because Flathub builds run offline. Regenerate
+  # via the flatpak-pip-generator command in the header comment.
+  - python-deps.json
+
+  - name: refrain
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=${FLATPAK_DEST} --no-deps --no-build-isolation .
+      - install -Dm644 packaging/flatpak/io.github.Rockykln.Refrain.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.Rockykln.Refrain.desktop
+      - install -Dm644 src/refrain/assets/icons/refrain.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.Rockykln.Refrain.svg
+      - install -Dm644 packaging/flatpak/io.github.Rockykln.Refrain.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.Rockykln.Refrain.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/Rockykln/refrain.git
+        tag: v0.1.4
+        commit: cd8665333ce223d875bd6cd1cc7be91ea1cea779

--- a/python-deps.json
+++ b/python-deps.json
@@ -1,0 +1,83 @@
+{
+    "name": "python-deps",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-meson-python",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/16/7f/d1b0c65b267a1463d752b324f11d3470e30889daefc4b9ec83029bfa30b5/meson_python-0.19.0-py3-none-any.whl",
+                    "sha256": "67b5906c37404396d23c195e12c8825506074460d4a2e7083266b845d14f0298"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1d/0b/da4851b1e2d9c40c9bd74c0abd94510a7d797da9ccde0a90e8953751ed4a/pyproject_metadata-0.11.0-py3-none-any.whl",
+                    "sha256": "85bbecca8694e2c00f63b492c96921d6c228454057c88e7c352b2077fcaa4096"
+                }
+            ]
+        },
+        {
+            "name": "python3-hatchling",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"hatchling\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl",
+                    "sha256": "50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl",
+                    "sha256": "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl",
+                    "sha256": "e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d6/bb/fbdc4e57731efb86b4209ffdd2519520782bf27b3c961beac3e5c20d2b87/trove_classifiers-2026.4.28.13-py3-none-any.whl",
+                    "sha256": "8f4b1eb4e16296b57d612965444f87a83861cc989a0451ac97fe4265ddef03b8"
+                }
+            ]
+        },
+        {
+            "name": "python3-pypresence",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pypresence>=4.3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/bd/0d/1c817c6769ce0b64cc0dcc20bc9d0edb4dc560e83a3b5f0d5cbda04c3d35/pypresence-4.6.1-py3-none-any.whl",
+                    "sha256": "33d4549fcdf4102f81935df4ba587bacb22193e0c50c541d1ab9329b21df33cd"
+                }
+            ]
+        },
+        {
+            "name": "python3-dbus-python",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python>=1.3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ff/24/63118050c7dd7be04b1ccd60eab53fef00abe844442e1b6dec92dae505d6/dbus-python-1.4.0.tar.gz",
+                    "sha256": "991666e498f60dbf3e49b8b7678f5559b8a65034fdf61aae62cdecdb7d89c770"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## App ID
io.github.Rockykln.Refrain

## App URL
https://github.com/Rockykln/refrain

## Screenshots
https://github.com/Rockykln/refrain/tree/main/docs/screenshots

## License
Refrain License (Use-Only) — source-available, redistribution of unmodified
binaries permitted; modifications + derivatives may not be redistributed.
Bundled deps (PySide6, pypresence, dbus-python) keep their LGPL/MIT licenses.
The bundled `org.flatpak.Builder` runtime + Qt are LGPL.

## Manifest tested locally
Built and ran successfully via `flatpak-builder` against
`org.kde.Platform//6.10` + `io.qt.PySide.BaseApp//6.10`. Verified
`flatpak run io.github.Rockykln.Refrain --version` returns
`refrain 0.1.4`.

## Notes for reviewers

- **PySide6** comes from `io.qt.PySide.BaseApp//6.10` (Flathub policy
  for Qt-for-Python apps); not vendored as a wheel.
- **patchelf 0.18.0** is built inline from a tarball because the KDE
  SDK doesn't ship it and `meson-python` (build backend for
  `dbus-python`) needs it during `dbus-python`'s build.
- **Python deps** (`meson-python`, `hatchling`, `pypresence`,
  `dbus-python`) are vendored in `python-deps.json` via
  `flatpak-pip-generator --runtime org.kde.Sdk//6.10` so the offline
  build resolves every transitive dep.
- **finish-args** are intentionally narrow: session bus access only
  for MPRIS players (`org.mpris.MediaPlayer2.*`) and notifications
  (`org.freedesktop.Notifications`), system bus only for BlueZ
  (`org.bluez`), Discord IPC sockets via `xdg-run/discord-ipc-N`,
  network for the iTunes Search cover-art lookup.

## Maintainer
Rockykln (also the upstream author of Refrain).