### PR TITLE
Add app.cinerename.CineRename

### DIFF
--- a/app.cinerename.CineRename.desktop
+++ b/app.cinerename.CineRename.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=CineRename
+Comment=Rename and organize movies, TV shows, anime, and subtitles.
+Exec=cinerename
+Icon=app.cinerename.CineRename
+Terminal=false
+Categories=AudioVideo;Video;
+StartupWMClass=cinerename

--- a/app.cinerename.CineRename.metainfo.xml
+++ b/app.cinerename.CineRename.metainfo.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>app.cinerename.CineRename</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://cinerename.app/terms</project_license>
+  <name>CineRename</name>
+  <summary>Rename and organize movies, TV shows, anime, and subtitles</summary>
+  <developer id="app.cinerename">
+    <name>CineRename</name>
+  </developer>
+  <description>
+    <p>
+      CineRename is a desktop application for importing, matching, renaming,
+      and organizing movies, TV shows, anime, and subtitles.
+    </p>
+    <p>
+      It includes preview workflows, undo history, naming templates, duplicate
+      comparison tools, and subtitle helpers for personal media libraries.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source" width="1483" height="780">https://cinerename.app/assets/img/Rename_direct.png</image>
+      <caption>Preview media renames before applying file changes</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1456" height="799">https://cinerename.app/assets/img/Dashboard.png</image>
+      <caption>Monitor the media library dashboard and recent activity</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1457" height="800">https://cinerename.app/docs/assets/img/duplicates-clusters.png</image>
+      <caption>Compare duplicate media files before deciding what to keep</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1457" height="799">https://cinerename.app/assets/img/Subtitle.png</image>
+      <caption>Search and manage subtitles alongside video files</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source" width="1457" height="799">https://cinerename.app/assets/img/Template.png</image>
+      <caption>Customize naming templates for personal media libraries</caption>
+    </screenshot>
+  </screenshots>
+  <launchable type="desktop-id">app.cinerename.CineRename.desktop</launchable>
+  <url type="homepage">https://cinerename.app</url>
+  <url type="help">https://cinerename.app/docs</url>
+  <categories>
+    <category>AudioVideo</category>
+    <category>Video</category>
+  </categories>
+  <keywords>
+    <keyword>rename</keyword>
+    <keyword>movies</keyword>
+    <keyword>series</keyword>
+    <keyword>subtitles</keyword>
+    <keyword>media</keyword>
+  </keywords>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.5.0" date="2026-07-09">
+      <description>
+        <p>Initial Linux store packaging for CineRename 0.5.0.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/app.cinerename.CineRename.yml
+++ b/app.cinerename.CineRename.yml
@@ -1,0 +1,37 @@
+app-id: app.cinerename.CineRename
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: cinerename
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+modules:
+  - name: cinerename
+    buildsystem: simple
+    build-commands:
+      - ar x cinerename.deb
+      - sh -c 'tar --extract --file="$(ls data.tar.*)"'
+      - install -Dm755 usr/bin/cinerename /app/bin/cinerename
+      - install -Dm644 app.cinerename.CineRename.desktop /app/share/applications/app.cinerename.CineRename.desktop
+      - install -Dm644 app.cinerename.CineRename.metainfo.xml /app/share/metainfo/app.cinerename.CineRename.metainfo.xml
+      - install -Dm644 usr/share/icons/hicolor/32x32/apps/cinerename.png /app/share/icons/hicolor/32x32/apps/app.cinerename.CineRename.png
+      - install -Dm644 usr/share/icons/hicolor/128x128/apps/cinerename.png /app/share/icons/hicolor/128x128/apps/app.cinerename.CineRename.png
+      - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/cinerename.png /app/share/icons/hicolor/256x256@2/apps/app.cinerename.CineRename.png
+      - install -Dm644 usr/share/icons/hicolor/512x512/apps/cinerename.png /app/share/icons/hicolor/512x512/apps/app.cinerename.CineRename.png
+    sources:
+      - type: file
+        url: https://github.com/CineRename/CineRename-Releases/releases/download/v0.5.0/CineRename_0.5.0_amd64.deb
+        sha256: 7d403785d760b65bfcaafd7c16b74b44770e94d306beafe9307ef2037bb3579b
+        dest-filename: cinerename.deb
+      - type: file
+        path: app.cinerename.CineRename.desktop
+      - type: file
+        path: app.cinerename.CineRename.metainfo.xml


### PR DESCRIPTION
### App submission

This adds CineRename as `app.cinerename.CineRename`.

CineRename is a desktop application for importing, matching, renaming, and organizing movies, TV shows, anime, and subtitles.

### Notes

- Uses the public CineRename v0.5.0 `.deb` release asset.
- AppStream metadata validates locally with `appstreamcli validate`.
- The generated Flatpak bundle was built successfully in the CineRename GitHub Actions workflow.
- The app is proprietary software; license metadata points to https://cinerename.app/terms.