### PR TITLE
Add io.github.minnowfm.Minnow

### DIFF
--- a/io.github.minnowfm.Minnow.yaml
+++ b/io.github.minnowfm.Minnow.yaml
@@ -1,0 +1,33 @@
+id: io.github.minnowfm.Minnow
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: minnow
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  # A file manager fundamentally needs broad filesystem access; this matches how other
+  # Flatpak'd file managers (Nautilus, Dolphin) are sandboxed.
+  - --filesystem=host
+  - --filesystem=xdg-run/dconf
+  - --talk-name=org.freedesktop.FileManager1
+  # Needed for KIO (thumbnailing, trash, mounted-drive listing via kiod).
+  - --talk-name=org.kde.kiod6
+  - --system-talk-name=org.freedesktop.UDisks2
+
+modules:
+  - name: minnow
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: git
+        url: https://github.com/minnowfm/minnow
+        tag: v0.1.1
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([0-9.]+)$
+          version-scheme: semantic


### PR DESCRIPTION
Minnow is a small, KIO-based file manager for KDE Plasma, built as a lighter alternative to Dolphin: grid/list views, a customizable places sidebar, tabbed browsing, and standard KIO file operations with undo/redo.

- Source: https://github.com/minnowfm/minnow
- License: GPL-3.0-or-later
- Manifest builds against org.kde.Platform 6.7