### PR TITLE
New application: org.gnome.Motif

### DIFF
--- a/org.gnome.Motif.json
+++ b/org.gnome.Motif.json
@@ -1,0 +1,44 @@
+{
+    "app-id": "org.gnome.Motif",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "46",
+    "sdk": "org.gnome.Sdk",
+    "command": "motif",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=network",
+        "--filesystem=xdg-data/themes:create",
+        "--filesystem=xdg-data/icons:create",
+        "--filesystem=xdg-data/backgrounds:create",
+        "--filesystem=~/.themes:create",
+        "--filesystem=~/.icons:create",
+        "--filesystem=xdg-config/dconf:ro",
+        "--talk-name=ca.desrt.dconf",
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+    ],
+    "modules": [
+        "python3-dependencies.json",
+        {
+            "name": "motif",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=${FLATPAK_DEST} --no-deps .",
+                "install -Dm644 org.gnome.Motif.desktop ${FLATPAK_DEST}/share/applications/org.gnome.Motif.desktop",
+                "install -Dm644 org.gnome.Motif.metainfo.xml ${FLATPAK_DEST}/share/metainfo/org.gnome.Motif.metainfo.xml",
+                "install -Dm644 org.gnome.Motif.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/org.gnome.Motif.svg",
+                "install -Dm644 motif/data/org.gnome.Motif.gschema.xml ${FLATPAK_DEST}/share/glib-2.0/schemas/org.gnome.Motif.gschema.xml",
+                "glib-compile-schemas ${FLATPAK_DEST}/share/glib-2.0/schemas"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/manasdotio/motif.git",
+                    "tag": "v1.0.0",
+                    "commit": "e167d47aa909227d4d574c6cca09480da774e894"
+                }
+            ]
+        }
+    ]
+}

--- a/python3-dependencies.json
+++ b/python3-dependencies.json
@@ -1,0 +1,44 @@
+{
+    "name": "python3-httpx",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} httpx"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz",
+            "sha256": "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz",
+            "sha256": "6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz",
+            "sha256": "cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz",
+            "sha256": "741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz",
+            "sha256": "4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz",
+            "sha256": "ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz",
+            "sha256": "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"
+        }
+    ]
+}


### PR DESCRIPTION
### New Application Submission: Motif 🎨

- **App ID:** 
- **Name:** Motif
- **Description:** Native GTK4 and Libadwaita desktop application for GNOME to browse, download, apply, and manage GTK, Shell, Icon, and Cursor themes.
- **Repository:** https://github.com/manasdotio/motif
- **License:** GPL-3.0-or-later