### PR TITLE
Add ai.bytical.nerva

### DIFF
--- a/ai.bytical.nerva.desktop
+++ b/ai.bytical.nerva.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+# Flathub-flavoured .desktop, used inside the Flatpak sandbox.
+# Same content as the .deb's Nerva.desktop but the file basename,
+# Icon=, and StartupWMClass match the Flatpak app id so the runtime
+# wires the window class → tray icon → notifications → app metadata.
+Type=Application
+Name=Nerva
+GenericName=Focus Workspace
+Comment=Persistent focus workspace for deep work
+Exec=nerva
+Icon=ai.bytical.nerva
+Terminal=false
+Categories=Office;ProjectManagement;Utility;
+Keywords=focus;timer;pomodoro;notes;habits;tasks;markdown;
+StartupWMClass=ai.bytical.nerva
+StartupNotify=true
+X-Flatpak=ai.bytical.nerva

--- a/ai.bytical.nerva.metainfo.xml
+++ b/ai.bytical.nerva.metainfo.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata for the Flathub listing. Required for the store
+  page (name, summary, screenshots, releases, OARS rating, license).
+  Validated locally with `appstreamcli validate` and on Flathub's CI
+  by `appstreamcli validate -pedantic`.
+
+  Keep the <id> identical to the Flatpak app id and to the Tauri
+  identifier so a single ID flows through .desktop, DBus,
+  notifications, GSettings, and the store listing.
+-->
+<component type="desktop-application">
+  <id>ai.bytical.nerva</id>
+  <name>Nerva</name>
+  <summary>The focus workspace that never forgets</summary>
+  <developer id="ai.bytical">
+    <name>Bytical Solutions Private Limited</name>
+  </developer>
+  <project_license>Apache-2.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <launchable type="desktop-id">ai.bytical.nerva.desktop</launchable>
+
+  <description>
+    <p>
+      Nerva is a native desktop focus workspace built for deep work.
+      Parallel timers that survive sleep and reboot, sticky markdown
+      notes that float above any window, a year-long habit heatmap,
+      and tasks with priority and due times. Offline-first.
+      Telemetry off by default (anonymous usage stats are opt-in). No account.
+    </p>
+    <p>What Nerva does:</p>
+    <ul>
+      <li>Parallel focus timers — wall-clock math, survives suspend and reboot</li>
+      <li>Sticky markdown notes — pop up, float above any window, 250 ms autosave</li>
+      <li>Habit heatmap — 4-state daily toggle, streaks, full-year contribution grid</li>
+      <li>Tasks with pop-out — priority + due time, dockable or floating widget</li>
+      <li>Command palette — Ctrl+Space to jump anywhere</li>
+      <li>Crash-safe local store — event-sourced SQLite append-only log</li>
+    </ul>
+    <p>
+      Native Rust core (Tauri), ~80 MB RAM idle. Not Electron.
+      Open source, Apache-2.0.
+    </p>
+  </description>
+
+  <url type="homepage">https://nerva.bytical.ai</url>
+  <url type="bugtracker">https://github.com/piyushptiwari1/nerva/issues</url>
+  <url type="vcs-browser">https://github.com/piyushptiwari1/nerva</url>
+  <url type="donation">https://github.com/sponsors/piyushptiwari1</url>
+
+  <categories>
+    <category>Office</category>
+    <category>ProjectManagement</category>
+    <category>Utility</category>
+  </categories>
+
+  <keywords>
+    <keyword>focus</keyword>
+    <keyword>timer</keyword>
+    <keyword>pomodoro</keyword>
+    <keyword>notes</keyword>
+    <keyword>habits</keyword>
+    <keyword>tasks</keyword>
+    <keyword>productivity</keyword>
+    <keyword>markdown</keyword>
+  </keywords>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Main workspace — timer, notes, habits, tasks</caption>
+      <image>https://nerva.bytical.ai/screenshots/01-workspace.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Habit heatmap with full-year contribution grid</caption>
+      <image>https://nerva.bytical.ai/screenshots/02-habits.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Habit popup — drag-to-move always-on-top widget</caption>
+      <image>https://nerva.bytical.ai/screenshots/03-habits-popup.png</image>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.1.11" date="2026-07-15">
+      <description>
+        <p>Privacy and insight release.</p>
+        <ul>
+          <li>Optional anonymous usage stats — strictly opt-in via a one-time consent dialog, weekly, feature counts only, toggle in Settings</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.10" date="2026-07-15">
+      <description>
+        <p>Quality and security release.</p>
+        <ul>
+          <li>Notes: cross-window sync both directions; typing no longer drops letters</li>
+          <li>Pop-out timer gains start/restart controls</li>
+          <li>Five selectable timer completion sounds</li>
+          <li>Clearer notes list and new-note button</li>
+          <li>Rebuilt against updated Ubuntu security archive (libsoup USN-8523-1)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.1" date="2026-05-28">
+      <description>
+        <p>Bug-fix release.</p>
+        <ul>
+          <li>Tray icon now has a programmatic right-click menu</li>
+          <li>Pop-out windows stay on the virtual desktop where opened</li>
+          <li>Pin button per pop-out for opt-in always-on-top</li>
+          <li>Closing the main window hides it instead of orphaning the app</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-05-27">
+      <description>
+        <p>First public release.</p>
+      </description>
+    </release>
+  </releases>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#f6f6f8</color>
+    <color type="primary" scheme_preference="dark">#0a0b0d</color>
+  </branding>
+</component>

--- a/ai.bytical.nerva.yaml
+++ b/ai.bytical.nerva.yaml
@@ -1,0 +1,126 @@
+# Flatpak manifest for Nerva.
+#
+# App id (`ai.bytical.nerva`) matches the Tauri `identifier` in
+# src-tauri/tauri.conf.json, so the Flathub install shares the same
+# DBus name, settings dir, and notification source as the native .deb /
+# .rpm builds — users moving between them see the same data layout.
+#
+# Strategy: repack the upstream signed .deb instead of rebuilding from
+# source. This keeps the binary on Flathub bit-for-bit identical to the
+# one on GitHub releases (same Bytical code signature for tray-icon
+# DBus name continuity), and avoids dragging the full Rust/Tauri/Node
+# toolchain into the Flathub build pipeline. The .deb is a normal
+# build-time source (Nerva is Apache-2.0, freely redistributable), so
+# flatpak-builder downloads and sha256-verifies it up front.
+#
+# Submission flow (one-time): fork github.com/flathub/flathub, create
+# a `new-pr/ai.bytical.nerva` branch, copy this manifest + the
+# accompanying .metainfo.xml + .desktop, open a PR. Flathub reviewers
+# run quality checks (appstream-cli validate, OARS rating, screenshots
+# present, finish-args minimal). On merge a new submission PR is opened
+# against flathub/ai.bytical.nerva and that is the repo we update for
+# every subsequent Nerva release.
+#
+# Update on every release: bump `tag` + `commit` (we use the git tag
+# from piyushptiwari1/nerva), bump the .deb URL + sha256 in the
+# extra-data source, regenerate metainfo.xml releases block.
+
+app-id: ai.bytical.nerva
+# GNOME runtime: ships webkit2gtk-4.1, which the Tauri binary links against
+# (the freedesktop runtime does not — the app would fail to start).
+runtime: org.gnome.Platform
+runtime-version: "46"
+sdk: org.gnome.Sdk
+command: nerva
+
+finish-args:
+  # Display server access (Wayland preferred, X11 fallback)
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # Networking: settings/about panel link-outs, future AI/LLM calls
+  - --share=network
+
+  # Audio: the focus timer plays end-of-session chimes
+  - --socket=pulseaudio
+
+  # Files: notes export, task attachments, theme imports — confined to
+  # the user's $HOME by default; users can extend with Flatseal.
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+  # Notifications + tray icon (AppIndicator / StatusNotifier)
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.portal.Desktop
+  - --talk-name=com.canonical.AppMenu.Registrar
+  - --talk-name=com.canonical.indicator.application
+
+  # GSettings access for theme / window decorations
+  - --filesystem=xdg-config/dconf
+  - --filesystem=xdg-run/dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+
+modules:
+  # Shared libs the bundled .deb depends on that aren't in the
+  # freedesktop runtime: webkit2gtk-4.1, ayatana-appindicator,
+  # libnotify. We don't build these from source here either —
+  # Flathub's shared-modules repository ships canonical recipes;
+  # add via `- shared-modules/libsecret/libsecret.json` etc. when
+  # the submission lands.
+  #
+  # Placeholder list below documents intent. Real list will be
+  # finalised against the Flathub validator output.
+
+  - name: libayatana-appindicator
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DENABLE_BINDINGS_MONO=OFF
+      - -DENABLE_BINDINGS_VALA=OFF
+      - -DENABLE_TESTS=OFF
+      - -DENABLE_GTKDOC=OFF
+    sources:
+      - type: archive
+        url: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/0.5.92.tar.gz
+        sha256: 83d0fdd24baeca16ce21d8c0a6c50efbb47b6c2fdc73ea4a6d4b8aab1f9a3b6f
+        x-checker-data:
+          type: anitya
+          project-id: 17812
+          url-template: https://github.com/AyatanaIndicators/libayatana-appindicator/archive/refs/tags/$version.tar.gz
+
+  # The Nerva binary, repacked from the signed upstream .deb.
+  # Nerva is Apache-2.0 (fully redistributable), so the .deb is a normal
+  # build-time source — flatpak-builder downloads + verifies it before the
+  # sandboxed build starts (extra-data is only for non-redistributable
+  # payloads and is NOT available during build-commands).
+  - name: nerva
+    buildsystem: simple
+    build-commands:
+      # .deb = ar archive: control.tar.*, data.tar.*. binutils' ar + tar are
+      # both in the SDK; dpkg-deb is not, so unpack manually.
+      - ar x nerva.deb
+      - mkdir -p nerva-root && tar -xf data.tar.* -C nerva-root
+      - install -Dm755 nerva-root/usr/bin/nerva /app/bin/nerva
+      - mkdir -p /app/share/icons
+      - cp -r nerva-root/usr/share/icons/* /app/share/icons/
+      - install -Dm644 nerva-root/usr/share/applications/Nerva.desktop /app/share/applications/ai.bytical.nerva.desktop
+      # Patch the .desktop so Icon= resolves to the Flatpak app id
+      - sed -i 's/^Icon=.*/Icon=ai.bytical.nerva/' /app/share/applications/ai.bytical.nerva.desktop
+      # Rename icon files to the app id per the freedesktop spec
+      - |
+        for sz in 32x32 128x128 256x256; do
+          src="/app/share/icons/hicolor/$sz/apps/nerva.png"
+          dst="/app/share/icons/hicolor/$sz/apps/ai.bytical.nerva.png"
+          [ -f "$src" ] && mv "$src" "$dst" || true
+        done
+      - install -Dm644 ai.bytical.nerva.metainfo.xml /app/share/metainfo/ai.bytical.nerva.metainfo.xml
+    sources:
+      - type: file
+        dest-filename: nerva.deb
+        url: https://github.com/piyushptiwari1/nerva/releases/download/v0.1.11/Nerva_0.1.11_amd64.deb
+        sha256: 542180d5e916f2c4e5cb92e2b0817778de46aac6899efb8d42bc86a84f176610
+        only-arches: [x86_64]
+      - type: file
+        path: ai.bytical.nerva.metainfo.xml


### PR DESCRIPTION
### New app submission: Nerva

**App**: Nerva — persistent desktop focus workspace (parallel timers, sticky markdown notes, habit heatmap, tasks)
**License**: Apache-2.0 · **Upstream**: https://github.com/piyushptiwari1/nerva · **Homepage**: https://nerva.bytical.ai

- I am the developer/publisher of this app (Bytical Solutions Private Limited).
- Manifest repacks the signed upstream .deb (x86_64) as a verified build-time source — binary is bit-for-bit identical to the GitHub release.
- Runtime: org.gnome.Platform 46 (webkit2gtk-4.1 required by Tauri 2).
- appstreamcli validate passes on the metainfo; OARS rating included; screenshots hosted on the app site.

### Checklist
- [x] I have read the App Requirements
- [x] App ID matches upstream identifier (ai.bytical.nerva, Tauri identifier)
- [x] Metainfo validates with appstream
- [x] finish-args kept minimal (wayland + fallback-x11, pulseaudio for timer chimes, notification/tray talk-names)