### PR TITLE
Add io.kinvolk.Headlamp.Tools.oci

### DIFF
--- a/io.kinvolk.Headlamp.Tools.oci.metainfo.xml
+++ b/io.kinvolk.Headlamp.Tools.oci.metainfo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>io.kinvolk.Headlamp.Tools.oci</id>
+  <extends>io.kinvolk.Headlamp</extends>
+  <name>OCI CLI for Headlamp</name>
+  <summary>Oracle Cloud Infrastructure CLI for authenticating to OKE clusters</summary>
+  <description>
+    <p>
+      Ships the Oracle Cloud Infrastructure (OCI) command-line interface inside
+      the Headlamp sandbox at /app/tools/oci. Headlamp uses it to run the
+      "oci ce cluster generate-token" exec-credential plugin required to
+      authenticate to Oracle Kubernetes Engine (OKE) clusters.
+    </p>
+  </description>
+  <url type="homepage">https://github.com/oracle/oci-cli</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0 OR UPL-1.0</project_license>
+</component>

--- a/io.kinvolk.Headlamp.Tools.oci.yaml
+++ b/io.kinvolk.Headlamp.Tools.oci.yaml
@@ -1,0 +1,31 @@
+id: io.kinvolk.Headlamp.Tools.oci
+branch: stable
+runtime: io.kinvolk.Headlamp
+runtime-version: stable
+sdk: org.freedesktop.Sdk//25.08
+build-extension: true
+separate-locales: false
+build-options:
+  prefix: /app/tools/oci
+  env:
+    PATH: /app/tools/oci/bin:/app/bin:/usr/bin
+    PYTHONPATH: /app/tools/oci/lib/python3.13/site-packages
+modules:
+  - python3-oci-cli.yaml
+  # pip console script imports oci_cli, whose site-packages are only on PYTHONPATH at
+  # build time. Wrap the entry point to set its OWN PYTHONPATH at runtime (scoped to
+  # this extension so multiple Python tool extensions never collide on shared deps).
+  - name: oci-pythonpath-wrapper
+    buildsystem: simple
+    build-commands:
+      - |
+        mv "${FLATPAK_DEST}/bin/oci" "${FLATPAK_DEST}/bin/oci.real"
+        printf '#!/bin/sh\nexport PYTHONPATH="/app/tools/oci/lib/python3.13/site-packages${PYTHONPATH:+:$PYTHONPATH}"\nexec /app/tools/oci/bin/oci.real "$@"\n' > "${FLATPAK_DEST}/bin/oci"
+        chmod 0755 "${FLATPAK_DEST}/bin/oci"
+  - name: metainfo
+    buildsystem: simple
+    sources:
+      - type: file
+        path: io.kinvolk.Headlamp.Tools.oci.metainfo.xml
+    build-commands:
+      - install -Dm644 io.kinvolk.Headlamp.Tools.oci.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.kinvolk.Headlamp.Tools.oci.metainfo.xml

--- a/python3-oci-cli.yaml
+++ b/python3-oci-cli.yaml
@@ -1,0 +1,94 @@
+# Generated with flatpak-pip-generator oci-cli -o python3-oci-cli --yaml --prefer-wheels cryptography,cffi,pyyaml --runtime org.freedesktop.Sdk//25.08
+name: python3-oci-cli
+buildsystem: simple
+build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+    --prefix=${FLATPAK_DEST} "oci-cli" --no-build-isolation
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/04/24/b7721e4845c2f162d26f50521b825fb061bc0a5afcf9a386840f23ea19fa/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    sha256: 70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/7c/9a/337322f27005c33bcb656c655fa78325b730324c78620e8328ae28b64d0c/PyYAML-6.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+    sha256: 0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl
+    sha256: 749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205
+  - type: file
+    url: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
+    sha256: 97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b
+  - type: file
+    url: https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sha256: 799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+    sha256: ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/ae/34/15f08edd4628f65217de1fc3c1a27c82e46fe357d60c217fc9881e12ebcc/circuitbreaker-2.1.3-py3-none-any.whl
+    sha256: 87ba6a3ed03fdc7032bc175561c2b04d52ade9d5faf94ca2b035fbdc5e6b1dd1
+  - type: file
+    url: https://files.pythonhosted.org/packages/a0/66/c8196ad693d62384d8e800e5bd27434a64c0057fe169b61c69a73f1614a8/click-8.1.2-py3-none-any.whl
+    sha256: 24e1a4a9ec5bf6299411369b208c1df2188d9eb8d916302fe6bf03faed227f1e
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/4c/4e40cc26347ac8254d3f25b9f94710b8e8df24ee4dddc1ba41907a88a94d/crc32c-2.7.1.tar.gz
+    sha256: f91b144a21eef834d64178e01982bb9179c354b3e9e5f4c803b0e5096384968c
+  - type: file
+    url: https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+    sha256: 5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308
+    only-arches:
+      - x86_64
+  - type: file
+    url: https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+    sha256: b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325
+    only-arches:
+      - aarch64
+  - type: file
+    url: https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl
+    sha256: 02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980
+  - type: file
+    url: https://files.pythonhosted.org/packages/d8/bd/7141e3f3b2ae7041a883d97bf3d0d9d9d4745c61b659743ebe3afe5e7624/oci-2.181.1-py3-none-any.whl
+    sha256: a7e4424e1c1f917afedfdf1a7b1bc0b99b75683a774e2270afba8ed09fcce95a
+  - type: file
+    url: https://files.pythonhosted.org/packages/51/7c/f16ff96cd9a3ceaf2c26ad459e01b1f388ca79cbb00c00038260fe29feb7/oci_cli-3.89.1-py3-none-any.whl
+    sha256: 3831754b493c1757a280098851499901c9ccd91e7b675ff9eb8eec56cf243e1c
+  - type: file
+    url: https://files.pythonhosted.org/packages/ee/fd/ca7bf3869e7caa7a037e23078539467b433a4e01eebd93f77180ab927766/prompt_toolkit-3.0.43-py3-none-any.whl
+    sha256: a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6
+  - type: file
+    url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+    sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+  - type: file
+    url: https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl
+    sha256: 66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+  - type: file
+    url: https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl
+    sha256: 4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70
+  - type: file
+    url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+    sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+  - type: file
+    url: https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl
+    sha256: 04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126
+  - type: file
+    url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+    sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+  - type: file
+    url: https://files.pythonhosted.org/packages/c4/fb/ea621e0a19733e01fe4005d46087d383693c0f4a8f824b47d8d4122c87e0/terminaltables-3.1.10-py2.py3-none-any.whl
+    sha256: e4fdc4179c9e4aab5f674d80f09d76fa436b96fdc698a8505e0a36bf0804a874
+  - type: file
+    url: https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl
+    sha256: dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+  - type: file
+    url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+    sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+  - type: file
+    url: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
+    sha256: d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly. Oracle OCI CLI extension for Headlamp Kubernetes IDE. Provides the oci command-line tool as an optional extension, enabling Oracle Cloud Infrastructure connectivity from within Headlamp.  Note: Since https://github.com/flathub/flathub/pull/8611 PR is stalled so I created this.
- [x] Please attach a video showcasing the application on Linux using the Flatpak. N/A - this is a CLI extension, not a graphical application. See https://github.com/flathub/flathub/pull/2290
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an developer to the project. I contacted upstream developers about this submission. *Link:* https://github.com/flathub/io.kinvolk.Headlamp/pull/70#issuecomment-4397336318

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
