### PR TITLE
Add io.github.JaredTweed.AudioToTextTranscriber

### DIFF
--- a/io.github.JaredTweed.AudioToTextTranscriber.yml
+++ b/io.github.JaredTweed.AudioToTextTranscriber.yml
@@ -1,0 +1,69 @@
+app-id: io.github.JaredTweed.AudioToTextTranscriber
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: audio-to-text-transcriber
+
+finish-args:
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --filesystem=xdg-download
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-desktop:ro
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/man
+  - /bin/bench
+  - /bin/main
+  - /bin/vad-speech-segments
+  - /bin/whisper-bench
+  - /bin/whisper-server
+
+modules:
+  - name: pyyaml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-build-isolation --no-index .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz
+        sha256: d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e
+        x-checker-data:
+          type: pypi
+          name: PyYAML
+          packagetype: sdist
+
+  - name: whisper-cpp
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DWHISPER_BUILD_TESTS=OFF
+      - -DWHISPER_BUILD_EXAMPLES=ON
+      - -DWHISPER_FFMPEG=ON
+    sources:
+      - type: git
+        url: https://github.com/ggerganov/whisper.cpp.git
+        tag: v1.7.6
+        commit: a8d002cfd879315632a579e73f0148d06959de36
+    post-install:
+      - install -Dm755 models/download-ggml-model.sh /app/bin/download-ggml-model.sh
+    cleanup:
+      - "*.a"
+      - "*.la"
+
+  - name: audio-to-text-transcriber
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-build-isolation --no-index .
+    sources:
+      - type: git
+        url: https://github.com/JaredTweed/AudioToTextTranscriber.git
+        commit: 38198bf660177cd16023b1e8b65c33882add82be


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.

Audio To Text Transcriber is a GTK/libadwaita desktop app that uses whisper.cpp to transcribe local audio files and folders into text files.

- [x] The application has a metainfo file with appstream metadata.
- [x] The application has a desktop file.
- [x] The application has an icon.
- [x] The application is using a reverse-DNS app ID.
- [x] The manifest builds from public, immutable upstream sources.
- [x] I have built and tested the Flatpak locally.

### Local validation performed

- `flatpak-builder --repo=repo --force-clean build-dir io.github.JaredTweed.AudioToTextTranscriber.yml`
- `flatpak-builder-lint manifest io.github.JaredTweed.AudioToTextTranscriber.yml`
- `flatpak-builder-lint appstream build-dir/files/share/metainfo/io.github.JaredTweed.AudioToTextTranscriber.metainfo.xml`
- `appstreamcli validate --no-net build-dir/files/share/metainfo/io.github.JaredTweed.AudioToTextTranscriber.metainfo.xml`
- `desktop-file-validate build-dir/files/share/applications/io.github.JaredTweed.AudioToTextTranscriber.desktop`
- Built and installed a local bundle for smoke testing.

### Notes

The app writes transcripts to Downloads by default. The manifest grants write access to `xdg-download` and `xdg-documents`, and read access to common media locations so users can select local audio files/folders without requiring broad host filesystem access.
