### PR TITLE
Add org.kde.bearwave

### DIFF
--- a/org.kde.bearwave.json
+++ b/org.kde.bearwave.json
@@ -1,0 +1,30 @@
+{
+    "app-id": "org.kde.bearwave",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.6",
+    "sdk": "org.kde.Sdk",
+    "command": "bearwave",
+    "finish-args": [
+        "--share=network",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--socket=pulseaudio",
+        "--own-name=org.mpris.MediaPlayer2.bearwave",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.StatusNotifierWatcher"
+    ],
+    "modules": [
+        {
+            "name": "bearwave",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/spalencsar/bearwave.git",
+                    "commit": "05e2fbbdbe124cbe4fe4bbb0d12421936ba54517"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Submission of BearWave: KDE-focused desktop internet radio app.