### PR TITLE
Add io.github.ajunior.fragments

### DIFF
--- a/io.github.ajunior.fragments.yml
+++ b/io.github.ajunior.fragments.yml
@@ -1,0 +1,39 @@
+app-id: io.github.ajunior.fragments
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: fragments
+
+# Provides ffmpeg and ffprobe for MP4 and GIF export.
+# Automatically installed alongside the app.
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    version: '25.08'
+    add-ld-path: .
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-music
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+modules:
+  - name: fragments
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+    post-install:
+      # Required mount point for the ffmpeg-full extension.
+      - mkdir -p /app/lib/ffmpeg
+    sources:
+      - type: git
+        url: https://github.com/ajunior/fragments.git
+        tag: v0.44.6
+        commit: 00bda033894079b990d95abe393f5a25fa2e8aae


### PR DESCRIPTION
## io.github.ajunior.fragments — Fragments

Fragments is a desktop app for building and playing scripted playlists from video and audio fragments. Users trim exact ranges from source media, reorder and annotate fragments, play the full playlist sequentially, and export to MP4 or animated GIF.

**Upstream:** https://github.com/ajunior/fragments  
**License:** GPL-3.0-or-later  
**Runtime:** org.kde.Platform//6.10  

### Checklist

- [x] App meets the [Flathub requirements](https://docs.flathub.org/docs/for-app-authors/requirements)
- [x] Manifest linter passes (`flatpak-builder-lint manifest`)
- [x] Uses versioned runtime (`org.kde.Platform//6.10`)
- [x] ffmpeg bundled via `org.freedesktop.Platform.ffmpeg-full//25.08`
- [x] No `--filesystem=home`; uses specific XDG dirs (xdg-videos, xdg-music, xdg-documents, xdg-download)
- [x] AppStream metainfo with screenshots, release, OARS rating, developer tag
- [x] LICENSE installed to `share/licenses/io.github.ajunior.fragments`
- [x] I am the upstream developer and repository owner