### PR TITLE
Add io.github.s7ntech82.Mate-Smart-Lock

### DIFF
--- a/io.github.s7ntech82.Mate-Smart-Lock.yml
+++ b/io.github.s7ntech82.Mate-Smart-Lock.yml
@@ -1,0 +1,28 @@
+app-id: io.github.s7ntech82.Mate-Smart-Lock
+runtime: org.gnome.Platform
+runtime-version: "50"
+sdk: org.gnome.Sdk
+command: mate-smart-lock
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --system-talk-name=org.bluez
+  - --system-talk-name=org.freedesktop.login1
+  - --talk-name=org.gnome.ScreenSaver
+  - --talk-name=org.mate.ScreenSaver
+  - --talk-name=org.freedesktop.ScreenSaver
+
+modules:
+  - name: mate-smart-lock
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps --no-build-isolation --prefix=/app .
+      - install -Dm644 data/io.github.s7ntech82.Mate-Smart-Lock.desktop /app/share/applications/io.github.s7ntech82.Mate-Smart-Lock.desktop
+      - install -Dm644 data/io.github.s7ntech82.Mate-Smart-Lock.metainfo.xml /app/share/metainfo/io.github.s7ntech82.Mate-Smart-Lock.metainfo.xml
+      - install -Dm644 data/icons/hicolor/scalable/apps/io.github.s7ntech82.Mate-Smart-Lock.svg /app/share/icons/hicolor/scalable/apps/io.github.s7ntech82.Mate-Smart-Lock.svg
+    sources:
+      - type: git
+        url: https://github.com/s7ntech82/Mate-Smart-Lock.git
+        commit: e5d70bcc414e58e07a924da2938520ef0b18b71f


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [X]  Please describe the application briefly. Mate Smart Lock needs access to org.freedesktop.login1 on the system bus to lock and unlock the current user session through systemd-logind. This is the core purpose of the application: it locks the session when the paired Bluetooth device disconnects and unlocks it when the device reconnects, subject to the user's local polkit configuration.

The app does not use login1 to power off, reboot, suspend, or manage other users. It only calls GetSession and Lock/Unlock for the current session.
- [X] Please attach a video showcasing the application on Linux using the Flatpak. 

https://github.com/user-attachments/assets/866e8fcd-c0b6-421f-bd31-76001b124e64

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer/upstream contributor to the project.

Permission note:

Mate Smart Lock needs access to 'org.freedesktop.login1' on the system bus to lock and unlock the current user session through systemd-logind. This is the core purpose of the application: it locks the session when the paired Bluetooth device disconnects and unlocks it when the device reconnects, subject to the user's local polkit configuration.

The app does not use login1 to power off, reboot, suspend, or manage other users. It only calls 'GetSession' and 'Lock'/'Unlock' for the current session.

No additional maintainers.

Hi, I'm repeating the PR because the first time I had attached screenshots instead of the video and because I had run the PR from main where I had squashed the initial comminits thus interrupting the history, this time it was run from a tag generated in develop

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission