### PR TITLE
Add io.github.guilhermefeitosa66.OpenEmux

### DIFF
--- a/io.github.guilhermefeitosa66.OpenEmux.yaml
+++ b/io.github.guilhermefeitosa66.OpenEmux.yaml
@@ -1,0 +1,63 @@
+# Flatpak manifest for OpenEmux.
+#
+# OpenEmux is a GNOME-native front-end; it plays games through the *separately
+# installed* RetroArch Flatpak (org.libretro.RetroArch), launched on the host via
+# flatpak-spawn. RetroArch is therefore NOT bundled here — the manifest only
+# packages the Python app and PyYAML.
+#
+# Local test build:
+#   flatpak install -y flathub org.gnome.Platform//48 org.gnome.Sdk//48 org.flatpak.Builder
+#   flatpak run org.flatpak.Builder --force-clean --user --install \
+#     build-dir packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.yaml
+#   flatpak run io.github.guilhermefeitosa66.OpenEmux
+#
+# For the Flathub submission, pin the `openemux` module source to a tagged commit.
+app-id: io.github.guilhermefeitosa66.OpenEmux
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: openemux
+
+finish-args:
+  # GTK UI
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Cover-art sync from the libretro thumbnail servers
+  - --share=network
+  # ROM library + cover writing, and reading the RetroArch Flatpak's cores dir
+  - --filesystem=home
+  # Launch the RetroArch Flatpak on the host via flatpak-spawn
+  - --talk-name=org.freedesktop.Flatpak
+
+cleanup:
+  - '*.pyc'
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+
+modules:
+  - python3-pyyaml.yaml
+
+  - name: openemux
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --no-build-isolation
+        --prefix=${FLATPAK_DEST} .
+      - install -Dm644 packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.guilhermefeitosa66.OpenEmux.metainfo.xml
+      - install -Dm644 packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.guilhermefeitosa66.OpenEmux.desktop
+      - install -Dm644 packaging/flatpak/io.github.guilhermefeitosa66.OpenEmux.png
+        ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.guilhermefeitosa66.OpenEmux.png
+      - install -Dm644 LICENSE
+        ${FLATPAK_DEST}/share/licenses/io.github.guilhermefeitosa66.OpenEmux/LICENSE
+    sources:
+      # Flathub builds from the app's git repo. Pin `commit:` (and `tag:`) to a
+      # specific release for the Flathub PR. For a local test against uncommitted
+      # changes, temporarily replace this with:  - type: dir\n    path: ../..
+      - type: git
+        url: https://github.com/guilhermefeitosa66/OpenEmux.git
+        tag: v1.1.0
+        commit: b40f9edae7163c9ebb2c1fcc81e7c69f7e09f82c

--- a/python3-pyyaml.yaml
+++ b/python3-pyyaml.yaml
@@ -1,0 +1,10 @@
+name: python3-pyyaml
+buildsystem: simple
+build-commands:
+  - pip3 install --verbose --exists-action=i --no-index
+    --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+    --no-build-isolation pyyaml
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz
+    sha256: d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. **OpenEmux is a GNOME-native frontend for RetroArch, inspired by OpenEmu. It lets you browse and organize your retro game library by console with cover art, and launch games — with a compatible gamepad — through the RetroArch Flatpak. It bundles no games, ROMs or BIOS. It requires the RetroArch Flatpak (`org.libretro.RetroArch`), which it launches via flatpak-spawn and which manages the emulator cores.**
- [x] Please attach a video showcasing the application on Linux using the Flatpak.
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

https://github.com/user-attachments/assets/ff3690fe-cff7-4b24-9107-64e1af874a28

**Permission notes for reviewers:**
- `--talk-name=org.freedesktop.Flatpak` — used only to launch the separately-installed RetroArch Flatpak (`org.libretro.RetroArch`) via flatpak-spawn. RetroArch is the emulation backend and is intentionally not bundled (it targets the KDE runtime; bundling it into this GNOME app would duplicate an existing Flathub app).
- `--filesystem=home` — OpenEmux is a ROM-library manager: it scans the user's ROM folder and writes downloaded cover art next to it.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
