### PR TITLE
Add io.github.rappel12.CairoQmlClock

### DIFF
--- a/io.github.rappel12.CairoQmlClock.json
+++ b/io.github.rappel12.CairoQmlClock.json
@@ -1,0 +1,38 @@
+{
+    "app-id": "io.github.rappel12.CairoQmlClock",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.9",
+    "sdk": "org.kde.Sdk",
+    "command": "cairo-qml-clock",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=xdg-config/gtk-3.0:ro"
+    ],
+    "modules": [
+        {
+            "name": "cairo-qml-clock",
+            "buildsystem": "cmake-ninja",
+            "config-opts": ["-DCMAKE_BUILD_TYPE=Release"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/rappel12/cairo-to-qml-clock.git",
+                    "tag": "v0.1.2",
+                    "commit": "e046bad7c014dc67f1b7b58a70fc20aebb49e264"
+                }
+            ],
+            "post-install": [
+                "install -Dm644 main.qml /app/share/cairo-qml-clock/main.qml",
+                "install -Dm644 InfoDialog.qml /app/share/cairo-qml-clock/InfoDialog.qml",
+                "install -Dm644 PropertiesDialog.qml /app/share/cairo-qml-clock/PropertiesDialog.qml",
+                "cp -r themes /app/share/cairo-qml-clock/",
+                "install -Dm644 io.github.rappel12.CairoQmlClock.desktop /app/share/applications/io.github.rappel12.CairoQmlClock.desktop",
+                "install -Dm644 cairo-qml-clock.png /app/share/icons/hicolor/256x256/apps/io.github.rappel12.CairoQmlClock.png",
+                "install -Dm644 io.github.rappel12.CairoQmlClock.metainfo.xml /app/share/metainfo/io.github.rappel12.CairoQmlClock.metainfo.xml"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Cairo QML Clock

A modern reimplementation of MacSlow's cairo-clock using Qt6 QML. Runs on modern Linux without deprecated dependencies.

- **Homepage:** https://github.com/rappel12/cairo-to-qml-clock
- **License:** GPL-2.0-only
- **Runtime:** org.kde.Platform//6.9

### Features
- 30 themes, frameless transparent window, smooth 60fps second hand
- Drag support on X11 and Wayland
- Sticky workspace (X11 and Wayland with XWayland via override_redirect)
- GTK-friendly appearance on non-KDE desktops
- Position/size/theme settings persisted across sessions

### Permissions rationale
- `--socket=x11` + `--socket=wayland`: supports both display servers; x11 required for XWayland override_redirect sticky-workspace behavior
- `--share=ipc`: required for shared memory with X11
- `--device=dri`: hardware-accelerated rendering
- `--filesystem=xdg-config/gtk-3.0:ro`: reads GTK theme for consistent appearance on non-KDE desktops