### PR TITLE
Add io.github.ArdaYalinOzkan.VpsBackup

### DIFF
--- a/io.github.ArdaYalinOzkan.VpsBackup.json
+++ b/io.github.ArdaYalinOzkan.VpsBackup.json
@@ -1,0 +1,104 @@
+{
+    "app-id": "io.github.ArdaYalinOzkan.VpsBackup",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "47",
+    "sdk": "org.gnome.Sdk",
+    "command": "io.github.ArdaYalinOzkan.VpsBackup",
+    "finish-args": [
+        "--share=ipc",
+        "--share=network",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--device=dri",
+        "--filesystem=xdg-download"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
+    "modules": [
+        {
+            "name": "python3-bcrypt",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} bcrypt"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/56/01/0a9cddc2e5c8a2e407dd07549a4bea89e09e71c4a5bef920e1574b756e6c/bcrypt-4.2.1.tar.gz",
+                    "sha256": "6765386e3ab87f569b276988742039baab087b2cdb01e809d74571571c90b354"
+                }
+            ]
+        },
+        {
+            "name": "python3-pynacl",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} PyNaCl"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a7/22/27582568be639dfe22ddb3902225f91f2f17ceff88ce80e4db396c8986da/PyNaCl-1.5.0.tar.gz",
+                    "sha256": "8ac7448f09ab85c2ed6d4b0ee7eb99e3332bc3ea58b23a5234895a5f3d7daf3b"
+                }
+            ]
+        },
+        {
+            "name": "python3-cryptography",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} cryptography"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/cd/25/4ce80c78963834b8a9fd1cc1266be5ed8d1840785c0f2e1b73b8d128d505/cryptography-44.0.0.tar.gz",
+                    "sha256": "b58b1df9e37af0c5ddf0a8a4be4f5c0afcf35e07e8f27e0873cbff8903ab89b2"
+                }
+            ]
+        },
+        {
+            "name": "python3-paramiko",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} paramiko"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1b/0f/c00d2e1890a97ad09382e6a4c8a95717c348e568e047960edab34905dbfc/paramiko-3.5.1.tar.gz",
+                    "sha256": "b2c665bc45b2b215bd291bf272a2d4adb8090c4b18e4a44a97e1f42f2528fcda"
+                }
+            ]
+        },
+        {
+            "name": "vps-backup",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm644 data/io.github.ArdaYalinOzkan.VpsBackup.desktop.in ${FLATPAK_DEST}/share/applications/io.github.ArdaYalinOzkan.VpsBackup.desktop",
+                "install -Dm644 data/io.github.ArdaYalinOzkan.VpsBackup.metainfo.xml.in ${FLATPAK_DEST}/share/metainfo/io.github.ArdaYalinOzkan.VpsBackup.metainfo.xml",
+                "install -Dm644 data/io.github.ArdaYalinOzkan.VpsBackup.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.ArdaYalinOzkan.VpsBackup.svg",
+                "install -Dm644 data/io.github.ArdaYalinOzkan.VpsBackup.gschema.xml ${FLATPAK_DEST}/share/glib-2.0/schemas/io.github.ArdaYalinOzkan.VpsBackup.gschema.xml",
+                "mkdir -p ${FLATPAK_DEST}/share/vps-backup/src",
+                "install -Dm644 src/__init__.py ${FLATPAK_DEST}/share/vps-backup/src/__init__.py",
+                "install -Dm644 src/main.py ${FLATPAK_DEST}/share/vps-backup/src/main.py",
+                "install -Dm644 src/window.py ${FLATPAK_DEST}/share/vps-backup/src/window.py",
+                "install -Dm644 src/connection.py ${FLATPAK_DEST}/share/vps-backup/src/connection.py",
+                "install -Dm755 vps-backup-launcher.sh ${FLATPAK_DEST}/bin/io.github.ArdaYalinOzkan.VpsBackup"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/ArdaYalinOzkan/vps-backup.git",
+                    "commit": "24b953bd5e16b76cc39b26f0a7a7a8f1dca99bd0"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## VPS Backup

A GNOME/Adwaita-styled GTK4 application for backing up files from a VPS server via SFTP.

### Features
- Login screen with host/IP/username/password and "Remember Me" option
- Remote file browser (GNOME Files-style) with directory navigation
- Backup checklist with custom display labels and total size calculation
- Download progress indicator in header bar
- Persistent state (credentials, selections, download directory)

### Links
- **Homepage**: https://github.com/ArdaYalinOzkan/vps-backup
- **Issue tracker**: https://github.com/ArdaYalinOzkan/vps-backup/issues

### Checklist
- [x] App ID follows reverse-DNS format: `io.github.ArdaYalinOzkan.VpsBackup`
- [x] Runtime: `org.gnome.Platform//47`
- [x] App uses only `--filesystem=xdg-download` (no broad home access)
- [x] Network access required for SFTP connections
- [x] Metainfo file included
- [x] Desktop file included
- [x] Icon (SVG) included
- [x] Source pinned to specific commit
- [ ] Please attach a video showing the app in action
