### PR TITLE
Add io.github.draughtsmind.DraughtsMind

### DIFF
--- a/io.github.draughtsmind.DraughtsMind.yml
+++ b/io.github.draughtsmind.DraughtsMind.yml
@@ -1,0 +1,69 @@
+app-id: io.github.draughtsmind.DraughtsMind
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: draughtsmind
+
+# ═══════════════════════════════════════════════════════════════════
+#  SECURITY SPECIFICATION v1.0 — Offline First + Zero Trust
+#  Flatpak Hardened Sandbox — Principle of Least Privilege
+# ═══════════════════════════════════════════════════════════════════
+finish-args:
+  # ── Interface gráfica (IPC mínimo para Wayland/X11) ────────────
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+
+  # ── GPU para renderização Cairo/GTK4 ──────────────────────────
+  - --device=dri
+
+  # ── REDE TOTALMENTE BLOQUEADA ──────────────────────────────────
+  - --unshare=network
+
+  # ── XDG Desktop Portal (import/export via diálogo do usuário) ─
+  # GTK4 FileDialog usa automaticamente o portal — sem permissão
+  # de filesystem necessária. Acesso é temporário e autorizado
+  # explicitamente pelo usuário em cada operação.
+
+  # PERMISSÕES PROIBIDAS (NUNCA ADICIONAR):
+  #   --filesystem=home
+  #   --filesystem=host
+  #   --filesystem=host-os
+  #   --filesystem=host-etc
+  #   --share=network
+  #   --socket=session-bus
+  #   --socket=system-bus
+  #   --talk-name=*
+  #   --own-name=*
+  #   --system-talk-name=*
+
+build-options:
+  cflags: '-O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2'
+  cxxflags: '-O2 -fstack-protector-strong -D_FORTIFY_SOURCE=2'
+  env:
+    # Nenhuma variável de rede ou telemetria
+    NO_AT_BRIDGE: '1'
+
+modules:
+  # ── libgee (coleções Vala) ─────────────────────────────────────
+  - name: libgee
+    buildsystem: autotools
+    config-opts:
+      - --enable-introspection=no
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libgee/0.20/libgee-0.20.6.tar.xz
+        sha256: 1bf834f5e10d60cc6124d74ed3c1dd38da646787fbf7872220b8b4068e476d6d
+
+  # ── DraughtsMind ──────────────────────────────────────────────
+  - name: draughtsmind
+    buildsystem: meson
+    config-opts:
+      - -Dbuildtype=release
+      - -Db_pie=true
+      - -Db_relro=true
+    sources:
+      - type: git
+        url: https://github.com/salemnopturn/DraughtsMind.git
+        tag: v1.0.0
+        commit: 47bdffe5c952d6db2b9b85d6ac952287f409a298


### PR DESCRIPTION
* [x] Please describe the application briefly.

  DraughtsMind is a professional Brazilian Draughts (Damas Brasileiras) platform for Linux. Play, analyze, study, and master Brazilian Draughts with a powerful offline engine and professional analysis tools. Built with GTK4 and Libadwaita, it features a strong alpha-beta search engine, opening book, MultiPV analysis, training puzzles, and a local game database — all 100% offline, with no telemetry and no account required.

* [ ] Please attach a video showcasing the application on Linux using the Flatpak.

  No video available yet.

* [x] The Flatpak ID follows all the rules listed in the Application ID requirements.

* [x] I have read and followed all the Submission requirements and the Submission guide and I agree to them.

* [x] I am an author to the project. **Link:** https://github.com/salemnopturn/DraughtsMind
