### PR TITLE
Add io.github.EmaLica.Tempus

### DIFF
--- a/io.github.EmaLica.Tempus.yml
+++ b/io.github.EmaLica.Tempus.yml
@@ -1,0 +1,37 @@
+app-id: io.github.EmaLica.Tempus
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: tempus
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --talk-name=org.freedesktop.Notifications
+  - --filesystem=home:ro
+  - --filesystem=xdg-documents:rw
+
+modules:
+  - name: tempus
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation --no-index --find-links=. --prefix=/app .
+      - install -Dm644 data/io.github.EmaLica.Tempus.gschema.xml
+          /app/share/glib-2.0/schemas/io.github.EmaLica.Tempus.gschema.xml
+      - glib-compile-schemas /app/share/glib-2.0/schemas
+      - install -Dm644 data/io.github.EmaLica.Tempus.desktop
+          /app/share/applications/io.github.EmaLica.Tempus.desktop
+      - install -Dm644 data/io.github.EmaLica.Tempus.metainfo.xml
+          /app/share/metainfo/io.github.EmaLica.Tempus.metainfo.xml
+      - install -Dm644 data/icons/hicolor/scalable/apps/io.github.EmaLica.Tempus.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.EmaLica.Tempus.svg
+      - install -Dm644 data/icons/hicolor/symbolic/apps/io.github.EmaLica.Tempus-symbolic.svg
+          /app/share/icons/hicolor/symbolic/apps/io.github.EmaLica.Tempus-symbolic.svg
+      - install -Dm644 data/icons/hicolor/512x512/apps/io.github.EmaLica.Tempus.png
+          /app/share/icons/hicolor/512x512/apps/io.github.EmaLica.Tempus.png
+    sources:
+      - type: git
+        url: https://github.com/EmaLica/Tempus.git
+        tag: v0.1.0
+        commit: 369bd7eeffb344f557c61ca4154c1a6cfce2e344


### PR DESCRIPTION
Tempus is a focused Pomodoro timer for GNOME built with GTK4 and libadwaita. Focus sessions, session dots, todo list with Markdown import/export, desktop notifications, live preferences. License: GPL-3.0-or-later. Source: https://github.com/EmaLica/Tempus