### PR TITLE
Add com.proton.drive

### DIFF
--- a/com.proton.drive.metainfo.xml
+++ b/com.proton.drive.metainfo.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.proton.drive</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>AGPL-3.0</project_license>
+  <name>Proton Drive</name>
+  <summary>Secure and encrypted cloud storage</summary>
+
+  <description>
+    <p>
+      Proton Drive is an end-to-end encrypted cloud storage service developed by Proton.
+      This is an unofficial desktop client for Linux built with Tauri, providing a fast
+      and native-feeling experience for managing your files.
+    </p>
+    <ul>
+      <li>End-to-end encryption: Your files are encrypted before they leave your device.</li>
+      <li>Privacy focused: Developed by the team behind Proton Mail and Proton VPN.</li>
+      <li>Native Linux experience: Lightweight and optimized for performance.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.proton.drive.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>The main file management interface</caption>
+      <image>https://raw.githubusercontent.com/DonnieDice/protondrive-linux/main/screenshots/main.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://github.com/DonnieDice/protondrive-linux</url>
+  <url type="bugtracker">https://github.com/DonnieDice/protondrive-linux/issues</url>
+
+  <provides>
+    <binary>proton-drive</binary>
+  </provides>
+
+  <releases>
+    <release version="1.4.3" date="2026-05-18">
+      <description>
+        <p>Proton Drive Linux v1.4.3 release:</p>
+        <ul>
+          <li>Stable release of the unofficial Linux client.</li>
+          <li>Optimized build pipeline for multiple Linux distributions.</li>
+          <li>Full support for end-to-end encrypted file management.</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+</component>

--- a/com.proton.drive.yml
+++ b/com.proton.drive.yml
@@ -1,0 +1,60 @@
+app-id: com.proton.drive
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node22
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: proton-drive
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-download
+  - --filesystem=xdg-documents
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Notifications
+modules:
+  - name: proton-drive
+    buildsystem: simple
+    sources:
+      - type: git
+        url: https://github.com/DonnieDice/protondrive-linux.git
+        commit: 469793bf6038ebecf2b7c23d6236d450b8a6a5c4
+      - type: file
+        path: packaging/com.proton.drive.metainfo.xml
+    build-commands:
+      # Enable SDK extensions
+      - . /usr/lib/sdk/node22/enable.sh
+      - . /usr/lib/sdk/rust-stable/enable.sh
+
+      # Build the application
+      - ./scripts/build-webclients.sh
+      - npm install
+      - cd src-tauri && cargo build --release
+
+      # Install binary and wrapper
+      - install -Dm755 src-tauri/target/release/proton-drive /app/bin/proton-drive-bin
+      - |
+        cat > /app/bin/proton-drive << 'EOF'
+        #!/bin/bash
+        export WEBKIT_DISABLE_DMABUF_RENDERER=1
+        exec /app/bin/proton-drive-bin "$@"
+        EOF
+        chmod +x /app/bin/proton-drive
+
+      # Install desktop file
+      - install -Dm644 src-tauri/linux/proton-drive.desktop /app/share/applications/com.proton.drive.desktop
+      - sed -i 's/Icon=proton-drive/Icon=com.proton.drive/' /app/share/applications/com.proton.drive.desktop
+
+      # Install AppStream metadata
+      - install -Dm644 packaging/com.proton.drive.metainfo.xml /app/share/metainfo/com.proton.drive.metainfo.xml
+
+      # Install icons
+      - install -Dm644 src-tauri/icons/32x32.png /app/share/icons/hicolor/32x32/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/128x128.png /app/share/icons/hicolor/128x128/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/128x128@2x.png /app/share/icons/hicolor/256x256/apps/com.proton.drive.png
+      - install -Dm644 src-tauri/icons/proton-drive.svg /app/share/icons/hicolor/scalable/apps/com.proton.drive.svg


### PR DESCRIPTION
## Description

Proton Drive is an end-to-end encrypted cloud storage service. This is an unofficial desktop client for Linux built with Tauri.

## Checklist

- [x] The application is a desktop application
- [x] The application id is in reverse DNS format
- [x] The application id matches the one in the manifest
- [x] The application is open source and the license is specified
- [x] The application is not already in Flathub
- [x] The application does not contain excessive AI-generated content