### PR TITLE
Add BudgetWiseAI manifest

### DIFF
--- a/io.github.josephnathanie.BudgetWiseAI.json
+++ b/io.github.josephnathanie.BudgetWiseAI.json
@@ -1,0 +1,33 @@
+{
+  "app-id": "io.github.josephnathanie.BudgetWiseAI",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "46",
+  "sdk": "org.gnome.Sdk",
+  "command": "budgetwise-ai",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--device=dri"
+  ],
+  "modules": [
+    {
+      "name": "budgetwise-ai",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p /app/bin",
+        "mkdir -p /app/share/applications",
+        "mkdir -p /app/share/icons/hicolor/scalable/apps",
+        "install -pD budgetwise-ai /app/bin/budgetwise-ai"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com",
+          "branch": "master"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] I have tested the build locally.
- [x] The application ID matches the repository name.
- [x] The manifest builds cleanly with flatpak-builder.

