### PR TITLE
Add io.github.j0ck4.Wren

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -1,0 +1,2088 @@
+[
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.4.crate",
+  "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
+  "dest": "cargo/vendor/aho-corasick-1.1.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\", \"files\": {}}",
+  "dest": "cargo/vendor/aho-corasick-1.1.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/ansi_term/ansi_term-0.12.1.crate",
+  "sha256": "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2",
+  "dest": "cargo/vendor/ansi_term-0.12.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2\", \"files\": {}}",
+  "dest": "cargo/vendor/ansi_term-0.12.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.102.crate",
+  "sha256": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c",
+  "dest": "cargo/vendor/anyhow-1.0.102"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\", \"files\": {}}",
+  "dest": "cargo/vendor/anyhow-1.0.102",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/async-channel/async-channel-2.5.0.crate",
+  "sha256": "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2",
+  "dest": "cargo/vendor/async-channel-2.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2\", \"files\": {}}",
+  "dest": "cargo/vendor/async-channel-2.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/atty/atty-0.2.14.crate",
+  "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+  "dest": "cargo/vendor/atty-0.2.14"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8\", \"files\": {}}",
+  "dest": "cargo/vendor/atty-0.2.14",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.0.crate",
+  "sha256": "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8",
+  "dest": "cargo/vendor/autocfg-1.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8\", \"files\": {}}",
+  "dest": "cargo/vendor/autocfg-1.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+  "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+  "dest": "cargo/vendor/bitflags-1.3.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+  "dest": "cargo/vendor/bitflags-1.3.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/bitflags/bitflags-2.11.1.crate",
+  "sha256": "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3",
+  "dest": "cargo/vendor/bitflags-2.11.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3\", \"files\": {}}",
+  "dest": "cargo/vendor/bitflags-2.11.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/bytes/bytes-1.11.1.crate",
+  "sha256": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33",
+  "dest": "cargo/vendor/bytes-1.11.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33\", \"files\": {}}",
+  "dest": "cargo/vendor/bytes-1.11.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.20.12.crate",
+  "sha256": "91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0",
+  "dest": "cargo/vendor/cairo-rs-0.20.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"91e3bd0f4e25afa9cabc157908d14eeef9067d6448c49414d17b3fb55f0eadd0\", \"files\": {}}",
+  "dest": "cargo/vendor/cairo-rs-0.20.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.20.10.crate",
+  "sha256": "059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b",
+  "dest": "cargo/vendor/cairo-sys-rs-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"059cc746549898cbfd9a47754288e5a958756650ef4652bbb6c5f71a6bda4f8b\", \"files\": {}}",
+  "dest": "cargo/vendor/cairo-sys-rs-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.20.7.crate",
+  "sha256": "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368",
+  "dest": "cargo/vendor/cfg-expr-0.20.7"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368\", \"files\": {}}",
+  "dest": "cargo/vendor/cfg-expr-0.20.7",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.4.crate",
+  "sha256": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801",
+  "dest": "cargo/vendor/cfg-if-1.0.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\", \"files\": {}}",
+  "dest": "cargo/vendor/cfg-if-1.0.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/clap/clap-2.34.0.crate",
+  "sha256": "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c",
+  "dest": "cargo/vendor/clap-2.34.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c\", \"files\": {}}",
+  "dest": "cargo/vendor/clap-2.34.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
+  "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
+  "dest": "cargo/vendor/concurrent-queue-2.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
+  "dest": "cargo/vendor/concurrent-queue-2.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/configparser/configparser-1.0.0.crate",
+  "sha256": "fe1d7dcda7d1da79e444bdfba1465f2f849a58b07774e1df473ee77030cb47a7",
+  "dest": "cargo/vendor/configparser-1.0.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"fe1d7dcda7d1da79e444bdfba1465f2f849a58b07774e1df473ee77030cb47a7\", \"files\": {}}",
+  "dest": "cargo/vendor/configparser-1.0.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.21.crate",
+  "sha256": "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28",
+  "dest": "cargo/vendor/crossbeam-utils-0.8.21"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28\", \"files\": {}}",
+  "dest": "cargo/vendor/crossbeam-utils-0.8.21",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/dbus/dbus-0.9.11.crate",
+  "sha256": "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73",
+  "dest": "cargo/vendor/dbus-0.9.11"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73\", \"files\": {}}",
+  "dest": "cargo/vendor/dbus-0.9.11",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/dbus-codegen/dbus-codegen-0.9.1.crate",
+  "sha256": "a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c",
+  "dest": "cargo/vendor/dbus-codegen-0.9.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c\", \"files\": {}}",
+  "dest": "cargo/vendor/dbus-codegen-0.9.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/dbus-tree/dbus-tree-0.9.2.crate",
+  "sha256": "f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508",
+  "dest": "cargo/vendor/dbus-tree-0.9.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508\", \"files\": {}}",
+  "dest": "cargo/vendor/dbus-tree-0.9.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/equivalent/equivalent-1.0.2.crate",
+  "sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f",
+  "dest": "cargo/vendor/equivalent-1.0.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\", \"files\": {}}",
+  "dest": "cargo/vendor/equivalent-1.0.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/errno/errno-0.3.14.crate",
+  "sha256": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
+  "dest": "cargo/vendor/errno-0.3.14"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
+  "dest": "cargo/vendor/errno-0.3.14",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/event-listener/event-listener-5.4.1.crate",
+  "sha256": "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab",
+  "dest": "cargo/vendor/event-listener-5.4.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab\", \"files\": {}}",
+  "dest": "cargo/vendor/event-listener-5.4.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.4.crate",
+  "sha256": "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93",
+  "dest": "cargo/vendor/event-listener-strategy-0.5.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93\", \"files\": {}}",
+  "dest": "cargo/vendor/event-listener-strategy-0.5.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/fastrand/fastrand-2.4.1.crate",
+  "sha256": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6",
+  "dest": "cargo/vendor/fastrand-2.4.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6\", \"files\": {}}",
+  "dest": "cargo/vendor/fastrand-2.4.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/field-offset/field-offset-0.3.6.crate",
+  "sha256": "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f",
+  "dest": "cargo/vendor/field-offset-0.3.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
+  "dest": "cargo/vendor/field-offset-0.3.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/foldhash/foldhash-0.1.5.crate",
+  "sha256": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2",
+  "dest": "cargo/vendor/foldhash-0.1.5"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2\", \"files\": {}}",
+  "dest": "cargo/vendor/foldhash-0.1.5",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.32.crate",
+  "sha256": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d",
+  "dest": "cargo/vendor/futures-channel-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-channel-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.32.crate",
+  "sha256": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d",
+  "dest": "cargo/vendor/futures-core-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-core-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.32.crate",
+  "sha256": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d",
+  "dest": "cargo/vendor/futures-executor-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-executor-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.32.crate",
+  "sha256": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718",
+  "dest": "cargo/vendor/futures-io-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-io-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.32.crate",
+  "sha256": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b",
+  "dest": "cargo/vendor/futures-macro-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-macro-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.32.crate",
+  "sha256": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393",
+  "dest": "cargo/vendor/futures-task-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-task-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.32.crate",
+  "sha256": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6",
+  "dest": "cargo/vendor/futures-util-0.3.32"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6\", \"files\": {}}",
+  "dest": "cargo/vendor/futures-util-0.3.32",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.20.10.crate",
+  "sha256": "2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c",
+  "dest": "cargo/vendor/gdk-pixbuf-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"2fd242894c084f4beed508a56952750bce3e96e85eb68fdc153637daa163e10c\", \"files\": {}}",
+  "dest": "cargo/vendor/gdk-pixbuf-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.20.10.crate",
+  "sha256": "5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96",
+  "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"5b34f3b580c988bd217e9543a2de59823fafae369d1a055555e5f95a8b130b96\", \"files\": {}}",
+  "dest": "cargo/vendor/gdk-pixbuf-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gdk4/gdk4-0.9.6.crate",
+  "sha256": "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60",
+  "dest": "cargo/vendor/gdk4-0.9.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60\", \"files\": {}}",
+  "dest": "cargo/vendor/gdk4-0.9.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gdk4-sys/gdk4-sys-0.9.6.crate",
+  "sha256": "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a",
+  "dest": "cargo/vendor/gdk4-sys-0.9.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a\", \"files\": {}}",
+  "dest": "cargo/vendor/gdk4-sys-0.9.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/getrandom/getrandom-0.4.2.crate",
+  "sha256": "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555",
+  "dest": "cargo/vendor/getrandom-0.4.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555\", \"files\": {}}",
+  "dest": "cargo/vendor/getrandom-0.4.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gio/gio-0.20.12.crate",
+  "sha256": "8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831",
+  "dest": "cargo/vendor/gio-0.20.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8e27e276e7b6b8d50f6376ee7769a71133e80d093bdc363bd0af71664228b831\", \"files\": {}}",
+  "dest": "cargo/vendor/gio-0.20.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.20.10.crate",
+  "sha256": "521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83",
+  "dest": "cargo/vendor/gio-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"521e93a7e56fc89e84aea9a52cfc9436816a4b363b030260b699950ff1336c83\", \"files\": {}}",
+  "dest": "cargo/vendor/gio-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/glib/glib-0.20.12.crate",
+  "sha256": "ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683",
+  "dest": "cargo/vendor/glib-0.20.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ffc4b6e352d4716d84d7dde562dd9aee2a7d48beb872dd9ece7f2d1515b2d683\", \"files\": {}}",
+  "dest": "cargo/vendor/glib-0.20.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.20.12.crate",
+  "sha256": "e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145",
+  "dest": "cargo/vendor/glib-macros-0.20.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e8084af62f09475a3f529b1629c10c429d7600ee1398ae12dd3bf175d74e7145\", \"files\": {}}",
+  "dest": "cargo/vendor/glib-macros-0.20.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.20.10.crate",
+  "sha256": "8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215",
+  "dest": "cargo/vendor/glib-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8ab79e1ed126803a8fb827e3de0e2ff95191912b8db65cee467edb56fc4cc215\", \"files\": {}}",
+  "dest": "cargo/vendor/glib-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.20.10.crate",
+  "sha256": "ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda",
+  "dest": "cargo/vendor/gobject-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ec9aca94bb73989e3cfdbf8f2e0f1f6da04db4d291c431f444838925c4c63eda\", \"files\": {}}",
+  "dest": "cargo/vendor/gobject-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/graphene-rs/graphene-rs-0.20.10.crate",
+  "sha256": "6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b",
+  "dest": "cargo/vendor/graphene-rs-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6b86dfad7d14251c9acaf1de63bc8754b7e3b4e5b16777b6f5a748208fe9519b\", \"files\": {}}",
+  "dest": "cargo/vendor/graphene-rs-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/graphene-sys/graphene-sys-0.20.10.crate",
+  "sha256": "df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea",
+  "dest": "cargo/vendor/graphene-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"df583a85ba2d5e15e1797e40d666057b28bc2f60a67c9c24145e6db2cc3861ea\", \"files\": {}}",
+  "dest": "cargo/vendor/graphene-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gsk4/gsk4-0.9.6.crate",
+  "sha256": "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855",
+  "dest": "cargo/vendor/gsk4-0.9.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855\", \"files\": {}}",
+  "dest": "cargo/vendor/gsk4-0.9.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gsk4-sys/gsk4-sys-0.9.6.crate",
+  "sha256": "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc",
+  "dest": "cargo/vendor/gsk4-sys-0.9.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc\", \"files\": {}}",
+  "dest": "cargo/vendor/gsk4-sys-0.9.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gtk4/gtk4-0.9.7.crate",
+  "sha256": "f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6",
+  "dest": "cargo/vendor/gtk4-0.9.7"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f274dd0102c21c47bbfa8ebcb92d0464fab794a22fad6c3f3d5f165139a326d6\", \"files\": {}}",
+  "dest": "cargo/vendor/gtk4-0.9.7",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gtk4-macros/gtk4-macros-0.9.5.crate",
+  "sha256": "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999",
+  "dest": "cargo/vendor/gtk4-macros-0.9.5"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999\", \"files\": {}}",
+  "dest": "cargo/vendor/gtk4-macros-0.9.5",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/gtk4-sys/gtk4-sys-0.9.6.crate",
+  "sha256": "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6",
+  "dest": "cargo/vendor/gtk4-sys-0.9.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6\", \"files\": {}}",
+  "dest": "cargo/vendor/gtk4-sys-0.9.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.5.crate",
+  "sha256": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1",
+  "dest": "cargo/vendor/hashbrown-0.15.5"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\", \"files\": {}}",
+  "dest": "cargo/vendor/hashbrown-0.15.5",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.0.crate",
+  "sha256": "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51",
+  "dest": "cargo/vendor/hashbrown-0.17.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51\", \"files\": {}}",
+  "dest": "cargo/vendor/hashbrown-0.17.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
+  "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+  "dest": "cargo/vendor/heck-0.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+  "dest": "cargo/vendor/heck-0.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.19.crate",
+  "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
+  "dest": "cargo/vendor/hermit-abi-0.1.19"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33\", \"files\": {}}",
+  "dest": "cargo/vendor/hermit-abi-0.1.19",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/id-arena/id-arena-2.3.0.crate",
+  "sha256": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954",
+  "dest": "cargo/vendor/id-arena-2.3.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\", \"files\": {}}",
+  "dest": "cargo/vendor/id-arena-2.3.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/indexmap/indexmap-2.14.0.crate",
+  "sha256": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9",
+  "dest": "cargo/vendor/indexmap-2.14.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9\", \"files\": {}}",
+  "dest": "cargo/vendor/indexmap-2.14.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/ini/ini-1.3.0.crate",
+  "sha256": "0a9271a5dfd4228fa56a78d7508a35c321639cc71f783bb7a5723552add87bce",
+  "dest": "cargo/vendor/ini-1.3.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0a9271a5dfd4228fa56a78d7508a35c321639cc71f783bb7a5723552add87bce\", \"files\": {}}",
+  "dest": "cargo/vendor/ini-1.3.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
+  "sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
+  "dest": "cargo/vendor/itoa-1.0.18"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\", \"files\": {}}",
+  "dest": "cargo/vendor/itoa-1.0.18",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/ksni/ksni-0.2.2.crate",
+  "sha256": "4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b",
+  "dest": "cargo/vendor/ksni-0.2.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b\", \"files\": {}}",
+  "dest": "cargo/vendor/ksni-0.2.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
+  "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
+  "dest": "cargo/vendor/lazy_static-1.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
+  "dest": "cargo/vendor/lazy_static-1.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/leb128fmt/leb128fmt-0.1.0.crate",
+  "sha256": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2",
+  "dest": "cargo/vendor/leb128fmt-0.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\", \"files\": {}}",
+  "dest": "cargo/vendor/leb128fmt-0.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.7.2.crate",
+  "sha256": "500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191",
+  "dest": "cargo/vendor/libadwaita-0.7.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"500135d29c16aabf67baafd3e7741d48e8b8978ca98bac39e589165c8dc78191\", \"files\": {}}",
+  "dest": "cargo/vendor/libadwaita-0.7.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/libadwaita-sys/libadwaita-sys-0.7.2.crate",
+  "sha256": "6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db",
+  "dest": "cargo/vendor/libadwaita-sys-0.7.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6680988058c2558baf3f548a370e4e78da3bf7f08469daa822ac414842c912db\", \"files\": {}}",
+  "dest": "cargo/vendor/libadwaita-sys-0.7.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
+  "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
+  "dest": "cargo/vendor/libc-0.2.186"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66\", \"files\": {}}",
+  "dest": "cargo/vendor/libc-0.2.186",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/libdbus-sys/libdbus-sys-0.2.7.crate",
+  "sha256": "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043",
+  "dest": "cargo/vendor/libdbus-sys-0.2.7"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043\", \"files\": {}}",
+  "dest": "cargo/vendor/libdbus-sys-0.2.7",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.12.1.crate",
+  "sha256": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53",
+  "dest": "cargo/vendor/linux-raw-sys-0.12.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53\", \"files\": {}}",
+  "dest": "cargo/vendor/linux-raw-sys-0.12.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/log/log-0.4.29.crate",
+  "sha256": "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897",
+  "dest": "cargo/vendor/log-0.4.29"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897\", \"files\": {}}",
+  "dest": "cargo/vendor/log-0.4.29",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/matchers/matchers-0.2.0.crate",
+  "sha256": "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9",
+  "dest": "cargo/vendor/matchers-0.2.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9\", \"files\": {}}",
+  "dest": "cargo/vendor/matchers-0.2.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/memchr/memchr-2.8.0.crate",
+  "sha256": "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79",
+  "dest": "cargo/vendor/memchr-2.8.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79\", \"files\": {}}",
+  "dest": "cargo/vendor/memchr-2.8.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
+  "sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
+  "dest": "cargo/vendor/memoffset-0.9.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
+  "dest": "cargo/vendor/memoffset-0.9.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/mio/mio-1.2.0.crate",
+  "sha256": "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1",
+  "dest": "cargo/vendor/mio-1.2.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1\", \"files\": {}}",
+  "dest": "cargo/vendor/mio-1.2.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/nu-ansi-term/nu-ansi-term-0.50.3.crate",
+  "sha256": "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5",
+  "dest": "cargo/vendor/nu-ansi-term-0.50.3"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5\", \"files\": {}}",
+  "dest": "cargo/vendor/nu-ansi-term-0.50.3",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/once_cell/once_cell-1.21.4.crate",
+  "sha256": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50",
+  "dest": "cargo/vendor/once_cell-1.21.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\", \"files\": {}}",
+  "dest": "cargo/vendor/once_cell-1.21.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/pango/pango-0.20.12.crate",
+  "sha256": "6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c",
+  "dest": "cargo/vendor/pango-0.20.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6576b311f6df659397043a5fa8a021da8f72e34af180b44f7d57348de691ab5c\", \"files\": {}}",
+  "dest": "cargo/vendor/pango-0.20.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.20.10.crate",
+  "sha256": "186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa",
+  "dest": "cargo/vendor/pango-sys-0.20.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"186909673fc09be354555c302c0b3dcf753cd9fa08dcb8077fa663c80fb243fa\", \"files\": {}}",
+  "dest": "cargo/vendor/pango-sys-0.20.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
+  "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
+  "dest": "cargo/vendor/parking-2.2.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
+  "dest": "cargo/vendor/parking-2.2.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
+  "sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
+  "dest": "cargo/vendor/pin-project-lite-0.2.17"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd\", \"files\": {}}",
+  "dest": "cargo/vendor/pin-project-lite-0.2.17",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.33.crate",
+  "sha256": "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e",
+  "dest": "cargo/vendor/pkg-config-0.3.33"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e\", \"files\": {}}",
+  "dest": "cargo/vendor/pkg-config-0.3.33",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.37.crate",
+  "sha256": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b",
+  "dest": "cargo/vendor/prettyplease-0.2.37"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\", \"files\": {}}",
+  "dest": "cargo/vendor/prettyplease-0.2.37",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
+  "sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
+  "dest": "cargo/vendor/proc-macro-crate-3.5.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f\", \"files\": {}}",
+  "dest": "cargo/vendor/proc-macro-crate-3.5.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.106.crate",
+  "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
+  "dest": "cargo/vendor/proc-macro2-1.0.106"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\", \"files\": {}}",
+  "dest": "cargo/vendor/proc-macro2-1.0.106",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/qrcode/qrcode-0.14.1.crate",
+  "sha256": "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec",
+  "dest": "cargo/vendor/qrcode-0.14.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec\", \"files\": {}}",
+  "dest": "cargo/vendor/qrcode-0.14.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/quote/quote-1.0.45.crate",
+  "sha256": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924",
+  "dest": "cargo/vendor/quote-1.0.45"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\", \"files\": {}}",
+  "dest": "cargo/vendor/quote-1.0.45",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/r-efi/r-efi-6.0.0.crate",
+  "sha256": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf",
+  "dest": "cargo/vendor/r-efi-6.0.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\", \"files\": {}}",
+  "dest": "cargo/vendor/r-efi-6.0.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.14.crate",
+  "sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
+  "dest": "cargo/vendor/regex-automata-0.4.14"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\", \"files\": {}}",
+  "dest": "cargo/vendor/regex-automata-0.4.14",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.10.crate",
+  "sha256": "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a",
+  "dest": "cargo/vendor/regex-syntax-0.8.10"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a\", \"files\": {}}",
+  "dest": "cargo/vendor/regex-syntax-0.8.10",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
+  "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+  "dest": "cargo/vendor/rustc_version-0.4.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
+  "dest": "cargo/vendor/rustc_version-0.4.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/rustix/rustix-1.1.4.crate",
+  "sha256": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
+  "dest": "cargo/vendor/rustix-1.1.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\", \"files\": {}}",
+  "dest": "cargo/vendor/rustix-1.1.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/semver/semver-1.0.28.crate",
+  "sha256": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd",
+  "dest": "cargo/vendor/semver-1.0.28"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\", \"files\": {}}",
+  "dest": "cargo/vendor/semver-1.0.28",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/serde/serde-1.0.228.crate",
+  "sha256": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
+  "dest": "cargo/vendor/serde-1.0.228"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\", \"files\": {}}",
+  "dest": "cargo/vendor/serde-1.0.228",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/serde_core/serde_core-1.0.228.crate",
+  "sha256": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad",
+  "dest": "cargo/vendor/serde_core-1.0.228"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\", \"files\": {}}",
+  "dest": "cargo/vendor/serde_core-1.0.228",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.228.crate",
+  "sha256": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
+  "dest": "cargo/vendor/serde_derive-1.0.228"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79\", \"files\": {}}",
+  "dest": "cargo/vendor/serde_derive-1.0.228",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.150.crate",
+  "sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
+  "dest": "cargo/vendor/serde_json-1.0.150"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9\", \"files\": {}}",
+  "dest": "cargo/vendor/serde_json-1.0.150",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.1.1.crate",
+  "sha256": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26",
+  "dest": "cargo/vendor/serde_spanned-1.1.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26\", \"files\": {}}",
+  "dest": "cargo/vendor/serde_spanned-1.1.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.7.crate",
+  "sha256": "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+  "dest": "cargo/vendor/sharded-slab-0.1.7"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6\", \"files\": {}}",
+  "dest": "cargo/vendor/sharded-slab-0.1.7",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.8.crate",
+  "sha256": "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b",
+  "dest": "cargo/vendor/signal-hook-registry-1.4.8"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b\", \"files\": {}}",
+  "dest": "cargo/vendor/signal-hook-registry-1.4.8",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/slab/slab-0.4.12.crate",
+  "sha256": "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5",
+  "dest": "cargo/vendor/slab-0.4.12"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5\", \"files\": {}}",
+  "dest": "cargo/vendor/slab-0.4.12",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/smallvec/smallvec-1.15.1.crate",
+  "sha256": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03",
+  "dest": "cargo/vendor/smallvec-1.15.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03\", \"files\": {}}",
+  "dest": "cargo/vendor/smallvec-1.15.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/strsim/strsim-0.8.0.crate",
+  "sha256": "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a",
+  "dest": "cargo/vendor/strsim-0.8.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a\", \"files\": {}}",
+  "dest": "cargo/vendor/strsim-0.8.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/syn/syn-2.0.117.crate",
+  "sha256": "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99",
+  "dest": "cargo/vendor/syn-2.0.117"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\", \"files\": {}}",
+  "dest": "cargo/vendor/syn-2.0.117",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/system-deps/system-deps-7.0.8.crate",
+  "sha256": "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7",
+  "dest": "cargo/vendor/system-deps-7.0.8"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7\", \"files\": {}}",
+  "dest": "cargo/vendor/system-deps-7.0.8",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.13.3.crate",
+  "sha256": "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c",
+  "dest": "cargo/vendor/target-lexicon-0.13.3"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c\", \"files\": {}}",
+  "dest": "cargo/vendor/target-lexicon-0.13.3",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tempfile/tempfile-3.27.0.crate",
+  "sha256": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd",
+  "dest": "cargo/vendor/tempfile-3.27.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\", \"files\": {}}",
+  "dest": "cargo/vendor/tempfile-3.27.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/textwrap/textwrap-0.11.0.crate",
+  "sha256": "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060",
+  "dest": "cargo/vendor/textwrap-0.11.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060\", \"files\": {}}",
+  "dest": "cargo/vendor/textwrap-0.11.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
+  "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
+  "dest": "cargo/vendor/thiserror-1.0.69"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\", \"files\": {}}",
+  "dest": "cargo/vendor/thiserror-1.0.69",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/thiserror/thiserror-2.0.18.crate",
+  "sha256": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4",
+  "dest": "cargo/vendor/thiserror-2.0.18"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4\", \"files\": {}}",
+  "dest": "cargo/vendor/thiserror-2.0.18",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
+  "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
+  "dest": "cargo/vendor/thiserror-impl-1.0.69"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\", \"files\": {}}",
+  "dest": "cargo/vendor/thiserror-impl-1.0.69",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-2.0.18.crate",
+  "sha256": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5",
+  "dest": "cargo/vendor/thiserror-impl-2.0.18"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5\", \"files\": {}}",
+  "dest": "cargo/vendor/thiserror-impl-2.0.18",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.9.crate",
+  "sha256": "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185",
+  "dest": "cargo/vendor/thread_local-1.1.9"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185\", \"files\": {}}",
+  "dest": "cargo/vendor/thread_local-1.1.9",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tokio/tokio-1.52.3.crate",
+  "sha256": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
+  "dest": "cargo/vendor/tokio-1.52.3"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe\", \"files\": {}}",
+  "dest": "cargo/vendor/tokio-1.52.3",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.7.0.crate",
+  "sha256": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496",
+  "dest": "cargo/vendor/tokio-macros-2.7.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496\", \"files\": {}}",
+  "dest": "cargo/vendor/tokio-macros-2.7.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/toml/toml-1.1.2+spec-1.1.0.crate",
+  "sha256": "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee",
+  "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee\", \"files\": {}}",
+  "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-1.1.1+spec-1.1.0.crate",
+  "sha256": "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7",
+  "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7\", \"files\": {}}",
+  "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.11+spec-1.1.0.crate",
+  "sha256": "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b",
+  "dest": "cargo/vendor/toml_edit-0.25.11+spec-1.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b\", \"files\": {}}",
+  "dest": "cargo/vendor/toml_edit-0.25.11+spec-1.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.1.2+spec-1.1.0.crate",
+  "sha256": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526",
+  "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526\", \"files\": {}}",
+  "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.1.1+spec-1.1.0.crate",
+  "sha256": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db",
+  "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\", \"files\": {}}",
+  "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tracing/tracing-0.1.44.crate",
+  "sha256": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
+  "dest": "cargo/vendor/tracing-0.1.44"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100\", \"files\": {}}",
+  "dest": "cargo/vendor/tracing-0.1.44",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.31.crate",
+  "sha256": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da",
+  "dest": "cargo/vendor/tracing-attributes-0.1.31"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da\", \"files\": {}}",
+  "dest": "cargo/vendor/tracing-attributes-0.1.31",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.36.crate",
+  "sha256": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a",
+  "dest": "cargo/vendor/tracing-core-0.1.36"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\", \"files\": {}}",
+  "dest": "cargo/vendor/tracing-core-0.1.36",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.2.0.crate",
+  "sha256": "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+  "dest": "cargo/vendor/tracing-log-0.2.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3\", \"files\": {}}",
+  "dest": "cargo/vendor/tracing-log-0.2.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.23.crate",
+  "sha256": "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319",
+  "dest": "cargo/vendor/tracing-subscriber-0.3.23"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319\", \"files\": {}}",
+  "dest": "cargo/vendor/tracing-subscriber-0.3.23",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.24.crate",
+  "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+  "dest": "cargo/vendor/unicode-ident-1.0.24"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\", \"files\": {}}",
+  "dest": "cargo/vendor/unicode-ident-1.0.24",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.14.crate",
+  "sha256": "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af",
+  "dest": "cargo/vendor/unicode-width-0.1.14"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af\", \"files\": {}}",
+  "dest": "cargo/vendor/unicode-width-0.1.14",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
+  "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
+  "dest": "cargo/vendor/unicode-xid-0.2.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
+  "dest": "cargo/vendor/unicode-xid-0.2.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/valuable/valuable-0.1.1.crate",
+  "sha256": "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65",
+  "dest": "cargo/vendor/valuable-0.1.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65\", \"files\": {}}",
+  "dest": "cargo/vendor/valuable-0.1.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/vec_map/vec_map-0.8.2.crate",
+  "sha256": "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191",
+  "dest": "cargo/vendor/vec_map-0.8.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191\", \"files\": {}}",
+  "dest": "cargo/vendor/vec_map-0.8.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/version-compare/version-compare-0.2.1.crate",
+  "sha256": "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e",
+  "dest": "cargo/vendor/version-compare-0.2.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e\", \"files\": {}}",
+  "dest": "cargo/vendor/version-compare-0.2.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
+  "sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
+  "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
+  "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.1+wasi-0.2.4.crate",
+  "sha256": "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7",
+  "dest": "cargo/vendor/wasip2-1.0.1+wasi-0.2.4"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7\", \"files\": {}}",
+  "dest": "cargo/vendor/wasip2-1.0.1+wasi-0.2.4",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasip3/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06.crate",
+  "sha256": "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5",
+  "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5\", \"files\": {}}",
+  "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.244.0.crate",
+  "sha256": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319",
+  "dest": "cargo/vendor/wasm-encoder-0.244.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319\", \"files\": {}}",
+  "dest": "cargo/vendor/wasm-encoder-0.244.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasm-metadata/wasm-metadata-0.244.0.crate",
+  "sha256": "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909",
+  "dest": "cargo/vendor/wasm-metadata-0.244.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909\", \"files\": {}}",
+  "dest": "cargo/vendor/wasm-metadata-0.244.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.244.0.crate",
+  "sha256": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe",
+  "dest": "cargo/vendor/wasmparser-0.244.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe\", \"files\": {}}",
+  "dest": "cargo/vendor/wasmparser-0.244.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+  "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+  "dest": "cargo/vendor/winapi-0.3.9"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+  "dest": "cargo/vendor/winapi-0.3.9",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+  "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+  "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+  "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+  "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+  "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+  "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows-link/windows-link-0.2.1.crate",
+  "sha256": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5",
+  "dest": "cargo/vendor/windows-link-0.2.1"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5\", \"files\": {}}",
+  "dest": "cargo/vendor/windows-link-0.2.1",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
+  "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+  "dest": "cargo/vendor/windows-sys-0.59.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
+  "dest": "cargo/vendor/windows-sys-0.59.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.61.2.crate",
+  "sha256": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc",
+  "dest": "cargo/vendor/windows-sys-0.61.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc\", \"files\": {}}",
+  "dest": "cargo/vendor/windows-sys-0.61.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+  "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+  "dest": "cargo/vendor/windows-targets-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+  "dest": "cargo/vendor/windows-targets-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+  "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+  "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+  "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+  "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+  "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+  "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+  "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+  "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+  "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+  "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+  "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+  "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+  "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+  "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+  "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+  "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+  "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/winnow/winnow-1.0.2.crate",
+  "sha256": "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0",
+  "dest": "cargo/vendor/winnow-1.0.2"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0\", \"files\": {}}",
+  "dest": "cargo/vendor/winnow-1.0.2",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.46.0.crate",
+  "sha256": "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59",
+  "dest": "cargo/vendor/wit-bindgen-0.46.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-bindgen-0.46.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.51.0.crate",
+  "sha256": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5",
+  "dest": "cargo/vendor/wit-bindgen-0.51.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-bindgen-0.51.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-bindgen-core/wit-bindgen-core-0.51.0.crate",
+  "sha256": "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc",
+  "dest": "cargo/vendor/wit-bindgen-core-0.51.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-bindgen-core-0.51.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-bindgen-rust/wit-bindgen-rust-0.51.0.crate",
+  "sha256": "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21",
+  "dest": "cargo/vendor/wit-bindgen-rust-0.51.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-bindgen-rust-0.51.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-bindgen-rust-macro/wit-bindgen-rust-macro-0.51.0.crate",
+  "sha256": "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a",
+  "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-component/wit-component-0.244.0.crate",
+  "sha256": "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2",
+  "dest": "cargo/vendor/wit-component-0.244.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-component-0.244.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/wit-parser/wit-parser-0.244.0.crate",
+  "sha256": "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736",
+  "dest": "cargo/vendor/wit-parser-0.244.0"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736\", \"files\": {}}",
+  "dest": "cargo/vendor/wit-parser-0.244.0",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.28.crate",
+  "sha256": "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f",
+  "dest": "cargo/vendor/xml-rs-0.8.28"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f\", \"files\": {}}",
+  "dest": "cargo/vendor/xml-rs-0.8.28",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "archive",
+  "archive-type": "tar-gzip",
+  "url": "https://static.crates.io/crates/zmij/zmij-1.0.21.crate",
+  "sha256": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa",
+  "dest": "cargo/vendor/zmij-1.0.21"
+ },
+ {
+  "type": "inline",
+  "contents": "{\"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\", \"files\": {}}",
+  "dest": "cargo/vendor/zmij-1.0.21",
+  "dest-filename": ".cargo-checksum.json"
+ },
+ {
+  "type": "inline",
+  "contents": "[source.vendored-sources]\ndirectory = \"/run/build/wren/cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+  "dest": "cargo",
+  "dest-filename": "config"
+ }
+]

--- a/io.github.j0ck4.Wren.json
+++ b/io.github.j0ck4.Wren.json
@@ -16,7 +16,6 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=org.freedesktop.Flatpak",
-        "--filesystem=xdg-config/autostart:create",
         "--system-talk-name=org.freedesktop.PolicyKit1"
     ],
     "build-options": {
@@ -38,9 +37,9 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/j0ck4/wren-project.git",
-                    "tag": "v0.2.1",
-                    "commit": "c56a56033a847d3421e659e7a15eee0067e2a1aa"
+                    "url": "https://github.com/j0ck4/wren.git",
+                    "tag": "v0.2.2",
+                    "commit": "bf2cb153c20cb9634dc280c321491c626eb53970"
                 },
                 "cargo-sources.json"
             ]

--- a/io.github.j0ck4.Wren.json
+++ b/io.github.j0ck4.Wren.json
@@ -1,0 +1,49 @@
+{
+    "id": "io.github.j0ck4.Wren",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.rust-stable",
+        "org.freedesktop.Sdk.Extension.llvm20"
+    ],
+    "command": "wren",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--filesystem=xdg-config/autostart:create",
+        "--system-talk-name=org.freedesktop.PolicyKit1"
+    ],
+    "build-options": {
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm20/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm20/lib",
+        "env": {
+            "CARGO_HOME": "/run/build/wren/cargo",
+            "CARGO_NET_OFFLINE": "true",
+            "RUST_BACKTRACE": "1"
+        }
+    },
+    "modules": [
+        {
+            "name": "wren",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dprofile=default"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/j0ck4/wren-project.git",
+                    "tag": "v0.2.1",
+                    "commit": "c56a56033a847d3421e659e7a15eee0067e2a1aa"
+                },
+                "cargo-sources.json"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This adds **Wren**, a native GTK4 / libadwaita client for managing WireGuard VPN tunnels.

- Source: https://github.com/j0ck4/wren-project (GPL-3.0-or-later)
- Built offline from vendored Cargo sources (`cargo-sources.json`); no network access at build time.

### Permissions justification

Wren is a GUI front-end for the host's `wg-quick`. Bringing a WireGuard tunnel up or down needs root and manipulates the host network namespace, so it cannot run inside the sandbox and there is no portal for it. Hence:

- `--talk-name=org.freedesktop.Flatpak` — runs `wg-quick up/down` on the host via `flatpak-spawn --host`. This is the core requirement; a WireGuard manager cannot work without host access.
- `--system-talk-name=org.freedesktop.PolicyKit1` — `wg-quick` is invoked through `pkexec`, so the user authenticates via polkit instead of the app holding privileges.
- `--talk-name=org.kde.StatusNotifierWatcher` — optional system-tray icon.
- `--talk-name=org.freedesktop.Notifications` — connect/disconnect notifications.
- `--filesystem=xdg-config/autostart:create` — optional “start at login” entry.
- Display sockets only; **no `--share=network`** — the app itself does no networking, all traffic is handled by the host's `wg-quick`.

I understand this grants host access and that the app will be flagged accordingly; it is inherent to a WireGuard tunnel manager. Happy to adjust per review.