### PR TITLE
Add io.github.ramm_fr.Orion (Orion Video Player)

### DIFF
--- a/io.github.ramm_fr.Orion.yml
+++ b/io.github.ramm_fr.Orion.yml
@@ -1,0 +1,32 @@
+app-id: io.github.ramm_fr.Orion
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: orion
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+  - --filesystem=home:ro
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download:ro
+  - --filesystem=xdg-music:ro
+
+modules:
+  - name: orion
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 bin/orion /app/bin/orion
+      - mkdir -p /app/share/orion
+      - cp -r orion /app/share/orion/
+      - cp main.py /app/share/orion/
+      - install -Dm644 io.github.ramm_fr.Orion.desktop /app/share/applications/io.github.ramm_fr.Orion.desktop
+      - install -Dm644 data/icons/io.github.ramm_fr.Orion.svg /app/share/icons/hicolor/scalable/apps/io.github.ramm_fr.Orion.svg
+      - install -Dm644 io.github.ramm_fr.Orion.metainfo.xml /app/share/metainfo/io.github.ramm_fr.Orion.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/ramm-fr/Orion.git
+        branch: main


### PR DESCRIPTION
App ID: io.github.ramm_fr.Orion
Source: https://github.com/ramm-fr/Orion
License: GPL-3.0-or-later

Orion is a modern video player for Linux built with GTK4 and GStreamer.
Supports 80+ video formats, HLS/RTSP streaming, multi-audio track selection,
subtitle management, equalizer, and real-time statistics.

All required files in source repo:
- AppStream metainfo ✓
- Desktop file ✓  
- SVG icon (square) ✓
- Screenshots ✓
- Builds successfully with flatpak-builder ✓
