### PR TITLE
Add space.itemfab.ItemFabricator

### DIFF
--- a/space.itemfab.ItemFabricator.desktop
+++ b/space.itemfab.ItemFabricator.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Type=Application
+Name=Item Fabricator
+GenericName=Crafting Planner
+Comment=Star Citizen crafting simulator, dismantling calculator and resource planner
+Exec=item-fabricator
+Icon=space.itemfab.ItemFabricator
+Terminal=false
+Categories=Utility;
+StartupWMClass=Item Fabricator

--- a/space.itemfab.ItemFabricator.metainfo.xml
+++ b/space.itemfab.ItemFabricator.metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>space.itemfab.ItemFabricator</id>
+
+  <name>Item Fabricator</name>
+  <summary>Star Citizen crafting simulator and resource planner</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="space.itemfab">
+    <name>TheSamon</name>
+  </developer>
+
+  <description>
+    <p>
+      Item Fabricator is a Star Citizen crafting simulator, dismantling
+      calculator and resource planner. Plan what to craft, work out the
+      resources you need, and calculate the yield of dismantling items.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">space.itemfab.ItemFabricator.desktop</launchable>
+
+  <url type="homepage">https://itemfab.space</url>
+  <url type="bugtracker">https://github.com/QuentinSostaric/space-craft-planner/issues</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Browse craftable blueprints and plan your builds</caption>
+      <image>https://raw.githubusercontent.com/QuentinSostaric/space-craft-planner/main/docs/screenshot-main.png</image>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="2.1.4" date="2026-05-27" />
+  </releases>
+</component>

--- a/space.itemfab.ItemFabricator.yml
+++ b/space.itemfab.ItemFabricator.yml
@@ -1,0 +1,47 @@
+# Flatpak manifest for Item Fabricator (Flathub).
+#
+# Flathub does NOT build from the app repo: this file is the source of truth that
+# gets submitted to github.com/flathub/flathub, where the Flathub buildbot builds
+# the Flatpak by unpacking the .deb published in our GitHub Release.
+#
+# On every release: bump the `url` + `sha256` of the .deb source below
+# (sha256sum <the-deb-file>), and add a <release> entry in the metainfo.xml.
+id: space.itemfab.ItemFabricator
+runtime: org.gnome.Platform
+runtime-version: '50' # GNOME runtime ships webkit2gtk-4.1 used by Tauri
+sdk: org.gnome.Sdk
+command: item-fabricator
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  - --share=network # reqwest calls to itemfab.space + OAuth
+  - --talk-name=org.freedesktop.secrets # keyring crate stores the auth token
+
+modules:
+  - name: item-fabricator
+    buildsystem: simple
+    sources:
+      - type: file
+        path: space.itemfab.ItemFabricator.metainfo.xml
+      - type: file
+        path: space.itemfab.ItemFabricator.desktop
+      - type: file
+        url: https://github.com/QuentinSostaric/space-craft-planner/releases/download/v2.1.4/Item.Fabricator-2.1.4-linux-amd64-deb.deb
+        sha256: 76c8d69eaa9d90cc6b942067d9e4ac5c68e0173d513db68062115a2ffd220419
+        only-arches: [x86_64]
+    build-commands:
+      # The Tauri .deb is self-contained: a single static binary plus the
+      # desktop entry and icons. No /usr/lib resources to copy.
+      - ar -x *.deb
+      - tar -xf data.tar.gz
+      - install -Dm755 usr/bin/item-fabricator /app/bin/item-fabricator
+      # Our own desktop file + metainfo, named after the Flathub app-id.
+      - install -Dm644 space.itemfab.ItemFabricator.desktop /app/share/applications/space.itemfab.ItemFabricator.desktop
+      - install -Dm644 space.itemfab.ItemFabricator.metainfo.xml /app/share/metainfo/space.itemfab.ItemFabricator.metainfo.xml
+      # Icons (named after the binary inside the .deb) -> renamed to the app-id.
+      - install -Dm644 usr/share/icons/hicolor/32x32/apps/item-fabricator.png /app/share/icons/hicolor/32x32/apps/space.itemfab.ItemFabricator.png
+      - install -Dm644 usr/share/icons/hicolor/128x128/apps/item-fabricator.png /app/share/icons/hicolor/128x128/apps/space.itemfab.ItemFabricator.png
+      - install -Dm644 "usr/share/icons/hicolor/256x256@2/apps/item-fabricator.png" /app/share/icons/hicolor/256x256@2/apps/space.itemfab.ItemFabricator.png


### PR DESCRIPTION
Item Fabricator — a Star Citizen crafting simulator, dismantling calculator and resource planner.

- Upstream: https://itemfab.space
- Source repo: https://github.com/QuentinSostaric/space-craft-planner
- Tauri 2 desktop app. The Flatpak is built from the released `.deb` (official Tauri approach).
- Built and tested locally against `org.gnome.Platform//50`; launches in the sandbox and renders correctly.

Permissions:
- `--share=network` — the app talks to its backend at itemfab.space (data + OAuth login).
- `--talk-name=org.freedesktop.secrets` — stores the auth token via the keyring.

The remaining `appstream-external-screenshot-url` linter note resolves once Flathub mirrors the screenshot.