### PR TITLE
Add io.github.todevelopers.GseProfiler

### DIFF
--- a/io.github.todevelopers.GseProfiler.yml
+++ b/io.github.todevelopers.GseProfiler.yml
@@ -36,6 +36,7 @@ modules:
       - pip3 install --verbose --exists-action=i --no-index
           --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
           --no-build-isolation .
+      - install -Dm644 LICENSE.txt /app/share/licenses/python3-systemd/LICENSE.txt
     sources:
       - type: archive
         url: https://files.pythonhosted.org/packages/10/9e/ab4458e00367223bda2dd7ccf0849a72235ee3e29b36dce732685d9b7ad9/systemd-python-235.tar.gz
@@ -56,6 +57,8 @@ modules:
       - install -Dm644
           app/data/icons/hicolor/scalable/apps/io.github.todevelopers.GseProfiler.svg
           /app/share/icons/hicolor/scalable/apps/io.github.todevelopers.GseProfiler.svg
+      - install -Dm644 LICENSE
+          /app/share/licenses/io.github.todevelopers.GseProfiler/LICENSE
     sources:
       - type: archive
         url: https://github.com/todevelopers/gseprofiler/releases/download/v1.0.1/gseprofiler-1.0.1.tar.gz

--- a/io.github.todevelopers.GseProfiler.yml
+++ b/io.github.todevelopers.GseProfiler.yml
@@ -1,0 +1,62 @@
+app-id: io.github.todevelopers.GseProfiler
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: gse-profiler
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --talk-name=org.gnome.Shell
+  - --talk-name=org.gnome.Shell.Extensions
+  # Read systemd journal directly (replaces flatpak-spawn --host journalctl).
+  # This app is a GNOME Shell extension debugger/profiler whose core purpose is
+  # to show extension logs to the developer. Read-only access to both the
+  # volatile (/run/log/journal) and persistent (/var/log/journal) journal
+  # locations is required: on systems with persistent journaling enabled
+  # (the default on Fedora, Arch, and most GNOME distros) current-boot logs
+  # live exclusively under /var/log/journal — /run/log/journal alone is empty
+  # and the log viewer shows nothing. Access is strictly :ro and limited to
+  # the journal subtree; no other parts of /var or /run are exposed. Same
+  # pattern is used by GNOME Logs and other journal-viewer applications.
+  - --filesystem=/run/log/journal:ro
+  - --filesystem=/var/log/journal:ro
+  # Bridge extension install path
+  - --filesystem=~/.local/share/gnome-shell/extensions:create
+  # Unix socket shared with the bridge extension running in gnome-shell.
+  # :create bind-mounts the whole directory so files created inside are
+  # visible on the host (bind-mounting a single non-existent file is unreliable).
+  - --filesystem=xdg-run/gse-profiler:create
+
+modules:
+  - name: python3-systemd
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index
+          --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+          --no-build-isolation .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/10/9e/ab4458e00367223bda2dd7ccf0849a72235ee3e29b36dce732685d9b7ad9/systemd-python-235.tar.gz
+        sha256: 4e57f39797fd5d9e2d22b8806a252d7c0106c936039d1e71c8c6b8008e695c0a
+
+  - name: gse-profiler
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/gse-profiler
+      - cp -r app bridge-extension /app/share/gse-profiler/
+      - install -Dm755 scripts/restart-shell.sh
+          /app/share/gse-profiler/scripts/restart-shell.sh
+      - install -Dm755 build-aux/gse-profiler.sh /app/bin/gse-profiler
+      - install -Dm644 data/io.github.todevelopers.GseProfiler.desktop
+          /app/share/applications/io.github.todevelopers.GseProfiler.desktop
+      - install -Dm644 data/io.github.todevelopers.GseProfiler.metainfo.xml
+          /app/share/metainfo/io.github.todevelopers.GseProfiler.metainfo.xml
+      - install -Dm644
+          app/data/icons/hicolor/scalable/apps/io.github.todevelopers.GseProfiler.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.todevelopers.GseProfiler.svg
+    sources:
+      - type: archive
+        url: https://github.com/todevelopers/gseprofiler/releases/download/v1.0.1/gseprofiler-1.0.1.tar.gz
+        sha256: 7ebe264d4c75d061273da5dc44a2c80f228223664efe51af5f6630d8dd141675


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.

**GSE Profiler** is a GTK4 desktop application for managing, debugging, and profiling GNOME Shell extensions. It installs a small bridge GJS extension into `gnome-shell` and communicates with it over a Unix socket to provide:

- Extension manager with enable/disable toggles and state badges
- Live log viewer (reads systemd journal directly) with UUID and log-level filtering
- Flame graph / swimlane / histogram profiler with per-function call table
- Read-only state inspector for browsing an extension's `stateObj` at runtime

Target audience: GNOME Shell extension developers, extensions reviewers, and GNOME Shell testers. Homepage: https://github.com/todevelopers/gseprofiler

- [X] Please attach a video showcasing the application on Linux using the Flatpak.

40-second demo video: https://youtu.be/cvdHlc9dXL0

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

`io.github.todevelopers.GseProfiler` based on the GitHub organization `todevelopers` which owns the source repository at https://github.com/todevelopers/gseprofiler.

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [X] I am an author/developer to the project.

---

## Community Reception

The project announcement on r/gnome received a positive response, including from a GNOME contributor: https://www.reddit.com/r/gnome/comments/1tkhci8/gse_gnome_shell_extensions_profiler_tool/

## Linter Exception Request

Requesting an exception for **`finish-args-host-var-access`**.

The manifest declares:
- `--filesystem=/run/log/journal:ro`
- `--filesystem=/var/log/journal:ro`

**Justification:** The core feature of this application is showing GNOME Shell extension logs to the developer via the systemd journal. Read-only access to both the volatile (`/run/log/journal`) and persistent (`/var/log/journal`) journal locations is required: on systems with persistent journaling enabled (the default on Fedora, Arch, and most GNOME distros), current-boot logs live exclusively under `/var/log/journal` 

*  `/run/log/journal` alone is empty and the log viewer would show nothing.

Access is strictly **read-only** and limited to the journal subtree; no other parts of `/var` or `/run` are exposed. This is the same pattern used by **GNOME Logs** (`org.gnome.Logs`) and other journal-viewer applications on Flathub.

A previous version used `flatpak-spawn --host journalctl`, which was replaced with direct `systemd.journal.Reader` access specifically to remove the `finish-args-flatpak-spawn-access` blocker.

## Bridge Extension

The app installs a small GJS extension (`gse-profiler-bridge@todevelopers`) into `~/.local/share/gnome-shell/extensions/`. This is the core mechanism by which the app inspects and profiles target extensions inside the `gnome-shell` process — there is no other way to do live introspection of GJS code running inside the shell.

- Source is bundled in the tarball under `bridge-extension/` and visible to the user
- Communication over a Unix socket at `$XDG_RUNTIME_DIR/gse-profiler.sock`
- `disable()` cleans up signals and monkey-patches

## Lint Status

| Error | Status |
|---|---|
| `finish-args-host-var-access` | Exception requested above |
| `appstream-external-screenshot-url` | Screenshots hosted at stable URLs (`raw.githubusercontent.com` pinned to tag `v1.0.1`) |
| `appstream-screenshots-not-mirrored-in-ostree` | Will be resolved by Flathub's mirroring after acceptance |
| `appstream-remote-icon-not-mirrored` | Same, applies to screenshot thumbnails generated by AppStream |

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission