### PR TITLE
Add io.github.MarcelineVPQ.Sonata

### DIFF
--- a/io.github.MarcelineVPQ.Sonata.yml
+++ b/io.github.MarcelineVPQ.Sonata.yml
@@ -1,0 +1,52 @@
+app-id: io.github.MarcelineVPQ.Sonata
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: sonata
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  - --socket=pulseaudio
+  - --share=network            # Widevine CDM is fetched at runtime, not bundled
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.Notifications
+  - --own-name=org.mpris.MediaPlayer2.chromium.*
+
+modules:
+  - name: sonata
+    buildsystem: simple
+    build-commands:
+      # castlabs Electron runtime
+      - mkdir -p /app/sonata
+      - cp -a electron/. /app/sonata/
+      # the app itself lives in Electron's resources/app
+      - mkdir -p /app/sonata/resources/app
+      - cp -a app/main.js app/miniplayer.html app/lyrics.html app/lastfm.js
+              app/discord.js app/package.json app/sonata.png
+              /app/sonata/resources/app/
+      # launcher (uses the BaseApp's zypak sandbox wrapper)
+      - install -Dm755 app/packaging/flathub/sonata.sh /app/bin/sonata
+      # desktop integration, all named after the app id
+      - install -Dm644 app/sonata.png
+              /app/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+      - install -Dm644 app/packaging/flathub/${FLATPAK_ID}.desktop
+              /app/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 app/${FLATPAK_ID}.metainfo.xml
+              /app/share/metainfo/${FLATPAK_ID}.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/castlabs/electron-releases/releases/download/v42.3.3+wvcus/electron-v42.3.3+wvcus-linux-x64.zip
+        sha256: 5b6ce3a4d13f07fc63d79e884f6a40d1bc8a1cdf82cb2d130c26e8c1530649cb
+        dest: electron
+      - type: git
+        url: https://github.com/MarcelineVPQ/apple-music-for-linux.git
+        # Flathub requires a reproducible pin (tag + matching commit sha);
+        # bump both on every release.
+        tag: v0.10.2
+        commit: 742b0db5d7c4434e3f6bd4a3489f8d5b7c670bfe
+        dest: app


### PR DESCRIPTION
## Sonata

An unofficial desktop player for the Apple Music web app.

- **App id**: `io.github.MarcelineVPQ.Sonata` (namespace repo: https://github.com/MarcelineVPQ/sonata)
- **Source**: https://github.com/MarcelineVPQ/apple-music-for-linux (GPL-3.0), pinned to tag `v0.10.2` + commit
- **Runtime**: `org.freedesktop.Platform` 25.08 on `org.electronjs.Electron2.BaseApp`

### Notes for reviewers
- **Not affiliated with Apple.** Neutral name (Sonata), original icon, and a trademark disclaimer in the metainfo. It wraps the public Apple Music web player.
- **DRM**: playback needs Widevine, which is **downloaded at runtime** by castlabs Electron (not bundled/redistributed). castlabs Electron is a prebuilt `archive` source with a sha256.
- **No runtime npm dependencies** — the manifest copies the app's JS/HTML into Electron's `resources/app` and launches via `zypak-wrapper`.
- Verified locally with `flatpak-builder` (25.08): builds, passes `appstreamcli compose`, exports desktop/icon/metainfo under the app id, launches. `flatpak-builder-lint manifest` is clean.

Thanks for reviewing!