### PR TITLE
Add net.shakaran.whatly

### DIFF
--- a/net.shakaran.whatly.yml
+++ b/net.shakaran.whatly.yml
@@ -1,0 +1,49 @@
+# Flathub submission manifest for Whatly.
+#
+# This is the manifest to submit to https://github.com/flathub/flathub (see
+# SUBMISSION.md next to this file). It differs from packaging/flatpak/ in the
+# ways Flathub requires: every source is pinned to an immutable commit (no
+# branches, no `dir` sources), and the libnotify-qt submodule is fetched as its
+# own pinned git source instead of relying on a local checkout.
+#
+# Whatly's real Qt floor is 6.8 (QWebEnginePermission); it targets the KDE 6.9
+# runtime here via -DQT_VERSION_MINOR=9. Bump the three runtime versions to 6.10
+# and drop that config-opt once a KDE 6.10 runtime is on Flathub.
+app-id: net.shakaran.whatly
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+base: io.qt.qtwebengine.BaseApp
+base-version: '6.9'
+command: whatly
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --device=all            # camera for video calls
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.ScreenSaver
+  - --filesystem=xdg-download
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - name: whatly
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DQT_VERSION_MINOR=9
+    sources:
+      # The app, pinned to the 6.1.0 release commit. flatpak-builder fetches the
+      # git source's submodules (libnotify-qt at src/libnotify-qt) automatically,
+      # each at the commit the tag pins — no separate source needed.
+      - type: git
+        url: https://github.com/shakaran/whatly.git
+        tag: v6.1.0
+        commit: b201cd95dc65d854c9270237aa519c54b15549bb


### PR DESCRIPTION
Submission for **Whatly** — a feature-rich desktop client for WhatsApp Web (MIT-licensed fork of WhatSie).

- App ID: `net.shakaran.whatly`
- Upstream: https://github.com/shakaran/whatly (built from the pinned `v6.1.0` tag/commit)
- Runtime: `org.kde.Platform` 6.9 + `io.qt.qtwebengine.BaseApp` (Qt WebEngine)
- License: MIT

Built and verified locally with `flatpak-builder` (`org.kde.Sdk` 6.9); the app launches and loads WhatsApp Web. Metainfo carries name, summary, description, `content_rating`, `launchable`, developer, URLs, licenses, releases and screenshots.

Notes:
- The Qt floor is lowered to 6.9 via `-DQT_VERSION_MINOR=9` (the code's real requirement is 6.8 — `QWebEnginePermission`); will bump to a 6.10/6.11 runtime when available.
- Screenshots are external URLs (raw.githubusercontent.com) for Flathub to mirror.
- Not affiliated with WhatsApp or Meta.