### PR TITLE
Add PipeRDC Flatpak packaging

### DIFF
--- a/apps/org.piperdc.PipeRDC/org.piperdc.PipeRDC.appdata.xml
+++ b/apps/org.piperdc.PipeRDC/org.piperdc.PipeRDC.appdata.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.piperdc.PipeRDC</id>
+  <name>PipeRDC</name>
+  <summary>RDP Connection Manager for Linux</summary>
+  <description>
+    <p>PipeRDC is a native GTK4 + LibAdwaita remote desktop connection manager for Linux. It helps you add, organize, and launch RDP sessions using FreeRDP.</p>
+  </description>
+  <project_license>MIT</project_license>
+  <metadata_license>MIT</metadata_license>
+  <url type="homepage">https://github.com/Darius662/PipeRDC</url>
+  <url type="bugtracker">https://github.com/Darius662/PipeRDC/issues</url>
+  <developer_name>Darius Jeleru</developer_name>
+  <launchable type="desktop-id">org.piperdc.PipeRDC.desktop</launchable>
+  <provides>
+    <binary>piperdc</binary>
+  </provides>
+  <releases>
+    <release version="1.0.0" date="2026-06-05"/>
+  </releases>
+  <categories>
+    <category>Network</category>
+    <category>RemoteAccess</category>
+  </categories>
+  <keywords>rdp</keywords>
+</component>

--- a/apps/org.piperdc.PipeRDC/org.piperdc.PipeRDC.yml
+++ b/apps/org.piperdc.PipeRDC/org.piperdc.PipeRDC.yml
@@ -1,0 +1,100 @@
+app-id: org.piperdc.PipeRDC
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: piperdc
+finish-args:
+  - --share=network
+  - --socket=wayland
+  - --socket=x11
+  - --socket=pulseaudio
+  - --share=ipc
+  - --device=dri
+  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=org.freedesktop.portal.Secret
+  - --own-name=com.piperdc.app
+  - --env=GTK_A11Y=none
+  - --filesystem=home
+  - --filesystem=xdg-run/keyrings
+modules:
+  - name: pycparser
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --no-build-isolation --prefix=/app .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz
+        sha256: e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206
+
+  - name: cffi
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --no-build-isolation --prefix=/app .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
+        sha256: 1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
+
+  - name: typing-extensions
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --prefix=/app typing_extensions-4.15.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl
+        sha256: f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548
+
+  - name: jeepney
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --prefix=/app jeepney-0.9.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl
+        sha256: 97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683
+
+  - name: cryptography
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --prefix=/app cryptography-46.0.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a8/5d/1fdbd2e5c1ba822828d250e5a966622ef00185e476d1cd2726b6dd135e53/cryptography-46.0.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: bca3f0ce67e5a2a2cf524e86f44697c4323a86e0fd7ba857de1c30d52c11ede1
+
+  - name: secretstorage
+    buildsystem: simple
+    build-commands:
+      - python3 -m pip install --no-deps --prefix=/app secretstorage-3.5.0-py3-none-any.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
+        sha256: 0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137
+
+  - name: freerdp
+    buildsystem: simple
+    build-commands:
+      - mkdir -p build
+      - cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/app -DWITH_CLIENT=ON -DWITH_SERVER=OFF -DWITH_CLIENT_COMMON=ON -DWITH_CHANNELS=ON -DWITH_WINPR_TOOLS=ON -DWITH_CLIENT_SDL=OFF -DWITH_PULSE=ON -DWITH_ALSA=OFF -DWITH_OPENSSL=ON -DWITH_JPEG=ON -DWITH_X11=ON -DWITH_XCURSOR=ON -DWITH_XINERAMA=ON -DWITH_XRENDER=ON -DWITH_XRANDR=ON -DWITH_XFIXES=ON -DWITH_FUSE=OFF
+      - cd build && cmake --build . --target install
+      - mkdir -p /app/bin && cd /app/bin && ln -sf xfreerdp xfreerdp3
+    sources:
+      - type: archive
+        url: https://github.com/FreeRDP/FreeRDP/archive/refs/tags/3.26.0.tar.gz
+        sha256: ae3b1c0b8e334ecbc2c784bce266249309fad32a0ef41947ce5c059eb18e2059
+
+  - name: piperdc
+    buildsystem: simple
+    build-commands:
+      - DEST="$(python3 -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix="/app"))')" && mkdir -p "$DEST" && cp -r /run/build/piperdc/src "$DEST/"
+      - mkdir -p /app/share/applications
+      - sed 's/^Icon=piperdc$/Icon=org.piperdc.PipeRDC/' /run/build/piperdc/data/piperdc.desktop > /app/share/applications/org.piperdc.PipeRDC.desktop
+      - install -Dm644 /run/build/piperdc/data/icons/piperdc.svg /app/share/icons/hicolor/scalable/apps/org.piperdc.PipeRDC.svg
+      - mkdir -p /app/bin
+      - printf '%s\n' '#!/bin/sh' 'exec python3 -m src.main "${@}"' > /app/bin/piperdc
+      - chmod +x /app/bin/piperdc
+    sources:
+      - type: archive
+        url: https://github.com/Darius662/PipeRDC/archive/v1.0.0.tar.gz
+        sha256: 4ed6b07c5cc7835db43a2d41e80c547f93c3ebdef2a3467c8ccbe9077be79ada


### PR DESCRIPTION
This PR adds PipeRDC packaging for Flathub under apps/org.piperdc.PipeRDC/. It includes the Flatpak manifest and AppStream metadata, sourced from the project's `pkg/flathub/` directory.

The package has been locally tested with `flatpak-builder --force-clean --disable-cache --repo=repo build org.piperdc.PipeRDC.yml`, and the installed app verifies `xfreerdp3` is present in the sandbox.

Please review the manifest, permissions, and sandbox requirements for Flathub acceptance.
