### PR TITLE
Add io.github.FrancescoPnr_dev.Kwall

### DIFF
--- a/io.github.FrancescoPnr_dev.Kwall.json
+++ b/io.github.FrancescoPnr_dev.Kwall.json
@@ -1,0 +1,48 @@
+{
+    "id": "io.github.FrancescoPnr_dev.Kwall",
+    "runtime": "org.kde.Platform",
+    "runtime-version": "6.10",
+    "sdk": "org.kde.Sdk",
+    "command": "kwall-flatpak",
+    "finish-args": [
+        "--socket=wayland",
+        "--device=dri",
+        "--share=network",
+        "--talk-name=org.kde.plasmashell",
+        "--filesystem=xdg-data/plasma/wallpapers:create",
+        "--filesystem=xdg-data/knewstuff3:create"
+    ],
+    "modules": [
+        {
+            "name": "plasma-wallpaper-packagestructure",
+            "buildsystem": "cmake-ninja",
+            "subdir": "flatpak/wallpaperstructure",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/FrancescoPnr-dev/Kwall.git",
+                    "tag": "v0.1.0",
+                    "commit": "724b1854e34d80ea09699e298c6657176edc5317"
+                }
+            ]
+        },
+        {
+            "name": "kwall",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "post-install": [
+                "install -Dm755 flatpak/kwall-flatpak.sh /app/bin/kwall-flatpak"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/FrancescoPnr-dev/Kwall.git",
+                    "tag": "v0.1.0",
+                    "commit": "724b1854e34d80ea09699e298c6657176edc5317"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Kwall is a showcase and applier of animated QML and shader wallpapers for KDE Plasma 6 on Wayland. It browses wallpapers tagged for Kwall on the KDE Store, runs a deep safety validation on every package before it is installed and before it is applied (byte identical runtime against the official template, strict whitelist of QML imports), and keeps GPU usage under control with a configurable FPS cap. Upstream repository: https://github.com/FrancescoPnr-dev/Kwall (GPL-3.0-or-later).
- [X] Please attach a video showcasing the application on Linux using the Flatpak. A short screen recording will be attached in a comment below.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author of the project.

### Permissions rationale and linter exceptions requested

The linter reports four errors; each is intentional and needed for the app to function:

- `finish-args-plasmashell-talk-name`: applying a wallpaper is the core function of the app and is done through the plasmashell scripting interface (`evaluateScript` on `org.kde.plasmashell`). There is no portal for this.
- `finish-args-unnecessary-xdg-data-plasma-create-access` and `finish-args-unnecessary-xdg-data-knewstuff3-create-access`: wallpaper packages must be installed where the host plasmashell can load them (`~/.local/share/plasma/wallpapers`), and the KNewStuff registry must stay consistent with them. A wrapper script re-exports `XDG_DATA_HOME=$HOME/.local/share`; these two directories are the only host data the app touches.
- `finish-args-only-wayland`: Kwall is Wayland only by design (the wallpaper pause behavior it relies on does not exist on X11); the app refuses to start on X11 sessions, so a fallback-x11 socket would be misleading.

About the runtime version: the manifest uses org.kde.Platform 6.10 instead of 6.11 because on our test system the CA certificate forwarding in 6.11 (p11-kit based) left the sandbox without a usable trust store, breaking the KDE Store connection. We will move to 6.11 once that is verified working.

The manifest also builds a copy of the tiny `Plasma/Wallpaper` KPackage structure plugin from libplasma (LGPL-2.0-or-later, attribution kept), which is not part of the KDE runtime and is required to install wallpaper packages.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission