### PR TITLE
Add net.shrieker.capsicum

### DIFF
--- a/net.shrieker.capsicum.yml
+++ b/net.shrieker.capsicum.yml
@@ -1,0 +1,100 @@
+# capsicum Flathub submission manifest (v1.29.0)
+#
+# packaging/linux/flathub/net.shrieker.capsicum.yml (ローカル確認用) から
+# SUBMISSION.md の手順で派生したオフラインビルド版。
+#   - bundle:        v1.29.0 Release tarball を type: archive + sha256 pin
+#   - metadata/icon: commit f2ffc7c (metainfo に 1.28.1/1.29.0 追記済み) の
+#                    raw URL + sha256 pin
+#
+# 重要: runtime に org.gnome.Platform を採用。flutter_web_auth_2 が引く
+# desktop_webview_window が libwebkit2gtk-4.1.so.0 をリンクしており、
+# org.freedesktop.Platform には webkit2gtk が含まれないため。
+
+app-id: net.shrieker.capsicum
+
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+
+command: capsicum
+
+finish-args:
+  # ネットワーク (Mastodon / Misskey / モロヘイヤ API)
+  - --share=network
+  # 共有メモリ (X11 描画高速化)
+  - --share=ipc
+  # ディスプレイサーバー
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU レンダリング
+  - --device=dri
+  # ローカル通知 (libnotify)
+  - --talk-name=org.freedesktop.Notifications
+  # アカウントトークン保存 (libsecret / gnome-keyring)
+  - --talk-name=org.freedesktop.secrets
+
+modules:
+  - name: capsicum
+    buildsystem: simple
+    build-commands:
+      # Flutter のバンドルは executable の隣に data/ と lib/ を要求する。
+      # /app/bin/ 配下にフラットに展開する (AppImage と同じ方針)。
+      - install -d /app/bin
+      - cp -r bundle/. /app/bin/
+      # crashpad_handler は tarball で実行ビットが落ちている (#639)。
+      # 付け直さないと posix_spawn EACCES で Sentry ネイティブクラッシュが無効。
+      - chmod +x /app/bin/lib/crashpad_handler
+
+      # Desktop entry / AppStream metainfo
+      - install -Dm644 net.shrieker.capsicum.desktop -t /app/share/applications/
+      - install -Dm644 net.shrieker.capsicum.metainfo.xml -t /app/share/metainfo/
+
+      # Icons (macOS の AppIconSet を流用、各サイズ hicolor に配置)
+      - install -Dm644 icon-16.png   /app/share/icons/hicolor/16x16/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-32.png   /app/share/icons/hicolor/32x32/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-64.png   /app/share/icons/hicolor/64x64/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-128.png  /app/share/icons/hicolor/128x128/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-256.png  /app/share/icons/hicolor/256x256/apps/net.shrieker.capsicum.png
+      - install -Dm644 icon-512.png  /app/share/icons/hicolor/512x512/apps/net.shrieker.capsicum.png
+    sources:
+      # Flutter Linux release bundle (オフライン: 事前ビルド済みを取り込む)
+      # tarball は中身 (./capsicum ./lib ./data) がルート直下に入っているため
+      # strip-components: 0 を明示 (デフォルト 1 だと最上位が剥がれて壊れる)。
+      - type: archive
+        url: https://github.com/pooza/capsicum/releases/download/v1.29.0/capsicum-bundle-1.29.0-x86_64.tar.gz
+        sha256: 192fb7b5399e94d18723db886d8d3e169e8d32ab500a7a788b34a64c73c095c8
+        strip-components: 0
+        dest: bundle
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packaging/linux/shared/net.shrieker.capsicum.desktop
+        sha256: 2b256ac434d6faf4153c618a705f07b2d126386b305bf8ab4f2783f194426ef0
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packaging/linux/shared/net.shrieker.capsicum.metainfo.xml
+        sha256: ab8c1f21193fc020f102d7f1d15e81397aa4592e796fb7dcfd15fb27253a1c62
+
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_16.png
+        sha256: e3ac430d5b3ef4d90d94ddfe0814f1b39b4084f5c773e7a8928d6e462accaeec
+        dest-filename: icon-16.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_32.png
+        sha256: a5e83d9b658ac50c16ea22ae216b964b6e2346e2e866a3959b092cb007baca09
+        dest-filename: icon-32.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_64.png
+        sha256: 78cdb945b4ca2c3538a4e8061e96b8b1e7a52dd7feb9483fbb6babd9a50e4053
+        dest-filename: icon-64.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_128.png
+        sha256: 394c5d38ef8e53e1370eb24af5005580f69c7754b057ddd078f99c8b3f874b70
+        dest-filename: icon-128.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_256.png
+        sha256: c5bb56613ab69c77f796ca58af0a00cae2ba2c48c80a52ad6d2db9dda7dc6145
+        dest-filename: icon-256.png
+      - type: file
+        url: https://raw.githubusercontent.com/pooza/capsicum/f2ffc7c05353f9504bb0506dcf70afa7650904d7/packages/capsicum/macos/Runner/Assets.xcassets/AppIcon.appiconset/app_icon_512.png
+        sha256: 9185d255ecd077f11b13a792b8eea5108f0f212616619de4207e28226df39250
+        dest-filename: icon-512.png


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.

capsicum is a Fediverse client built with Flutter that supports both Mastodon and Misskey.
Whether you use a Mastodon or Misskey backend, you can browse timelines and post using the same UI, and switch seamlessly between accounts.

capsicum aims to provide not just a standalone app experience, but a sense of integration with the server.
In addition to its functionality as a general-purpose client, on Mastodon/Misskey servers operated by the developers themselves, you can utilize unique features—such as live anime commentary—through integration with server-side extensions.
This sense of integration is the very reason capsicum exists.

Anyone is welcome to use it, though development is centered on the servers the developers operate.

- [x] Please attach a video showcasing the application on Linux using the Flatpak.

https://github.com/user-attachments/assets/fab52b4e-c62d-4c7d-bcf2-a16f59f76a6c

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

  `net.shrieker.capsicum` — reverse-DNS of `shrieker.net`, a domain owned by the submitter.

- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [x] I am an _author_ to the project.

---

### Notes on the Manifest

#### Runtime
- `org.gnome.Platform//49` is used.
- The `desktop_webview_window` plugin links to `libwebkit2gtk-4.1.so.0`. Since this is only available on the GNOME runtime, it was chosen over Freedesktop.

#### Build Inputs
- Pre-built Linux release bundles obtained from GitHub release tags. The SHA256 checksum is pinned.
- Since `flutter pub get` cannot be executed in the offline Flathub sandbox, this binary is installed during the build.

#### Permissions
- Network
  - Mastodon / Misskey API
- IPC
- Wayland with X11 fallback
- DRI for rendering
- org.freedesktop.Notifications
  - Local notifications
- org.freedesktop.secrets
  - Account token storage via libsecret
- No extensive filesystem access
  - Media selection and saving are handled via xdg-desktop-portal

### Local Validation

- `flatpak-builder --user --force-clean --install-deps-from=flathub --disable-rofiles-fuse build-dir net.shrieker.capsicum.yml`
  - Builds successfully on Debian 13.5 / LXQt.
- `appstreamcli validate`
  - Passes metadata file validation
- Flatpak behavior after installation
  - Starts normally
  - Can log in to Mastodon / Misskey accounts
  - Input via Japanese IME (ibus + mozc) works normally

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission