### PR TITLE
Add io.github.zoutmax.FifineControlDeck

### DIFF
--- a/fifine-control-deck.launcher
+++ b/fifine-control-deck.launcher
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Flatpak launcher: the app package lives under /app/lib, the python
+# dependencies (BaseApp PyQt6 + pip-installed) under /app's site-packages,
+# which the runtime python does not search by default.
+SITE=$(ls -d /app/lib/python3.*/site-packages 2>/dev/null | head -n1)
+export PYTHONPATH="/app/lib/fifine-control-deck${SITE:+:$SITE}${PYTHONPATH:+:$PYTHONPATH}"
+exec python3 -m fifine_deck "$@"

--- a/flatpak-fixes.patch
+++ b/flatpak-fixes.patch
@@ -1,0 +1,38 @@
+diff --git a/fifine_deck/model.py b/fifine_deck/model.py
+index eea4cf7..3460c84 100644
+--- a/fifine_deck/model.py
++++ b/fifine_deck/model.py
+@@ -17,7 +17,12 @@ import uuid
+ from dataclasses import dataclass, field
+ from typing import Optional
+ 
+-CONFIG_DIR = os.path.expanduser("~/.config/fifine-control-deck")
++# XDG_CONFIG_HOME matters: under Flatpak it points into ~/.var/app/<id>/,
++# and hardcoding ~/.config there writes into the sandbox's throwaway home —
++# the config would silently vanish on every restart.
++CONFIG_DIR = os.path.join(
++    os.environ.get("XDG_CONFIG_HOME") or os.path.expanduser("~/.config"),
++    "fifine-control-deck")
+ CONFIG_PATH = os.path.join(CONFIG_DIR, "config.json")
+ ICONS_DIR = os.path.join(CONFIG_DIR, "icons")
+ CONFIG_VERSION = 1
+diff --git a/fifine_deck/rendering.py b/fifine_deck/rendering.py
+index 86aae91..cfb35ba 100644
+--- a/fifine_deck/rendering.py
++++ b/fifine_deck/rendering.py
+@@ -11,9 +11,15 @@ from functools import lru_cache
+ 
+ from PIL import Image, ImageDraw, ImageFont, ImageEnhance
+ 
++# Cover the common layouts: Debian/Ubuntu (truetype/…), Fedora and the
++# Flatpak runtimes (dejavu/…, liberation-fonts/…), Arch (TTF/…). Missing all
++# of them silently degrades to Pillow's tiny bitmap font — which is exactly
++# what happened in the Flatpak sandbox before the runtime paths were added.
+ _FONT_CANDIDATES = [
+     "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
++    "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+     "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
++    "/usr/share/fonts/liberation-fonts/LiberationSans-Bold.ttf",
+     "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",
+ ]
+ 

--- a/io.github.zoutmax.FifineControlDeck.yaml
+++ b/io.github.zoutmax.FifineControlDeck.yaml
@@ -1,0 +1,76 @@
+# Flatpak / Flathub manifest for fifine Control Deck.
+#
+# Local test build:
+#   flatpak-builder --user --install --force-clean build-dir \
+#       flatpak/io.github.zoutmax.FifineControlDeck.yaml
+#
+# PyQt6 comes prebuilt from the PyQt BaseApp (both arches); the remaining
+# python dependencies are pinned, offline sdist sources in python3-deps.json
+# (regenerate with flatpak-pip-generator Pillow psutil pyudev).
+#
+id: io.github.zoutmax.FifineControlDeck
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '6.11'
+command: fifine-control-deck
+
+build-options:
+  env:
+    - BASEAPP_REMOVE_WEBENGINE=1
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --socket=pulseaudio               # volume / media actions
+  - --share=network                   # open-url action
+  # The deck is driven over /dev/hidraw (vendor HID protocol); there is no
+  # narrower device permission that covers hidraw nodes.
+  - --device=all
+  # Host helper tools (hotkeys via ydotool/xdotool, playerctl, wpctl,
+  # xdg-open) are launched via flatpak-spawn --host:
+  - --talk-name=org.freedesktop.Flatpak
+  # "Type password" action stores secrets in the keyring:
+  - --talk-name=org.freedesktop.secrets
+
+modules:
+  # Pillow, psutil, pyudev as pinned offline sdists (PyQt6 is in the BaseApp).
+  # (path is relative to this manifest file)
+  - python3-deps.json
+
+  - name: fifine-control-deck
+    buildsystem: simple
+    build-commands:
+      - install -d ${FLATPAK_DEST}/lib/fifine-control-deck
+      - cp -r fifine_deck assets ${FLATPAK_DEST}/lib/fifine-control-deck/
+      # drop non-Linux transport binaries from the vendored SDK
+      - find ${FLATPAK_DEST}/lib/fifine-control-deck -type f \( -name '*.dll' -o -name '*.dylib' \) -delete
+      # launcher ships next to this manifest (file source below), so launcher
+      # fixes don't require retagging the app
+      - install -Dm755 fifine-control-deck.launcher ${FLATPAK_DEST}/bin/fifine-control-deck
+      - install -Dm644 flatpak/io.github.zoutmax.FifineControlDeck.desktop
+          ${FLATPAK_DEST}/share/applications/io.github.zoutmax.FifineControlDeck.desktop
+      - install -Dm644 flatpak/io.github.zoutmax.FifineControlDeck.metainfo.xml
+          ${FLATPAK_DEST}/share/metainfo/io.github.zoutmax.FifineControlDeck.metainfo.xml
+      - install -Dm644 assets/app/fifine-deck.png
+          ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/io.github.zoutmax.FifineControlDeck.png
+      - install -Dm644 assets/app/fifine-deck-256.png
+          ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/io.github.zoutmax.FifineControlDeck.png
+    sources:
+      - type: git
+        url: https://github.com/ZoutMax/fifine-control-deck-linux.git
+        tag: v0.6.0
+        commit: 93203ccabf558c0c2c751138d9d2ed00d9b14383
+      # Two post-v0.6.0 upstream fixes needed inside the sandbox (drop with
+      # the next tag): honor XDG_CONFIG_HOME so the config persists, and add
+      # the runtime's font paths so key text doesn't fall back to Pillow's
+      # tiny bitmap font.
+      - type: patch
+        path: flatpak-fixes.patch
+      - type: file
+        path: fifine-control-deck.launcher

--- a/python3-deps.json
+++ b/python3-deps.json
@@ -1,0 +1,63 @@
+{
+    "name": "python3-deps",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-pybind11",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pybind11\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b3/06/c3a23c9a0263b136c519f033a58d4641e73065fefc7754e9667ec206d992/pybind11-3.0.4-py3-none-any.whl",
+                    "sha256": "961720ee652da51d531b7b2451a6bd2bc042b0106e6d9baa48ecb7d58034ce63"
+                }
+            ]
+        },
+        {
+            "name": "python3-Pillow",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Pillow\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz",
+                    "sha256": "3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce"
+                }
+            ]
+        },
+        {
+            "name": "python3-psutil",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"psutil\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz",
+                    "sha256": "0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"
+                }
+            ]
+        },
+        {
+            "name": "python3-pyudev",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyudev\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/2a/51/3dc0cd6498b24dea3cdeaed648568e3ca7454d41334d840b114156d7479f/pyudev-0.24.4-py3-none-any.whl",
+                    "sha256": "b3b6b01c68e6fc628428cc45ff3fe6c277afbb5d96507f14473ddb4a6b959e00"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. **fifine Control Deck** is a native Linux control app for the fifine AmpliGame D6 / Mirabox "Stream Dock" 293V3-family macro keypads (per-key LCD keys, USB 3142:0060). Draw icons, labels and animated GIFs on the keys and bind them to actions: launch apps, hotkeys, typed text, media/volume, brightness, profiles/pages/folders, multi-step macros, and live system-monitor readouts (CPU/RAM/network/disk) rendered on the key LCDs. PyQt6 GUI, MIT licensed. Upstream: https://github.com/ZoutMax/fifine-control-deck-linux — website: https://zoutmax.github.io/fifine-control-deck-linux/
- [X] Please attach a video showcasing the application on Linux using the Flatpak.
  https://github.com/user-attachments/assets/7d2a8239-a992-4e5b-9c66-b625e302a974
  (recorded from this exact Flatpak build; the status bar shows the `[flatpak]` tag and the live connection to the physical deck, `fw=V3.D6.1.009`)
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

---

### Build/runtime notes

- `org.kde.Platform 6.11` + `com.riverbankcomputing.PyQt.BaseApp` (PyQt6); remaining python deps are pinned offline sdists (pybind11, Pillow, psutil, pyudev).
- App source pinned to the `v0.6.0` tag. `flatpak-fixes.patch` carries two post-tag upstream commits needed in the sandbox (XDG_CONFIG_HOME so the config persists; runtime font paths) — both already merged upstream and will be dropped at the next tag.
- Built and tested locally on real hardware from inside the sandbox: device I/O works, config persists in `~/.var/app`, fonts render.

### Permissions rationale

- `--device=all`: the keypad is driven over `/dev/hidraw*` with a vendor HID protocol (key images + key events). There is no portal or narrower device permission that covers hidraw. (Host still needs the udev rule for unprivileged access; documented upstream, ships with the deb/PPA.)
- `--talk-name=org.freedesktop.Flatpak` (flatpak-spawn, flagged by the linter): running user-defined actions on the host is the core purpose of a macro keypad — launching applications, sending hotkeys via host tools (ydotool/xdotool), media/volume via playerctl/wpctl, opening URLs. Without host access the app can only draw pictures on keys. Happy to discuss alternatives (portals cover some actions, but not user-arbitrary commands/hotkeys, which are the product).
- `--talk-name=org.freedesktop.secrets`: the "type password" action stores its secret in the keyring instead of the config file.

### Note on a vendored binary

The upstream repo vendors the device transport library (`libtransport.so`, x86_64 + aarch64) from the Mirabox StreamDock vendor SDK — the vendor does not publish its source. Everything else builds from source. If this is a blocker I'd appreciate guidance on the preferred handling.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission