### PR TITLE
Add org.nordstjernen.WebBrowser

### DIFF
--- a/org.nordstjernen.WebBrowser.yml
+++ b/org.nordstjernen.WebBrowser.yml
@@ -1,0 +1,56 @@
+# Flathub manifest for Nordstjernen. Builds against the GNOME runtime, which
+# supplies GTK 4, libcurl, OpenSSL, SQLite, libpsl, libwebp, librsvg,
+# gdk-pixbuf, libepoxy, fontconfig and Pango; only uchardet is an extra module.
+app-id: org.nordstjernen.WebBrowser
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: nordstjernen
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --filesystem=xdg-download
+  # Let the shell hand <audio>/<video> URLs to an external player.
+  - --talk-name=org.freedesktop.portal.OpenURI
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /share/man
+  - '*.a'
+  - '*.la'
+
+modules:
+  - name: uchardet
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DBUILD_BINARY=OFF
+    sources:
+      - type: archive
+        url: https://www.freedesktop.org/software/uchardet/releases/uchardet-0.0.8.tar.xz
+        sha256: e97a60cfc00a1c147a674b097bb1422abd9fa78a2d9ce3f3fdcc2e78a34ac5f0
+
+  - name: nordstjernen
+    buildsystem: meson
+    config-opts:
+      - --buildtype=release
+      - -Db_lto=true
+      - -Dai=disabled
+    sources:
+      - type: git
+        url: https://github.com/nordstjernen-web/nordstjernen.git
+        tag: 1.0.7-flatpak
+        commit: ca6a50888634647bc175fd2be40d625aa149d9fd
+    post-install:
+      # Flathub expects the app icon and AppStream id to match the app-id.
+      - cp /app/share/icons/hicolor/scalable/apps/nordstjernen.svg
+          /app/share/icons/hicolor/scalable/apps/org.nordstjernen.WebBrowser.svg
+      - desktop-file-edit --set-icon=org.nordstjernen.WebBrowser
+          /app/share/applications/org.nordstjernen.WebBrowser.desktop


### PR DESCRIPTION
This submission adds **Nordstjernen**, a clean-room web browser written from scratch in C with a GTK 4 UI and a libcurl network stack. No forked browser engine.

- App ID: `org.nordstjernen.WebBrowser` (matches the project domain nordstjernen.org)
- Upstream: https://github.com/nordstjernen-web/nordstjernen
- Built against `org.gnome.Platform//50`; only `uchardet` is an extra module (everything else comes from the runtime). AI/llama.cpp is disabled to keep the bundle lean.
- Source pinned to tag `1.0.7-flatpak` (commit `ca6a50888634647bc175fd2be40d625aa149d9fd`).

Checklist:
- [x] I am the developer / authorized to submit this app.
- [x] The app does not phone home and ships no telemetry.
- [x] AppStream metainfo (`org.nordstjernen.WebBrowser.metainfo.xml`) is installed and validates.
- [x] Permissions are minimal: network, wayland/fallback-x11, dri (WebGL), ipc, xdg-download, and the OpenURI portal for handing media URLs to an external player.
- [x] Locally built and run-tested with `flatpak-builder` on the GNOME 50 runtime (toolbar icons, about:start, Wikipedia rendering all verified).


<img width="1343" height="959" alt="bilde" src="https://github.com/user-attachments/assets/36d6bb4f-cdf3-4e08-89f7-7bb1b9161831" />

https://nordstjernen.org/
