### PR TITLE
Add Flatpak configuration for erikraft-drop app

### DIFF
--- a/io.github.erikraft.Drop/io.github.erikraft.Drop.yml
+++ b/io.github.erikraft.Drop/io.github.erikraft.Drop.yml
@@ -1,0 +1,33 @@
+app-id: io.github.erikraft.Drop
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: erikraft-drop
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-download
+modules:
+  - name: erikraft-drop
+    buildsystem: simple
+    build-commands:
+      - npm ci
+      - npm run validate:linux-icon
+      - npx electron-builder --linux dir --x64 --config electron-builder.yml
+      - install -Dm755 flatpak/erikraft-drop-flatpak.sh /app/bin/erikraft-drop
+      - mkdir -p /app/erikraft-drop
+      - cp -a dist/desktop/linux-unpacked/. /app/erikraft-drop/
+      - install -Dm644 flatpak/io.github.erikraft.Drop.desktop /app/share/applications/io.github.erikraft.Drop.desktop
+      - install -Dm644 flatpak/io.github.erikraft.Drop.metainfo.xml /app/share/metainfo/io.github.erikraft.Drop.metainfo.xml
+      - install -Dm644 packaging/linux/icons/icon-drop.svg /app/share/icons/hicolor/scalable/apps/io.github.erikraft.Drop.svg
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop.png
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512-maskable.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop-maskable.png
+    sources:
+      - type: dir
+        path: ..


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

* [x] Please describe the application briefly.
  ErikrafT Drop is a lightweight file sharing application (similar to AirDrop / WeTransfer) that allows users to upload, share and download files using temporary links with expiration time. It is built with Electron and runs as a desktop wrapper for the web version at https://drop.erikraft.com/.

* [ ] Please attach a video showcasing the application on Linux using the Flatpak.
  Not available yet (N/A — Flatpak build is still in submission/testing phase). I will provide a demo video once the Flatpak package is fully validated.

* [x] The Flatpak ID follows all the rules listed in the Application ID requirements.
  The application ID used is: io.github.erikraft.Drop

* [x] I have read and followed all the Submission requirements and the Submission guide and I agree to them.

* [x] I am an author/developer/upstream contributor to the project.
  GitHub repository: https://github.com/erikraft/Drop
  GitHub profile: https://github.com/erikraft

### Additional notes

This application is currently in active development. The Flatpak manifest has been added and tested locally using flatpak-builder in a Linux environment. Future updates will include a demo video and additional sandbox validation if required.