### PR TITLE
New submission: org.walltz.walltz

### DIFF
--- a/org.walltz.walltz/org.walltz.walltz.yml
+++ b/org.walltz.walltz/org.walltz.walltz.yml
@@ -1,0 +1,31 @@
+id: org.walltz.walltz
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+
+command: walltz
+rename-icon: org.walltz.walltz
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-pictures
+  - --env=QT_ENABLE_HIGHDPI_SCALING=1
+
+modules:
+  - name: walltz
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    post-install:
+      - install -Dm644 /run/build/walltz/COPYING /app/share/licenses/org.walltz.walltz/COPYING
+    sources:
+      - type: git
+        url: https://github.com/kirijin/walltz
+        tag: v0.1.1
+        commit: 1dbff3dc8f06c3dbd3b7203e04da12477abe4c52
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
""Walltz — create wallpapers from images with blur and color backgrounds

KDE Kirigami Qt6 application. Tested on Bazzite and Flathub CI.
- Flatpak builds with org.kde.Platform 6.11
- Screenshots in metainfo (5 total)
- Minimal sandbox: ipc, wayland/x11, dri, xdg-pictures only
- GPL-3.0-or-later license