### PR TITLE
Add io.github.oguzemrebal.ServiceToggle

### DIFF
--- a/io.github.oguzemrebal.ServiceToggle.yaml
+++ b/io.github.oguzemrebal.ServiceToggle.yaml
@@ -1,0 +1,33 @@
+app-id: io.github.oguzemrebal.ServiceToggle
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+command: service-toggle
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=system-bus
+  - --socket=session-bus
+  - --filesystem=/sys/devices/system/cpu:rw
+  - --system-talk-name=org.freedesktop.systemd1
+
+modules:
+  - name: service-toggle
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 service_toggle/__main__.py /app/bin/service-toggle
+      - install -Dm644 data/service-toggle.desktop
+          /app/share/applications/io.github.oguzemrebal.ServiceToggle.desktop
+      - install -Dm644 data/icons/service-toggle.svg
+          /app/share/icons/hicolor/scalable/apps/io.github.oguzemrebal.ServiceToggle.svg
+      - sed -i 's|^Icon=.*|Icon=io.github.oguzemrebal.ServiceToggle|'
+          /app/share/applications/io.github.oguzemrebal.ServiceToggle.desktop
+      - sed -i 's|^Exec=.*|Exec=service-toggle|'
+          /app/share/applications/io.github.oguzemrebal.ServiceToggle.desktop
+    sources:
+      - type: git
+        url: https://github.com/oguzemrebal/service-toggle.git
+        tag: v1.0.0
+        commit: bdfa70351ed31feb8a09571e203709d02ec2e892


### PR DESCRIPTION
## New app submission: Service Toggle

**App ID:** `io.github.oguzemrebal.ServiceToggle`
**Source:** https://github.com/oguzemrebal/service-toggle

### Description
A lightweight GTK4/Adwaita app for Ubuntu/GNOME that lets you start and stop
background services with a single click, and switch CPU core counts to control
power consumption — all without opening a terminal.

### Features
- One-click toggles for Docker, Ollama, VMs (KVM), CUPS, Bluetooth, Tailscale, Avahi
- CPU core presets: 8 / 16 / max cores for power control
- Live CPU activity bar visualiser
- GTK4 + Adwaita — follows system dark/light theme
- GPL-3.0 licensed

### Links
- GitHub: https://github.com/oguzemrebal/service-toggle
- Release: https://github.com/oguzemrebal/service-toggle/releases/tag/v1.0.0