### PR TITLE
Add studio.show.ShowStudio

### DIFF
--- a/studio.show.ShowStudio.yml
+++ b/studio.show.ShowStudio.yml
@@ -1,0 +1,31 @@
+app-id: studio.show.ShowStudio
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: show-studio
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --socket=pulseaudio        # the in-app voice session's microphone + audio
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - '*.a'
+
+modules:
+  - name: show-studio
+    buildsystem: meson
+    # Upstream files are named show.studio.*; flatpak-builder renames them to the flatpak app-id
+    # (studio.show.ShowStudio) and rewrites the id/launchable/icon references so the app validates.
+    rename-desktop-file: show.studio.desktop
+    rename-appdata-file: show.studio.metainfo.xml
+    rename-icon: show.studio
+    sources:
+      - type: git
+        url: https://github.com/Show-Studio/show-studio-linux.git
+        commit: 405467f6081ba30f76f208c847719df279e22787


### PR DESCRIPTION
This adds **Show Studio**, a drill-design app for marching band.

- **App ID:** `studio.show.ShowStudio` (reverse-DNS of the domain we own, [show.studio](https://show.studio))
- **What it is:** a lightweight GTK4 + WebKitGTK 6.0 shell that opens the app at show.studio. The wrapper source is public and MIT-simple; the product itself is a proprietary web app served from show.studio (proprietary apps are permitted on Flathub).
- **Source:** built from a pinned commit of our public shell repo, [Show-Studio/show-studio-linux](https://github.com/Show-Studio/show-studio-linux).
- **Permissions:** network, display (wayland + fallback-x11), dri, and audio (for the in-app voice session). File access goes through portals — no broad filesystem permission requested.

I'm the developer/publisher (Show Studio) and authorized to submit this. Domain verification will be completed once the app is accepted.