### PR TITLE
Add io.github.iutinfoaix_s201.VigieChiro

### DIFF
--- a/io.github.iutinfoaix_s201.VigieChiro.metainfo.xml
+++ b/io.github.iutinfoaix_s201.VigieChiro.metainfo.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.iutinfoaix_s201.VigieChiro</id>
+  <name>VigieChiro PR Companion</name>
+  <summary>Préparer et déposer les nuits d'enregistrement de chiroptères</summary>
+  <developer id="io.github.iutinfoaix_s201">
+    <name>Sébastien Nedjar</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      Compagnon du protocole Vigie-Chiro : importer une nuit depuis la carte SD d'un enregistreur
+      passif, vérifier sa cohérence, écouter et valider les espèces détectées, puis préparer le
+      dépôt sur la plateforme Vigie-Chiro.
+    </p>
+    <p>Les données restent sur votre ordinateur : aucun compte, aucun serveur intermédiaire.</p>
+  </description>
+
+  <launchable type="desktop-id">io.github.iutinfoaix_s201.VigieChiro.desktop</launchable>
+  <url type="homepage">https://iutinfoaix-s201.github.io/vigiechiro-pr-companion/</url>
+  <url type="bugtracker">https://github.com/IUTInfoAix-S201/vigiechiro-pr-companion/issues</url>
+  <url type="vcs-browser">https://github.com/IUTInfoAix-S201/vigiechiro-pr-companion</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/IUTInfoAix-S201/vigiechiro-pr-companion/main/.github/assets/apercu-accueil.png</image>
+      <caption>L'accueil et ses activités : sites, import, écoute et validation, carte.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/IUTInfoAix-S201/vigiechiro-pr-companion/main/.github/assets/apercu-import-assistant.png</image>
+      <caption>L'import d'une nuit depuis la carte SD d'un enregistreur passif.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/IUTInfoAix-S201/vigiechiro-pr-companion/main/.github/assets/apercu-sons-validation.png</image>
+      <caption>L'écoute et la validation des espèces détectées.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/IUTInfoAix-S201/vigiechiro-pr-companion/main/.github/assets/apercu-multisite.png</image>
+      <caption>La carte des sites et le tableau des passages.</caption>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="2.26.0" date="2026-07-20"/>
+  </releases>
+</component>

--- a/io.github.iutinfoaix_s201.VigieChiro.yml
+++ b/io.github.iutinfoaix_s201.VigieChiro.yml
@@ -1,0 +1,94 @@
+app-id: io.github.iutinfoaix_s201.VigieChiro
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk
+command: vigiechiro-runner
+rename-desktop-file: VigieChiro.desktop
+
+finish-args:
+  # Affichage. Wayland en premier, X11 en repli : le parc des naturalistes est hétérogène.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # Lecture audio des séquences (écoute et validation des cris).
+  - --socket=pulseaudio
+
+  # API Vigie-Chiro (dépôt, résultats Tadarida) et consultation des versions publiées.
+  - --share=network
+
+  # Espace de travail, et RIEN d'autre du dossier personnel. `Workspace.parDefaut()` code ce
+  # chemin en dur, on peut donc n'accorder que lui : ni le reste de Documents, ni le home.
+  # `:create` laisse l'application créer le dossier au premier lancement.
+  - --filesystem=~/Documents/VigieChiro-Companion:create
+
+  # LE point qui décide de l'utilité du paquet : les cartes SD. udisks2 les monte sous
+  # /run/media/<utilisateur>/<étiquette> (Ubuntu, Fedora récents) ou /media/<utilisateur>/…
+  # (Debian, dérivées plus anciennes). Sans ces deux accès, l'application s'ouvre mais ne peut
+  # RIEN importer - c'est-à-dire qu'elle ne sert à rien.
+  - --filesystem=/run/media
+  - --filesystem=/media
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      - /usr/lib/sdk/openjdk/install.sh
+
+  - name: vigiechiro
+    buildsystem: simple
+    build-commands:
+      # On extrait le .deb PUBLIÉ plutôt que de construire depuis les sources : les builds Flathub
+      # sont hors ligne, et une résolution Maven y est impossible sans déclarer chaque dépendance
+      # transitive en source vérifiée. Même choix que Gluon Scene Builder, pour la même raison.
+      - mkdir -p paquet
+      - ar p vigiechiro.deb data.tar.zst | tar --use-compress-program=unzstd -xf - -C paquet
+      # Le fat-jar embarque déjà JavaFX et ses natifs Linux : contrairement à Scene Builder, aucun
+      # SDK JavaFX séparé n'est nécessaire.
+      - install -Dm644 paquet/opt/vigiechiro/lib/app/vigiechiro-*-shaded.jar /app/lib/vigiechiro.jar
+      - install -Dm644 paquet/opt/vigiechiro/lib/VigieChiro.png
+        /app/share/icons/hicolor/256x256/apps/io.github.iutinfoaix_s201.VigieChiro.png
+      - install -Dm755 vigiechiro-runner /app/bin/vigiechiro-runner
+      - install -Dm644 io.github.iutinfoaix_s201.VigieChiro.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 paquet/opt/vigiechiro/lib/vigiechiro-VigieChiro.desktop /app/lib/VigieChiro.desktop
+      # `Categories` d'abord : jpackage écrit `Categories=Unknown`, valeur INVALIDE que
+      # desktop-file-edit refuse - il valide le fichier à chaque appel, donc toute autre édition
+      # échouerait avant d'y arriver. (Défaut présent aussi dans le .deb installé normalement.)
+      - desktop-file-edit --remove-key=Categories /app/lib/VigieChiro.desktop
+      - desktop-file-edit --set-key=Categories --set-value='Science;Biology;' /app/lib/VigieChiro.desktop
+      - desktop-file-edit --remove-key=Comment /app/lib/VigieChiro.desktop
+      - desktop-file-edit --set-key=Comment --set-value='Préparer et déposer les nuits de chiroptères'
+        /app/lib/VigieChiro.desktop
+      - desktop-file-edit --set-key=Exec --set-value='vigiechiro-runner' /app/lib/VigieChiro.desktop
+      - desktop-file-edit --set-icon=io.github.iutinfoaix_s201.VigieChiro /app/lib/VigieChiro.desktop
+      - desktop-file-install /app/lib/VigieChiro.desktop --dir=/app/share/applications
+
+    sources:
+      - type: file
+        dest-filename: vigiechiro.deb
+        url: https://github.com/IUTInfoAix-S201/vigiechiro-pr-companion/releases/download/v2.26.0/vigiechiro_2.26.0_amd64-x64.deb
+        sha256: 391595b095d82fa825eaa8bbf6c3c59666a081970a2b480a376e75402a8e32ab
+        # Le robot de Flathub détecte les nouvelles versions et ouvre la mise à jour tout seul :
+        # c'est ce qui rend la maintenance quasi nulle une fois le paquet accepté.
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/IUTInfoAix-S201/vigiechiro-pr-companion/releases/latest
+          version-query: .tag_name | ltrimstr("v")
+          timestamp-query: .published_at
+          url-query: .assets[] | select(.name=="vigiechiro_" + $version + "_amd64-x64.deb")
+            | .browser_download_url
+
+      - type: file
+        path: io.github.iutinfoaix_s201.VigieChiro.metainfo.xml
+
+      - type: script
+        dest-filename: vigiechiro-runner
+        commands:
+          # `--enable-native-access` et `--sun-misc-unsafe-memory-access` : mêmes options que
+          # l'installeur jpackage (JNI SQLite, natifs JavaFX, Unsafe de Guice/Guava).
+          - exec /app/jre/bin/java --enable-native-access=ALL-UNNAMED
+            --sun-misc-unsafe-memory-access=allow -cp /app/lib/vigiechiro.jar
+            fr.univ_amu.iut.Launcher "$@"


### PR DESCRIPTION
VigieChiro PR Companion is a desktop tool for the French **Vigie-Chiro** bat monitoring programme
(Muséum national d'Histoire naturelle). Volunteer naturalists leave passive recorders in the field
overnight; this application imports a night from the recorder's SD card, checks it for consistency,
lets them listen to and validate the detected species, and prepares the upload to the Vigie-Chiro
platform.

It is free software (GPL-3.0-or-later), works entirely offline apart from the Vigie-Chiro upload, and
stores everything locally - no account, no intermediate server.

- Source: https://github.com/IUTInfoAix-S201/vigiechiro-pr-companion
- Documentation: https://iutinfoaix-s201.github.io/vigiechiro-pr-companion/

## About the manifest

**It extracts the published `.deb` rather than building from source.** Flathub builds have no network
access, so resolving the Maven dependency tree would require declaring every transitive dependency as
a verified source. This is the same approach as
[com.gluonhq.SceneBuilder](https://github.com/flathub/com.gluonhq.SceneBuilder), for the same reason -
and simpler here, since the shaded jar already embeds JavaFX and its Linux natives, so no separate
JavaFX SDK is needed.

The `.deb` and its SHA-256 are published with each GitHub release, and `x-checker-data` is wired so
the update bot can follow new versions.

## About the permissions

Two of them are unusual and I would rather explain them up front.

**`--filesystem=/media` and `--filesystem=/run/media`.** The application's entire purpose is to import
recordings from a **removable SD card**. `udisks2` mounts those under `/media/<user>/` on Debian and
Ubuntu, and under `/run/media/<user>/` on Fedora and derivatives - both are needed to cover the user
base. Without them the app starts but cannot do the one thing it exists for. This was verified inside
the sandbox against a real recorder card (4291 files).

**`--filesystem=~/Documents/VigieChiro-Companion:create`.** The workspace path is hard-coded in the
application, so only that directory is granted rather than the whole home. Verified in the sandbox:
`$HOME` shows 3 entries instead of 74, and `~/Documents` shows only the workspace.

## Testing

Built and launched locally with `flatpak-builder` on x86_64 (runtime 25.08, openjdk extension), and
exercised against a real SD card. `appstreamcli validate` passes.
