### PR TITLE
Add io.github.frankspeu.flippi

### DIFF
--- a/io.github.frankspeu.flippi/io.github.frankspeu.flippi.yml
+++ b/io.github.frankspeu.flippi/io.github.frankspeu.flippi.yml
@@ -1,0 +1,57 @@
+app-id: io.github.frankspeu.flippi
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: flippi
+
+finish-args:
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --filesystem=/tmp
+
+modules:
+  - name: wl-clipboard
+    buildsystem: meson
+    config-opts:
+      - -Dzshcompletiondir=no
+      - -Dfishcompletiondir=no
+    sources:
+      - type: archive
+        url: https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.2.1.tar.gz
+        sha256: 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+
+  - name: keybinder-3.0
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/kupferlauncher/keybinder/releases/download/keybinder-3.0-v0.3.2/keybinder-3.0-0.3.2.tar.gz
+        sha256: e6e3de4e1f3b201814a956ab8f16dfc8a262db1937ff1eee4d855365398c6020
+
+  - name: flippi
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/flippi /app/bin
+      - cp flippi /app/flippi/flippi
+      - chmod +x /app/flippi/flippi
+      - cp -r lib /app/flippi/lib
+      - cp -r data /app/flippi/data
+      - printf '#!/bin/sh\ncd /app/flippi && exec ./flippi "$@"\n' > /app/bin/flippi
+      - chmod +x /app/bin/flippi
+      - install -Dm644 source/flatpak/io.github.frankspeu.flippi.desktop /app/share/applications/io.github.frankspeu.flippi.desktop
+      - install -Dm644 source/flatpak/io.github.frankspeu.flippi.appdata.xml /app/share/metainfo/io.github.frankspeu.flippi.appdata.xml
+      - install -Dm644 source/flatpak/icons/128x128/io.github.frankspeu.flippi.png /app/share/icons/hicolor/128x128/apps/io.github.frankspeu.flippi.png
+      - install -Dm644 source/flatpak/icons/256x256/io.github.frankspeu.flippi.png /app/share/icons/hicolor/256x256/apps/io.github.frankspeu.flippi.png
+      - install -Dm644 source/flatpak/icons/512x512/io.github.frankspeu.flippi.png /app/share/icons/hicolor/512x512/apps/io.github.frankspeu.flippi.png
+    sources:
+      - type: archive
+        url: https://github.com/Riksorax/flippi/releases/download/v1.0.0/flippi-1.0.0-linux-x64.tar.gz
+        sha256: 652bd0928c7432028be06fc6bc23cb21b8d69f353218356a9a6dbf1244112009
+        strip-components: 1
+      - type: archive
+        url: https://github.com/Riksorax/flippi/archive/refs/tags/v1.0.0.tar.gz
+        sha256: 547725266716e6dc9a5ca3496ee3ce1ee89022445c45923874392fd28f3f464d
+        dest: source
+        strip-components: 1


### PR DESCRIPTION
## App Description

**Flippi** is a system-wide clipboard/emoji/GIF picker for Linux Wayland, built with Flutter Desktop.

- Clipboard history with automatic type detection (text, URL, code)
- Unicode emojis, Material Icons, and custom emojis
- GIF search via Giphy API
- Wayland-native, no taskbar entry, shows via global shortcut (Super + .)
- Popup window auto-hides on focus loss

## App Details

- **App ID:** `io.github.frankspeu.flippi`
- **Source:** https://github.com/Riksorax/flippi
- **License:** MIT
- **Runtime:** `org.freedesktop.Platform//24.08`

## Build Notes

The app is built with Flutter Desktop (Linux). Since Flathub build servers don't have Flutter installed, the manifest uses a pre-built release bundle from GitHub Releases. Dependencies `wl-clipboard` and `keybinder-3.0` are built from source within the sandbox.

## Checklist

- [x] App builds successfully with `flatpak-builder`
- [x] AppStream metainfo included
- [x] Icons in 128x128, 256x256, 512x512
- [x] Screenshot included
- [x] `--filesystem=/tmp` needed for Unix socket toggle mechanism (`/tmp/flippi.sock`)