### PR TITLE
Add io.github.riemarukarurosu.ZTManager

### DIFF
--- a/io.github.riemarukarurosu.ZTManager.json
+++ b/io.github.riemarukarurosu.ZTManager.json
@@ -1,0 +1,52 @@
+{
+    "app-id": "io.github.riemarukarurosu.ZTManager",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "ztmanager",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--socket=system-bus",
+        "--talk-name=org.freedesktop.systemd1",
+        "--filesystem=xdg-config/ztlib"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        "python3-requests.json",
+        "python3-psutil.json",
+        "python3-pydbus.json",
+        {
+            "name": "ztmanager",
+            "builddir": true,
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/RiemaruKarurosu/ZT-Manager.git",
+                    "tag": "v2.0.2"
+                }
+            ],
+            "config-opts": [
+                "--libdir=lib"
+            ]
+        }
+    ],
+    "build-options": {
+        "env": {}
+    }
+}

--- a/python3-pathlib2.json
+++ b/python3-pathlib2.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pathlib2",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pathlib2\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/09/eb/4af4bcd5b8731366b676192675221c5324394a580dfae469d498313b5c4a/pathlib2-2.3.7.post1-py2.py3-none-any.whl",
+            "sha256": "5266a0fd000452f1b3467d782f079a4343c63aaa119221fbdc4e39577489ca5b"
+        }
+    ]
+}

--- a/python3-psutil.json
+++ b/python3-psutil.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-psutil",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"psutil\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/d6/0f/96b7309212a926c1448366e9ce69b081ea79d63265bde33f11cc9cfc2c07/psutil-5.9.5.tar.gz",
+            "sha256": "5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"
+        }
+    ]
+}

--- a/python3-pydbus.json
+++ b/python3-pydbus.json
@@ -1,0 +1,14 @@
+{
+    "name": "python3-pydbus",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pydbus\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/92/56/27148014c2f85ce70332f18612f921f682395c7d4e91ec103783be4fce00/pydbus-0.6.0-py2.py3-none-any.whl",
+            "sha256": "66b80106352a718d80d6c681dc2a82588048e30b75aab933e4020eb0660bf85e"
+        }
+    ]
+}

--- a/python3-requests.json
+++ b/python3-requests.json
@@ -1,0 +1,34 @@
+{
+    "name": "python3-requests",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/9d/19/59961b522e6757f0c9097e4493fa906031b95b3ebe9360b2c3083561a6b4/certifi-2023.5.7-py3-none-any.whl",
+            "sha256": "c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/ff/d7/8d757f8bd45be079d76309248845a04f09619a7b17d6dfc8c9ff6433cac2/charset-normalizer-3.1.0.tar.gz",
+            "sha256": "34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl",
+            "sha256": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+            "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/4b/1d/f8383ef593114755429c307449e7717b87044b3bcd5f7860b89b1f759e34/urllib3-2.0.2-py3-none-any.whl",
+            "sha256": "d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
+        }
+    ]
+}


### PR DESCRIPTION
ZT Manager is yet another GTK4/Libadwaita client for managing ZeroTier networks on Linux. It provides a GUI to join/leave networks and monitor node status.

Justification for permissions:

- --socket=system-bus and --talk-name=org.freedesktop.systemd1: Required to manage (start/stop/enable) the `zerotier-one.service` via D-Bus on the host
- --talk-name=org.freedesktop.Flatpak: Used via flatpak-spawn --host to securely retrieve the ZeroTier authentication token from the host system when the user enables "Host Mode".
- --filesystem=xdg-config/ztlib: Used to store user preferences and manual API tokens.

This project is not officially affiliated with ZeroTier.