### PR TITLE
Add net.shrieker.capsicum

### DIFF
--- a/net.shrieker.capsicum.yml
+++ b/net.shrieker.capsicum.yml
@@ -1,0 +1,96 @@
+# capsicum Flathub submission manifest (v1.24.0 initial submission)
+#
+# Derived from packaging/linux/flathub/net.shrieker.capsicum.yml
+# (local development manifest) per packaging/linux/flathub/SUBMISSION.md.
+#
+# Source layout:
+# - capsicum bundle: GitHub Releases tarball (v1.24.0 tag asset)
+# - desktop / icons: capsicum repo at v1.24.0 tag
+# - metainfo: capsicum repo at commit 72d54060 (Phase 5b screenshots /
+#   release date 反映 + screenshot URL を SHA 参照に固定)
+
+app-id: net.shrieker.capsicum
+
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+
+command: capsicum
+
+finish-args:
+  # ネットワーク (Mastodon / Misskey / モロヘイヤ API)
+  - --share=network
+  # 共有メモリ (X11 描画高速化)
+  - --share=ipc
+  # ディスプレイサーバー
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU レンダリング
+  - --device=dri
+  # ローカル通知 (libnotify)
+  - --talk-name=org.freedesktop.Notifications
+  # アカウントトークン保存 (libsecret / gnome-keyring)
+  - --talk-name=org.freedesktop.secrets
+  # 画像添付 (image_picker / file_selector)
+  - --filesystem=xdg-pictures
+  # 動画 / その他添付・ダウンロード
+  - --filesystem=xdg-download
+
+modules:
+  - name: capsicum
+    buildsystem: simple
+    build-commands:
+      # Flutter のバンドルは executable の隣に data/ と lib/ を要求する。
+      # /app/bin/ 配下にフラットに展開することで Flutter のパス解決が機能する。
+      - install -d /app/bin
+      - cp -r bundle/. /app/bin/
+
+      # Desktop entry / AppStream metainfo
+      - install -Dm644 net.shrieker.capsicum.desktop -t /app/share/applications/
+      - install -Dm644 net.shrieker.capsicum.metainfo.xml -t /app/share/metainfo/
+
+      # Icons (各サイズ hicolor に配置)
+      - install -Dm644 icon-16.png   /app/share/icons/hicolor/16x16/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-32.png   /app/share/icons/hicolor/32x32/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-64.png   /app/share/icons/hicolor/64x64/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-128.png  /app/share/icons/hicolor/128x128/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-256.png  /app/share/icons/hicolor/256x256/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-512.png  /app/share/icons/hicolor/512x512/apps/net.shrieker.capsicum.png
+    sources:
+      - type: archive
+        url: https://github.com/pooza/capsicum/releases/download/v1.24.0/capsicum-bundle-1.24.0-x86_64.tar.gz
+        sha256: e29bd017c57d7efe017b0b73f53fe39cb77effe17bd4299be706397a4debc2a8
+        dest: bundle
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packaging/linux/shared/net.shrieker.capsicum.desktop
+        sha256: 0faa93226beb7fdf148340de6f5aa27c29ece14b4eb0e5beb9bd97eb6d12e5bb
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/72d54060c2bd0c6740836ff0810a2f546ef9c502/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
+        sha256: cca637d82353c88fdae5b70f5a1cc69d352bd2871c42a29411492e24ac66f65f
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_16.png
+        sha256: e3ac430d5b3ef4d90d94ddfe0814f1b39b4084f5c773e7a8928d6e462accaeec
+        dest-filename: icon-16.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_32.png
+        sha256: a5e83d9b658ac50c16ea22ae216b964b6e2346e2e866a3959b092cb007baca09
+        dest-filename: icon-32.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_64.png
+        sha256: 78cdb945b4ca2c3538a4e8061e96b8b1e7a52dd7feb9483fbb6babd9a50e4053
+        dest-filename: icon-64.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_128.png
+        sha256: 394c5d38ef8e53e1370eb24af5005580f69c7754b057ddd078f99c8b3f874b70
+        dest-filename: icon-128.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_256.png
+        sha256: c5bb56613ab69c77f796ca58af0a00cae2ba2c48c80a52ad6d2db9dda7dc6145
+        dest-filename: icon-256.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/v1.24.0/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_512.png
+        sha256: 9185d255ecd077f11b13a792b8eea5108f0f212616619de4207e28226df39250
+        dest-filename: icon-512.png


### PR DESCRIPTION
## Description

[capsicum](https://github.com/pooza/capsicum) is a Mastodon / Misskey Fediverse client built with Flutter. It supports both Mastodon and Misskey APIs through a unified adapter layer, so the same UI works on both servers and switches between accounts seamlessly. The desktop release adds Linux to the existing macOS / iOS / Android lineup.

- Homepage: https://capsicum.shrieker.net/
- Source: https://github.com/pooza/capsicum
- License: AGPL-3.0-or-later
- Latest release: [v1.24.0](https://github.com/pooza/capsicum/releases/tag/v1.24.0) (2026-05-10)

## Manifest notes

- **Source layout**: prebuilt Flutter Linux release bundle is fetched from a GitHub Releases tarball. The Flathub sandbox is offline, so `flutter pub get` cannot run inside the build — using the pre-bundled output instead.
- **Runtime**: `org.gnome.Platform//49`. GNOME runtime is selected over Freedesktop because the bundled `desktop_webview_window` plugin links against `libwebkit2gtk-4.1.so.0`, which only ships in the GNOME runtime.
- **`finish-args`**: minimum required surface (network, IPC, Wayland + X11 fallback, DRI for GPU rendering, secrets / notifications via portal-aware D-Bus, xdg-pictures / xdg-download for media attachment).

## Verification

- `flatpak-builder --user --force-clean --install-deps-from=flathub --disable-rofiles-fuse build-dir net.shrieker.capsicum.yml` succeeds locally on Debian 13.
- `appstreamcli compose` during the build emits no warnings or errors.
- `appstreamcli validate` against the metainfo file passes (`✔ Validation was successful.`).
- The resulting Flatpak runs and Japanese IME (ibus + mozc) input works correctly.

## Self-review checklist

- [x] App ID matches the reverse-DNS of a domain owned by the submitter (`shrieker.net`).
- [x] AppStream metainfo includes screenshots, OARS rating, license, releases, and developer.
- [x] No use of `--filesystem=host` / `--filesystem=home` or other broad permissions.
- [x] Runtime version is the latest stable GNOME runtime (49).
- [x] All sources referenced by URL with sha256 (no `path:` references).
