### PR TITLE
Add io.github.ntman.PerDeviceEQ

### DIFF
--- a/io.github.ntman.PerDeviceEQ.yaml
+++ b/io.github.ntman.PerDeviceEQ.yaml
@@ -1,0 +1,145 @@
+# Flathub manifest for Per-Device EQ.
+# Upstream: https://github.com/NTMan/PerDeviceEQ
+# The four filesystem grants below are each justified in place;
+# the WirePlumber hook and its access rule are installed
+# per-user by the app itself, with the user's consent, and
+# removed the same way.
+
+app-id: io.github.ntman.PerDeviceEQ
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: per-device-eq
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # The PipeWire native socket: the app drives pw-dump, pw-cli,
+  # pw-metadata and pw-cat against the HOST's PipeWire.
+  - --filesystem=xdg-run/pipewire-0
+  # The WirePlumber hook. install_full writes the script and the
+  # conf.d fragment per-user through these binds; both installed
+  # files carry their provenance and the removal command in a
+  # header. WirePlumber restart stays a one-line user action by
+  # design -- no host-command permission.
+  - --filesystem=~/.local/share/wireplumber:create
+  - --filesystem=xdg-config/wireplumber:create
+  # One profile store for every incarnation of the app: RPM,
+  # flatpak and a bare checkout share ~/.config/per-device-eq
+  # (field verdict: the Bitwig way).
+  - --filesystem=xdg-config/per-device-eq:create
+
+modules:
+  - name: pipewire-tools
+    # The GNOME runtime carries libpipewire but none of the CLI
+    # tools the app shells out to; build only the tools from the
+    # matching upstream source, everything optional disabled.
+    buildsystem: meson
+    config-opts:
+      - -Dsession-managers=[]
+      - -Dalsa=disabled
+      - -Dpipewire-alsa=disabled
+      - -Djack=disabled
+      - -Dpipewire-jack=disabled
+      - -Dbluez5=disabled
+      - -Dgstreamer=disabled
+      - -Dgstreamer-device-provider=disabled
+      - -Dsystemd-user-service=disabled
+      - -Dselinux=disabled
+      - -Dlibcamera=disabled
+      - -Dx11=disabled
+      - -Dvulkan=disabled
+      - -Dtests=disabled
+      - -Dexamples=disabled
+      - -Dman=disabled
+      - -Ddocs=disabled
+    sources:
+      - type: archive
+        url: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/1.6.8/pipewire-1.6.8.tar.gz
+        sha256: 8181172a1d95131f6af8bbc0b98f90b2a33349b042b84c3ce57dd5d11348cc58
+
+  - name: python3-deps
+    # numpy + scipy + soundfile (and soundfile's cffi/pycparser),
+    # pinned cp313 manylinux wheels for both Flathub arches.
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index
+        --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+        --no-build-isolation numpy scipy soundfile
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+        sha256: a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/7b/a2/70fd4432b924684c372df8b0a45708c36c057ef3596c9eb53e0a806b980b/soundfile-0.14.0-py2.py3-none-manylinux_2_28_x86_64.whl
+        sha256: 1e38bac1853412871318e82a1ba69a8be677619b56025bbfcccdb41b6cafe82d
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/4a/f8/fc39fad6f879633461d27394cd1ddaf1f769ffa0597dca35872f51b16461/soundfile-0.14.0-py2.py3-none-manylinux_2_28_aarch64.whl
+        sha256: e85724a90bc99a6e8062c0b4ddf725f53b2a3b70afd4da875e9d2cfc4e92f377
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f
+      - type: file
+        url: https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl
+        sha256: b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+      - type: file
+        url: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+        sha256: 481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+
+  - name: per-device-eq
+    # Mirrors the RPM layout into /app: the launcher in bin, the
+    # package + data + hook under share/per-device-eq, so
+    # _DATA_ROOT resolves identically in every incarnation.
+    buildsystem: simple
+    build-commands:
+      - install -Dpm0755 per-device-eq.py ${FLATPAK_DEST}/bin/per-device-eq
+      - install -d ${FLATPAK_DEST}/share/per-device-eq/perdeviceeq
+      - install -pm0644 -t ${FLATPAK_DEST}/share/per-device-eq/perdeviceeq
+        perdeviceeq/*.py
+      - install -Dpm0644 data/io.github.ntman.PerDeviceEQ.ui
+        ${FLATPAK_DEST}/share/per-device-eq/data/io.github.ntman.PerDeviceEQ.ui
+      - install -Dpm0644 data/io.github.ntman.PerDeviceEQ.Measure.ui
+        ${FLATPAK_DEST}/share/per-device-eq/data/io.github.ntman.PerDeviceEQ.Measure.ui
+      - install -Dpm0644 wireplumber/90-per-device-eq.lua
+        ${FLATPAK_DEST}/share/per-device-eq/wireplumber/90-per-device-eq.lua
+      - install -Dpm0644 data/io.github.ntman.PerDeviceEQ.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.ntman.PerDeviceEQ.desktop
+      - install -Dpm0644 data/icons/hicolor/scalable/apps/io.github.ntman.PerDeviceEQ.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.ntman.PerDeviceEQ.svg
+      - install -Dpm0644 data/icons/pde-level-symbolic.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/actions/pde-level-symbolic.svg
+      - install -Dpm0644 data/io.github.ntman.PerDeviceEQ.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.ntman.PerDeviceEQ.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/NTMan/PerDeviceEQ/archive/refs/tags/v4.0.0.tar.gz
+        sha256: 146db39fefbc9e0d49a3b64d7febd8d5b689af07cacb68c2756534ef5234e52c
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/NTMan/PerDeviceEQ/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: >-
+            "https://github.com/NTMan/PerDeviceEQ/archive/refs/tags/"
+            + .tag_name + ".tar.gz"


### PR DESCRIPTION
# Add io.github.ntman.PerDeviceEQ

Per-Device EQ: per-device parametric equalization for PipeWire desktops. The app measures headphones and speakers with a Farina sweep, fits a constrained parametric EQ against the measured response, and applies it per output device through a small WirePlumber hook in the user session -- the EQ survives reboots and device reconnects, and follows the device, not the stream.

Upstream: https://github.com/NTMan/PerDeviceEQ
Latest release: v4.0.0 (measurement schema v4, first Flatpak). AppStream metainfo validates clean (`appstreamcli validate`, one pedantic note). CI builds this manifest for x86_64 and aarch64 on every push and attaches installable bundles to every release.

## Permissions

Four filesystem grants beyond the display/dri basics, each commented in place in the manifest:

`xdg-run/pipewire-0` -- the app drives the host PipeWire through its own bundled CLI tools (pw-dump, pw-metadata, pw-cli, pw-cat): device discovery, live EQ application, and the measurement sweep and meter.

`~/.local/share/wireplumber:create` and `xdg-config/wireplumber:create` -- the app installs (and removes) a per-user WirePlumber hook: one Lua script and one conf.d fragment, both carrying provenance headers and the hand-removal commands. Installation is explicit and consent-shaped: a first-run dialog or a menu switch, never silent. The conf fragment also carries a WirePlumber access rule granting full PipeWire permissions to this app id only, keyed to the kernel-verified `pipewire.access.portal.app_id` -- without it, a sandboxed client holds read-only permissions and every metadata write is silently dropped.

On lifecycle honesty: uninstalling the Flatpak cannot remove these per-user files -- Flatpak has no maintainer scripts, and this is true of every package manager (the RPM's scriptlets must not touch user homes either; its `dnf remove` prints the same hand-removal instructions instead). Both installed files carry the removal commands in their headers, and the README documents the full story under "The hook outlives the package". The app and the hook also share a versioned channel: the hook stamps its protocol into the metadata, and a mismatch (an older hook next to a newer app, or the reverse) surfaces a one-click reinstall dialog instead of silent misbehavior.

`xdg-config/per-device-eq:create` -- one profile store shared by every incarnation of the app (Flatpak, distro package, checkout).

## Worth stating for the record

None of the WirePlumber-directory machinery would exist if Flatpak offered two primitives: ownership of host config exports the way it owns .desktop exports, and a scoped, consent-gated portal to restart a user service. The app's integration switch, its "run this one command on the host" dialogs with a copy-to-clipboard chip -- all of it bridges exactly that gap, and is removed symmetrically with the app's own Remove integration. A portal proposal is filed alongside this submission.
