### PR TITLE
Add app.better_craft.aurorapulse

### DIFF
--- a/app.better_craft.aurorapulse.yml
+++ b/app.better_craft.aurorapulse.yml
@@ -1,0 +1,55 @@
+app-id: app.better_craft.aurorapulse
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '23.08'
+command: aurora-pulse
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --share=network
+  - --device=dri
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-download:ro
+  - --filesystem=xdg-documents:ro
+  - --filesystem=/media:ro
+  - --filesystem=/run/media:ro
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --own-name=org.mpris.MediaPlayer2.AuroraPulse
+
+modules:
+  - name: aurora-pulse
+    buildsystem: simple
+    build-commands:
+      - install -d /app/lib/aurora-pulse
+      - cp -r aurora-pulse-linux-x64/* /app/lib/aurora-pulse/
+      - install -Dm755 aurora-pulse-wrapper.sh /app/bin/aurora-pulse
+      - install -Dm644 app.better_craft.aurorapulse.desktop /app/share/applications/app.better_craft.aurorapulse.desktop
+      - install -Dm644 app.better_craft.aurorapulse.metainfo.xml /app/share/metainfo/app.better_craft.aurorapulse.metainfo.xml
+      - install -Dm644 icons/256x256/app.better_craft.aurorapulse.png /app/share/icons/hicolor/256x256/apps/app.better_craft.aurorapulse.png
+      - install -Dm644 icons/128x128/app.better_craft.aurorapulse.png /app/share/icons/hicolor/128x128/apps/app.better_craft.aurorapulse.png
+      - install -Dm644 icons/64x64/app.better_craft.aurorapulse.png /app/share/icons/hicolor/64x64/apps/app.better_craft.aurorapulse.png
+    sources:
+      # Update this URL and sha256 for each release
+      - type: archive
+        url: https://github.com/galdo/aurora/releases/download/v1.5.6/Aurora-Pulse-1.5.6-linux-x64.tar.gz
+        sha256: REPLACE_WITH_ACTUAL_SHA256
+        dest: aurora-pulse-linux-x64
+      - type: file
+        path: app.better_craft.aurorapulse.desktop
+      - type: file
+        path: app.better_craft.aurorapulse.metainfo.xml
+      - type: dir
+        path: icons
+        dest: icons
+      - type: script
+        dest-filename: aurora-pulse-wrapper.sh
+        commands:
+          - export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
+          - exec zypak-wrapper /app/lib/aurora-pulse/aurora-pulse "$@"


### PR DESCRIPTION
## New App Submission: Aurora Pulse

**App ID:** `app.better_craft.aurorapulse`

**Description:** Aurora Pulse is a local-first music player built with Electron, supporting local music libraries (FLAC, MP3, AAC, OGG, WAV), DLNA/UPnP streaming, podcasts, CD ripping, and DAP synchronization.

**Homepage:** https://github.com/galdo/aurora
**License:** MIT

**Checklist:**
- [x] App ID follows reverse-DNS naming
- [x] Manifest uses `org.electronjs.Electron2.BaseApp` for Electron sandbox compatibility
- [x] Desktop file included
- [x] AppStream metainfo.xml included
- [x] Icons in multiple sizes (64, 128, 256)
- [x] Content rating included (OARS 1.1)
