### PR TITLE
Add io.kinvolk.Headlamp.Tools.oci

### DIFF
--- a/io.kinvolk.Headlamp.Tools.oci.metainfo.xml
+++ b/io.kinvolk.Headlamp.Tools.oci.metainfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.kinvolk.Headlamp.Tools.oci</id>
+  <extends>io.kinvolk.Headlamp</extends>
+  <name>OCI CLI for Headlamp</name>
+  <summary>Oracle Cloud Infrastructure CLI for authenticating to OKE clusters</summary>
+  <description>
+    <p>
+      Ships the Oracle Cloud Infrastructure (OCI) command-line interface inside
+      the Headlamp sandbox at /app/tools/oci. Headlamp uses it to run the
+      "oci ce cluster generate-token" exec-credential plugin required to
+      authenticate to Oracle Kubernetes Engine (OKE) clusters.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/oracle/oci-cli</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0 OR UPL-1.0</project_license>
+</component>

--- a/io.kinvolk.Headlamp.Tools.oci.yaml
+++ b/io.kinvolk.Headlamp.Tools.oci.yaml
@@ -5,7 +5,6 @@ runtime-version: stable
 sdk: org.freedesktop.Sdk//25.08
 build-extension: true
 separate-locales: false
-appstream-compose: false
 build-options:
   prefix: /app/tools/oci
   env:
@@ -13,3 +12,10 @@ build-options:
     PYTHONPATH: /app/tools/oci/lib/python3.13/site-packages
 modules:
   - python3-oci-cli.yaml
+  - name: metainfo
+    buildsystem: simple
+    sources:
+      - type: file
+        path: io.kinvolk.Headlamp.Tools.oci.metainfo.xml
+    build-commands:
+      - install -Dm644 io.kinvolk.Headlamp.Tools.oci.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.kinvolk.Headlamp.Tools.oci.metainfo.xml

--- a/io.kinvolk.Headlamp.Tools.oci.yaml
+++ b/io.kinvolk.Headlamp.Tools.oci.yaml
@@ -1,0 +1,15 @@
+id: io.kinvolk.Headlamp.Tools.oci
+branch: stable
+runtime: io.kinvolk.Headlamp
+runtime-version: stable
+sdk: org.freedesktop.Sdk//25.08
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+  prefix: /app/tools/oci
+  env:
+    PATH: /app/tools/oci/bin:/app/bin:/usr/bin
+    PYTHONPATH: /app/tools/oci/lib/python3.13/site-packages
+modules:
+  - python3-oci-cli.yaml

--- a/python3-oci-cli.yaml
+++ b/python3-oci-cli.yaml
@@ -1,0 +1,88 @@
+# Generated with flatpak-pip-generator oci-cli -o python3-oci-cli --yaml --prefer-wheels cryptography,cffi,pyyaml --runtime org.freedesktop.Sdk//25.08
+name: python3-oci-cli
+buildsystem: simple
+build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "oci-cli" --no-build-isolation
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    sha256: 70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+    sha256: 0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
+    sha256: 749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205
+  - type: file
+    url: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
+    sha256: 97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b
+  - type: file
+    url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+    sha256: d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
+    sha256: 87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1
+  - type: file
+    url: https://files.pythonhosted.org/packages/4a/a8/0b2ced25639fb20cc1c9784de90a8c25f9504a7f18cd8b5397bd61696d7d/click-8.0.4-py3-none-any.whl
+    sha256: 6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1
+  - type: file
+    url: https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sha256: 5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+    sha256: b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
+    sha256: 02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980
+  - type: file
+    url: https://files.pythonhosted.org/packages/f8/35/ddbc4bec5f0eca26e334afc3f37a39ce52018c28732c6b8b0f5cbe2e7c5e/oci-2.173.0-py3-none-any.whl
+    sha256: b50fe600d460c2643fc38e94a359e5d84c6411e6e111fa133485bdf1883a9628
+  - type: file
+    url: https://files.pythonhosted.org/packages/45/08/82a1f3e6a07f55519223f0eaee5dbb683856c2115de85bc24ac4666563f9/oci_cli-3.81.1-py3-none-any.whl
+    sha256: 2afe34eda2874041c8c2ba81a2d36550c1cb791509b0ad7131f43a0e8101a61a
+  - type: file
+    url: https://files.pythonhosted.org/packages/ee/fd/ca7bf3869e7caa7a037e23078539467b433a4e01eebd93f77180ab927766/prompt_toolkit-3.0.43-py3-none-any.whl
+    sha256: a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6
+  - type: file
+    url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+    sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+  - type: file
+    url: https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl
+    sha256: 4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70
+  - type: file
+    url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+    sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+  - type: file
+    url: https://files.pythonhosted.org/packages/11/c3/005fcca25ce078d2cc29fd559379817424e94885510568bc1bc53d7d5846/pytz-2024.2-py2.py3-none-any.whl
+    sha256: 31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725
+  - type: file
+    url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+    sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+  - type: file
+    url: https://files.pythonhosted.org/packages/c4/fb/ea621e0a19733e01fe4005d46087d383693c0f4a8f824b47d8d4122c87e0/terminaltables-3.1.10-py2.py3-none-any.whl
+    sha256: e4fdc4179c9e4aab5f674d80f09d76fa436b96fdc698a8505e0a36bf0804a874
+  - type: file
+    url: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
+    sha256: bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+    sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+  - type: file
+    url: https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl
+    sha256: 5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly. Oracle OCI CLI extension for Headlamp Kubernetes IDE. Provides the `oci` command-line tool as an optional extension, enabling Oracle Cloud Infrastructure connectivity from within Headlamp.
**Note:** This extension depends on https://github.com/flathub/io.kinvolk.Headlamp/pull/70 being merged first (adds the `io.kinvolk.Headlamp.Tools` extension point).
- [x] Please attach a video showcasing the application on Linux using the Flatpak. N/A - this is a CLI extension, not a graphical application. See https://github.com/flathub/flathub/pull/2290
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
* [x] I am a third-party packager. I contacted upstream developers about this submission. **Link:** https://github.com/flathub/io.kinvolk.Headlamp/pull/70#issuecomment-4397336318

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission