### PR TITLE
Add page.codeberg.elth0r0.iqpuzzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build-dir/
+.flatpak-builder/

--- a/page.codeberg.elth0r0.iqpuzzle.yml
+++ b/page.codeberg.elth0r0.iqpuzzle.yml
@@ -2,7 +2,6 @@ app-id: page.codeberg.elth0r0.iqpuzzle
 runtime: org.kde.Platform
 runtime-version: '6.10'
 sdk: org.kde.Sdk
-separate-locales: false
 command: iqpuzzle
 finish-args:
   - --share=ipc

--- a/page.codeberg.elth0r0.iqpuzzle.yml
+++ b/page.codeberg.elth0r0.iqpuzzle.yml
@@ -14,7 +14,6 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_INSTALL_PREFIX=/app
     sources:
       - type: git
         url: https://codeberg.org/ElTh0r0/iqpuzzle.git

--- a/page.codeberg.elth0r0.iqpuzzle.yml
+++ b/page.codeberg.elth0r0.iqpuzzle.yml
@@ -1,0 +1,22 @@
+app-id: page.codeberg.elth0r0.iqpuzzle
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+separate-locales: false
+command: iqpuzzle
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+modules:
+  - name: iqpuzzle
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/app
+    sources:
+      - type: git
+        url: https://codeberg.org/ElTh0r0/iqpuzzle.git
+        tag: v1.5.1
+        commit: d824cfee2da96639f14ad6fb40255578199a5b69


### PR DESCRIPTION
### Please confirm your submission meets all the criteria
- [X] Please describe the application briefly. iQPuzzle is a diverting and challenging puzzle. The puzzle pieces are pentominoes, and there are many different board shapes to fill with them. The game is already publish on [Flathub/com.github.elth0r0.iqpuzzle](https://flathub.org/apps/details/com.github.elth0r0.iqpuzzle) with a **different AppID** (published by me as well; [see here](https://github.com/flathub/flathub/pull/2155)), but I am in the process  of moving my repository from Github to Codeberg and therefore the AppID changes. According to the Flathub docs, a re-submission with the new ID is required ([metainfo.xml](https://codeberg.org/ElTh0r0/iqpuzzle/raw/branch/main/data/unix/page.codeberg.elth0r0.iqpuzzle.metainfo.xml) already includes `provides` and `replaces` tags and I'll proceed with [End of life Rebase](https://docs.flathub.org/docs/for-app-authors/maintenance#end-of-life-rebase) once this new ID is published).
- [X] Please attach a video showcasing the application on Linux using the Flatpak [recording.webm](https://github.com/user-attachments/assets/90e8d34f-85a3-4d26-8ae4-db4ef840f251)
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am the author of the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
