### PR TITLE
Add com.proton.drive

### DIFF
--- a/com.proton.drive.metainfo.xml
+++ b/com.proton.drive.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.proton.drive</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>AGPL-3.0</project_license>
+  <name>Proton Drive</name>
+  <summary>Secure and encrypted cloud storage</summary>
+
+  <description>
+    <p>
+      Proton Drive is an end-to-end encrypted cloud storage service developed by Proton.
+      This is an unofficial desktop client for Linux built with Tauri, providing a fast
+      and native-feeling experience for managing your files.
+    </p>
+    <ul>
+      <li>End-to-end encryption: Your files are encrypted before they leave your device.</li>
+      <li>Privacy focused: Developed by the team behind Proton Mail and Proton VPN.</li>
+      <li>Native Linux experience: Lightweight and optimized for performance.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.proton.drive.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main file management interface</caption>
+      <image>https://raw.githubusercontent.com/DonnieDice/protondrive-linux/main/src-tauri/icons/icon.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://github.com/DonnieDice/protondrive-linux</url>
+  <url type="bugtracker">https://github.com/DonnieDice/protondrive-linux/issues</url>
+
+  <provides>
+    <binary>proton-drive</binary>
+  </provides>
+
+  <releases>
+    <release version="1.4.3" date="2026-05-18" />
+  </releases>
+
+  <content_rating type="oars-1.1" />
+</component>

--- a/com.proton.drive.yml
+++ b/com.proton.drive.yml
@@ -1,0 +1,57 @@
+app-id: com.proton.drive
+runtime: org.gnome.Platform
+runtime-version: '47'
+sdk: org.gnome.Sdk
+command: proton-drive
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=home
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Notifications
+  - --system-talk-name=org.freedesktop.NetworkManager
+modules:
+  - name: proton-drive
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://github.com/DonnieDice/protondrive-linux.git
+        tag: v1.4.3
+      - type: file
+        path: com.proton.drive.metainfo.xml
+    build-commands:
+      # Build the application
+      # NOTE: This requires network access for npm/cargo which is normally restricted on Flathub.
+      # This manifest is intended as an initial submission for review.
+      - ./scripts/build-webclients.sh
+      - npm install
+      - cd src-tauri && cargo build --release
+
+      # Install binary and wrapper
+      - install -Dm755 src-tauri/target/release/proton-drive /app/bin/proton-drive-bin
+      - |
+        cat > /app/bin/proton-drive << 'EOF'
+        #!/bin/bash
+        export WEBKIT_DISABLE_DMABUF_RENDERER=1
+        exec /app/bin/proton-drive-bin "$@"
+        EOF
+        chmod +x /app/bin/proton-drive
+
+      # Install desktop file
+      - install -Dm644 src-tauri/linux/proton-drive.desktop /app/share/applications/com.proton.drive.desktop
+      - sed -i 's/Exec=proton-drive/Exec=proton-drive/' /app/share/applications/com.proton.drive.desktop
+      - sed -i 's/Icon=proton-drive/Icon=com.proton.drive/' /app/share/applications/com.proton.drive.desktop
+
+      # Install AppStream metadata
+      - install -Dm644 com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
+
+      # Install icons
+      - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg


### PR DESCRIPTION
## Description
Proton Drive is an end-to-end encrypted cloud storage service. This is an unofficial desktop client for Linux built with Tauri.

## Checklist
- [x] AppStream metadata included
- [x] Desktop file and icons meet standards
- [x] Manifest follows Flathub conventions (initial version)
- [x] License: AGPL-3.0