### PR TITLE
Add io.github.bilbolab.dadoom

### DIFF
--- a/io.github.bilbolab.dadoom.yml
+++ b/io.github.bilbolab.dadoom.yml
@@ -1,0 +1,81 @@
+app-id: io.github.bilbolab.dadoom
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: dadoom
+
+finish-args:
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+
+modules:
+  - name: fluidsynth
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -Denable-alsa=off
+      - -Denable-aufile=off
+      - -Denable-dbus=off
+      - -Denable-jack=off
+      - -Denable-ladspa=off
+      - -Denable-libinstpatch=off
+      - -Denable-libsndfile=off
+      - -Denable-midishare=off
+      - -Denable-network=off
+      - -Denable-oss=off
+      - -Denable-pipewire=off
+      - -Denable-pulseaudio=off
+      - -Denable-readline=off
+      - -Denable-sdl3=off
+      - -Denable-systemd=off
+    sources:
+      - type: archive
+        url: https://github.com/FluidSynth/fluidsynth/archive/refs/tags/v2.5.2.tar.gz
+        sha256: 1dcb13308b3aa383db658c60a7b63d73d0ff4601ccee589582ba7a816475410e
+      - type: archive
+        url: https://github.com/kthohr/gcem/archive/012ae73c6d0a2cb09ffe86475f5c6fba3926e200.zip
+        sha256: 28159274c54e9640354852e172d10d88eb159f4e7f2fea42edbcd20105ed3526
+        dest: gcem
+        strip-components: 1
+  - name: SDL2_mixer
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      env:
+        PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_PREFIX_PATH=/app
+      - -DFluidSynth_DIR=/app/lib/cmake/fluidsynth
+      - -DSDL2MIXER_INSTALL=ON
+      - -DSDL2MIXER_DEPS_SHARED=ON
+      - -DSDL2MIXER_VENDORED=OFF
+      - -DSDL2MIXER_CMD=OFF
+      - -DSDL2MIXER_FLAC=OFF
+      - -DSDL2MIXER_GME=OFF
+      - -DSDL2MIXER_MOD=OFF
+      - -DSDL2MIXER_MP3=OFF
+      - -DSDL2MIXER_OPUS=OFF
+      - -DSDL2MIXER_VORBIS=OFF
+      - -DSDL2MIXER_WAVPACK=OFF
+      - -DSDL2MIXER_WAVE=ON
+      - -DSDL2MIXER_MIDI=ON
+      - -DSDL2MIXER_MIDI_FLUIDSYNTH=ON
+      - -DSDL2MIXER_MIDI_FLUIDSYNTH_SHARED=ON
+      - -DSDL2MIXER_MIDI_NATIVE=OFF
+      - -DSDL2MIXER_MIDI_TIMIDITY=OFF
+    sources:
+      - type: archive
+        url: https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.0/SDL2_mixer-2.8.0.tar.gz
+        sha256: 1cfb34c87b26dbdbc7afd68c4f545c0116ab5f90bbfecc5aebe2a9cb4bb31549
+  - name: dadoom
+    buildsystem: simple
+    build-commands:
+      - make -C src -j$(nproc)
+      - make -C src install PREFIX=/app
+    sources:
+      - type: git
+        url: https://github.com/bilbolab/dadoom.git
+        tag: v1.0.1
+        commit: 67ad54f0505321ba87ed34913224b08ce3c35465


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. DADOOM is a privacy-first, security-hardened Doom source port for modern Linux systems, built directly from the original linuxdoom-1.10 source. It runs inside a Flatpak sandbox with a Wayland-only display model, MIDI music via FluidSynth, high-resolution widescreen rendering, and full IWAD/PWAD support. Game data (WAD files) is not included; users provide their own.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. < VIDEO NEEDED — please add link before review >
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer/upstream contributor to the project. **Link:** https://github.com/bilbolab/dadoom

## Linter exception request: `finish-args-only-wayland`

DADOOM is intentionally Wayland-only by design — no X11 or fallback-x11 socket is used. This is a deliberate privacy and security decision: X11 allows applications to observe input and window content of other clients, which is incompatible with the project's data autonomy goals.

Please add a linter exception for `finish-args-only-wayland`:  
`"this program is intentionally Wayland-only for privacy and security reasons"`

This follows the same pattern as `org.catacombing.kumo` and `page.codeberg.dnkl.foot`.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission