### PR TITLE
Update red.ghs.axolotl to 1.5.3

### DIFF
--- a/red.ghs.axolotl.yml
+++ b/red.ghs.axolotl.yml
@@ -1,0 +1,96 @@
+app-id: red.ghs.axolotl
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+
+command: axolotl-launcher
+
+finish-args:
+  - --socket=wayland
+  - --socket=x11
+  - --share=ipc
+  - --share=network
+  - --device=dri
+  - --socket=pulseaudio
+  - --filesystem=host
+  - --env=WEBKIT_DISABLE_DMABUF_RENDERER=1
+
+modules:
+  - name: webkit
+    only-arches: [x86_64]
+    buildsystem: simple
+    build-commands:
+      - |
+        for deb in *.deb; do
+          ar x "$deb" 2>/dev/null || true
+          f=""; for df in data.tar.*; do [ -f "$df" ] && f="$df" && break; done
+          [ -n "$f" ] && zstdcat "$f" 2>/dev/null | bsdtar -xf - 2>/dev/null || true
+          rm -f data.tar.* control.tar.* debian-binary 2>/dev/null
+        done
+      - |
+        mkdir -p /app/lib
+        find usr -name '*.so*' -exec cp -L {} /app/lib/ \;
+    sources:
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/w/webkit2gtk/libwebkit2gtk-4.1-0_2.52.3-0ubuntu0.24.04.1_amd64.deb
+        sha256: ba550f6b4ae9c00dd2ed1d1a21a0d8855983f4555cde44b7fe1519da2a250104
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/w/webkit2gtk/libjavascriptcoregtk-4.1-0_2.52.3-0ubuntu0.24.04.1_amd64.deb
+        sha256: 3ef1d9c7f437ba43492a7c4d02eeb0a68e2bc9b5e74974c8434cac2e78e369eb
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu74_74.2-1ubuntu3_amd64.deb
+        sha256: d29c97a21a3e3254731cfac186e4d4e611e5e67d2c9a0430f6acfbd9acaefa2e
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_2.1.5-2ubuntu2_amd64.deb
+        sha256: f68b5b23bc8a1688fb787d2aed7e2cdf895a73022f6a5025e183162dac4500b2
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/e/enchant-2/libenchant-2-2_2.3.3-2build2_amd64.deb
+        sha256: 4faecb5cee57ff00649b3ea4d83c072d9da2670797b7d2854708ff60cef17426
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/libm/libmanette/libmanette-0.2-0_0.2.7-1build2_amd64.deb
+        sha256: 8fbb67e94abf563c01398ad7458df1a6824f19a0b4337f67d61c0889771805db
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/libs/libsecret/libsecret-1-0_0.21.4-1build3_amd64.deb
+        sha256: 7d7263ffc92c33042328f99c93433a846e8d9e549876dab18ba18606e6541ecd
+        only-arches: [x86_64]
+      - type: file
+        url: http://kr.archive.ubuntu.com/ubuntu/pool/main/libe/libevdev/libevdev2_1.13.6+dfsg-3_amd64.deb
+        sha256: 3118e6e45ae953986db9c222cff19583a3ed566e906c87ea6e756ac5b860b796
+        only-arches: [x86_64]
+
+  - name: axolotl
+    buildsystem: simple
+    build-commands:
+      - bsdtar -xf Axolotl.Launcher_*.deb 2>/dev/null || ar x Axolotl.Launcher_*.deb
+      - bsdtar -xf data.tar.* 2>/dev/null || bsdtar -xf data.tar
+      - cp -r usr/* /app/
+      - mv "/app/bin/Axolotl Launcher" /app/bin/axolotl-launcher 2>/dev/null || true
+      - |
+        find /app/share/icons -name '*.png' | while read f; do
+          d="$(dirname "$f")"
+          [ -f "$d/red.ghs.axolotl.png" ] || cp "$f" "$d/red.ghs.axolotl.png"
+        done
+      - install -Dm644 red.ghs.axolotl.desktop /app/share/applications/red.ghs.axolotl.desktop
+      - install -Dm644 red.ghs.axolotl.metainfo.xml /app/share/metainfo/red.ghs.axolotl.metainfo.xml
+      - install -Dm644 red.ghs.axolotl.xml /app/share/mime/packages/red.ghs.axolotl.xml
+    sources:
+      - type: file
+        url: https://github.com/Mystic-Stars/Axolotl/releases/download/v1.5.3/Axolotl.Launcher_1.5.3_amd64.deb
+        sha256: d6ae1e29b9cabfca8b3518bdd9971a42c6480fd8cc7b94cfbd6f8876afbbca22
+        only-arches: [x86_64]
+      - type: file
+        url: https://github.com/Mystic-Stars/Axolotl/releases/download/v1.5.3/Axolotl.Launcher_1.5.3_arm64.deb
+        sha256: 7477d4abbf35c0def1820f6730f9219738b52cd42f24c7b90dc68ff88c182736
+        only-arches: [aarch64]
+      - type: file
+        path: red.ghs.axolotl.desktop
+      - type: file
+        path: red.ghs.axolotl.metainfo.xml
+      - type: file
+        path: red.ghs.axolotl.xml


### PR DESCRIPTION
Update red.ghs.axolotl to version 1.5.3

Release: https://github.com/Mystic-Stars/Axolotl/releases/tag/v1.5.3