### PR TITLE
Add io.github.oliverhubtech_source.Casca

### DIFF
--- a/io.github.oliverhubtech_source.Casca.yml
+++ b/io.github.oliverhubtech_source.Casca.yml
@@ -1,0 +1,54 @@
+app-id: io.github.oliverhubtech_source.Casca
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: casca
+
+finish-args:
+  # Interface gráfica (Wayland nativo, X11 como fallback), áudio e aceleração de vídeo
+  # pra WebKit (a janela própria de cada web app criado usa WebKitGTK).
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=ipc
+  # O WebKitGTK tem seu próprio sandbox interno pros processos de conteúdo web, que
+  # não aninha bem dentro do sandbox do Flatpak — desabilitar evita crash do processo web.
+  - --env=WEBKIT_FORCE_SANDBOX=0
+  # Buscar favicon/ícone dos sites e o catálogo remoto opcional da Loja
+  - --share=network
+  # Cria o atalho .desktop de cada web app/pacote no menu de aplicativos e na área de trabalho
+  - --filesystem=xdg-data/applications:create
+  - --filesystem=xdg-desktop:create
+  # Guarda o registro de apps/pacotes, ícones baixados e perfis (sessão) isolados de cada site
+  - --filesystem=~/.local/share/casca:create
+  - --filesystem=~/.local/share/icons/casca:create
+  # Sem --talk-name=org.freedesktop.Flatpak de propósito: essa permissão dá acesso a
+  # rodar qualquer comando no host (flatpak-spawn --host) e é fortemente escrutinada no
+  # review do Flathub. Sandboxado, o Casca só oferece a "janela própria" (WebKitGTK) —
+  # não detecta nem oferece navegadores externos (isso continua funcional na instalação
+  # local via install.sh, fora do Flatpak). Reabrir a própria janela do Casca a partir de
+  # um .desktop criado usa `flatpak run`, que roda no HOST (GNOME Shell), não precisando
+  # dessa permissão.
+
+modules:
+  - python3-requirements.yaml
+
+  - name: casca
+    buildsystem: simple
+    build-commands:
+      # site.getsitepackages() usa sys.prefix do próprio python3 do runtime (/usr,
+      # somente leitura) — precisa forçar o "base" pra /app via sysconfig, senão o
+      # cp falha com "Read-only file system".
+      - site_packages="$(python3 -c "import sysconfig; print(sysconfig.get_path('purelib', vars=dict(base='/app')))")"
+        && mkdir -p "$site_packages" && cp -r casca "$site_packages/"
+      - install -Dm755 run.py /app/bin/casca
+      - install -Dm755 run_webview.py /app/bin/casca-webview
+      - install -Dm755 run_package.py /app/bin/casca-package
+      - install -Dm644 casca/data/io.github.oliverhubtech_source.Casca.desktop /app/share/applications/io.github.oliverhubtech_source.Casca.desktop
+      - install -Dm644 casca/data/io.github.oliverhubtech_source.Casca.metainfo.xml /app/share/metainfo/io.github.oliverhubtech_source.Casca.metainfo.xml
+      - install -Dm644 casca/data/icons/io.github.oliverhubtech_source.Casca.png /app/share/icons/hicolor/256x256/apps/io.github.oliverhubtech_source.Casca.png
+    sources:
+      - type: git
+        url: https://github.com/oliverhubtech-source/casca.git
+        commit: 2037e16187aa87c3647cc23326b99e192418aa52

--- a/python3-requirements.yaml
+++ b/python3-requirements.yaml
@@ -1,0 +1,55 @@
+# Gerado com flatpak-pip-generator --yaml --runtime org.gnome.Sdk//48 \
+#   --wheel-arches x86_64,aarch64 -o python3-requirements requests==2.33.1 Pillow==12.2.0
+#
+# Pillow usa sdist (compila do zero) em vez de wheel: não existe uma wheel única que
+# sirva x86_64 e aarch64 ao mesmo tempo, e o Flathub builda as duas arquiteturas por
+# padrão. Compilar do sdist exige pybind11 (requerido pelo build-system do Pillow
+# 12.x) disponível ANTES — e como não há acesso à rede durante o build do
+# flatpak-builder, ele precisa estar vendorizado como módulo próprio, instalado antes
+# do módulo do Pillow. Testado localmente (fora de rede, dentro do org.gnome.Sdk//48)
+# pra confirmar que compila com sucesso.
+name: python3-requirements
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests==2.33.1" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
+        sha256: 2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl
+        sha256: 68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+      - type: file
+        url: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
+        sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+
+  - name: python3-pybind11
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pybind11==3.0.4" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b3/06/c3a23c9a0263b136c519f033a58d4641e73065fefc7754e9667ec206d992/pybind11-3.0.4-py3-none-any.whl
+        sha256: 961720ee652da51d531b7b2451a6bd2bc042b0106e6d9baa48ecb7d58034ce63
+
+  - name: python3-Pillow
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "Pillow==12.2.0" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz
+        sha256: a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5


### PR DESCRIPTION
## O que é

Casca transforma sites em apps nativos do GNOME (ícone próprio, janela própria via WebKitGTK, atalho no menu de aplicativos), com uma loja de sites/serviços prontos pra instalar em um clique.

- Código-fonte: https://github.com/oliverhubtech-source/casca
- Licença: MIT

## Sobre o `finish-args-unnecessary-xdg-data-applications-create-access`

O Casca cria um app "de verdade" (com seu próprio `.desktop`, ícone e atalho) pra cada site que o usuário adiciona — essa é a funcionalidade central do programa, não um efeito colateral. Sem `--filesystem=xdg-data/applications:create` os web apps criados não apareceriam no menu de aplicativos do sistema. `--filesystem=xdg-desktop:create` segue o mesmo motivo, pra criar o atalho na Área de Trabalho quando o usuário escolhe essa opção.

Note que **não** solicitamos `--talk-name=org.freedesktop.Flatpak` (que permitiria rodar comandos arbitrários no host via `flatpak-spawn --host`): o Casca abre os web apps na sua própria janela (WebKitGTK), sem depender de invocar navegadores externos quando rodando em sandbox.

## Testes locais

- `flatpak-builder-lint manifest` limpo, exceto o item justificado acima.
- Build validado com sucesso via GitHub Actions CI no commit referenciado pelo manifesto (multi-arch x86_64/aarch64).