### PR TITLE
Add com.github.hdmain.immich-desktop

### DIFF
--- a/com.github.hdmain.immich-desktop.yml
+++ b/com.github.hdmain.immich-desktop.yml
@@ -1,0 +1,48 @@
+id: com.github.hdmain.immich-desktop
+runtime: org.kde.Platform
+runtime-version: "6.9"
+sdk: org.kde.Sdk
+command: immich
+
+rename-desktop-file: immich-desktop.desktop
+rename-appdata-file: immich-desktop.metainfo.xml
+rename-icon: immich-desktop
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-config/autostart:create
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - "*.a"
+  - "*.la"
+
+modules:
+  - name: immich-desktop
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/hdmain/immich-desktop.git
+        tag: v0.1.7
+        commit: 0569382adfa6635e11dd5323c8ca86676a6f1760
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. Unofficial Qt 6 desktop client for Immich (self-hosted photo and video library). Connect with an API key to browse the timeline, explore people and places, upload/download media, stream video, and use offline cache. MIT licensed. Not affiliated with the official Immich project. Homepage: https://github.com/hdmain/immich-desktop
- [x] Please attach a video showcasing the application on Linux using the Flatpak. Temporary UI capture until a Flatpak test build is available: https://raw.githubusercontent.com/hdmain/immich-desktop/v0.1.7/docs/screenshots/immich-desktop-library.png — I will replace this with a Flatpak screen recording after `bot, build`.
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project. If not, I contacted upstream developers about this submission. **Link:** https://github.com/hdmain/immich-desktop

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission