### PR TITLE
Add com.obsproject.Studio.Plugin.Lenscast

### DIFF
--- a/com.obsproject.Studio.Plugin.Lenscast.metainfo.xml
+++ b/com.obsproject.Studio.Plugin.Lenscast.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.Lenscast</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>Lenscast Control</name>
+  <summary>Control a Lenscast phone camera from inside OBS</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      A native OBS Studio dock for Lenscast, which turns an Android phone into a network
+      camera. OBS plays the video itself via a Media or Browser Source; this plugin is the
+      control layer on top, driving the phone over its REST API.
+    </p>
+    <p>From the dock you can:</p>
+    <ul>
+      <li>Start/stop streaming and pick the protocol (MJPEG, RTSP, SRT, RIST, WebRTC)</li>
+      <li>Switch camera, toggle torch, mirror and autofocus, adjust zoom and exposure</li>
+      <li>Take a snapshot and set resolution and frame rate, with a live status line</li>
+      <li>Add or refresh the matching OBS source for the phone's current stream</li>
+      <li>Bind hotkeys for start/stop, switch camera, torch and snapshot</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/frebergguru/Lenscast</url>
+  <url type="bugtracker">https://github.com/frebergguru/Lenscast/issues</url>
+  <url type="vcs-browser">https://github.com/frebergguru/Lenscast</url>
+
+  <developer id="guru.freberg">
+    <name>Morten Freberg</name>
+  </developer>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="1.1.4" date="2026-06-04"/>
+    <release version="1.1.2" date="2026-05-30"/>
+  </releases>
+</component>

--- a/com.obsproject.Studio.Plugin.Lenscast.yaml
+++ b/com.obsproject.Studio.Plugin.Lenscast.yaml
@@ -1,0 +1,43 @@
+id: com.obsproject.Studio.Plugin.Lenscast
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.freedesktop.Sdk//25.08
+
+# Build into the OBS plugin extension point rather than as a standalone app.
+build-extension: true
+appstream-compose: false
+separate-locales: false
+
+build-options:
+  # Extensions mount under /app/plugins/<Name>; this sets CMAKE_INSTALL_PREFIX too.
+  prefix: /app/plugins/Lenscast
+  # libobs.pc / obs-frontend-api.pc and Qt6 .pc files ship inside the OBS app at /app.
+  prepend-pkg-config-path: /app/lib/pkgconfig
+
+modules:
+  - name: lenscast-control
+    buildsystem: cmake-ninja
+    # CMakeLists lives in the plugin subdir of the Lenscast repo.
+    subdir: obs/lenscast-control
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLINUX_PORTABLE=OFF          # system/prefix layout (lib/obs-plugins + share/obs)
+      - -DCMAKE_PREFIX_PATH=/app      # find OBS' bundled Qt6 cmake config
+      - -DOBS_INCLUDEDIR=/app/include # Arch/flatpak quirk: headers live in /app/include/obs
+    sources:
+      - type: git
+        url: https://github.com/frebergguru/Lenscast.git
+        tag: v1.1.4
+        # Flathub requires git sources to pin the commit alongside the tag (a retag can't
+        # then change the build). Keep this in sync with the tag on each release.
+        commit: 432c899e9c697b5a72bea49e2d50f7a04404171a
+
+  # AppStream metainfo (required by Flathub). appstream-compose is off, so install it by hand.
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 com.obsproject.Studio.Plugin.Lenscast.metainfo.xml
+          /app/plugins/Lenscast/share/metainfo/com.obsproject.Studio.Plugin.Lenscast.metainfo.xml
+    sources:
+      - type: file
+        path: com.obsproject.Studio.Plugin.Lenscast.metainfo.xml


### PR DESCRIPTION
## Lenscast Control — OBS Studio plugin extension

Adds **Lenscast Control** (`com.obsproject.Studio.Plugin.Lenscast`), a native OBS
Studio plugin extension for [Lenscast](https://github.com/frebergguru/Lenscast), an
open-source app that turns an Android phone into a network camera.

The plugin adds a control dock to OBS — start/stop, protocol, switch camera, torch,
mirror, autofocus, zoom, exposure, snapshot, resolution/FPS, a one-click
"add/refresh source", and hotkeys — driving the phone over its REST API. OBS plays
the video itself via a Media/Browser Source; this is the control layer on top.

It builds against the `com.obsproject.Studio.Plugin` extension point, the same model
as the existing `com.obsproject.Studio.Plugin.DroidCam`.

- **Upstream:** https://github.com/frebergguru/Lenscast
- **License:** GPL-3.0-or-later
- **Runtime:** com.obsproject.Studio (stable) · **SDK:** org.freedesktop.Sdk//25.08

### Notes for review
- I am the author/maintainer of Lenscast and of this plugin.
- Built locally with `flatpak-builder`; both `flatpak-builder-lint manifest` and
  `flatpak-builder-lint repo` pass clean.
- The git source pins both `tag` and `commit`.
- AppStream metainfo is included (validates with `appstreamcli validate`).