### PR TITLE
Add io.github.podheitor.bigbox

### DIFF
--- a/io.github.podheitor.bigbox.desktop
+++ b/io.github.podheitor.bigbox.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=BigBox
+GenericName=Messaging Hub
+Comment=All your messaging apps in one blazing-fast window
+Comment[pt_BR]=Todos os seus apps de mensagens em uma janela rápida
+Exec=bigbox
+Icon=io.github.podheitor.bigbox
+Terminal=false
+Categories=Network;InstantMessaging;Chat;
+Keywords=whatsapp;telegram;gmail;slack;discord;messaging;chat;
+StartupWMClass=BigBox
+StartupNotify=true

--- a/io.github.podheitor.bigbox.metainfo.xml
+++ b/io.github.podheitor.bigbox.metainfo.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.podheitor.bigbox</id>
+  <launchable type="desktop-id">io.github.podheitor.bigbox.desktop</launchable>
+  <name>BigBox</name>
+  <summary>All your messaging apps in one window</summary>
+  <summary xml:lang="pt_BR">Todos os apps de mensagens em uma janela</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <developer id="io.github.podheitor">
+    <name>Heitor Faria</name>
+  </developer>
+
+  <description>
+    <p>
+      BigBox is a lightweight, native alternative to Rambox, Franz, and Ferdi.
+      It packs WhatsApp, Telegram, Gmail, Slack, Discord, and other web-based
+      messaging services into a single window with isolated sessions per
+      service, real-time unread badges, and Wayland-native rendering.
+    </p>
+    <p xml:lang="pt_BR">
+      BigBox é uma alternativa leve e nativa para Rambox, Franz e Ferdi.
+      Reúne WhatsApp, Telegram, Gmail, Slack, Discord e outros serviços de
+      mensagens web em uma única janela, com sessões isoladas por serviço,
+      badges de não lidos em tempo real e renderização Wayland nativa.
+    </p>
+    <p>Highlights:</p>
+    <ul>
+      <li>Built on Tauri v2 + Rust + WebKitGTK — under 150 MB RAM idle</li>
+      <li>Isolated cookies and storage per service</li>
+      <li>Real-time unread notification counters</li>
+      <li>Smart preload for instant service switching</li>
+      <li>Drag-and-drop sidebar reordering</li>
+      <li>Per-service zoom (Ctrl+wheel, Ctrl++/-/0)</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/podheitor/BigBox</url>
+  <url type="bugtracker">https://github.com/podheitor/BigBox/issues</url>
+  <url type="vcs-browser">https://github.com/podheitor/BigBox</url>
+
+  <categories>
+    <category>Network</category>
+    <category>InstantMessaging</category>
+    <category>Chat</category>
+  </categories>
+
+  <keywords>
+    <keyword>whatsapp</keyword>
+    <keyword>telegram</keyword>
+    <keyword>gmail</keyword>
+    <keyword>slack</keyword>
+    <keyword>discord</keyword>
+    <keyword>messaging</keyword>
+  </keywords>
+
+  <content_rating type="oars-1.1" />
+
+  <branding>
+    <color type="primary" scheme_preference="light">#4a8cff</color>
+    <color type="primary" scheme_preference="dark">#1d3a6e</color>
+  </branding>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/podheitor/BigBox/main/flatpak/screenshots/01-overview.png</image>
+      <caption>BigBox showing multiple messaging services side-by-side</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/podheitor/BigBox/main/flatpak/screenshots/02-whatsapp.png</image>
+      <caption>WhatsApp Web with native unread badge</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/podheitor/BigBox/main/flatpak/screenshots/03-sidebar.png</image>
+      <caption>Multi-service sidebar with drag-and-drop reordering</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/podheitor/BigBox/main/flatpak/screenshots/04-zoom.png</image>
+      <caption>Per-service zoom and isolated session storage</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.1.1" date="2026-05-08">
+      <description>
+        <p>WhatsApp and Telegram videos now play with audio on WebKitGTK.</p>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-04-16">
+      <description>
+        <p>Initial public release.</p>
+      </description>
+    </release>
+  </releases>
+
+  <provides>
+    <binary>bigbox</binary>
+  </provides>
+</component>

--- a/io.github.podheitor.bigbox.yaml
+++ b/io.github.podheitor.bigbox.yaml
@@ -1,0 +1,68 @@
+app-id: io.github.podheitor.bigbox
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node20
+command: bigbox
+
+finish-args:
+  # Network: required for messaging services and Service Worker fetches.
+  - --share=network
+  - --share=ipc
+  # Display: Wayland preferred, X11 fallback for legacy compositors.
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU access for WebKit hardware-accelerated video decoding.
+  - --device=dri
+  # Audio: PipeWire (Pulse fallback handled automatically by xdg-portal).
+  - --socket=pulseaudio
+  # Notifications, file chooser, screen sharing portals.
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.portal.Notification
+  # Persistent per-service WebKit data: cookies, localStorage, IndexedDB.
+  - --persist=.local/share/io.github.podheitor.bigbox
+  # Downloads land in the user's Downloads folder.
+  - --filesystem=xdg-download:rw
+
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node20/bin
+  build-args:
+    # Cargo + npm need network for first build inside the sandbox.
+    # Once vendored (see x-vendor below), remove this for offline builds.
+    - --share=network
+  env:
+    CARGO_HOME: /run/build/bigbox/cargo
+    RUST_BACKTRACE: '1'
+
+modules:
+  - name: bigbox
+    buildsystem: simple
+    build-commands:
+      - cargo build --release --manifest-path src-tauri/Cargo.toml
+      # Strip + install binary
+      - install -Dm755 src-tauri/target/release/bigbox /app/bin/bigbox
+      # Desktop entry (uses Flathub-required app-id name)
+      - install -Dm644 flatpak/io.github.podheitor.bigbox.desktop /app/share/applications/io.github.podheitor.bigbox.desktop
+      # Metainfo
+      - install -Dm644 flatpak/io.github.podheitor.bigbox.metainfo.xml /app/share/metainfo/io.github.podheitor.bigbox.metainfo.xml
+      # Icon — install all sizes provided in the repo
+      - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/io.github.podheitor.bigbox.png
+      - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/io.github.podheitor.bigbox.png
+      - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/io.github.podheitor.bigbox.png
+      - install -Dm644 frontend/bigbox.svg /app/share/icons/hicolor/scalable/apps/io.github.podheitor.bigbox.svg
+    sources:
+      - type: git
+        url: https://github.com/podheitor/BigBox.git
+        # x-checker-data lets flathub-bot track upstream releases automatically:
+        # whenever a new v* tag appears on GitHub, it opens a PR bumping `tag`
+        # and `commit` here. See https://github.com/flathub/flatpak-external-data-checker
+        x-checker-data:
+          type: anitya
+          project-id: 0  # TODO: register at release-monitoring.org and replace
+          stable-only: true
+          url-template: https://github.com/podheitor/BigBox/archive/refs/tags/v$version.tar.gz
+        tag: v0.1.1
+        commit: 17387c4c2dc09490185246b87bb76d9ca0725eba


### PR DESCRIPTION
## BigBox

Lightweight, native multi-service messaging hub built on Tauri v2 + Rust + WebKitGTK. Combines WhatsApp, Telegram, Gmail, Slack, Discord, and other web-based messaging services into a single window with isolated sessions per service, real-time unread badges, and Wayland-native rendering.

- Upstream: https://github.com/podheitor/BigBox
- License: GPL-3.0-or-later
- Latest tag: v0.1.1

### Verification of ownership

The reverse-DNS app-id `io.github.podheitor.bigbox` is derived from the GitHub user namespace `podheitor`, which I control (and from which this PR is being opened). All upstream code, releases, and screenshots referenced in the metainfo live under that namespace.

### Build notes

- Runtime: `org.gnome.Platform//46`
- SDK extensions: `rust-stable` and `node20`
- Source is a git tag pin (`v0.1.1` @ `17387c4c2dc09490185246b87bb76d9ca0725eba`)
- `x-checker-data` set to `anitya` with placeholder `project-id: 0`; will be updated once the project is registered at release-monitoring.org

Happy to address review feedback.