### PR TITLE
Add se.sjoerd.lockpicker

### DIFF
--- a/se.sjoerd.lockpicker.json
+++ b/se.sjoerd.lockpicker.json
@@ -1,64 +1,53 @@
 {
-  "id": "se.sjoerd.lockpicker",
-  "runtime": "org.gnome.Platform",
-  "runtime-version": "50",
-  "sdk": "org.gnome.Sdk",
-
-  "command": "lockpicker",
-
-  "finish-args": [
-    "--share=ipc",
-    "--socket=wayland",
-    "--socket=fallback-x11",
-    "--device=dri"
-  ],
-
-  "cleanup": [
-    "*.la",
-    "*.a"
-  ],
-
-  "modules": [
-	{
-	  "name": "hashcat",
-	  "buildsystem": "simple",
-	  "build-commands": [
-	    "make PREFIX=/app",
-	    "make install PREFIX=/app"
-	  ],
-	  "sources": [
-	    {
-	      "type": "archive",
-	      "url": "https://github.com/hashcat/hashcat/archive/refs/tags/v7.1.2.tar.gz",
-	      "sha256": "9546a6326d747530b44fcc079babad40304a87f32d3c9080016d58b39cfc8b96",
-	      "x-checker-data": {
-	        "type": "json",
-	        "url": "https://api.github.com/repos/hashcat/hashcat/releases/latest",
-	        "version-query": ".tag_name | sub(\"^hashcat-\"; \"\")",
-	        "url-query": ".assets[] | select(.name==\"hashcat-\" + $version + \".tar.gz\") | .browser_download_url"
-	      }
-	    }
-	  ]
-	},
-
-    {
-      "name": "lockpicker",
-      "buildsystem": "meson",
-      "config-opts": [
-        "--buildtype=release"
-      ],
-      "sources": [
-	{
-	  "type": "git",
-	  "url": "https://codeberg.org/sstendahl/Lockpicker.git",
-	  "commit": "f039f706966e81014454c5cd388d2c7e8918d895",
-	  "tag": "v1.0.0",
-	  "x-checker-data": {
-	    "type": "git",
-	    "tag-pattern": "^v([\\d.]+)$"
-	  }
-	}
-      ],
-    }
-  ]
+    "id": "se.sjoerd.lockpicker",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "lockpicker",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "hashcat",
+            "buildsystem": "simple",
+            "build-commands": [
+                "make PREFIX=/app",
+                "make install PREFIX=/app"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/hashcat/hashcat/archive/refs/tags/v7.1.2.tar.gz",
+                    "sha256": "9546a6326d747530b44fcc079babad40304a87f32d3c9080016d58b39cfc8b96",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/hashcat/hashcat/releases/latest",
+                        "version-query": ".tag_name | sub(\"^hashcat-\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"hashcat-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "lockpicker",
+            "buildsystem": "meson",
+            "config-opts": [
+                "--buildtype=release"
+            ],
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "."
+                }
+            ]
+        }
+    ]
 }

--- a/se.sjoerd.lockpicker.json
+++ b/se.sjoerd.lockpicker.json
@@ -44,8 +44,14 @@
             ],
             "sources": [
                 {
-                    "type": "dir",
-                    "path": "."
+                    "type": "git",
+                    "url": "https://codeberg.org/sstendahl/Lockpicker.git",
+                    "commit": "f039f706966e81014454c5cd388d2c7e8918d895",
+                    "tag": "v1.0.0",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         }

--- a/se.sjoerd.lockpicker.json
+++ b/se.sjoerd.lockpicker.json
@@ -46,8 +46,8 @@
                 {
                     "type": "git",
                     "url": "https://codeberg.org/sstendahl/Lockpicker.git",
-                    "commit": "f039f706966e81014454c5cd388d2c7e8918d895",
-                    "tag": "v1.0.0",
+                    "commit": "bec22ebd0090818fb3b784002ac79e7a9f387eea",
+                    "tag": "v1.0.1",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"

--- a/se.sjoerd.lockpicker.json
+++ b/se.sjoerd.lockpicker.json
@@ -51,7 +51,7 @@
 	{
 	  "type": "git",
 	  "url": "https://codeberg.org/sstendahl/Lockpicker.git",
-	  "commit": "f7969e9059cb7f6f40a638fbb7628aa8580cd333",
+	  "commit": "f039f706966e81014454c5cd388d2c7e8918d895",
 	  "tag": "v1.0.0",
 	  "x-checker-data": {
 	    "type": "git",

--- a/se.sjoerd.lockpicker.json
+++ b/se.sjoerd.lockpicker.json
@@ -1,0 +1,64 @@
+{
+  "id": "se.sjoerd.lockpicker",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
+
+  "command": "lockpicker",
+
+  "finish-args": [
+    "--share=ipc",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--device=dri"
+  ],
+
+  "cleanup": [
+    "*.la",
+    "*.a"
+  ],
+
+  "modules": [
+	{
+	  "name": "hashcat",
+	  "buildsystem": "simple",
+	  "build-commands": [
+	    "make PREFIX=/app",
+	    "make install PREFIX=/app"
+	  ],
+	  "sources": [
+	    {
+	      "type": "archive",
+	      "url": "https://github.com/hashcat/hashcat/archive/refs/tags/v7.1.2.tar.gz",
+	      "sha256": "9546a6326d747530b44fcc079babad40304a87f32d3c9080016d58b39cfc8b96",
+	      "x-checker-data": {
+	        "type": "json",
+	        "url": "https://api.github.com/repos/hashcat/hashcat/releases/latest",
+	        "version-query": ".tag_name | sub(\"^hashcat-\"; \"\")",
+	        "url-query": ".assets[] | select(.name==\"hashcat-\" + $version + \".tar.gz\") | .browser_download_url"
+	      }
+	    }
+	  ]
+	},
+
+    {
+      "name": "lockpicker",
+      "buildsystem": "meson",
+      "config-opts": [
+        "--buildtype=release"
+      ],
+      "sources": [
+	{
+	  "type": "git",
+	  "url": "https://codeberg.org/sstendahl/Lockpicker.git",
+	  "commit": "f7969e9059cb7f6f40a638fbb7628aa8580cd333",
+	  "tag": "v1.0.0",
+	  "x-checker-data": {
+	    "type": "git",
+	    "tag-pattern": "^v([\\d.]+)$"
+	  }
+	}
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly. 

Lockpicker is a tool to recover passwords from a hash. Essentially it functions as a front-end for hashcat, making it possible to do password recovery without  the hassle of hashcat syntax in a GNOME native graphical interface. 

The purpose of Lockpicker is as an academic or educational tool, it does not provide more capabilities than regular hashcat on purpose. Custom modules can be added though through the interface.

- [x] Please attach a video showcasing the application on Linux using the Flatpak.

https://github.com/user-attachments/assets/2241ac56-ea21-4f4c-90e9-710509ccb315



- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author+developer to the project.


<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
