### PR TITLE
Add org.cairoclock.CairoQmlClock

### DIFF
--- a/org.cairoclock.CairoQmlClock.json
+++ b/org.cairoclock.CairoQmlClock.json
@@ -1,0 +1,40 @@
+{
+    "app-id": "org.cairoclock.CairoQmlClock",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.8",
+    "sdk": "org.kde.Sdk",
+    "command": "cairo-qml-clock",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri"
+    ],
+    "modules": [
+        {
+            "name": "cairo-qml-clock",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/rappel12/cairo-to-qml-clock.git",
+                    "tag": "v0.2.8",
+                    "commit": "4ccbfbcdd96f5ab1230e2c9a9fb76196c79185f4"
+                }
+            ],
+            "post-install": [
+                "install -Dm644 main.qml /app/share/cairo-qml-clock/main.qml",
+                "install -Dm644 InfoDialog.qml /app/share/cairo-qml-clock/InfoDialog.qml",
+                "install -Dm644 PropertiesDialog.qml /app/share/cairo-qml-clock/PropertiesDialog.qml",
+                "install -Dm644 ThemeImage.qml /app/share/cairo-qml-clock/ThemeImage.qml",
+                "cp -r themes /app/share/cairo-qml-clock/",
+                "install -Dm644 org.cairoclock.CairoQmlClock.desktop /app/share/applications/org.cairoclock.CairoQmlClock.desktop",
+                "install -Dm644 cairo-qml-clock.png /app/share/icons/hicolor/256x256/apps/org.cairoclock.CairoQmlClock.png",
+                "install -Dm644 org.cairoclock.CairoQmlClock.metainfo.xml /app/share/metainfo/org.cairoclock.CairoQmlClock.metainfo.xml"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
A Qt6 QML reimplementation of MacSlow's cairo-clock.

Runs on modern Linux desktops without deprecated dependencies. Features a smooth sweep second hand, multiple clock face themes, configurable hand colors, and a Stay on Top toggle. Supports both X11 and Wayland (via XWayland).

- Runtime: org.kde.Platform 6.8
- Buildsystem: cmake-ninja
- No bundled dependencies — links only against Qt6 and libX11 (both in KDE SDK)

Replaces #8684, which was closed automatically due to incorrect base branch (master instead of new-pr).