### PR TITLE
Add io.github.angelodelorenzo.couch-remote

### DIFF
--- a/io.github.angelodelorenzo.couch-remote.yml
+++ b/io.github.angelodelorenzo.couch-remote.yml
@@ -1,0 +1,71 @@
+app-id: io.github.angelodelorenzo.couch-remote
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: couch-remote-gui
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+modules:
+  - name: python-dependencies
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-index --find-links=. androidtvremote2==0.3.1 aiofiles==25.1.0 cryptography==48.0.0 cffi==2.0.0 protobuf==7.35.0 pycparser==3.0
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/70/43/7b0fabee435bf1cbb37c04ee644f142af8056313a6babfbf2a82c3030323/androidtvremote2-0.3.1-py3-none-any.whl
+        sha256: 645bb36f8b1b5997a36a89f033ebd91c7a8bb61fbca54fda3247abbb7aebd17e
+      - type: file
+        url: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
+        sha256: abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695
+      - type: file
+        url: https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl
+        sha256: bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl
+        sha256: 7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602
+        only-arches:
+          - aarch64
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b
+        only-arches:
+          - aarch64
+      - type: file
+        url: https://files.pythonhosted.org/packages/70/5b/6baf9008817964454055ff3fe65f1de0b5f1e26c80c82f7fb108b7cd4ea3/protobuf-7.35.0-cp310-abi3-manylinux2014_x86_64.whl
+        sha256: 6c0f98f10c8a05ea30f8993dfef2de093d27b490fdae78bb60c8343795d55011
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/8b/39/1c76c2da93f3c507e958e0aecee2391cc44d4625de6c728bbc555195b5a8/protobuf-7.35.0-cp310-abi3-manylinux2014_aarch64.whl
+        sha256: fcbe42a4ac09d3ec9c987ddfcd956afd0b15f1ff613bd8371bde9405ffd5c8e5
+        only-arches:
+          - aarch64
+      - type: file
+        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+
+  - name: couch-remote
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-index --no-deps --no-build-isolation .
+      - install -Dm644 data/io.github.angelodelorenzo.couch-remote.desktop /app/share/applications/io.github.angelodelorenzo.couch-remote.desktop
+      - install -Dm644 data/io.github.angelodelorenzo.couch-remote.metainfo.xml /app/share/metainfo/io.github.angelodelorenzo.couch-remote.metainfo.xml
+      - install -Dm644 data/icons/hicolor/scalable/apps/io.github.angelodelorenzo.couch-remote.svg /app/share/icons/hicolor/scalable/apps/io.github.angelodelorenzo.couch-remote.svg
+    sources:
+      - type: git
+        url: https://github.com/AngeloDeLorenzo/couch-remote.git
+        tag: v1.0.2
+        commit: 2d3073c3207445a5add713d3469967fdd3dbf711
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
Adds Couch Remote, a GTK remote control for Android TV and Google TV devices on the local network.

Validation performed locally:
- Built with org.flatpak.Builder from the GitHub v1.0.2 tag
- Ran flatpak-builder-lint on the manifest
- Ran flatpak-builder-lint on the generated repo
- Validated desktop file and AppStream metadata

The manifest uses pinned Python wheel sources with SHA256 hashes for x86_64 and aarch64 builds.