### PR TITLE
Add io.github.ycderman.qmediacenter

### DIFF
--- a/io.github.ycderman.qmediacenter.yml
+++ b/io.github.ycderman.qmediacenter.yml
@@ -1,0 +1,193 @@
+app-id: io.github.ycderman.qmediacenter
+
+runtime: org.kde.Platform
+runtime-version: '6.8'
+sdk: org.kde.Sdk
+
+base: io.qt.PySide.BaseApp
+base-version: '6.8'
+
+command: qmediacenter
+
+# ── Sandbox permissions ───────────────────────────────────────────────────────
+finish-args:
+  - --share=network          # IPTV streams, Emby/Plex API
+  - --share=ipc              # X11 shared-memory extension
+  - --socket=wayland         # primary display protocol
+  - --socket=fallback-x11    # X11 fallback for non-Wayland compositors
+  - --socket=pulseaudio      # audio (PipeWire exposes a PulseAudio socket)
+  - --device=dri             # GPU access for VAAPI/OpenGL
+  - --filesystem=xdg-videos:ro
+  - --filesystem=xdg-music:ro
+  - --filesystem=xdg-pictures:ro
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --own-name=org.mpris.MediaPlayer2.qmediacenter
+  - --talk-name=org.mpris.MediaPlayer2.*
+  - --env=LC_NUMERIC=C       # libmpv requires C locale for numeric parsing
+
+build-options:
+  env:
+    - PIP_DISABLE_PIP_VERSION_CHECK=1
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - /lib/build-python-deps
+  - /share/doc
+  - /share/man
+  - '*.a'
+  - '*.la'
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  # ── libass ────────────────────────────────────────────────────────────────
+  - name: libass
+    config-opts:
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://github.com/libass/libass/releases/download/0.17.3/libass-0.17.3.tar.gz
+        sha256: da7c348deb6fa6c24507afab2dee7545ba5dd5bbf90a137bfe9e738f7df68537
+
+  # ── jinja2 (build-time dep of libplacebo) ────────────────────────────────
+  - name: python3-build-jinja2
+    buildsystem: simple
+    build-commands:
+      - pip3 install --exists-action=i --no-index --find-links="file://${PWD}"
+          --target=${FLATPAK_DEST}/lib/build-python-deps --no-build-isolation
+          "MarkupSafe==2.1.5" "jinja2==3.1.6"
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz
+        sha256: d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b
+      - type: file
+        url: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+        sha256: 85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+
+  # ── libplacebo ────────────────────────────────────────────────────────────
+  - name: libplacebo
+    buildsystem: meson
+    build-options:
+      env:
+        - PYTHONPATH=/app/lib/build-python-deps
+    config-opts:
+      - -Dvulkan=enabled
+      - -Dglslang=enabled
+      - -Dopengl=disabled
+      - -Dd3d11=disabled
+      - -Ddemos=false
+    sources:
+      - type: archive
+        url: https://github.com/haasn/libplacebo/archive/refs/tags/v6.338.2.tar.gz
+        sha256: 2f1e624e09d72a8c9db70f910f7560e764a1c126dae42acc5b3bcef836a7aec6
+
+  # ── mpv (libmpv only) ─────────────────────────────────────────────────────
+  - name: mpv
+    buildsystem: meson
+    config-opts:
+      - -Dlibmpv=true
+      - -Dcplayer=false
+      - -Dbuild-date=false
+      - -Dgl=enabled
+      - -Dvaapi=enabled
+      - -Dwayland=enabled
+      - -Dx11=disabled
+      - -Dsdl2=disabled
+      - -Dalsa=disabled
+      - -Dpulse=enabled
+      - -Dmanpage-build=disabled
+    sources:
+      - type: archive
+        url: https://github.com/mpv-player/mpv/archive/refs/tags/v0.39.0.tar.gz
+        sha256: 2ca92437affb62c2b559b4419ea4785c70d023590500e8a52e95ea3ab4554683
+
+  # ── Python runtime dependencies ───────────────────────────────────────────
+  - name: python3-mpv
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "mpv==1.0.8" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f4/cf/0d5f52753366ecf2c3d763e331dcda54b0f20a1a8e52b175feb9c625399d/mpv-1.0.8-py3-none-any.whl
+        sha256: dcf77f612e3f5ce49bd89393f37d286de7ac290db6b0800f1fdcfe0aeb5ba9b8
+
+  - name: python3-PyOpenGL
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "PyOpenGL==3.1.10" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl
+        sha256: 794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f
+
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "requests==2.34.2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
+        sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+      - type: file
+        url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
+        sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+
+  - name: python3-yt-dlp
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "yt-dlp==2026.6.9" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f3/ee/188a3dadf9dfdac713243521f919feca1cd091d4358c9ea7e8ebb710a7cc/yt_dlp-2026.6.9-py3-none-any.whl
+        sha256: 442ba4c75724b9496144c8434b617962ee08d0ee7c26ec663848fe9b78d5a3e4
+
+  - name: python3-setuptools-scm
+    buildsystem: simple
+    build-commands:
+      - pip3 install --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} "setuptools_scm==9.2.2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/3d/ea/ac2bf868899d0d2e82ef72d350d97a846110c709bacf2d968431576ca915/setuptools_scm-9.2.2-py3-none-any.whl
+        sha256: 30e8f84d2ab1ba7cb0e653429b179395d0c33775d54807fc5f1dd6671801aef7
+
+  # ── QMediaCenter ──────────────────────────────────────────────────────────
+  - name: qmediacenter
+    buildsystem: simple
+    build-options:
+      env:
+        - SETUPTOOLS_SCM_PRETEND_VERSION=0.7.0
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} . --no-build-isolation
+      - install -Dm644 data/io.github.ycderman.qmediacenter.metainfo.xml
+          /app/share/metainfo/io.github.ycderman.qmediacenter.metainfo.xml
+      - install -Dm644 packaging/qmediacenter.desktop
+          /app/share/applications/io.github.ycderman.qmediacenter.desktop
+      - install -Dm644 data/qmediacenter.png
+          /app/share/icons/hicolor/256x256/apps/io.github.ycderman.qmediacenter.png
+      - install -Dm644 LICENSE /app/share/licenses/io.github.ycderman.qmediacenter/LICENSE
+    sources:
+      # ── Flathub / release build ──
+      # Update tag + commit when releasing a new version.
+      # Get commit with: git rev-list -n 1 vX.Y.Z
+      - type: git
+        url: https://github.com/ycderman/qmediacenter
+        tag: v0.7.0
+        commit: 9193a174a8d0b312648949086ca4bec90a91245a  # v0.7.0 tag commit


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] I am the upstream maintainer/developer of this application.
- [x] The application ID is `io.github.ycderman.qmediacenter`.
- [x] The manifest is pinned to a tagged release: `v0.7.0`.
- [x] The source commit is pinned: `9193a174a8d0b312648949086ca4bec90a91245a`.
- [x] AppStream metadata validates successfully.
- [x] Desktop file validates successfully.
- [x] Screenshots are included in AppStream metadata.
- [x] No broad `--filesystem=home` permission is used.
- [x] No broad `--socket=session-bus` permission is used.
- [x] Network access is required for IPTV, M3U playlists, Emby/Plex connections, and online metadata.
- [x] Audio and DRI access are required for mpv-based media playback.
- [x] The manifest was built locally with `flatpak-builder`.
- [x] `qmediacenter --version` returns `qmediacenter 0.7.0` inside the Flatpak sandbox.

### Application summary

QMediaCenter is a Qt6/libmpv media center for Linux. It supports IPTV/M3U playlists, Xtream Codes, Emby, Plex, and local media libraries with hardware-accelerated video decoding via VA-API.

### Local test results

```text
flatpak-builder --force-clean /tmp/qmc-flathub-build io.github.ycderman.qmediacenter.yml
flatpak-builder --run /tmp/qmc-flathub-build io.github.ycderman.qmediacenter.yml qmediacenter --version
# qmediacenter 0.7.0
flatpak-builder --run /tmp/qmc-flathub-build io.github.ycderman.qmediacenter.yml qmediacenter --help
# Qt6/libmpv media center — IPTV, Emby, Plex and local media
```

### Notes

The app uses `io.qt.PySide.BaseApp//6.8` with `org.kde.Platform//6.8`.
Named D-Bus access (`--own-name=org.mpris.MediaPlayer2.qmediacenter`, `--talk-name=org.mpris.MediaPlayer2.*`) is used for MPRIS2 media player integration. No `--socket=session-bus` is granted.