### PR TITLE
Add com.github.Lateralus138.txt2img

### DIFF
--- a/com.github.Lateralus138.txt2img/com.github.Lateralus138.txt2img.yaml
+++ b/com.github.Lateralus138.txt2img/com.github.Lateralus138.txt2img.yaml
@@ -1,0 +1,24 @@
+app-id: com.github.Lateralus138.txt2img
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: txt2img
+separate-locales: false
+finish-args:
+  - --device=all
+  - --filesystem=host
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+
+modules:
+  - name: txt2img
+    buildsystem: cmake-ninja
+    sources:
+      - type: git
+        url: https://github.com/Lateralus138/txt2img.git
+        tag: v1.0.0
+        commit: cc5318730156f5502433cc33cfc88ebeb7b3703d
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_STATIC=OFF


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.  
  txt2img is a desktop application that generates images from text prompts using a Stable Diffusion–based workflow. It runs locally and is intended for experimentation with text-to-image generation models through a graphical interface.

- [X] Please attach a video showcasing the application on Linux using the Flatpak.  

https://github.com/user-attachments/assets/a78028a7-6dd4-4d3f-884f-72f63429c8a9



- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [X] I am an author/developer/upstream contributor to the project.  
  If not, I contacted upstream developers about this submission. **Link:** https://github.com/Lateralus138/txt2img
