### PR TITLE
Add io.github.ch3w3y.tuxbellum

### DIFF
--- a/io.github.ch3w3y.tuxbellum.yml
+++ b/io.github.ch3w3y.tuxbellum.yml
@@ -1,0 +1,51 @@
+app-id: io.github.ch3w3y.tuxbellum
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: tuxbellum
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=home
+  - --filesystem=/usr/share/wine
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  # ── Python dependencies ─────────────────────────────
+  - name: python3-pygobject
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app PyGObject
+    build-extensions:
+      - org.freedesktop.Sdk.Extension.python3
+
+  # ── TuxBellum ────────────────────────────────────────
+  - name: tuxbellum
+    buildsystem: meson
+    builddir: true
+    config-opts:
+      - -Dpython=/app/bin/python3
+    sources:
+      - type: git
+        url: https://github.com/Ch3w3y/tuxbellum.git
+        tag: v3.0.0
+      # Bundled packages
+      - type: file
+        path: packages/dxvk-2.7.1-3-521-low-latency.tar.gz
+        dest: packages/
+      - type: file
+        path: packages/winetricks-20250102-modified.tar.gz
+        dest: packages/
+    post-install:
+      # Ensure data files are available in the Flatpak
+      - mkdir -p /app/share/tuxbellum/packages
+      - mkdir -p /app/share/tuxbellum/locales
+    cleanup:
+      - /include
+      - /lib/pkgconfig
+      - '*.a'
+      - '*.la'


### PR DESCRIPTION
## New App Submission: TuxBellum

**App ID:** io.github.ch3w3y.tuxbellum
**Homepage:** https://github.com/Ch3w3y/tuxbellum
**License:** Apache-2.0

TuxBellum is a GTK4 application for installing and managing the Bellum tactical shooter on Linux via Wine/Proton. It handles GPU detection, Proton-CachyOS setup, WINEPREFIX configuration, and desktop integration.

**Runtime:** org.gnome.Platform 47
**SDK:** org.gnome.Sdk