### PR TITLE
Add org.cairoclock.CairoQmlClock

### DIFF
--- a/org.cairoclock.CairoQmlClock.json
+++ b/org.cairoclock.CairoQmlClock.json
@@ -1,0 +1,39 @@
+{
+    "app-id": "org.cairoclock.CairoQmlClock",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.8",
+    "sdk": "org.kde.Sdk",
+    "command": "cairo-qml-clock",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "modules": [
+        {
+            "name": "cairo-qml-clock",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/rappel12/cairo-to-qml-clock.git",
+                    "tag": "v0.1.1",
+                    "commit": "ac8a8236e6af67bed50e18ef7d60dda849e75bba"
+                }
+            ],
+            "post-install": [
+                "install -Dm644 main.qml /app/share/cairo-qml-clock/main.qml",
+                "install -Dm644 InfoDialog.qml /app/share/cairo-qml-clock/InfoDialog.qml",
+                "install -Dm644 PropertiesDialog.qml /app/share/cairo-qml-clock/PropertiesDialog.qml",
+                "cp -r themes /app/share/cairo-qml-clock/",
+                "install -Dm644 org.cairoclock.CairoQmlClock.desktop /app/share/applications/org.cairoclock.CairoQmlClock.desktop",
+                "install -Dm644 cairo-qml-clock.png /app/share/icons/hicolor/256x256/apps/org.cairoclock.CairoQmlClock.png",
+                "install -Dm644 org.cairoclock.CairoQmlClock.metainfo.xml /app/share/metainfo/org.cairoclock.CairoQmlClock.metainfo.xml"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Cairo QML Clock is a modern reimplementation of MacSlow's cairo-clock using Qt6 QML, running on modern Linux without deprecated dependencies.

**App details:**
- App ID: org.cairoclock.CairoQmlClock
- License: GPL-2.0-only
- Homepage: https://github.com/rappel12/cairo-to-qml-clock
- Runtime: org.kde.Platform 6.8

**What it does:**
Frameless transparent analog clock with 30 themes, smooth sweep second hand, right-click menu, Properties/Info dialogs, size presets, show seconds/date/24h mode, keep-on-top and sticky workspace (X11), draggable on X11 and Wayland.

**Flatpak notes:**
- Uses C++ launcher (QQmlApplicationEngine) — no bundled host binaries
- Detects XDG_CURRENT_DESKTOP and applies GTK3/Adwaita theme on non-KDE desktops (both plugins are already in the KDE Platform runtime)
- finish-args: ipc, fallback-x11, wayland, dri — no filesystem or home access needed

**Checklist:**
- [x] App builds and runs correctly in Flatpak sandbox
- [x] AppStream metadata passes appstreamcli validate
- [x] Desktop file present
- [x] Icon at 256x256 present
- [x] GPL-2.0-only license
- [x] No bundled libraries beyond KDE Platform runtime
