### PR TITLE
Add io.github.s4solutionsllc.Nexis

### DIFF
--- a/io.github.s4solutionsllc.Nexis.yml
+++ b/io.github.s4solutionsllc.Nexis.yml
@@ -1,0 +1,78 @@
+app-id: io.github.s4solutionsllc.Nexis
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+command: nexis
+
+# Rename the installed assets to match the Flatpak app-id convention.
+# flatpak-builder also updates the <launchable> reference in the metainfo.
+rename-icon: nexis
+rename-desktop-file: nexis.desktop
+
+finish-args:
+  # ── Display ──────────────────────────────────────────────────────────────
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+
+  # ── Broad filesystem access ───────────────────────────────────────────────
+  # Nexis is a system monitor and optimiser. It reads /proc, /sys, /dev,
+  # /run, and arbitrary user directories to collect CPU, memory, swap, disk
+  # I/O, GPU, temperature, fan, and network metrics in real time; it also
+  # manages APT sources in /etc/apt, clean up files across the full home
+  # tree, and invokes host tools (systemctl, apt, pkexec, smartctl, etc.)
+  # via QProcess. --filesystem=host is the minimal permission that covers all
+  # of these without requiring code changes to use individual D-Bus portals.
+  # See docs/flatpak-reviewer-justification.md for the full write-up.
+  - --filesystem=host
+
+  # ── Hardware device access ────────────────────────────────────────────────
+  # GPU utilisation and VRAM readings via nvidia-smi, amdgpu sysfs nodes,
+  # and /dev/dri; temperature and fan speed via hwmon; disk device handles
+  # for S.M.A.R.T. queries.
+  - --device=all
+
+  # ── Network ──────────────────────────────────────────────────────────────
+  # Network diagnostics (ping, traceroute, open-ports scan, Wake-on-LAN).
+  - --share=network
+
+  # ── System D-Bus names ───────────────────────────────────────────────────
+  # PolicyKit — privilege escalation for APT, disk, CPU tuning, firewall ops.
+  - --system-talk-name=org.freedesktop.PolicyKit1
+  # systemd — Services page: start/stop/enable/disable units.
+  - --system-talk-name=org.freedesktop.systemd1
+  # UDisks2 — Disk Tools page: S.M.A.R.T. health, partition info, benchmark.
+  - --system-talk-name=org.freedesktop.UDisks2
+  # hostname1/login1 — System Info: hostname, machine-id, session details.
+  - --system-talk-name=org.freedesktop.hostname1
+  - --system-talk-name=org.freedesktop.login1
+  # NetworkManager — Network Usage page: interface listing and stats.
+  - --system-talk-name=org.freedesktop.NetworkManager
+
+  # ── Session D-Bus names ──────────────────────────────────────────────────
+  - --talk-name=org.freedesktop.Notifications
+
+  # ── PATH ─────────────────────────────────────────────────────────────────
+  # With --filesystem=host the host's /usr/bin, /usr/sbin, etc. are
+  # accessible, but the sandbox PATH only contains Flatpak directories.
+  # Override PATH so QProcess invocations of systemctl, apt, pkexec, etc.
+  # resolve without the app needing to hard-code absolute paths.
+  - --env=PATH=/app/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+modules:
+  - name: nexis
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: git
+        url: https://github.com/s4solutionsllc/Nexis.git
+        tag: v2.3.7
+        commit: da814255d56c8db4235fae33a02ee2a465a1772d
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/s4solutionsllc/Nexis/releases/latest
+          tag-query: .tag_name
+          version-query: .tag_name | ltrimstr("v")
+          timestamp-query: .published_at


### PR DESCRIPTION
Initial submission for Nexis — a Linux system optimiser and monitoring tool (C++17 / Qt6 / GPL-3.0-or-later). Originally forked from oguzhaninan/Stacer, now independently maintained at s4solutionsllc/Nexis.

Reviewer justification for --filesystem=host + --device=all (system monitor use case, with precedent from GNOME Usage, Stacer, and htop-flatpak):
https://github.com/s4solutionsllc/Nexis/blob/native/docs/flatpak-reviewer-justification.md

<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

- [x] Application description: Nexis is a comprehensive Linux system optimiser and monitoring tool — live dashboard for CPU/memory/swap/disk/GPU/network, hardware info, process manager, services manager, system cleaner, disk tools (S.M.A.R.T., benchmark), APT repository manager, Docker container/image manager, helpers (swappiness, CPU turbo, SSD TRIM, Wake-on-LAN), HTML system report export, and scheduled cleaning with restore points. C++17 / Qt6 / GPL-3.0-or-later. Originally forked from oguzhaninan/Stacer, now independently maintained.
- [x] The Flatpak ID `io.github.s4solutionsllc.Nexis` follows the [Application ID rules](https://docs.flathub.org/docs/for-app-authors/requirements#application-id).
- [x] I have read and followed the [Submission requirements](https://docs.flathub.org/docs/for-app-authors/requirements) and [Submission guide](https://docs.flathub.org/docs/for-app-authors/submission).
- [x] I am the maintainer of the upstream project (s4solutionsllc/Nexis).
- [x] AppStream metainfo is shipped by upstream at `linux/metainfo/io.github.s4solutionsllc.Nexis.metainfo.xml` and installed to `share/metainfo/` via CMake (validated with `appstreamcli validate`).

### Notes for reviewers

This submission uses `--filesystem=host` + `--device=all` because Nexis is a system monitor: it reads `/proc`, `/sys`, `/dev`, `/run`, hwmon nodes, `/etc/apt`, and arbitrary user directories, and invokes `systemctl` / `apt` / `pkexec` / `smartctl` / `nvidia-smi` via QProcess. Privileged actions go through `org.freedesktop.PolicyKit1` (declared via `--system-talk-name`), not a setuid helper.

The minimal `finish-args` for the full feature set, with per-feature rationale, is documented in the upstream repo:

https://github.com/s4solutionsllc/Nexis/blob/native/docs/flatpak-reviewer-justification.md

Precedents accepted by Flathub for the same access pattern:

- GNOME Usage
- Stacer-flatpak (the upstream this project forked from)
- htop-flatpak

`x-checker-data` is wired so Flathub's bot can keep the tag/commit current after submission. The manifest currently pins `tag: v2.3.7` / `commit: da814255d56c8db4235fae33a02ee2a465a1772d`.

### Build verification

- Built cleanly with `flatpak-builder --force-clean --sandbox` against `org.kde.Sdk//6.9`
- Desktop file and all six icon sizes renamed to `io.github.s4solutionsllc.Nexis.*`
- App launches under the sandbox and the GUI renders correctly

Happy to make any adjustments — thanks for reviewing!


<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
