### PR TITLE
Add com.hamidfzm.glyph

### DIFF
--- a/com.hamidfzm.glyph.desktop
+++ b/com.hamidfzm.glyph.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Name=Glyph
+GenericName=Markdown Viewer
+Comment=Cross-platform markdown viewer and editor
+Exec=glyph %F
+Icon=com.hamidfzm.glyph
+Terminal=false
+Categories=Office;Utility;TextEditor;
+MimeType=text/markdown;
+Keywords=markdown;md;viewer;editor;notes;
+StartupNotify=true
+StartupWMClass=Glyph

--- a/com.hamidfzm.glyph.metainfo.xml
+++ b/com.hamidfzm.glyph.metainfo.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Maintainer: hamidfzm <hamidfzm@users.noreply.github.com> -->
+<component type="desktop-application">
+  <id>com.hamidfzm.glyph</id>
+
+  <name>Glyph</name>
+  <summary>Cross-platform markdown viewer and editor</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="com.hamidfzm">
+    <name>hamidfzm</name>
+  </developer>
+
+  <description>
+    <p>
+      Glyph is a modern, cross-platform markdown viewer and editor with
+      platform-native styling. Built with Tauri v2, React 19, and TypeScript.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>GitHub Flavored Markdown with syntax highlighting</li>
+      <li>KaTeX math and Mermaid diagrams</li>
+      <li>Multi-file tabs and a table-of-contents outline</li>
+      <li>Live file watching that reloads on disk changes</li>
+      <li>Wikilinks, backlinks, and workspace navigation</li>
+      <li>Optional AI summarization (Claude, OpenAI, Ollama) and text-to-speech</li>
+      <li>Light and dark themes that follow the system appearance</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.hamidfzm.glyph.desktop</launchable>
+
+  <url type="homepage">https://github.com/hamidfzm/glyph</url>
+  <url type="bugtracker">https://github.com/hamidfzm/glyph/issues</url>
+  <url type="vcs-browser">https://github.com/hamidfzm/glyph</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/hamidfzm/glyph/main/docs/assets/hero.png</image>
+      <caption>Glyph rendering a markdown document with the outline sidebar</caption>
+    </screenshot>
+  </screenshots>
+
+  <categories>
+    <category>Office</category>
+    <category>Utility</category>
+    <category>TextEditor</category>
+  </categories>
+
+  <keywords>
+    <keyword>markdown</keyword>
+    <keyword>md</keyword>
+    <keyword>viewer</keyword>
+    <keyword>editor</keyword>
+    <keyword>notes</keyword>
+  </keywords>
+
+  <provides>
+    <binary>glyph</binary>
+  </provides>
+
+  <content_rating type="oars-1.1" />
+
+  <branding>
+    <color type="primary" scheme_preference="light">#f5f5f5</color>
+    <color type="primary" scheme_preference="dark">#1e1e1e</color>
+  </branding>
+
+  <releases>
+    <release version="0.10.0" date="2026-06-11">
+      <url type="details">https://github.com/hamidfzm/glyph/releases/tag/v0.10.0</url>
+    </release>
+  </releases>
+</component>

--- a/com.hamidfzm.glyph.yml
+++ b/com.hamidfzm.glyph.yml
@@ -1,0 +1,64 @@
+# Flatpak manifest for Glyph.
+#
+# This installs the released Debian package into the GNOME runtime rather than
+# recompiling from source, matching the AUR/PPA pattern already used in
+# `.github/workflows/release.yml`. flatpak-builder understands `.deb` archives
+# and unpacks the embedded data tarball, so `usr/...` paths below come straight
+# from the Tauri-generated package.
+#
+# The `url` versions and `sha256` checksums below are placeholders. They are
+# filled in per release (the SHA256s are the same ones computed by the
+# `publish-aur` / `publish-debian` jobs). Validate this manifest in a Linux
+# environment with:
+#   flatpak-builder --user --install --force-clean build-dir flatpak/com.hamidfzm.glyph.yml
+#
+# See the Tauri Flatpak guide: https://v2.tauri.app/distribute/flatpak/
+id: com.hamidfzm.glyph
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: glyph
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Network access is needed for the optional AI features (Claude/OpenAI/Ollama).
+  - --share=network
+  # Read/write access to the user's documents so markdown files can be opened.
+  - --filesystem=home
+  # Desktop notifications.
+  - --talk-name=org.freedesktop.Notifications
+
+modules:
+  - name: glyph
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 usr/bin/glyph /app/bin/glyph
+      - install -Dm644 com.hamidfzm.glyph.desktop /app/share/applications/com.hamidfzm.glyph.desktop
+      - install -Dm644 com.hamidfzm.glyph.metainfo.xml /app/share/metainfo/com.hamidfzm.glyph.metainfo.xml
+      # Re-home every Tauri-generated PNG icon under the Flatpak app-id,
+      # preserving its hicolor size directory (the .deb ships 32x32, 128x128,
+      # and 256x256@2). Iterating over whatever exists avoids hardcoding the
+      # exact set of sizes the bundler emits.
+      - |
+        for src in $(find usr/share/icons -name glyph.png); do
+          dest="/app/${src#usr/}"
+          install -Dm644 "$src" "${dest%/glyph.png}/com.hamidfzm.glyph.png"
+        done
+    sources:
+      - type: archive
+        only-arches:
+          - x86_64
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_amd64.deb
+        sha256: 93e5d40ba44ee78563bc27e717ee954c714bbe6e63337d361a801c6c8cb53e4d
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://github.com/hamidfzm/glyph/releases/download/v0.10.0/Glyph_0.10.0_arm64.deb
+        sha256: 86dbc1e9b0f29e8c20464b7e2aaa33daead86f270d65a3b0f8ebed7f204c8dcb
+      - type: file
+        path: com.hamidfzm.glyph.desktop
+      - type: file
+        path: com.hamidfzm.glyph.metainfo.xml


### PR DESCRIPTION
Submitting [Glyph](https://github.com/hamidfzm/glyph), a cross-platform markdown viewer and editor built with Tauri v2, React 19, and TypeScript.

- App ID: `com.hamidfzm.glyph`
- License: MIT
- Upstream: https://github.com/hamidfzm/glyph

The manifest installs the upstream-released `.deb` (per-arch `x86_64`/`aarch64`) into the GNOME 50 runtime, following the Tauri Flatpak guide. Glyph on Linux is a GTK + WebKitGTK app, hence the GNOME runtime.

Permissions rationale:
- `--share=network`: optional AI summarization/TTS (Claude/OpenAI/Ollama) and update checks.
- `--filesystem=home`: it is a document editor that opens markdown files and folder workspaces from the user's files.

Happy to adjust the manifest or finish-args per review feedback.
