### PR TITLE
Add io.github.Daniel_v8.Loudless

### DIFF
--- a/io.github.Daniel_v8.Loudless.yml
+++ b/io.github.Daniel_v8.Loudless.yml
@@ -1,0 +1,64 @@
+app-id: io.github.Daniel_v8.Loudless
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+
+command: loudless
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=home
+
+modules:
+  - name: python3-PyQt6-sip
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="." --prefix=/app PyQt6-sip
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/d4/e3/65b605759859d38231ce7544065d4c61f891eb7766c351318e2a0b08a473/pyqt6_sip-13.11.1-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl
+        sha256: a72f4ebdab16a8a484019ff593de90d8013d3286b678c6ba1c0bdb117f4fcb13
+
+  - name: python3-PyQt6-Qt6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="." --prefix=/app PyQt6-Qt6
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/e1/be/21d0df9bde717131f4245f8801676120d466afe198c4641c9e4982cf85fe/pyqt6_qt6-6.11.1-py3-none-manylinux_2_34_x86_64.whl
+        sha256: 254af349e0ef4b2fa581f86ee9d65eb797bb1d4f0c01ae5ceaa7b2446b458be9
+
+  - name: python3-PyQt6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="." --prefix=/app PyQt6
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c3/a0/bd1399740dfa80c0a94d20b02d89962a31458233dcf70eaa09bfbccf3d0f/pyqt6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl
+        sha256: 8555277989fa7d114cb3c3443fd261d566909f7268ceedd41d93a5f02d37ec05
+
+  - name: python3-mutagen
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="." --prefix=/app mutagen
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl
+        sha256: edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719
+
+  - name: loudless
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 main.py /app/share/loudless/main.py
+      - install -Dm644 loudless.png /app/share/loudless/loudless.png
+      - install -Dm644 loudless.png /app/share/icons/hicolor/512x512/apps/io.github.Daniel_v8.Loudless.png
+      - install -Dm644 flatpak/io.github.Daniel_v8.Loudless.desktop /app/share/applications/io.github.Daniel_v8.Loudless.desktop
+      - install -Dm644 flatpak/io.github.Daniel_v8.Loudless.metainfo.xml /app/share/metainfo/io.github.Daniel_v8.Loudless.metainfo.xml
+      - install -Dm755 flatpak/loudless-launch.sh /app/bin/loudless
+    sources:
+      - type: git
+        url: https://github.com/Daniel-v8/Loudless.git
+        tag: v1.0.0
+        commit: 00521043186a27e880d2acc9236254e694f40867

--- a/io.github.Daniel_v8.Loudless.yml
+++ b/io.github.Daniel_v8.Loudless.yml
@@ -61,4 +61,4 @@ modules:
       - type: git
         url: https://github.com/Daniel-v8/Loudless.git
         tag: v1.0.0
-        commit: 00521043186a27e880d2acc9236254e694f40867
+        commit: bc7cbeaf88f91e3e4b15ab2585ec40fef5a722ca


### PR DESCRIPTION
## Loudless — Audio Loudness Normalizer

**App ID:** `io.github.Daniel_v8.Loudless`
**Source:** https://github.com/Daniel-v8/Loudless
**License:** MIT

### Description

Loudless normalizes the loudness of your audio files using the EBU R128 standard (LUFS). Unlike tag-based solutions (ReplayGain), it writes the gain directly into the audio data so every player handles the volume correctly without configuration.

### Features

- Drag and drop files or entire folders
- Supports FLAC, WAV, MP3, OGG, OPUS, M4A, AAC, WMA, APE, WavPack
- Lossless processing for FLAC, WAV, AIFF, APE and WavPack
- Automatic backup of originals before modifying
- Three loudness targets: Streaming (−14 LUFS), ReplayGain (−18 LUFS), CD/Mastering (−23 LUFS)

### Build notes

- Runtime: `org.kde.Platform//6.10` (includes Python 3.13 and ffmpeg)
- Python dependencies (PyQt6, mutagen) installed via pip wheels
- Built and tested locally with `flatpak-builder 1.4.8`