### PR TITLE
Add org.gnome.gnomint

### DIFF
--- a/org.gnome.gnomint.yml
+++ b/org.gnome.gnomint.yml
@@ -1,0 +1,76 @@
+app-id: org.gnome.gnomint
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: gnomint
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=home
+  - --metadata=X-DConf=migrate-path=/org/gnome/gnomint/
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/man
+  - /share/info
+  - /share/gtk-doc
+  - '*.la'
+  - '*.a'
+
+modules:
+  - name: libgpg-error
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-1.51.tar.bz2
+        sha256: be0f1b2db6b93eed55369cdf79f19f72750c8c7c39fc20b577e724545427e6b2
+
+  - name: libgcrypt
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.11.0.tar.bz2
+        sha256: 09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c
+
+  - name: gnutls
+    buildsystem: autotools
+    config-opts:
+      - --disable-doc
+      - --disable-static
+      - --disable-tests
+      - --disable-tools
+      - --disable-guile
+      - --with-included-libtasn1
+      - --with-included-unistring
+      - --without-p11-kit
+    sources:
+      - type: archive
+        url: https://www.gnupg.org/ftp/gcrypt/gnutls/v3.8/gnutls-3.8.8.tar.xz
+        sha256: ac4f020e583880b51380ed226e59033244bc536cad2623f2e26f5afa2939d8fb
+
+  - name: intltool
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: gnomint
+    buildsystem: autotools
+    post-install:
+      - glib-compile-schemas /app/share/glib-2.0/schemas/
+    sources:
+      - type: git
+        url: https://github.com/davefx/gnoMint.git
+        tag: v1.6.4
+        commit: d73b1deb1ba74a17d1058fc0c6a59de027c7eafe


### PR DESCRIPTION
This submits **gnoMint** — an X.509 Certification Authority management tool with a GTK 4 GUI and a readline CLI.

- **App ID:** `org.gnome.gnomint`
- **Upstream:** https://github.com/davefx/gnoMint
- **License:** GPL-3.0-or-later
- **I am the upstream author/maintainer** of this application.

The manifest is pinned to the **v1.6.4** release (commit `d73b1de`). I built and verified it locally with `flatpak-builder` against `org.gnome.Platform//48`: both binaries (`gnomint`, `gnomint-cli`) build, and the MetaInfo (`org.gnome.gnomint.metainfo.xml`, passes `appstreamcli validate`), desktop file, hicolor icons (svg/192/64/48), and compiled GSettings schema all export correctly.

Bundled modules: libgpg-error, libgcrypt, GnuTLS (with included libtasn1/libunistring), intltool.

Checklist:
- [x] I am the original author of this application, or have permission from the author.
- [x] The application is Free Software and the license is correctly declared.
- [x] A valid MetaInfo/AppData file is present and validates.
- [x] The manifest builds from a stable, pinned release.