### PR TITLE
Add io.github.pawanrai9999.respite

### DIFF
--- a/io.github.pawanrai9999.respite.json
+++ b/io.github.pawanrai9999.respite.json
@@ -1,0 +1,45 @@
+{
+    "id": "io.github.pawanrai9999.respite",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "respite",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--socket=wayland"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/pkgconfig",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "respite",
+            "builddir": true,
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/pawanrai9999/respite.git",
+                    "tag": "0.1.0",
+                    "commit": "cfb53a1ffe0c2e37ac35caa1ed6d70b04b8d7dd7"
+                }
+            ],
+            "config-opts": [
+                "--libdir=lib"
+            ]
+        }
+    ],
+    "build-options": {
+        "env": {}
+    }
+}


### PR DESCRIPTION
## Respite

A break-reminder application for the GNOME desktop (C, GTK4 + libadwaita, Wayland). You set a work interval and break length; when the interval elapses, Respite blacks out every monitor with a centered countdown, with a limited, configurable number of postponements. It can run as an autostarting background daemon.

- **Upstream:** https://github.com/pawanrai9999/respite
- **License:** AGPL-3.0-or-later
- **Release:** built from the pinned `0.1.0` tag (commit `cfb53a1`).

### Checklist
- [x] I am the author/maintainer of this application, or have permission to submit it.
- [x] App ID follows the `io.github.<user>.<repo>` convention for a code-hosted project.
- [x] Manifest source is pinned to a tagged release commit.
- [x] `flatpak-builder-lint manifest` passes.
- [x] `flatpak-builder-lint repo` passes (only the expected `screenshots-not-mirrored` notices remain, which Flathub mirrors on build).
- [x] AppStream metainfo validates (`appstreamcli validate`), with screenshots, releases, content_rating and branding.
- [x] Minimal `finish-args` (wayland/fallback-x11, dri, ipc); all privileged behavior goes through XDG portals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)