### PR TITLE
Add org.acreetionos.MediaWriter

### DIFF
--- a/org.acreetionos.MediaWriter.json
+++ b/org.acreetionos.MediaWriter.json
@@ -1,0 +1,36 @@
+{
+    "id": "org.acreetionos.MediaWriter",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.10",
+    "sdk": "org.kde.Sdk",
+    "command": "mediawriter",
+    "finish-args": [
+        "--device=all",
+        "--filesystem=host",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=network",
+        "--share=ipc",
+        "--system-talk-name=org.freedesktop.UDisks2",
+        "--talk-name=org.freedesktop.Notifications"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/cmake",
+        "/lib/pkgconfig"
+    ],
+    "modules": [
+        {
+            "name": "MediaWriter",
+            "buildsystem": "cmake-ninja",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.acreetionos.org/natalie/AcreetionMediaWriter.git",
+                    "tag": "v5.3.1",
+                    "commit": "ff85a2389455b3cfcdfe2b036663d952ce6eda51"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
AcreetionOS Media Writer is a tool to create bootable live USB drives with editions of AcreetionOS. Based on Fedora Media Writer.

Homepage: https://gitlab.acreetionos.org/natalie/AcreetionMediaWriter
Source: https://gitlab.acreetionos.org/natalie/AcreetionMediaWriter