### PR TITLE
Add online.donutsdelivery.Arbit

### DIFF
--- a/online.donutsdelivery.Arbit.desktop
+++ b/online.donutsdelivery.Arbit.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Arbit
+Comment=Harmonic composition workstation and MIDI editor
+Exec=arbit
+Icon=online.donutsdelivery.Arbit
+Categories=AudioVideo;Audio;Midi;Music;
+Terminal=false
+StartupNotify=true
+Keywords=music;midi;daw;composition;microtonal;just intonation;

--- a/online.donutsdelivery.Arbit.metainfo.xml
+++ b/online.donutsdelivery.Arbit.metainfo.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>online.donutsdelivery.Arbit</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <name>Arbit</name>
+  <summary>Harmonic composition workstation and MIDI editor</summary>
+  <developer id="online.donutsdelivery">
+    <name>Donuts Delivery</name>
+  </developer>
+  <launchable type="desktop-id">online.donutsdelivery.Arbit.desktop</launchable>
+  <url type="homepage">https://donutsdelivery.online/arbit</url>
+  <url type="help">https://github.com/DonutsDelivery/arbit-developer-resources</url>
+  <url type="bugtracker">https://github.com/DonutsDelivery/arbit-developer-resources/issues</url>
+  <url type="vcs-browser">https://github.com/DonutsDelivery/arbit-developer-resources</url>
+  <content_rating type="oars-1.1" />
+  <description>
+    <p>
+      Arbit is a piano-roll-first composition workstation for harmonic writing,
+      microtonal MIDI, built-in instruments, plugin hosting, and note-based sampling workflows.
+    </p>
+    <p>
+      The free edition includes the harmonic piano roll, SF2 and SFZ instruments,
+      VST3 instrument hosting, Airwindows effects, MIDI workflows, and core DAW functionality.
+      Arbit Pro unlocks audio transformation features such as sampling, vocal engines,
+      and audio pitch correction.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://donutsdelivery.online/assets/screenshots/arbit/pianoroll.png</image>
+      <caption>Compose in a harmonic piano roll with note relationships and ratio-based tuning.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://donutsdelivery.online/assets/screenshots/arbit/overview-hero.png</image>
+      <caption>Build compositions around harmonic links instead of a fixed twelve-tone grid.</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.2" date="2026-05-25">
+      <description>
+        <p>Initial open beta Flatpak packaging for the Arbit standalone app.</p>
+      </description>
+    </release>
+  </releases>
+  <provides>
+    <binary>arbit</binary>
+  </provides>
+</component>

--- a/online.donutsdelivery.Arbit.svg
+++ b/online.donutsdelivery.Arbit.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="apexGlow" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#4F46E5" />   <stop offset="40%" stop-color="#0EA5E9" />  <stop offset="80%" stop-color="#7DD3FC" />  <stop offset="100%" stop-color="#B3EFFF" /> </linearGradient>
+
+    <filter id="iconDepth" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="12" stdDeviation="15" flood-color="#000" flood-opacity="0.35" />
+    </filter>
+  </defs>
+
+  <g filter="url(#iconDepth)">
+    <path d="M 215 105 
+             C 230 70, 282 70, 297 105 
+             L 405 435 
+             C 412 458, 395 465, 375 465 
+             L 340 465 
+             C 330 465, 323 458, 320 450 
+             L 300 395 
+             C 298 388, 292 382, 285 382 
+             L 227 382 
+             C 220 382, 214 388, 212 395 
+             L 192 450 
+             C 189 458, 182 465, 172 465 
+             L 137 465 
+             C 117 465, 100 458, 107 435 
+             Z 
+             
+             M 238 345 
+             C 233 345, 228 340, 231 330 
+             L 242 300 
+             C 245 288, 267 288, 270 300 
+             L 281 330 
+             C 284 340, 279 345, 274 345 
+             Z" 
+          fill="url(#apexGlow)" fill-rule="evenodd" />
+  </g>
+</svg>

--- a/online.donutsdelivery.Arbit.yml
+++ b/online.donutsdelivery.Arbit.yml
@@ -1,0 +1,65 @@
+app-id: online.donutsdelivery.Arbit
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: arbit
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --device=all
+  - --share=network
+  - --filesystem=xdg-music
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-desktop
+
+modules:
+  - name: squashfs-tools
+    buildsystem: simple
+    build-options:
+      no-debuginfo: true
+    build-commands:
+      - make -C squashfs-tools -j ${FLATPAK_BUILDER_N_JOBS} XZ_SUPPORT=1 ZSTD_SUPPORT=1 LZO_SUPPORT=0 LZ4_SUPPORT=0
+      - install -Dm755 squashfs-tools/unsquashfs -t /app/bin/
+    sources:
+      - type: git
+        url: https://github.com/plougher/squashfs-tools.git
+        tag: 4.6.1
+        commit: d8cb82d9840330f9344ec37b992595b5d7b44184
+
+  - name: arbit
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 arbit -t /app/bin/
+      - install -Dm755 apply_extra -t /app/bin/
+      - install -Dm644 online.donutsdelivery.Arbit.desktop -t /app/share/applications/
+      - install -Dm644 online.donutsdelivery.Arbit.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 online.donutsdelivery.Arbit.svg -t /app/share/icons/hicolor/scalable/apps/
+    sources:
+      - type: extra-data
+        filename: Arbit-x86_64.AppImage
+        only-arches:
+          - x86_64
+        url: https://donutsdelivery.online/download-arbit/files/Arbit-x86_64.AppImage
+        sha256: 776f325c643fb4b98b8c9dad7f4ed1561911e45699ae8023ba8c711753cdcf2b
+        size: 67107320
+      - type: script
+        dest-filename: apply_extra
+        commands:
+          - tail -c +944633 Arbit-x86_64.AppImage > Arbit.squashfs
+          - unsquashfs -d squashfs-root -quiet -no-progress Arbit.squashfs
+          - mv squashfs-root/usr .
+          - rm -rf squashfs-root Arbit-x86_64.AppImage Arbit.squashfs
+      - type: script
+        dest-filename: arbit
+        commands:
+          - exec /app/extra/usr/bin/Arbit "$@"
+      - type: file
+        path: online.donutsdelivery.Arbit.desktop
+      - type: file
+        path: online.donutsdelivery.Arbit.metainfo.xml
+      - type: file
+        path: online.donutsdelivery.Arbit.svg


### PR DESCRIPTION
This submits Arbit, a standalone harmonic composition workstation and MIDI editor by Donuts Delivery.\n\nThe app is proprietary and uses Flatpak extra-data to download the official AppImage from https://donutsdelivery.online/download-arbit/files/Arbit-x86_64.AppImage during install.\n\nLocal checks performed:\n- flathub-build completed successfully\n- installed locally from generated repo\n- flatpak run online.donutsdelivery.Arbit starts and loads bundled soundfonts\n- flatpak-builder-lint manifest passed\n- flatpak-builder-lint repo passed