### PR TITLE
Add Karmac Dashboard - A privacy-focused desktop dashboard for Linux

### DIFF
--- a/io.gitlab.team_karmac1.KarmacDashboard.yml
+++ b/io.gitlab.team_karmac1.KarmacDashboard.yml
@@ -1,0 +1,131 @@
+app-id: io.gitlab.team_karmac1.KarmacDashboard
+runtime: org.kde.Platform
+runtime-version: '6.6'
+sdk: org.kde.Sdk
+command: karmac
+
+finish-args:
+  - --socket=x11
+  - --share=ipc
+  - --share=network
+  - --device=all
+  - --filesystem=home
+  - --filesystem=/sys/class/hwmon:ro
+  - --filesystem=/sys/class/thermal:ro
+  - --filesystem=/sys/class/drm:ro
+  - --filesystem=/sys/class/powercap:ro
+
+modules:
+  - name: shiboken6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps shiboken6-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/6a/05/a2f348685041495be25709f85ca30d9f79fdc4f3bcd4f8da8b980b1de071/shiboken6-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+        sha256: 7887ba7ecfddb09ee9966325c1e229a17f3f444b0257b77cb7838792287d3e05
+
+  - name: pyside6-essentials
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps PySide6_Essentials-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/d8/f7/7a8a0c3a87fc9a898a521ae34aea5806f71f7bef1a0e032a6d954550fcea/PySide6_Essentials-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+        sha256: e013238fe40596b804068e34ac173514943a41bf8e5fbb4edfc7c30b00431bd5
+
+  - name: pyside6-addons
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps PySide6_Addons-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/59/4f/7baa3b9081141242b161e80b5ae080f36b420d5cb779bb469fa5cb79a458/PySide6_Addons-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+        sha256: 888df2a916f1d59984e2f351e7d5850da0a04103e39501eb7d6a9b150e7431e6
+
+  - name: pyside6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps PySide6-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/fb/c6/20149db21d8daefb529e81623bb4abbf20bb46958cec5b43935ae1628c96/PySide6-6.7.0-cp39-abi3-manylinux_2_28_x86_64.whl
+        sha256: 64d6b5751f8d04aedc5e8ea53ddc6613b392919056511a988b790fd3a00f7d01
+
+  - name: certifi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps certifi-2026.5.20-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl
+        sha256: 3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897
+
+  - name: idna
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps idna-3.17-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl
+        sha256: 466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c
+
+  - name: urllib3
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps urllib3-2.7.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+
+  - name: charset-normalizer
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df
+
+  - name: requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps requests-2.34.2-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+
+  - name: psutil
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9
+
+  - name: speedtest-cli
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-deps speedtest_cli-2.1.3-py2.py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/9f/39/65259b7054368b370d3183762484fa2c779ddc41633894d895f9d1720f45/speedtest_cli-2.1.3-py2.py3-none-any.whl
+        sha256: 75ff32c91af9ac1ce2b905476d6e92bd9eb2c0783f9e7d1939d74605c7d0b9ea
+
+  - name: karmac
+    buildsystem: simple
+    build-commands:
+      - cd SRC && pip3 install --prefix=/app --no-deps .
+      - install -Dm755 SRC/main.py /app/bin/karmac-main.py
+      - printf '#!/bin/bash\nexec python3 /app/bin/karmac-main.py "$@"\n' > /app/bin/karmac
+      - chmod +x /app/bin/karmac
+      - install -Dm644 io.gitlab.team_karmac1.KarmacDashboard.desktop /app/share/applications/io.gitlab.team_karmac1.KarmacDashboard.desktop
+      - install -Dm644 io.gitlab.team_karmac1.KarmacDashboard.metainfo.xml /app/share/metainfo/io.gitlab.team_karmac1.KarmacDashboard.metainfo.xml
+      - install -Dm644 Assets/Karmac_Logo.svg /app/share/icons/hicolor/scalable/apps/io.gitlab.team_karmac1.KarmacDashboard.svg
+    sources:
+      - type: git
+        url: https://gitlab.com/team.karmac1/Karmac-dashboard.git
+        branch: main


### PR DESCRIPTION
## Karmac Dashboard

A free and open source desktop dashboard for Linux built with Python and PySide6.

**App ID:** io.gitlab.team_karmac1.KarmacDashboard
**License:** GPL-3.0-or-later
**Homepage:** https://gitlab.com/team.karmac1/Karmac-dashboard

### Description
Karmac gives everyday Linux users a beautiful, organized view of their system health and personal information — no technical knowledge required. 15 panels covering clock, weather, network, temperatures, fan speeds, CPU cores, RAM, drives, GPU, power, FPS, network traffic, processes, and disk I/O.

### Privacy
- No telemetry, no analytics, no accounts required
- Default ping uses Quad9 (9.9.9.9) — non-profit, privacy-focused DNS
- Weather via Open-Meteo — FOSS, EU-based, no tracking
- Speed test manual only — never runs automatically

### Testing
- Built and tested locally with flatpak-builder
- Tested on Linux Mint 22.3 with X-Cinnamon