### PR TITLE
Add com.adibhanna.zennotes

### DIFF
--- a/com.adibhanna.zennotes.desktop
+++ b/com.adibhanna.zennotes.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=ZenNotes
+Comment=Keyboard-first Markdown notes app
+Exec=zennotes %U
+Terminal=false
+Type=Application
+Icon=com.adibhanna.zennotes
+StartupWMClass=ZenNotes
+MimeType=text/markdown;x-scheme-handler/zennotes;
+Categories=Office;Utility;TextEditor;

--- a/com.adibhanna.zennotes.metainfo.xml
+++ b/com.adibhanna.zennotes.metainfo.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.adibhanna.zennotes</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>ZenNotes</name>
+  <summary>Keyboard-first Markdown notes app</summary>
+  <description>
+    <p>
+      ZenNotes is a keyboard-first Markdown notes app that keeps your notes as
+      ordinary Markdown files on disk — yours to own, sync, and version however
+      you like.
+    </p>
+    <p>On top of the files you already own, it adds:</p>
+    <ul>
+      <li>Vim-friendly editing with split and live-preview workflows</li>
+      <li>Wiki-links, tags, tasks, daily notes, and full-text search</li>
+      <li>Diagrams (Mermaid, TikZ), math (KaTeX), and syntax-highlighted code</li>
+      <li>CSV databases with Notion-style Table and Board views over plain .csv files</li>
+      <li>Archive, trash, quick capture, and a built-in command-line companion</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">com.adibhanna.zennotes.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://zennotes.org/images/app.png</image>
+      <caption>Editing Markdown with live preview, sidebar, and tabs</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://zennotes.org</url>
+  <url type="bugtracker">https://github.com/ZenNotes/zennotes/issues</url>
+  <url type="vcs-browser">https://github.com/ZenNotes/zennotes</url>
+  <developer id="com.adibhanna">
+    <name>Adib Hanna</name>
+  </developer>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="2.5.0" date="2026-06-22"/>
+    <release version="2.4.0" date="2026-06-19"/>
+    <release version="2.3.0" date="2026-06-13"/>
+  </releases>
+</component>

--- a/com.adibhanna.zennotes.yml
+++ b/com.adibhanna.zennotes.yml
@@ -1,0 +1,59 @@
+app-id: com.adibhanna.zennotes
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: zennotes
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --socket=pulseaudio
+  # Notes are plain Markdown files on disk — allow access to the home dir.
+  - --filesystem=home
+  - --talk-name=org.freedesktop.Notifications
+
+modules:
+  - name: zennotes
+    buildsystem: simple
+    build-commands:
+      # Unpack the official AppImage. `--appimage-extract` uses the embedded
+      # squashfs extractor and needs no FUSE, so it runs inside the build sandbox.
+      - chmod +x ZenNotes.AppImage
+      - ./ZenNotes.AppImage --appimage-extract
+      # Install icons from the AppImage's hicolor tree, renamed to the app-id.
+      - |
+        for s in 16 24 32 48 64 128 256 512; do
+          install -Dm644 "squashfs-root/usr/share/icons/hicolor/${s}x${s}/apps/ZenNotes.png" \
+            "/app/share/icons/hicolor/${s}x${s}/apps/com.adibhanna.zennotes.png"
+        done
+      # Copy the unpacked Electron app into /app, dropping AppImage-only bits.
+      - mkdir -p /app/zennotes
+      - cp -a squashfs-root/. /app/zennotes/
+      - rm -rf /app/zennotes/usr /app/zennotes/AppRun /app/zennotes/.DirIcon
+          /app/zennotes/ZenNotes.png /app/zennotes/ZenNotes.desktop
+      # The SUID chrome-sandbox is unusable in Flatpak; zypak handles sandboxing.
+      - rm -f /app/zennotes/chrome-sandbox
+      - chmod -R a+rX /app/zennotes
+      - install -Dm755 zennotes.sh /app/bin/zennotes
+      - install -Dm644 com.adibhanna.zennotes.desktop
+          /app/share/applications/com.adibhanna.zennotes.desktop
+      - install -Dm644 com.adibhanna.zennotes.metainfo.xml
+          /app/share/metainfo/com.adibhanna.zennotes.metainfo.xml
+    sources:
+      # Bump `url` + `sha256` on each release (see README.md).
+      - type: file
+        url: https://github.com/ZenNotes/zennotes/releases/download/v2.5.0/ZenNotes-2.5.0-linux-x86_64.AppImage
+        sha256: 8a45df0b12edcf6ce272625e89edc9a7a5fa855b04d9bf4f1dcdd18efde8fb49
+        dest-filename: ZenNotes.AppImage
+      - type: file
+        path: zennotes.sh
+      - type: file
+        path: com.adibhanna.zennotes.desktop
+      - type: file
+        path: com.adibhanna.zennotes.metainfo.xml

--- a/zennotes.sh
+++ b/zennotes.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wrap the Electron binary with zypak so Chromium's sandbox works inside the
+# Flatpak sandbox (the SUID chrome-sandbox is unavailable here).
+exec zypak-wrapper /app/zennotes/ZenNotes "$@"


### PR DESCRIPTION
## com.adibhanna.zennotes — ZenNotes

[ZenNotes](https://zennotes.org) is a keyboard-first, local-first Markdown notes app — your notes stay as ordinary `.md` files on disk. This is the **official** package, submitted by the maintainer (https://github.com/ZenNotes/zennotes).

### Packaging
- Built on `org.electronjs.Electron2.BaseApp` + `org.freedesktop.Platform//25.08`, sandboxed via zypak (SUID `chrome-sandbox` removed).
- Repackages the upstream **signed** `x86_64` AppImage via `--appimage-extract` (embedded squashfs extractor — no FUSE, fully offline in the build sandbox). Source is pinned by `sha256`.
- `x86_64` only — upstream currently ships a Linux `x64` build.

### Permissions (`finish-args`)
- `--filesystem=home` — notes are plain Markdown files the user keeps in arbitrary folders under home; the app needs to open/save vaults there.
- `--share=network` — optional connect-to-self-hosted-server sync, `zennotes://` deep links, and remote image embeds in notes.
- `--socket=wayland` / `--socket=fallback-x11` / `--device=dri` / `--socket=pulseaudio` / `--share=ipc` — standard Electron desktop needs.
- `--talk-name=org.freedesktop.Notifications` — note/reminder notifications.

Updates are handled by Flathub; the app's own updater is inert in the read-only `/app`.

### Metadata
AppStream metainfo includes a screenshot, release history, MIT license, homepage/bugtracker/VCS URLs, and an OARS content rating.

Happy to adjust permissions or packaging per review.
