### PR TITLE
Add dev.lab897.beviamolo

### DIFF
--- a/dev.lab897.beviamolo/dev.lab897.beviamolo.yml
+++ b/dev.lab897.beviamolo/dev.lab897.beviamolo.yml
@@ -1,0 +1,50 @@
+# Manifest per la pubblicazione su Flathub.
+#
+# A differenza di ../dev.lab897.beviamolo.yml (build/test locale, sorgente
+# type: dir), Flathub compila sulla propria infrastruttura: la sorgente deve
+# essere un archivio versionato raggiungibile pubblicamente. Il tarball viene
+# prodotto dal job CI `build-linux-bundle` e pubblicato nel Generic Package
+# Registry di GitLab. Procedura completa: ../FLATHUB.md.
+app-id: dev.lab897.beviamolo
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: beviamolo
+
+finish-args:
+  # Rete — API backend
+  - --share=network
+  # GPU e grafica
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # File system — per importare Excel/CSV e foto
+  - --filesystem=home
+  # Keyring di sistema — per flutter_secure_storage (token auth)
+  - --talk-name=org.freedesktop.secrets
+  # Apertura URL nel browser dell'host via XDG portal
+  - --talk-name=org.freedesktop.portal.OpenURI
+  # NetworkManager via D-Bus — per connectivity_plus
+  - --system-talk-name=org.freedesktop.NetworkManager
+
+modules:
+  - name: beviamolo
+    buildsystem: simple
+    build-commands:
+      # Installa il bundle Flutter preservando la struttura (RPATH relativo)
+      - cp -r bundle/. /app/bin/
+      - chmod +x /app/bin/beviamolo
+      # Desktop entry, icona, metadati AppStream
+      - install -Dm644 dev.lab897.beviamolo.desktop
+          /app/share/applications/dev.lab897.beviamolo.desktop
+      - install -Dm644 dev.lab897.beviamolo.png
+          /app/share/icons/hicolor/512x512/apps/dev.lab897.beviamolo.png
+      - install -Dm644 dev.lab897.beviamolo.metainfo.xml
+          /app/share/metainfo/dev.lab897.beviamolo.metainfo.xml
+    sources:
+      # Tarball prodotto dal job CI build-linux-bundle (vedi ../FLATHUB.md):
+      # aggiornare url e sha256 a ogni release.
+      - type: archive
+        url: https://gitlab.com/api/v4/projects/82474658/packages/generic/beviamolo-linux/1.0.0.18/beviamolo-linux-x64.tar.gz
+        sha256: 24c699b0a52933fa891505c7f47cc6ceacf62f92e2cafd978bb60c096640e799


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. Beviamolo is a personal wine cellar manager built with Flutter: photograph a bottle label and the app recognises the wine, organise bottles by their physical position in the cellar, track tastings and import existing collections from spreadsheets. It is a proprietary application (`LicenseRef-proprietary`); the manifest installs a prebuilt release tarball from our public GitLab package registry (the source repository is private). `--filesystem=home` is needed for spreadsheet import and label photos; `--talk-name=org.freedesktop.secrets` is used by flutter_secure_storage for the login token.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. (video coming shortly)
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. It matches our Android application id (`dev.lab897.beviamolo`); we control the lab897.dev domain and the verification file is in place at lab897.dev/.well-known/org.flathub.VerifiedApps.txt.
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
