### PR TITLE
Add io.github.kamsiob.LocalAIHub

### DIFF
--- a/io.github.kamsiob.LocalAIHub.yaml
+++ b/io.github.kamsiob.LocalAIHub.yaml
@@ -1,0 +1,67 @@
+# Flatpak manifest for Local AI Hub.
+#
+# Local AI Hub is a *host service manager*: it starts/stops/queries the user's
+# systemd --user services (Ollama, Open WebUI, ComfyUI) and, outside the sandbox,
+# reads their logs. Under Flatpak it can't shell out to systemctl/journalctl, so
+# the app talks to the host user systemd manager over D-Bus (org.freedesktop.
+# systemd1) — see hub/services/_systemd_dbus.py. finish-args below are the
+# minimum for that; each is justified in flatpak/PACKAGING-NOTES.md.
+#
+# PySide6 (with QtWebEngine + QtDBus) comes from the official Flathub PySide
+# BaseApp on top of the KDE runtime, so no second copy of Qt is bundled.
+
+app-id: io.github.kamsiob.LocalAIHub
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: '6.10'
+command: local-ai-hub
+
+finish-args:
+  # --- GUI (QtWebEngine desktop app) ---
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # --- Talk to the host user systemd manager to start/stop/query the services
+  #     this app exists to manage. Scoped to that one well-known name — not a
+  #     broad session-bus grant, not org.freedesktop.Flatpak (host escape). ---
+  - --talk-name=org.freedesktop.systemd1
+
+  # --- User-initiated model work: Ollama's local REST API (127.0.0.1:11434) and
+  #     model downloads/updates the user explicitly clicks. No telemetry. ---
+  - --share=network
+
+  # --- Read/write the ComfyUI model folders (scan installed models, download
+  #     updates into place). Restricted to the ComfyUI tree, not all of $HOME. ---
+  - --filesystem=~/ComfyUI
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - name: local-ai-hub
+    buildsystem: simple
+    build-commands:
+      - install -d ${FLATPAK_DEST}/share/local-ai-hub
+      - cp -r app.py hub web ${FLATPAK_DEST}/share/local-ai-hub/
+      - |
+        cat > ${FLATPAK_DEST}/bin/local-ai-hub <<'EOF'
+        #!/bin/sh
+        # PySide6 (from the BaseApp) looks for the WebEngine helper under its own
+        # package dir / /usr; in this layout it lives at the /app prefix, so point
+        # QtWebEngine at it explicitly.
+        export QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
+        exec python3 /app/share/local-ai-hub/app.py "$@"
+        EOF
+        chmod +x ${FLATPAK_DEST}/bin/local-ai-hub
+      - install -Dm644 flatpak/io.github.kamsiob.LocalAIHub.desktop ${FLATPAK_DEST}/share/applications/io.github.kamsiob.LocalAIHub.desktop
+      - install -Dm644 flatpak/io.github.kamsiob.LocalAIHub.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.kamsiob.LocalAIHub.metainfo.xml
+      - install -Dm644 packaging/local-ai-hub-256.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/io.github.kamsiob.LocalAIHub.png
+    sources:
+      - type: git
+        url: https://github.com/kamsiob/LocalAIHub.git
+        tag: v1.0.0
+        commit: 67f71f1798c6466a0401bd552fdb85b2cfe2492c


### PR DESCRIPTION
## Add io.github.kamsiob.LocalAIHub

**Local AI Hub** is a free, open-source control panel for the local AI services running on a user's own machine — Ollama, Open WebUI, and ComfyUI. It shows live status, starts/stops each service with a toggle, and manages models, so the user doesn't need a terminal for day-to-day use. Fully local; no account, no telemetry.

- Source: https://github.com/kamsiob/LocalAIHub (tag `v1.0.0`, commit pinned)
- Homepage: https://kamsiob.com

PySide6 comes from the official **`io.qt.PySide.BaseApp//6.10`** on `org.kde.Platform//6.10`, so Qt6 + QtWebEngine are shared from the runtime rather than bundled.

### About the permissions — please read

This app is, by design, a **manager for the user's own host systemd services**. That shapes the sandbox request, and I've kept it as tight as the job allows. Each finish-arg and why it's the minimum:

| finish-arg | Why |
|---|---|
| `--socket=wayland`, `--socket=fallback-x11`, `--share=ipc`, `--device=dri` | It's a QtWebEngine desktop GUI. `--device=dri` is for rendering only. |
| **`--talk-name=org.freedesktop.systemd1`** | The core of the app: start/stop/query the user's Ollama / Open WebUI / ComfyUI **user** services. The app talks to the host user systemd manager over the session bus (StartUnit/StopUnit/RestartUnit + reading ActiveState/SubState/LoadState). Scoped to that **one** well-known name — deliberately **not** `--socket=session-bus` (unfiltered) and **not** `--talk-name=org.freedesktop.Flatpak` (host-command escape). |
| `--share=network` | User-initiated model actions only: Ollama's local REST API on `127.0.0.1:11434`, and model downloads/updates the user explicitly clicks. No background traffic, no telemetry. |
| `--filesystem=~/ComfyUI` | Scan the ComfyUI model folders and write downloaded model updates into place. Restricted to the ComfyUI tree — **not** `--filesystem=home` or `host`. |

The linter flags `finish-args-systemd1-talk-name`, which I understand needs review — that permission is the whole point of the app, and it's the narrowest form (one bus name, talk-only) that lets it work. Happy to adjust if there's a tighter pattern you'd prefer.

**Deliberately not requested:** `--filesystem=host`, unfiltered `--socket=session-bus`, `--talk-name=org.freedesktop.Flatpak`, `--device=all`, or any always-on network use.

### Honest degradation under the sandbox

Outside Flatpak the app reads a crashed service's journal via `journalctl`. The sandbox can't reach the host journal, so in the Flatpak build the app doesn't fake it: crash **detection** still works (it reads unit state over D-Bus, not the journal), and where the log detail would appear it shows a short, honest note that full log viewing is in the AppImage on the releases page. No feature silently pretends to work.

### Checklist

- [x] App ID is `io.github.<user>.<repo>` matching a repo I control (github.com/kamsiob/LocalAIHub).
- [x] Source is a stable tag (`v1.0.0`) with the commit pinned.
- [x] MetaInfo validates (`appstreamcli validate`) and screenshots (light + dark) are provided.
- [x] Manifest passes `flatpak-builder-lint` apart from the systemd talk-name above.
- [x] Built and run locally with `flatpak-builder --install`; the app launches and controls services over D-Bus.
