### PR TITLE
Add io.github.eagredev.Daint

### DIFF
--- a/io.github.eagredev.Daint.yml
+++ b/io.github.eagredev.Daint.yml
@@ -1,0 +1,25 @@
+app-id: io.github.eagredev.Daint
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: daint
+
+finish-args:
+  # A windowed Qt app: needs a display socket and GPU access.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # File open/save via the desktop portal (no broad filesystem access needed).
+  - --filesystem=xdg-pictures
+
+modules:
+  - name: daint
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/eagredev/daint.git
+        tag: v0.1.0
+        commit: c2887eee16681e4f8a0188b8bc1e3b6530e625a8


### PR DESCRIPTION
New app submission: Daint, a simple MS-Paint-style raster paint program (Qt6/KDE).