### PR TITLE
Add io.github.hdmain.immich-desktop

### DIFF
--- a/com.github.hdmain.immich-desktop.yml
+++ b/com.github.hdmain.immich-desktop.yml
@@ -1,0 +1,48 @@
+id: com.github.hdmain.immich-desktop
+runtime: org.kde.Platform
+runtime-version: "6.9"
+sdk: org.kde.Sdk
+command: immich
+
+rename-desktop-file: immich-desktop.desktop
+rename-appdata-file: immich-desktop.metainfo.xml
+rename-icon: immich-desktop
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-download
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-config/autostart:create
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/doc
+  - /share/man
+  - "*.a"
+  - "*.la"
+
+modules:
+  - name: immich-desktop
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: git
+        url: https://github.com/hdmain/immich-desktop.git
+        tag: v0.1.7
+        commit: 0569382adfa6635e11dd5323c8ca86676a6f1760
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig


### PR DESCRIPTION
### Please confirm your submission meets all the criteria below

- [x] The app meets Flathub requirements
- [x] App ID is reverse-DNS: `io.github.hdmain.immich-desktop`
- [x] Manifest filename matches App ID
- [x] Metainfo / AppStream data is included and valid
- [x] At least one screenshot is listed in metainfo
- [x] License is OSI-approved (MIT)
- [x] Runtime is a current Flathub runtime (org.kde.Platform 6.11)
- [x] Build uses a tagged release (`v0.1.7`) with commit pinned
- [x] Checklist completed (no AI-generated fluff; human-maintained submission)

### Application

- **Name:** Immich Desktop (unofficial)
- **App ID:** `io.github.hdmain.immich-desktop`
- **Homepage:** https://github.com/hdmain/immich-desktop
- **Source:** https://github.com/hdmain/immich-desktop
- **License:** MIT
- **Summary:** Unofficial Immich Qt6 desktop client

### Notes

Renamed from `com.github.*` because Flathub rejects code-hosting domains for new apps. Removed unnecessary `xdg-config/autostart:create` finish-arg. Screenshot URL is used as a temporary stand-in for the required media checklist item; a real Flatpak screen recording can be provided during review if needed.