### PR TITLE
Add io.github.mutlukurt.NexoraAIEnvironment

### DIFF
--- a/io.github.mutlukurt.NexoraAIEnvironment.desktop
+++ b/io.github.mutlukurt.NexoraAIEnvironment.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=NexoraAI
+Comment=Build web apps with a local AI agent
+Exec=nexora-ai %U
+Terminal=false
+Type=Application
+Icon=io.github.mutlukurt.NexoraAIEnvironment
+StartupWMClass=NexoraAI
+Categories=Development;IDE;
+Keywords=AI;LLM;GGUF;agent;code;

--- a/io.github.mutlukurt.NexoraAIEnvironment.metainfo.xml
+++ b/io.github.mutlukurt.NexoraAIEnvironment.metainfo.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.mutlukurt.NexoraAIEnvironment</id>
+  <name>NexoraAI</name>
+  <summary>Build web apps with a local AI agent</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer id="io.github.mutlukurt">
+    <name>Mutlu Kurt</name>
+  </developer>
+  <description>
+    <p>
+      NexoraAI is a local-first, agent-first AI development environment for the desktop.
+      You describe a web project in plain words and a GGUF model running entirely on your
+      own machine writes the project, shows you every file it creates, runs it on localhost
+      in your browser, and lets you refine it by chatting. When you are happy, one click
+      exports a complete Vite + React + TypeScript + Tailwind project folder.
+    </p>
+    <p>
+      By default nothing leaves your computer: inference, file generation, package
+      installation and the dev server all run locally. An optional, clearly-labelled
+      bring-your-own-key API mode (157 providers, keys stored in the OS keychain) is there
+      if you ever want a frontier cloud model.
+    </p>
+    <p>Highlights:</p>
+    <ul>
+      <li>On-device code generation with a capability-adaptive pipeline for small and large models</li>
+      <li>A debug engine that detects issues and repairs them through the model</li>
+      <li>Intent directives the model emits and the app executes (shell, image generation, retrieval, and more)</li>
+      <li>Offline image generation and vision, a git-truth diff review, checkpoints, and a task queue</li>
+      <li>A two-layer trust and permission system, and a 10-language interface</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">io.github.mutlukurt.NexoraAIEnvironment.desktop</launchable>
+  <categories>
+    <category>Development</category>
+    <category>IDE</category>
+  </categories>
+  <keywords>
+    <keyword>AI</keyword>
+    <keyword>LLM</keyword>
+    <keyword>GGUF</keyword>
+    <keyword>agent</keyword>
+    <keyword>local</keyword>
+    <keyword>code</keyword>
+    <keyword>React</keyword>
+  </keywords>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/mutlukurt/NexoraAIEnvironment/main/docs/screenshots/ui-chat-ubuntu.png</image>
+      <caption>Chatting with a local model to build a project</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/mutlukurt/NexoraAIEnvironment/main/docs/screenshots/21-v010-workspace.png</image>
+      <caption>The generated project files in the workspace</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/mutlukurt/NexoraAIEnvironment/main/docs/screenshots/27-portfolio-site.png</image>
+      <caption>A portfolio site generated and running on localhost</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/mutlukurt/NexoraAIEnvironment/main/docs/screenshots/v019-picker.png</image>
+      <caption>Switching freely between local text, API, and local image models</caption>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://github.com/mutlukurt/NexoraAIEnvironment</url>
+  <url type="bugtracker">https://github.com/mutlukurt/NexoraAIEnvironment/issues</url>
+  <url type="vcs-browser">https://github.com/mutlukurt/NexoraAIEnvironment</url>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="0.20.1" date="2026-07-12">
+      <description>
+        <p>Patch: fixed a startup bug where a leftover queued or scheduled task could auto-fire before a model was ready.</p>
+      </description>
+    </release>
+    <release version="0.20.0" date="2026-07-12">
+      <description>
+        <p>The Intent Brain: retrieval-driven context, an ask-before-you-build intent gate, and fully model-based repair.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.github.mutlukurt.NexoraAIEnvironment.yml
+++ b/io.github.mutlukurt.NexoraAIEnvironment.yml
@@ -1,0 +1,59 @@
+# Flathub manifest for NexoraAI.
+#
+# NOTE ON APPROACH: NexoraAI is an Electron app that, by design, downloads its
+# heavy inference binaries (llama-server / sd-server) and GGUF models at RUNTIME.
+# This manifest installs the app from the project's own MIT-licensed, CI-built
+# .deb (published on GitHub Releases) and runs the bundled Electron under zypak.
+# The runtime downloads require network + home access (declared below).
+app-id: io.github.mutlukurt.NexoraAIEnvironment
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '24.08'
+command: nexora-ai
+separate-locales: false
+
+finish-args:
+  # Display
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Model / binary downloads and the opt-in API mode
+  - --share=network
+  # Projects live under the user's home; the app also opens arbitrary project folders
+  - --filesystem=home
+  # Desktop notifications when a long generation finishes
+  - --talk-name=org.freedesktop.Notifications
+  - --env=ELECTRON_TRASH=gio
+
+modules:
+  - name: nexora-ai
+    buildsystem: simple
+    build-commands:
+      # Extract the Debian package (offline: ar + tar only)
+      - ar x nexora-ai.deb
+      - mkdir -p data && tar -C data -xf data.tar.*
+      # Install the app payload
+      - cp -a data/opt/NexoraAI /app/NexoraAI
+      # Launcher: run the bundled Electron under zypak (handles the chrome sandbox)
+      - install -Dm755 nexora-ai.sh /app/bin/nexora-ai
+      # Desktop entry, AppStream metadata and icon (renamed to the app-id)
+      - install -Dm644 io.github.mutlukurt.NexoraAIEnvironment.desktop /app/share/applications/io.github.mutlukurt.NexoraAIEnvironment.desktop
+      - install -Dm644 io.github.mutlukurt.NexoraAIEnvironment.metainfo.xml /app/share/metainfo/io.github.mutlukurt.NexoraAIEnvironment.metainfo.xml
+      - install -Dm644 data/usr/share/icons/hicolor/512x512/apps/nexora-ai.png /app/share/icons/hicolor/512x512/apps/io.github.mutlukurt.NexoraAIEnvironment.png
+      - install -Dm644 data/usr/share/icons/hicolor/256x256/apps/nexora-ai.png /app/share/icons/hicolor/256x256/apps/io.github.mutlukurt.NexoraAIEnvironment.png || true
+    sources:
+      - type: file
+        url: https://github.com/mutlukurt/NexoraAIEnvironment/releases/download/v0.20.1/nexora-ai_0.20.1_amd64.deb
+        sha256: 2d4323e149bcbaf6c9f0291a3755561d090dc80a65bf596c5f186fe0a257d5c1
+        dest-filename: nexora-ai.deb
+      - type: script
+        dest-filename: nexora-ai.sh
+        commands:
+          - exec zypak-wrapper /app/NexoraAI/nexora-ai "$@"
+      - type: file
+        path: io.github.mutlukurt.NexoraAIEnvironment.desktop
+      - type: file
+        path: io.github.mutlukurt.NexoraAIEnvironment.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. **NexoraAI is a local-first, agent-first AI development environment (MIT). You describe a web project in plain words and a GGUF model running entirely on your own machine writes it, runs it on localhost, and lets you refine it by chatting; nothing leaves the device by default (an opt-in BYO-key API mode is available). Source: https://github.com/mutlukurt/NexoraAIEnvironment**
- [x] Please attach a video showcasing the application on Linux using the Flatpak.

https://github.com/mutlukurt/NexoraAIEnvironment/releases/download/v0.20.1/nexora-flathub-demo.mp4

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. (`io.github.mutlukurt.NexoraAIEnvironment` — GitHub-hosted `io.github.<user>.<repo>` pattern.)
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

Notes for reviewers: NexoraAI is an Electron app that downloads its inference binaries (`llama-server`/`sd-server`) and GGUF models at runtime. This manifest installs the project's own MIT-licensed CI-built `.deb` and runs the bundled Electron under zypak; it builds locally with `flatpak-builder`, passes `appstreamcli validate`, and launches. Happy to move to a from-source manifest and narrow permissions if preferred — guidance welcome.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
