### PR TITLE
Add io.github.calstfrancis.rubric

### DIFF
--- a/io.github.calstfrancis.rubric.yml
+++ b/io.github.calstfrancis.rubric.yml
@@ -1,0 +1,39 @@
+app-id: io.github.calstfrancis.rubric
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: rubric
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=home
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  - name: rubric
+    buildsystem: simple
+    build-commands:
+      # Application files
+      - install -d /app/share/rubric
+      - install -m 644 rubric.py bible_api.py hymn_lookup.py hymn_suggestions.py rcl_data.py snippets.py /app/share/rubric/
+      - cp -r data /app/share/rubric/
+      - cp -r rubric_package /app/share/rubric/
+
+      # Launcher wrapper
+      - install -Dm 755 rubric-launcher.sh /app/bin/rubric
+
+      # Desktop integration
+      - install -Dm 644 io.github.calstfrancis.rubric.desktop /app/share/applications/io.github.calstfrancis.rubric.desktop
+      - install -Dm 644 io.github.calstfrancis.rubric.metainfo.xml /app/share/metainfo/io.github.calstfrancis.rubric.metainfo.xml
+      - install -Dm 644 rubric.svg /app/share/icons/hicolor/scalable/apps/io.github.calstfrancis.rubric.svg
+      - install -Dm 644 rubric-symbolic.svg /app/share/icons/hicolor/symbolic/apps/io.github.calstfrancis.rubric-symbolic.svg
+
+    sources:
+      - type: git
+        url: https://github.com/calstfrancis/rubric
+        tag: v0.12
+        commit: ce716d8f980f33e9f47cd686ca096b7a0b6d6076


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.

Rubric is a GNOME-native worship service planning tool for United Church of Canada ministry. It integrates the Revised Common Lectionary (RCL), hymn lookup for Voices United, More Voices, and Let Us Sing (via Hymnary.org), Bible passage retrieval (WEB, KJV, ASV, ESV), and export to HTML for bulletin production. Simple mode requires no LaTeX; advanced mode adds PDF compilation via xelatex, snippets, and a responsive reading builder. GPL-3.0-or-later.

- [ ] Please attach a video showcasing the application on Linux using the Flatpak.

N/A — happy to provide a screencast if reviewers need one.

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [X] I am the author/developer/upstream maintainer of the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission