### PR TITLE
Add io.github.kamsiob.Bearings

### DIFF
--- a/io.github.kamsiob.Bearings.yaml
+++ b/io.github.kamsiob.Bearings.yaml
@@ -1,0 +1,139 @@
+# Flathub manifest for Bearings by Kamsiob.
+#
+# A local PySide6 + QtWebEngine desktop app. The Python bindings come from the
+# official PySide6 wheels (pinned + hashed for the offline Flathub builders); the
+# KDE runtime provides the matching Qt 6.11 base and system libraries QtWebEngine
+# needs (krb5, nss, ...).
+#
+# Sandbox is deliberately tight: Wayland/X11 + GPU for the window, and network
+# ONLY for the optional, off-by-default content-update check. No filesystem
+# access — user data lives in the app's own sandboxed dirs, and saving a cheat
+# sheet PDF goes through the file-chooser portal.
+app-id: io.github.kamsiob.Bearings
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+command: bearings
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Only for the optional, off-by-default "check for updated tips" request to a
+  # public GitHub file. Nothing about the user or device is sent. Flatpak network
+  # permission is all-or-nothing; this is the least it can be while allowing that.
+  - --share=network
+
+cleanup:
+  - '*.pyc'
+  - '/lib/python*/site-packages/*/__pycache__'
+  - '*.a'
+  - '*.la'
+
+modules:
+  # QtNetwork in the PySide6 wheels is built with GSSAPI enabled, so it needs
+  # libgssapi_krb5, which neither the KDE nor freedesktop runtime ships. Build a
+  # minimal krb5 to provide just those shared libraries.
+  - name: krb5
+    buildsystem: autotools
+    subdir: src
+    # krb5 1.21 still has K&R-style declarations that a C23-default GCC rejects;
+    # build it as gnu17 (we only want the GSSAPI/krb5 shared libraries anyway).
+    build-options:
+      cflags: -std=gnu17
+      cflags-override: true
+    config-opts:
+      - --disable-static
+      - --disable-rpath
+      - --without-ldap
+      - --without-tcl
+      - --without-keyutils
+      - --disable-nls
+    cleanup:
+      - /bin
+      - /sbin
+      - /share
+      - /etc
+      - /var
+      - /include
+      - '*.a'
+    sources:
+      - type: archive
+        url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.3.tar.gz
+        sha256: b7a4cd5ead67fb08b980b21abd150ff7217e85ea320c9ed0c6dadd304840ad35
+
+  - name: python3-pyside6
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --no-build-isolation
+        --find-links="file://${PWD}/pip-wheels"
+        --prefix=${FLATPAK_DEST} PySide6
+    sources:
+      # x86_64 wheels
+      - type: file
+        url: https://files.pythonhosted.org/packages/c7/9b/e0355d8897b5c150770f1d95718aad17d432fcc9c035c04f3f58427d4693/shiboken6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl
+        sha256: 9a8bccfafc8805254cabcfa1edfaf55cd52889f4998c91ad0d9a4433fb1bcdbe
+        dest: pip-wheels
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/5c/49/0e1237c4400bec7e335d2c4eeb49bc40d9fd88a9ac44ca9083ce1abdc308/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl
+        sha256: e3ef7027b41e4e55fadb56e3b3257dc8ee92154b639fe67fc4c8e05e9d976c60
+        dest: pip-wheels
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/dd/62/fb1428a523b2a4541e232aab50d9e789e6b4526f37fd9593452a7ea5b6b3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl
+        sha256: 8e6c65fbd73a512d6f72cda8d8277444a85a34dc99dd1dae9c21d35b8671bb1f
+        dest: pip-wheels
+        only-arches: [x86_64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/d8/de/af89d71410c83b10654d86ff9aff2a4f87c30163658f1cc145242e222526/pyside6-6.11.1-cp310-abi3-manylinux_2_34_x86_64.whl
+        sha256: b1fc521ba2bb5109425ab8add06bddbdd524abcad06cfa012cc39a22a189feb2
+        dest: pip-wheels
+        only-arches: [x86_64]
+      # aarch64 wheels
+      - type: file
+        url: https://files.pythonhosted.org/packages/57/d5/dd4f1defed400be03340f2ede34b61f846776650b4e7ed9ebaf4c71979a2/shiboken6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl
+        sha256: 1bd2f4314414df2d122d9f646e03b731bc6d6b5f77a5f53f99a4fe4e97d84e6f
+        dest: pip-wheels
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/4c/c5/da4c5f23c6540ac5211a1f60177c8dee84b1bf40f2719479587ab8c60731/pyside6_essentials-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl
+        sha256: a039b6da68a3a4b9d243217b2b98d475eed3f617159ef6be925badab53c11b0d
+        dest: pip-wheels
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/ee/9b/2ccd52f66db55c06de65d0501170a1935d04d64d0a230c0d892284a02ce3/pyside6_addons-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl
+        sha256: bf1c6c4e954e5eba3d2a7c661ad4b9689e8f09c7f4a16bdf29713371d11af993
+        dest: pip-wheels
+        only-arches: [aarch64]
+      - type: file
+        url: https://files.pythonhosted.org/packages/b6/0e/d583bd3f7bf5046a4497b36f3902cfb64aa29554489a5a25c18e6b4ac0ac/pyside6-6.11.1-cp310-abi3-manylinux_2_39_aarch64.whl
+        sha256: 75f0005c3eb95c07cfb65522ec50d0815ac007a96482c21dc3cb4b4c04895d84
+        dest: pip-wheels
+        only-arches: [aarch64]
+
+  - name: bearings
+    buildsystem: simple
+    build-commands:
+      # App payload (source layout; run by the runtime's python3).
+      - mkdir -p ${FLATPAK_DEST}/share/bearings
+      - cp -r app.py bearings web content assets ${FLATPAK_DEST}/share/bearings/
+      - install -Dm755 packaging/flatpak/bearings ${FLATPAK_DEST}/bin/bearings
+      # Desktop entry, AppStream metadata, and icons.
+      - install -Dm644 packaging/flatpak/io.github.kamsiob.Bearings.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.kamsiob.Bearings.desktop
+      - install -Dm644 packaging/flatpak/io.github.kamsiob.Bearings.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.kamsiob.Bearings.metainfo.xml
+      - install -Dm644 assets/icon.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.kamsiob.Bearings.svg
+      - for s in 16 32 48 64 128 256 512; do
+        install -Dm644 assets/icons/icon-$s.png
+        ${FLATPAK_DEST}/share/icons/hicolor/${s}x${s}/apps/io.github.kamsiob.Bearings.png;
+        done
+    sources:
+      # Pinned to the v1.0.0 code plus the small Flatpak app-id handling that
+      # landed just after the tag. Future releases will pin tag + commit together.
+      - type: git
+        url: https://github.com/kamsiob/bearings.git
+        commit: b668848685955d5f26f46d1369dcbb53adfdcf61


### PR DESCRIPTION
## Bearings

A free, local companion for people new to [Bazzite](https://bazzite.gg) — the gaming-focused, immutable, Fedora-based Linux distro. It's a field guide for switchers: honest app-equivalents, bite-sized tips, printable cheat sheets, and search — all offline.

- **Upstream / source:** https://github.com/kamsiob/bearings (MIT, public)
- **First release:** https://github.com/kamsiob/bearings/releases/tag/v1.0.0

### Checklist

- [x] Built and tested locally with `org.flatpak.Builder` (builds, installs, and runs; the app boots and QtWebEngine renders).
- [x] `flatpak-builder-lint manifest` and `builddir` are clean, aside from `appstream-external-screenshot-url` (screenshots are hosted in the source repo and are expected to be mirrored by Flathub's build pipeline).
- [x] App ID `io.github.kamsiob.Bearings` matches the source repository owner.
- [x] MetaInfo validates with `appstreamcli validate`.

### App ID note

I originally intended `com.kamsiob.Bearings` (I own kamsiob.com), but the site's WAF returns HTTP 406 to the linter's requests, so the domain-ownership check can't pass reliably. I've used `io.github.kamsiob.Bearings`, which verifies via the public GitHub repo — the recommended form for a GitHub-hosted project.

### Sandbox

Deliberately tight — this is a local app:

- `--socket=wayland`, `--socket=fallback-x11`, `--share=ipc`, `--device=dri` for the window.
- `--share=network` **only** for an optional, off-by-default "check for updated tips" request to a public file on GitHub. Nothing about the user or device is sent. (Flatpak network permission is all-or-nothing; this is the minimum that allows that one feature.)
- **No filesystem access.** User data lives in the app's own sandboxed dirs; saving a cheat-sheet PDF goes through the file-chooser portal.

### Packaging notes

- Runtime `org.kde.Platform//6.11`, which matches the Qt version of the official PySide6 6.11.1 wheels and provides the system libraries QtWebEngine needs.
- PySide6 is installed from the pinned, hashed official wheels (offline), for both `x86_64` and `aarch64`.
- A minimal `krb5` module supplies `libgssapi_krb5`, which `QtNetwork` in the wheels links against and neither runtime ships. Nothing on the network path uses Kerberos; it's only there to satisfy the dynamic link.

Happy to adjust anything — thanks for reviewing!
