### PR TITLE
Add io.github.henr1quess30.CamView

### DIFF
--- a/io.github.henr1quess30.CamView.yml
+++ b/io.github.henr1quess30.CamView.yml
@@ -1,0 +1,143 @@
+# Flatpak manifest for CamView.
+#
+# Build:  cd packaging/flatpak && ./build.sh
+# See README.md in this directory for the full procedure.
+#
+# The hard part of packaging this app is libVLC: the runtime has no VLC,
+# and libvlc without its plugins cannot play RTSP at all. So VLC is built
+# here as a module, cut down to what a live-view client actually needs —
+# no interface, no Lua, no recording — with live555 (the RTSP transport)
+# built first because VLC has to find it at configure time.
+#
+# PySide6 is not pip-installed here: Flathub publishes it as a base
+# application (io.qt.PySide.BaseApp), which is both the supported way and
+# far smaller than bundling a second copy of Qt. That base is built on
+# the KDE runtime, which is where the Qt6 libraries come from.
+app-id: io.github.henr1quess30.CamView
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+base: io.qt.PySide.BaseApp
+base-version: '6.9'
+command: camview
+
+# The base runtime ships ffmpeg with a reduced codec set; H.265 — which
+# every camera here streams — lives in the ffmpeg-full extension. Without
+# this the app would connect and then fail to decode.
+add-extensions:
+  org.freedesktop.Platform.ffmpeg-full:
+    directory: lib/ffmpeg
+    add-ld-path: .
+    version: '24.08'
+    autodownload: true
+    autodelete: false
+
+cleanup-commands:
+  - mkdir -p /app/lib/ffmpeg
+  # Drops the PySide modules this app never imports (WebEngine, Charts,
+  # 3D and friends), which is most of the base's weight.
+  - /app/cleanup-BaseApp.sh
+
+finish-args:
+  # RTSP to the cameras and HTTP (ISAPI) to the recorders.
+  - --share=network
+  # libVLC 3.x can only embed video into an X11 window, so the app runs
+  # through XWayland even on a Wayland session — see camview/__main__.py.
+  - --socket=x11
+  - --share=ipc
+  # Video output.
+  - --device=dri
+  # Passwords live in the system keyring, reached through the portal.
+  - --talk-name=org.freedesktop.secrets
+  # Nothing else: no home access, no filesystem, no audio. The app's own
+  # database and logs land in ~/.var/app/io.github.henr1quess30.CamView.
+
+modules:
+  # --- RTSP transport -----------------------------------------------
+  # Without live555, libVLC falls back to satip/realrtsp and every
+  # camera connection fails. This is not optional for this app.
+  - name: live555
+    buildsystem: simple
+    build-commands:
+      # -DNO_OPENSSL=1, exactly as VLC's own contrib builds it: recent
+      # live555 pulls in OpenSSL for RTSPS, and without it the plugin
+      # fails to link on EVP_MD_CTX_free. Plain RTSP needs none of it.
+      - sed -i 's|^COMPILE_OPTS =\(.*\)|COMPILE_OPTS =\1 -DNO_OPENSSL=1|' config.linux-64bit
+      - ./genMakefiles linux-64bit
+      - make -j$FLATPAK_BUILDER_N_JOBS
+      - make install PREFIX=/app
+    sources:
+      - type: archive
+        # VideoLAN's mirror, not live555.com: upstream serves only the
+        # newest tarball and replaces it in place, which breaks checksums.
+        url: https://downloads.videolan.org/pub/contrib/live555/live.2026.06.24.tar.gz
+        sha256: b22182db20fe554be886f74c453f6b900e471de9585a401b0b60228aebc27ef7
+    cleanup:
+      - /include
+      - '*.a'
+
+  # --- libVLC --------------------------------------------------------
+  - name: vlc
+    build-options:
+      env:
+        # VLC's configure hunts for a compiler literally named c99/c11 to
+        # build its own host-side tools; the SDK only ships gcc.
+        BUILDCC: gcc
+      # live555 installs its headers one directory per library, and VLC's
+      # check is a preprocessor include of <liveMedia_version.hh> — it
+      # fails on the path, not on the version.
+      cppflags: -I/app/include/liveMedia -I/app/include/groupsock
+        -I/app/include/BasicUsageEnvironment -I/app/include/UsageEnvironment
+    config-opts:
+      - --disable-lua
+      - --disable-qt
+      - --disable-skins2
+      - --disable-ncurses
+      - --disable-vlc          # the player binary; we only need the library
+      - --disable-sout         # no streaming out
+      - --disable-vlm
+      - --enable-live555       # RTSP
+      - --enable-avcodec       # H.264/H.265
+      - --enable-xcb           # the xcb_x11 video output this app asks for
+      - --disable-a52
+      - --disable-dbus
+    sources:
+      - type: archive
+        # 3.0.23 is what this app was developed and validated against.
+        url: https://download.videolan.org/vlc/3.0.23/vlc-3.0.23.tar.xz
+        sha256: e891cae6aa3ccda69bf94173d5105cbc55c7a7d9b1d21b9b21666e69eff3e7e0
+    cleanup:
+      - /bin
+      - /include
+      - /share/man
+      - '*.la'
+
+  # --- Python dependencies -------------------------------------------
+  # Generated, not hand-written: flatpak-builder builds offline, so every
+  # wheel has to be declared with its checksum. build.sh regenerates this
+  # file with flatpak-pip-generator whenever requirements.txt changes.
+  - python3-requirements.json
+
+  # --- CamView itself -------------------------------------------------
+  - name: camview
+    buildsystem: simple
+    build-commands:
+      # Copied rather than pip-installed. CamView is a pure-Python
+      # src-layout package, so pip adds nothing except a dependency on
+      # its build backend — which it would have to fetch from a network
+      # the sandbox does not have.
+      - PYVER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+        && install -d "/app/lib/python${PYVER}/site-packages"
+        && cp -r src/camview "/app/lib/python${PYVER}/site-packages/"
+      - install -Dm755 packaging/flatpak/camview-launcher /app/bin/camview
+      - install -Dm644 packaging/flatpak/io.github.henr1quess30.CamView.desktop
+        /app/share/applications/io.github.henr1quess30.CamView.desktop
+      - install -Dm644 packaging/flatpak/io.github.henr1quess30.CamView.metainfo.xml
+        /app/share/metainfo/io.github.henr1quess30.CamView.metainfo.xml
+      - install -Dm644 packaging/flatpak/io.github.henr1quess30.CamView.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.henr1quess30.CamView.svg
+    sources:
+      - type: git
+        url: https://github.com/henr1quess30/camview.git
+        tag: v0.3.0
+        commit: 456d85a66aae9782101ac25651bba9a936b436ff

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -1,0 +1,102 @@
+{
+    "name": "python3-requirements",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-python-vlc",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"python-vlc>=3.0.20123\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5b/ee/7d76eb3b50ccb1397621f32ede0fb4d17aa55a9aa2251bc34e6b9929fdce/python_vlc-3.0.21203-py3-none-any.whl",
+                    "sha256": "1613451a31b692ec276296ceeae0c0ba82bfc2d094dabf9aceb70f58944a6320"
+                }
+            ]
+        },
+        {
+            "name": "python3-keyring",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"keyring>=25.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl",
+                    "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl",
+                    "sha256": "bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl",
+                    "sha256": "99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl",
+                    "sha256": "97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl",
+                    "sha256": "be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl",
+                    "sha256": "4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+                    "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl",
+                    "sha256": "0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Live-view client for RTSP cameras and NVRs: several streams side by side in a mosaic, and nothing else — no recording, no motion detection, no analytics, no web server.
- [X] Please attach a video showcasing the application on Linux using the Flatpak. [camview-demo.webm](https://github.com/henr1quess30/camview/releases/download/v0.3.0/camview-demo.webm) — recorded from this Flatpak build. The four feeds are synthetic test patterns served over local RTSP, not real camera footage.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author to the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission

---

### Notes for reviewers

- Source: https://github.com/henr1quess30/camview (MIT), built from tag `v0.3.0`.
- `flatpak-builder-lint manifest` passes; the only remark is the 6.11 runtime being available, which I am happy to move to if preferred.
- The manifest builds **live555** and **VLC 3.0.23** as modules. The runtime has no VLC, and libvlc without its plugins cannot play RTSP at all, so this is not optional. VLC is cut down to the library: no interface, no Lua, no streaming output.
- `org.freedesktop.Platform.ffmpeg-full` is required rather than nice to have: these cameras stream H.265, and without the extension they connect and then close instantly.
- PySide6 comes from `io.qt.PySide.BaseApp`, and the base's cleanup script drops the modules the app never imports.
- The app is installed by copy rather than pip — a pure-Python src-layout package, so pip would only add a dependency on its build backend, which cannot be fetched offline.
- Permissions are deliberately narrow: network, x11 (libVLC 3.x can only embed video into an X11 window), dri, and `org.freedesktop.secrets` for the keyring where camera passwords are kept. No home or filesystem access — the database and logs live in the app's own data directory.
