### PR TITLE
Add io.github.ycderman.qmediacenter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/io.github.ycderman.qmediacenter.yml
+++ b/io.github.ycderman.qmediacenter.yml
@@ -1,0 +1,111 @@
+app-id: io.github.ycderman.qmediacenter
+
+runtime: org.kde.Platform
+runtime-version: '6.8'
+sdk: org.kde.Sdk
+
+# PySide6 is provided by the official Flathub PySide BaseApp —
+# no need to bundle Qt or PySide6 ourselves.
+base: io.qt.PySide.BaseApp
+base-version: '6.8'
+build-options:
+  env:
+    - PIP_DISABLE_PIP_VERSION_CHECK=1
+
+command: qmediacenter
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-pictures:ro
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --own-name=org.mpris.MediaPlayer2.qmediacenter
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --socket=session-bus
+  - --env=LC_NUMERIC=C
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  # ── libmpv ────────────────────────────────────────────────────────────────
+  - shared-modules/libmpv/libmpv.json
+
+  # ── Python dependencies (PySide6 comes from BaseApp) ─────────────────────
+  - name: python3-mpv
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "mpv==1.0.8" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f4/cf/0d5f52753366ecf2c3d763e331dcda54b0f20a1a8e52b175feb9c625399d/mpv-1.0.8-py3-none-any.whl
+        sha256: dcf77f612e3f5ce49bd89393f37d286de7ac290db6b0800f1fdcfe0aeb5ba9b8
+
+  - name: python3-PyOpenGL
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "PyOpenGL==3.1.10" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+        sha256: 794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f
+
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "requests==2.34.2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
+        sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+      - type: file
+        url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
+        sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+
+  - name: python3-yt-dlp
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "yt-dlp==2026.6.9" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f3/ee/188a3dadf9dfdac713243521f919feca1cd091d4358c9ea7e8ebb710a7cc/yt_dlp-2026.6.9-py3-none-any.whl
+        sha256: 442ba4c75724b9496144c8434b617962ee08d0ee7c26ec663848fe9b78d5a3e4
+
+  # ── QMediaCenter ──────────────────────────────────────────────────────────
+  - name: qmediacenter
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/qmediacenter
+      - cp -r main.py iptv ui media data /app/share/qmediacenter/
+      - install -Dm755 packaging/qmediacenter.sh /app/bin/qmediacenter
+      - install -Dm644 data/io.github.ycderman.qmediacenter.metainfo.xml
+          /app/share/metainfo/io.github.ycderman.qmediacenter.metainfo.xml
+      - install -Dm644 packaging/qmediacenter.desktop
+          /app/share/applications/io.github.ycderman.qmediacenter.desktop
+      - install -Dm644 data/qmediacenter.png
+          /app/share/icons/hicolor/256x256/apps/io.github.ycderman.qmediacenter.png
+      - install -Dm644 LICENSE /app/share/licenses/io.github.ycderman.qmediacenter/LICENSE
+    sources:
+      - type: git
+        url: https://github.com/ycderman/qmediacenter
+        tag: v0.5.5
+        commit: 086c923982effc0c5c64b2da7db9ac204e52632e


### PR DESCRIPTION
QMediaCenter is a Qt6 and libmpv based media center for Linux. It supports IPTV via Xtream Codes, Emby, Plex and local or network mounted libraries. Playback uses libmpv with VA-API hardware acceleration. The UI is built with PySide6.

App ID: io.github.ycderman.qmediacenter
License: MIT
Source: https://github.com/ycderman/qmediacenter