### PR TITLE
Add tomodorange: Native COSMIC Pomodoro

### DIFF
--- a/tomodorange/tomodorange.yaml
+++ b/tomodorange/tomodorange.yaml
@@ -1,0 +1,26 @@
+app-id: tomodorange
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: tomodorange
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --socket=pulseaudio
+  - --persist=.config/tomodorange
+modules:
+  - name: tomodorange
+    buildsystem: simple
+    build-commands:
+      - cargo build --release
+      - install -Dm755 target/release/tomodorange /app/bin/tomodorange
+      - install -Dm644 tomodorange.desktop /app/share/applications/tomodorange.desktop
+      - install -Dm644 assets/icon.png /app/share/icons/hicolor/256x256/apps/tomodorange.png
+      - install -Dm644 tomodorange.metainfo.xml /app/share/metainfo/tomodorange.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/1dragon-xyz/tomodorange.git


### PR DESCRIPTION
This PR adds TomodOrange, a native COSMIC™ desktop Pomodoro timer built with Rust/libcosmic. It uses a hardened sandbox with zero network permissions. Repo: https://github.com/1dragon-xyz/tomodorange