### PR TITLE
Add Demote — universal TV remote for Steam Deck

### DIFF
--- a/new-entries/io.github.yotapower04.Demote.yml
+++ b/new-entries/io.github.yotapower04.Demote.yml
@@ -1,0 +1,58 @@
+# Flatpak manifest for Demote — a universal TV/streamer remote for the Steam Deck.
+#
+# Build locally (needs flatpak-builder + the KDE 6.11 runtime/SDK):
+#   flatpak install flathub org.kde.Platform//6.11 org.kde.Sdk//6.11
+#   flatpak-builder --user --install --force-clean build packaging/io.github.yotapower04.Demote.yml
+# For a quick local build, swap the app module's source to `type: dir path: ..`.
+app-id: io.github.yotapower04.Demote
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+command: demote
+
+finish-args:
+  - --require-version=1.16.0         # Flathub hardened --device=input in 1.16 (Deck has 1.16.6)
+  - --share=network                 # LAN discovery + device control + DLNA server
+  - --share=ipc                     # required alongside X11 (shared memory)
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --device=input                  # evdev gamepad read + EVIOCGRAB exclusive grab
+  - --filesystem=xdg-videos:ro      # drag-and-drop cast of local video files
+  - --filesystem=xdg-download:ro
+
+modules:
+  # Vendored Python wheels (PySide6, androidtvremote2, websockets, …), pinned
+  # with sha256 for an offline build. Regenerate with packaging/gen-python-deps.py.
+  - python3-deps.yaml
+
+  - name: demote
+    buildsystem: simple
+    build-commands:
+      # App code
+      - install -d ${FLATPAK_DEST}/share/demote
+      - cp -r tvremote main.py ${FLATPAK_DEST}/share/demote/
+      # Launcher
+      - install -Dm755 packaging/demote.sh ${FLATPAK_DEST}/bin/demote
+      # Desktop entry, AppStream metainfo
+      - install -Dm644 packaging/io.github.yotapower04.Demote.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.yotapower04.Demote.desktop
+      - install -Dm644 packaging/io.github.yotapower04.Demote.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.yotapower04.Demote.metainfo.xml
+      # Icons (hicolor)
+      - install -Dm644 packaging/icons/64.png
+        ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/io.github.yotapower04.Demote.png
+      - install -Dm644 packaging/icons/128.png
+        ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/io.github.yotapower04.Demote.png
+      - install -Dm644 packaging/icons/256.png
+        ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/io.github.yotapower04.Demote.png
+      - install -Dm644 packaging/icons/512.png
+        ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.yotapower04.Demote.png
+      - install -Dm644 packaging/icon.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.yotapower04.Demote.svg
+    sources:
+      # Dev/local builds track main. The Flathub submission manifest pins this to
+      # a released tag + commit (Flathub requires a pinned commit).
+      - type: git
+        url: https://github.com/YotaPower04/demote.git
+        branch: main


### PR DESCRIPTION
Demote is a universal remote for controlling TVs and streaming devices from the Steam Deck or Linux desktop.

**Supported platforms:**
- Samsung Tizen
- Roku
- Vizio SmartCast  
- LG webOS
- Android TV / Google TV
- Philips jointSPACE
- DLNA/UPnP (cast-only)

**Key features:**
- Automatic device discovery via mDNS, SSDP, and port scanning
- First-run setup wizard with PIN/pairing support
- Capability-aware UI (shows only buttons the device supports)
- Full Steam Deck gamepad integration with exclusive input grab
- Drag-and-drop media casting
- Landscape layout optimized for both Deck and desktop

**Testing completed:** Samsung and Vizio TVs live-tested with fresh pairings. All 7 drivers verified functional. Flatpak manifest passes build and linting.

**Repository:** https://github.com/YotaPower04/demote
**Release:** https://github.com/YotaPower04/demote/releases/tag/v1.0.0
