### PR TITLE
Add com.batorrent.BATorrent

### DIFF
--- a/com.batorrent.BATorrent.metainfo.xml
+++ b/com.batorrent.BATorrent.metainfo.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.batorrent.BATorrent</id>
+  <name>BATorrent</name>
+  <summary>Open-source BitTorrent client with VPN kill switch, anti-Xunlei, and 7 languages</summary>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="com.batorrent">
+    <name>Mateus Cruz</name>
+  </developer>
+  <description>
+    <p>BATorrent is a modern, cross-platform BitTorrent client focused on privacy, performance, and clarity. Built from scratch in C++ with Qt 6 and libtorrent-rasterbar.</p>
+    <p>Features include VPN kill switch, private tracker (PT) mode, Tor proxy preset, anti-Xunlei/leecher peer blocking, Telegram notifications, Discord Rich Presence, WebUI with QR pairing, RSS auto-download with Nyaa presets, and full support for 7 languages.</p>
+    <p>No ads, no telemetry, no account required. MIT licensed.</p>
+  </description>
+  <launchable type="desktop-id">com.batorrent.BATorrent.desktop</launchable>
+  <url type="homepage">https://github.com/Mateuscruz19/BAT-Torrent</url>
+  <url type="bugtracker">https://github.com/Mateuscruz19/BAT-Torrent/issues</url>
+  <url type="donation">https://github.com/sponsors/Mateuscruz19</url>
+  <url type="vcs-browser">https://github.com/Mateuscruz19/BAT-Torrent</url>
+  <content_rating type="oars-1.1" />
+  <categories>
+    <category>Network</category>
+    <category>FileTransfer</category>
+    <category>P2P</category>
+  </categories>
+  <provides>
+    <binary>BATorrent</binary>
+    <mediatype>application/x-bittorrent</mediatype>
+    <mediatype>x-scheme-handler/magnet</mediatype>
+  </provides>
+  <releases>
+    <release version="2.5.1" date="2026-05-24">
+      <description>
+        <p>Anti-Xunlei peer blocking, thunder:// link decoding, auto-detect system language, disk-full protection.</p>
+      </description>
+    </release>
+    <release version="2.5.0" date="2026-05-24">
+      <description>
+        <p>PT mode, Tor preset, Telegram webhook, Discord Rich Presence, QR pairing, Smart Paste, Torrent Inspector, Tags, Force Start, Full Backup, Gitee mirror, locale formatting, 7 languages with 622 keys each.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/com.batorrent.BATorrent.yml
+++ b/com.batorrent.BATorrent.yml
@@ -1,0 +1,56 @@
+app-id: com.batorrent.BATorrent
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: BATorrent
+
+finish-args:
+  # Network access for BitTorrent + WebUI + tracker announces
+  - --share=network
+  # Filesystem for save paths + resume data
+  - --filesystem=home
+  # System tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # D-Bus notifications
+  - --talk-name=org.freedesktop.Notifications
+  # File manager reveal (org.freedesktop.FileManager1)
+  - --talk-name=org.freedesktop.FileManager1
+  # X11 + Wayland
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # GPU for Qt rendering
+  - --device=dri
+
+modules:
+  - name: boost
+    buildsystem: simple
+    build-commands:
+      - ./bootstrap.sh --prefix=/app --with-libraries=system
+      - ./b2 install variant=release link=shared threading=multi -j$FLATPAK_BUILDER_N_JOBS
+    sources:
+      - type: archive
+        url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.gz
+        sha256: 2575e74ffc3ef1cd0babac2c1ee8bdb5782a0ee672b1912da40e5b4b591ca01f
+
+  - name: libtorrent-rasterbar
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: archive
+        url: https://github.com/arvidn/libtorrent/releases/download/v2.0.10/libtorrent-rasterbar-2.0.10.tar.gz
+        sha256: fc935b8c1daca5c0a4d304bff59e64e532be16bb877c012aea4bda73d9ca885d
+
+  - name: batorrent
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: archive
+        url: https://github.com/Mateuscruz19/BAT-Torrent/archive/refs/tags/v2.5.1.tar.gz
+        sha256: 5218de308188cd4fa606baba28f2d461ae486097f42e4b686616c61946638ef6
+    post-install:
+      - install -Dm644 dist/batorrent.desktop /app/share/applications/com.batorrent.BATorrent.desktop
+      - install -Dm644 src/images/logo1.png /app/share/icons/hicolor/256x256/apps/com.batorrent.BATorrent.png
+      - install -Dm644 dist/flatpak/com.batorrent.BATorrent.metainfo.xml /app/share/metainfo/com.batorrent.BATorrent.metainfo.xml


### PR DESCRIPTION
## New App: BATorrent

**App ID:** com.batorrent.BATorrent
**Homepage:** https://github.com/Mateuscruz19/BAT-Torrent
**License:** MIT
**Category:** Network / FileTransfer / P2P

BATorrent is a free, open-source BitTorrent client built with C++, Qt 6, and libtorrent-rasterbar. No ads, no telemetry, 7 languages.

Key features: VPN kill switch, PT mode, Tor proxy, anti-Xunlei peer blocking, Telegram notifications, Discord Rich Presence, WebUI with QR pairing, RSS auto-download with Nyaa presets.

Built against org.kde.Platform 6.7. Boost headers-only, libtorrent-rasterbar from source, OpenSSL from runtime.