### PR TITLE
Add engineering.mess.Blitz

### DIFF
--- a/engineering.mess.Blitz.yml
+++ b/engineering.mess.Blitz.yml
@@ -1,0 +1,61 @@
+# Flatpak manifest for BLITZ
+# App ID / Flathub name: engineering.mess.Blitz
+# Brand: M.E.S.S. (mess.engineering) — future suite apps use engineering.mess.*
+#
+# Build (from this directory):
+#   flatpak run org.flatpak.Builder --user --install --force-clean \
+#     --install-deps-from=flathub build-dir engineering.mess.Blitz.yml
+#   flatpak run engineering.mess.Blitz
+#
+# This manifest is Flathub-ready (git source). For a local tree build without
+# pushing, temporarily switch the blitz module source to:
+#   - type: dir
+#     path: ..
+
+id: engineering.mess.Blitz
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
+base: com.riverbankcomputing.PyQt.BaseApp
+base-version: '6.10'
+command: blitz
+
+build-options:
+  env:
+    BASEAPP_REMOVE_WEBENGINE: '1'
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --share=network
+  - --filesystem=home
+  # Webcam (OpenCV /dev/video*): enable with:
+  #   flatpak override --user --device=all engineering.mess.Blitz
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - python3-blitz-deps.yml
+
+  - name: blitz
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --prefix=${FLATPAK_DEST} --no-deps --no-build-isolation .
+      - install -Dm644 data/engineering.mess.Blitz.desktop
+          ${FLATPAK_DEST}/share/applications/engineering.mess.Blitz.desktop
+      - install -Dm644 data/engineering.mess.Blitz.metainfo.xml
+          ${FLATPAK_DEST}/share/metainfo/engineering.mess.Blitz.metainfo.xml
+      - install -Dm644 data/icons/hicolor/64x64/apps/engineering.mess.Blitz.png
+          ${FLATPAK_DEST}/share/icons/hicolor/64x64/apps/engineering.mess.Blitz.png
+      - install -Dm644 data/icons/hicolor/128x128/apps/engineering.mess.Blitz.png
+          ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/engineering.mess.Blitz.png
+      - install -Dm644 data/icons/hicolor/256x256/apps/engineering.mess.Blitz.png
+          ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/engineering.mess.Blitz.png
+    sources:
+      - type: git
+        url: https://github.com/PiMaV/BLITZ.git
+        tag: v2.0.2
+        commit: 0a989c8ffc3f432483c0c72f59e7f0adf53d389d

--- a/python3-blitz-deps.yml
+++ b/python3-blitz-deps.yml
@@ -1,0 +1,152 @@
+# Generated with flatpak-pip-generator -r flatpak/requirements-flatpak.txt -o flatpak/python3-blitz-deps --prefer-wheels=numpy,opencv-python-headless,numba,llvmlite --runtime=org.kde.Sdk//6.10 --yaml
+name: python3-blitz-deps
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-numpy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "numpy>=2.0.2,<3" --no-build-isolation
+    sources:
+      - &id001
+        type: file
+        url: https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+        sha256: a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089
+        only-arches:
+          - x86_64
+      - &id002
+        type: file
+        url: https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b
+        only-arches:
+          - aarch64
+  - name: python3-opencv-python-headless
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "opencv-python-headless>=4.10.0.84,<5" --no-build-isolation
+    sources:
+      - *id001
+      - *id002
+      - type: file
+        url: https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
+        sha256: 5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb
+        only-arches:
+          - aarch64
+  - name: python3-natsort
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "natsort>=8.4.0,<9" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
+        sha256: 4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests>=2.32.3,<3" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+        sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+      - type: file
+        url: https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl
+        sha256: 68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5
+      - type: file
+        url: https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl
+        sha256: 7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+  - name: python3-python-socketio
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "python-socketio>=5.11.4,<6" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl
+        sha256: 5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5
+      - type: file
+        url: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
+        sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
+      - type: file
+        url: https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl
+        sha256: 1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f
+      - type: file
+        url: https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl
+        sha256: e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041
+      - type: file
+        url: https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl
+        sha256: 4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c
+      - type: file
+        url: https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl
+        sha256: 61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584
+  - name: python3-websocket-client
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "websocket-client>=1.8.0,<2" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl
+        sha256: af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef
+  - name: python3-psutil
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "psutil>=6.1.0,<7" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz
+        sha256: cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5
+  - name: python3-pyqtgraph
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pyqtgraph>=0.13.7,<0.14" --no-build-isolation
+    sources:
+      - *id001
+      - *id002
+      - type: file
+        url: https://files.pythonhosted.org/packages/7b/34/5702b3b7cafe99be1d94b42f100e8cc5e6957b761fcb1cf5f72d492851da/pyqtgraph-0.13.7-py3-none-any.whl
+        sha256: 7754edbefb6c367fa0dfb176e2d0610da3ada20aa7a5318516c74af5fb72bf7a
+  - name: python3-numba
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "numba>=0.61.0,<1" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/1b/4a/90715fa12006d681270b08d881195b6fab3ec39572e048764a1f7f59fed7/llvmlite-0.48.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 8761b9e522f55207e24424fcd98370289eec2710bf8e915c82d1053f642450dc
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/70/5e/7b3e20d64650ca3c80af0cdb664ec4b575ec83d9d4dd05bea8bd31f9bbb6/llvmlite-0.48.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 2fe5cb59b2063bfa039dcb8ca6481c0181bf552f340d10dcf61d7996a665556e
+        only-arches:
+          - aarch64
+      - type: file
+        url: https://files.pythonhosted.org/packages/44/b5/e930010965568fe7f2c6c962fd2849d458cb9f62c3ab7584af8a19a2b40a/numba-0.66.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+        sha256: 939316d5d8619751207b8972a67852b5a7646665298cb4de693cd6bf135152f4
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/d0/ec/5b51457cbe96e4831141d83e892e65191b23a1b78728456c62909d231ace/numba-0.66.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: cdf506775d9f02eb92a87bf5c5b1e0d25506fd18cafd769f4ed914a8feac73e7
+        only-arches:
+          - aarch64
+      - *id001
+      - *id002


### PR DESCRIPTION
<!-- Submission against new-pr base branch -->

### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. **BLITZ** (Bulk Loading and Interactive Time series Zonal analysis) is a high-performance, matrix-based image exploration and analysis tool (PyQt6). It loads large image sets, video, and NumPy matrices for interactive zonal/time-series analysis. Published by M.E.S.S. (mess.engineering); upstream: https://github.com/PiMaV/BLITZ
- [x] Please attach a video showcasing the application on Linux using the Flatpak. https://github.com/PiMaV/BLITZ/releases/download/v2.0.3/blitz-flatpak-linux-demo.webm
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements](https://docs.flathub.org/docs/for-app-authors/requirements#application-id). (`engineering.mess.Blitz` — domain mess.engineering controlled by publisher; `.well-known/org.flathub.VerifiedApps.txt` reserved for verification token)
- [x] I have read and followed all the [Submission requirements](https://docs.flathub.org/docs/for-app-authors/requirements) and the [Submission guide](https://docs.flathub.org/docs/for-app-authors/submission) and I agree to them.
- [x] I am an **author/developer** to the project. If not, I contacted upstream developers about this submission. **Link:** https://github.com/PiMaV/BLITZ (maintainer PiMaV / Philipp Mattern, mattern@mess.engineering)

### Linter / finish-args

`flatpak-builder-lint` reports `finish-args-home-ro-filesystem-access`.

**Requesting an exception for `--filesystem=home:ro`:** BLITZ is a scientific image analysis tool. Users routinely open large image folders and single files via **Drag-and-Drop from the file manager (e.g. Dolphin)** as well as Open dialogs. These datasets live under `$HOME` at arbitrary paths. Without read access to home, DnD of local paths does not work reliably under Flatpak portals alone.

Writes do **not** require home write access: image/LUT/export use `QFileDialog.getSaveFileName` (XDG portal). Application settings use XDG config inside the sandbox. We intentionally use `home:ro` rather than `home` (rw).

Source pin: tag `v2.0.3` / https://github.com/PiMaV/BLITZ