### PR TITLE
Add com.mineracks.wifi2qr

### DIFF
--- a/com.mineracks.wifi2qr.desktop
+++ b/com.mineracks.wifi2qr.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=WiFi2QR
+Comment=Turn this device's Wi-Fi into a scannable QR code
+Exec=desktop
+Icon=com.mineracks.wifi2qr
+Terminal=false
+Categories=Utility;Network;
+Keywords=wifi;qr;password;network;hotspot;

--- a/com.mineracks.wifi2qr.metainfo.xml
+++ b/com.mineracks.wifi2qr.metainfo.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.mineracks.wifi2qr</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>WiFi2QR</name>
+  <summary>Turn this device's Wi-Fi into a scannable QR code</summary>
+  <description>
+    <p>
+      WiFi2QR reads the Wi-Fi network your computer is connected to and turns it into a QR code
+      your guests can scan to join — no reading passwords aloud, no typing. Everything runs on
+      your device; nothing is uploaded.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>One-click read of your current Wi-Fi network (via NetworkManager)</li>
+      <li>Or type any network name and password by hand</li>
+      <li>Print a full-page "Join the Wi-Fi" poster, or a sheet of cut-out cards for a hotel, café or event</li>
+      <li>Save the QR code as an image, or copy it to share</li>
+      <li>Available in 16 languages</li>
+      <li>Fully offline and private — nothing leaves your device</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">com.mineracks.wifi2qr.desktop</launchable>
+  <url type="homepage">https://wifi2qr.app</url>
+  <url type="bugtracker">https://git.mineracks.com/mineracks/wifi2qr/issues</url>
+  <url type="vcs-browser">https://git.mineracks.com/mineracks/wifi2qr</url>
+  <developer id="com.mineracks">
+    <name>mineracks</name>
+  </developer>
+  <content_rating type="oars-1.1" />
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/mineracks/wifi2qr/main/web/app-preview.png</image>
+      <caption>Read this device's Wi-Fi and show the scannable code</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.0.6" date="2026-07-16">
+      <description>
+        <p>Printable Wi-Fi posters and cut-out cards, 16 languages, and signed build provenance.</p>
+      </description>
+    </release>
+    <release version="1.0.2" date="2026-07-06">
+      <description>
+        <p>Flatpak reads Wi-Fi via NetworkManager D-Bus with a scoped permission.</p>
+      </description>
+    </release>
+    <release version="1.0.1" date="2026-07-05">
+      <description>
+        <p>Linux Flatpak support with sandboxed Wi-Fi auto-read via flatpak-spawn.</p>
+      </description>
+    </release>
+    <release version="1.0.0" date="2026-07-04">
+      <description>
+        <p>Initial release.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/com.mineracks.wifi2qr.yml
+++ b/com.mineracks.wifi2qr.yml
@@ -1,0 +1,44 @@
+# Flathub manifest for WiFi2QR. Builds from the released Debian package (the Tauri app),
+# re-homing it under the app-id and granting the D-Bus name that lets the sandboxed app
+# run the host's `nmcli` via `flatpak-spawn --host` for Wi-Fi auto-read (see wifi.rs).
+#
+# NOTE: the sha256 below must match the .deb release asset. Update it whenever the .deb is
+# rebuilt:  sha256sum Wi-Fi2QR_<ver>_amd64.deb  (also in the release's signed SHA256SUMS).
+#
+# Flathub caveat: reviewers prefer source builds. Building Tauri from source needs offline
+# cargo+npm vendoring (a larger effort); this binary-repackage is the pragmatic first cut,
+# common for Tauri/Electron apps on Flathub.
+id: com.mineracks.wifi2qr
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: desktop
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Wi-Fi auto-read: talk to NetworkManager over D-Bus (scoped) — the app uses this instead of
+  # the broad org.freedesktop.Flatpak spawn permission when it detects the sandbox (see wifi.rs).
+  - --system-talk-name=org.freedesktop.NetworkManager
+
+modules:
+  - name: wifi2qr
+    buildsystem: simple
+    build-commands:
+      - ar x *.deb
+      - tar -xf data.tar.gz
+      - install -Dm755 usr/bin/desktop /app/bin/desktop
+      - install -Dm644 com.mineracks.wifi2qr.desktop /app/share/applications/com.mineracks.wifi2qr.desktop
+      - install -Dm644 com.mineracks.wifi2qr.metainfo.xml /app/share/metainfo/com.mineracks.wifi2qr.metainfo.xml
+      - install -Dm644 usr/share/icons/hicolor/32x32/apps/desktop.png /app/share/icons/hicolor/32x32/apps/com.mineracks.wifi2qr.png
+      - install -Dm644 usr/share/icons/hicolor/128x128/apps/desktop.png /app/share/icons/hicolor/128x128/apps/com.mineracks.wifi2qr.png
+    sources:
+      - type: file
+        url: https://git.mineracks.com/mineracks/wifi2qr/releases/download/v1.0.6/Wi-Fi2QR_1.0.6_amd64.deb
+        sha256: 48fcd09b68febde7a6dde344c7c2836a0ca257f3fe51a677a5affd624d7eb362
+      - type: file
+        path: com.mineracks.wifi2qr.desktop
+      - type: file
+        path: com.mineracks.wifi2qr.metainfo.xml


### PR DESCRIPTION
Submitting **WiFi2QR** (com.mineracks.wifi2qr) — an MIT-licensed utility that turns the Wi-Fi network the computer is on into a QR code guests scan to join (or type any network by hand). Everything runs on-device; nothing is uploaded. It can also print a poster or a sheet of cut-out cards.

- **Upstream / developer:** https://github.com/mineracks/wifi2qr (I am the developer — mineracks)
- **Website:** https://wifi2qr.app
- **License:** MIT (app), CC0 (metainfo)

### Notes for reviewers
- **Binary repackage of the upstream Tauri `.deb`** (v1.0.6). A from-source build would need offline cargo+npm vendoring; happy to move to a source build as a follow-up — this is the pragmatic first cut common for Tauri apps.
- **Permissions:** the only non-default finish-arg is `--system-talk-name=org.freedesktop.NetworkManager`, used to read the current Wi-Fi via NetworkManager D-Bus (scoped) rather than a broad host-spawn permission.
- **Validated locally** with `flatpak-builder` 1.4.9 on Ubuntu 24.04: builds cleanly, `appstreamcli compose` passes, `flatpak-builder-lint manifest` is clean, and the screenshot mirrors (hosted on `raw.githubusercontent.com`).
- Runtime is freedesktop 24.08; happy to bump to 25.08 if preferred.

Thanks for reviewing!