### PR TITLE
Add com.github.xxerm.calcx

### DIFF
--- a/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.desktop
+++ b/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=CalcX
+Comment=A modern, fully customizable calculator for Linux
+Exec=CalcX
+Icon=com.github.xxerm.calcx
+Terminal=false
+Type=Application
+Categories=Math;Calculator;Utility;
+StartupNotify=true
+StartupWMClass=CalcX

--- a/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.metainfo.xml
+++ b/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.metainfo.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.github.xxerm.calcx</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>CalcX</name>
+  <summary>A modern, fully customizable calculator for Linux</summary>
+  <description>
+    <p>A beautifully designed calculator with 4 theme modes (Dark, White, System, and Custom), full customization of colors, corner radius, opacity, and background images, keyboard and numpad input support, and persistent theme settings.</p>
+  </description>
+  <categories>
+    <category>Calculator</category>
+  </categories>
+  <keywords>
+    <keyword>calculator</keyword>
+    <keyword>math</keyword>
+    <keyword>arithmetic</keyword>
+  </keywords>
+  <url type="homepage">https://github.com/xXerM/CalcX</url>
+  <url type="bugtracker">https://github.com/xXerM/CalcX/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/xXerM/CalcX/main/src/icons/Calcx.svg</image>
+    </screenshot>
+  </screenshots>
+  <developer id="com.github.xxerm">
+    <name>xxerm</name>
+  </developer>
+  <releases>
+    <release version="1.0.0" date="2026-07-22"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+  <launchable type="desktop-id">com.github.xxerm.calcx.desktop</launchable>
+</component>

--- a/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.yml
+++ b/apps/com.github.xxerm.calcx/com.github.xxerm.calcx.yml
@@ -1,0 +1,30 @@
+id: com.github.xxerm.calcx
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+command: CalcX
+
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+
+modules:
+  - name: CalcX
+    buildsystem: simple
+    build-commands:
+      - qmake PREFIX=/app
+      - make -j${FLATPAK_BUILDER_N_JOBS:-$(nproc)}
+      - install -Dm755 CalcX /app/bin/CalcX
+      - install -Dm644 src/icons/Calcx.svg /app/share/icons/hicolor/scalable/apps/com.github.xxerm.calcx.svg
+      - install -Dm644 com.github.xxerm.calcx.desktop /app/share/applications/com.github.xxerm.calcx.desktop
+      - install -Dm644 com.github.xxerm.calcx.metainfo.xml /app/share/metainfo/com.github.xxerm.calcx.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/xXerM/CalcX.git
+        commit: 2888315b68cd00ca7f33c51e23101c61acbe2374
+      - type: file
+        path: com.github.xxerm.calcx.desktop
+      - type: file
+        path: com.github.xxerm.calcx.metainfo.xml


### PR DESCRIPTION
A modern, fully customizable calculator for Linux built with Qt6 and C++. Supports Dark, White, System, and CUSTOM theme modes with full color, opacity, border-radius, and background image customization.

- Qt 6.10, KDE Platform
- qmake build system
- Theme engine with 4 modes (Dark/White/System/CUSTOM)
- Keyboard and numpad input
- MIT License