### PR TITLE
Add com.issary.issary

### DIFF
--- a/com.issary.issary.desktop
+++ b/com.issary.issary.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Issary
+Comment=AI-native email client for any IMAP/SMTP account
+Exec=run.sh %U
+Terminal=false
+Type=Application
+Icon=com.issary.issary
+StartupWMClass=Issary
+Categories=Network;Email;
+Keywords=email;mail;imap;smtp;client;ai;

--- a/com.issary.issary.metainfo.xml
+++ b/com.issary.issary.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.issary.issary</id>
+  <name>Issary</name>
+  <summary>AI-native email client for any IMAP/SMTP account</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary=https://issary.com/terms</project_license>
+  <developer id="com.issary">
+    <name>MONOTIVE</name>
+  </developer>
+  <description>
+    <p>
+      Issary is a desktop email client that connects to any IMAP/SMTP account
+      and adds AI-assisted writing and summarization.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.issary.issary.desktop</launchable>
+  <url type="homepage">https://issary.com</url>
+  <url type="bugtracker">https://github.com/MONOTIVE/com.issary.issary/issues</url>
+  <url type="contact">https://issary.com/help</url>
+  <branding>
+    <color type="primary" scheme_preference="light">#66b2ff</color>
+    <color type="primary" scheme_preference="dark">#004c99</color>
+  </branding>
+  <content_rating type="oars-1.1" />
+  <screenshots>
+    <screenshot type="default">
+      <caption>Inbox with the built-in AI assistant</caption>
+      <image>https://issary.com/assets/screenshots/inbox.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>One-click AI actions for a selected email</caption>
+      <image>https://issary.com/assets/screenshots/assistant.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>AI-assisted editing directly in the compose window</caption>
+      <image>https://issary.com/assets/screenshots/compose.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.29" date="2026-07-16" />
+  </releases>
+</component>

--- a/com.issary.issary.yml
+++ b/com.issary.issary.yml
@@ -1,0 +1,54 @@
+app-id: com.issary.issary
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: run.sh
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --filesystem=xdg-download
+  - --env=ELECTRON_TRASH=gio
+modules:
+  - name: issary
+    buildsystem: simple
+    build-commands:
+      - ar x issary.deb
+      - tar -xf data.tar.xz
+      - mkdir -p /app/main
+      - cp -a opt/Issary/. /app/main/
+      # The SUID chrome-sandbox cannot work inside flatpak; zypak (from the
+      # Electron BaseApp) provides the sandboxing instead.
+      - rm -f /app/main/chrome-sandbox
+      - install -Dm755 -t /app/bin/ run.sh
+      - install -Dm644 com.issary.issary.desktop -t /app/share/applications/
+      - install -Dm644 com.issary.issary.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 usr/share/icons/hicolor/512x512/apps/issary.png /app/share/icons/hicolor/512x512/apps/com.issary.issary.png
+      - install -Dm644 icon.svg /app/share/icons/hicolor/scalable/apps/com.issary.issary.svg
+    sources:
+      - type: file
+        url: https://releases.issary.com/issary_0.1.29_amd64.deb
+        sha512: aad2787112a892e2c3554e993bb78736325253c11abd122ebe32bc97ddcb2b6a9bd44edea6eef9b155e5e1abc24b32dc05d538916edab582292826f325dfdec8
+        dest-filename: issary.deb
+        only-arches:
+          - x86_64
+        x-checker-data:
+          type: electron-updater
+          url: https://releases.issary.com/latest-linux.yml
+          is-main-source: true
+      - type: file
+        path: com.issary.issary.desktop
+      - type: file
+        path: com.issary.issary.metainfo.xml
+      - type: file
+        path: icon.svg
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - zypak-wrapper.sh /app/main/issary "$@"

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "only-arches": ["x86_64"],
+  "require-important-update": true
+}

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="41.671875mm"
+   height="41.671883mm"
+   viewBox="0 0 41.671875 41.671883"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="icon-blue.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview141"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="3.8969433"
+     inkscape:cx="35.027453"
+     inkscape:cy="60.688591"
+     inkscape:window-width="1854"
+     inkscape:window-height="1011"
+     inkscape:window-x="1986"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <defs
+     id="defs1" />
+  <path
+     id="circle48"
+     style="fill:#007fff;fill-opacity:1;stroke-width:3.37049;stroke-linecap:round"
+     d="m 28.442707,7.60678 a 13.229167,13.229167 0 0 0 -13.229166,13.22916 13.229167,13.229167 0 0 0 1.632458,6.29574 h 6.795451 a 7.9375,7.9375 0 0 1 -3.136243,-6.29574 7.9375,7.9375 0 0 1 7.9375,-7.9375 7.9375,7.9375 0 0 1 6.871932,3.96875 h 3.042192 v 10e-4 a 3.96875,3.96875 0 0 1 0.0078,-10e-4 3.96875,3.96875 0 0 1 3.023072,1.39889 A 13.229167,13.229167 0 0 0 28.442756,7.60678 Z M 41.429512,23.3469 a 3.96875,3.96875 0 0 1 -3.06493,1.45779 3.96875,3.96875 0 0 1 -0.0078,-0.001 v 0.001 h -3.060278 a 7.9375,7.9375 0 0 1 -6.853846,3.96875 2.6458333,2.6458333 0 0 0 -2.645833,2.64584 2.6458333,2.6458333 0 0 0 2.645833,2.64583 13.229167,13.229167 0 0 0 12.986805,-10.71821 z" />
+  <path
+     id="rect52"
+     style="fill:#66b2ff;fill-opacity:1;stroke-width:2.66666;stroke-linecap:round"
+     d="m 6.46007,18.19011 a 7.2760415,7.2760415 0 0 0 -0.506946,2.64583 7.2760415,7.2760415 0 0 0 0.506946,2.64584 h 8.365381 a 13.890625,13.890625 0 0 1 -0.273369,-2.64584 13.890625,13.890625 0 0 1 0.273369,-2.64583 z m 15.213541,0 a 7.2760415,7.2760415 0 0 0 -0.506945,2.64583 7.2760415,7.2760415 0 0 0 0.506945,2.64584 h 8.365381 8.987049 a 2.6458333,2.6458333 0 0 0 2.645833,-2.64584 2.6458333,2.6458333 0 0 0 -2.645833,-2.64583 h -8.987049 z" />
+  <path
+     id="path44"
+     style="fill:#004c99;fill-opacity:1;stroke-width:3.37049;stroke-linecap:round"
+     d="M 13.229166,7.60678 A 13.229167,13.229167 0 0 0 -10e-7,20.83594 a 13.229167,13.229167 0 0 0 13.229167,13.22917 2.6458333,2.6458333 0 0 0 2.645833,-2.64583 2.6458333,2.6458333 0 0 0 -2.645833,-2.64584 7.9375,7.9375 0 0 1 -7.9375,-7.9375 7.9375,7.9375 0 0 1 7.9375,-7.9375 A 7.9375,7.9375 0 0 1 16.584,13.6431 13.890625,13.890625 0 0 1 20.27008,9.64645 13.229167,13.229167 0 0 0 13.229166,7.60678 Z m 11.613244,6.92567 a 7.2760415,7.2760415 0 0 0 -2.483052,2.33474 h 3.469039 A 13.229167,13.229167 0 0 0 24.84241,14.53245 Z m -2.483052,10.27224 a 7.2760415,7.2760415 0 0 0 2.469616,2.32699 13.229167,13.229167 0 0 0 0.989604,-2.32699 z" />
+</svg>


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Issary is an AI-native desktop email client that works with any IMAP/SMTP account, adding AI-assisted writing, summarization, and one-click mail actions. Homepage: https://issary.com
- [X] Please attach a video showcasing the application on Linux using the Flatpak. <[startup.webm](https://github.com/user-attachments/assets/16f9deb2-0411-4ca2-b67d-92ae8d16c385)>
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

### Additional context

**Upstream / developer status:** I am the upstream developer (MONOTIVE, owner of issary.com and of the packaged binaries). The application source is not public, so this manifest repacks our official amd64 .deb release; as the publisher we grant redistribution of these binaries. Packaging is staged at https://github.com/MONOTIVE/com.issary.issary

**Technical notes:**
- Built on org.electronjs.Electron2.BaseApp 25.08 with zypak.
- `only-arches: x86_64` — upstream currently ships amd64 builds only.
- Release automation: `x-checker-data` (electron-updater type) tracks our `latest-linux.yml` feed, so flathubbot PRs land automatically per release.
- Built and tested locally with the `flathub-build` wrapper from org.flatpak.Builder; `flatpak-builder-lint` passes for manifest, appstream, and the built repo with no errors or warnings.

**Permissions rationale:**
- `--share=network`: core function — IMAP/SMTP connections and the AI backend.
- `--filesystem=xdg-download`: saving mail attachments.
- `--talk-name=org.freedesktop.Notifications`: new-mail and calendar reminders.
- `--socket=wayland` + `--socket=fallback-x11`, `--device=dri`, `--share=ipc`: standard Electron requirements.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
