### PR TITLE
Add Flatpak configuration for erikraft.Drop app

### DIFF
--- a/flatpak/io.github.erikraft.Drop.yml
+++ b/flatpak/io.github.erikraft.Drop.yml
@@ -1,0 +1,33 @@
+app-id: io.github.erikraft.Drop
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: erikraft-drop
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-download
+modules:
+  - name: erikraft-drop
+    buildsystem: simple
+    build-commands:
+      - npm ci
+      - npm run validate:linux-icon
+      - npx electron-builder --linux dir --x64 --config electron-builder.yml
+      - install -Dm755 flatpak/erikraft-drop-flatpak.sh /app/bin/erikraft-drop
+      - mkdir -p /app/erikraft-drop
+      - cp -a dist/desktop/linux-unpacked/. /app/erikraft-drop/
+      - install -Dm644 flatpak/io.github.erikraft.Drop.desktop /app/share/applications/io.github.erikraft.Drop.desktop
+      - install -Dm644 flatpak/io.github.erikraft.Drop.metainfo.xml /app/share/metainfo/io.github.erikraft.Drop.metainfo.xml
+      - install -Dm644 packaging/linux/icons/icon-drop.svg /app/share/icons/hicolor/scalable/apps/io.github.erikraft.Drop.svg
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop.png
+      - install -Dm644 packaging/linux/icons/android-chrome-512x512-maskable.png /app/share/icons/hicolor/512x512/apps/io.github.erikraft.Drop-maskable.png
+    sources:
+      - type: dir
+        path: ..


### PR DESCRIPTION
- [X] Please describe the application briefly.
  ErikrafT Drop is a lightweight file sharing application inspired by tools like AirDrop and WeTransfer. It allows users to upload files and generate temporary shareable links with expiration support.

  The app runs as an Electron-based desktop wrapper for the web version available at https://drop.erikraft.com.

- [ ] Please attach a video showcasing the application on Linux using the Flatpak.
  N/A — The Flatpak build is still in initial review/testing stage. A demo video will be added after the build pipeline is fully validated.

- [X] The Flatpak ID follows all the rules listed in the Application ID requirements.
  io.github.erikraft.Drop

- [X] I have read and followed all the Submission requirements and the Submission guide and I agree to them.

- [X] I am an author/developer/upstream contributor to the project.
  GitHub: https://github.com/erikraft/Drop
