### PR TITLE
Add com.siftergames.desktop

### DIFF
--- a/com.siftergames.desktop.metainfo.xml
+++ b/com.siftergames.desktop.metainfo.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- AppStream metadata for the Flathub listing. The screenshots are real
+     app UI (the desktop shell renders the same interface), captured
+     headlessly and served from the site's own /flathub/ path — see
+     public/flathub/. Known cosmetic limit: cover-art tiles show the
+     monogram fallback in these captures (the capture environment can't
+     reach Steam's CDN); recapture from a normal machine anytime for
+     prettier ones. -->
+
+<component type="desktop-application">
+  <id>com.siftergames.desktop</id>
+  <name>Sifter</name>
+  <summary>Every game on your PC in one honest launcher</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <description>
+    <p>
+      Sifter is the trust layer for your game library: it finds every game
+      installed on your PC — Steam, and on Linux also Heroic (Epic/GOG) and
+      Lutris — scores how aggressively each one's monetisation is designed
+      (Design Risk), how much players actually enjoy it (Joy Index), and
+      whether it respects your time, then launches anything with one click.
+    </p>
+    <p>
+      On Linux, Windows titles launch through Valve's Proton via Steam, and
+      every Steam game carries an honest compatibility badge from a bundled
+      snapshot of ProtonDB community reports, anti-cheat support status, and
+      Valve's official Deck Verified rating — including "Blocked by
+      anti-cheat" when a game simply will not run, shown before you press
+      Play, never after.
+    </p>
+    <p>
+      Free, no account required to scan and score your library. Sifter never
+      charges you, and money never moves a score.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.siftergames.desktop.desktop</launchable>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <url type="homepage">https://www.siftergames.com</url>
+  <!-- Must be PUBLICLY reachable — reviewers and users click these. The
+       GitHub repo is private, so its issues page 404s for everyone else;
+       /support is the public contact surface. -->
+  <url type="bugtracker">https://www.siftergames.com/support</url>
+  <url type="help">https://www.siftergames.com/support</url>
+  <developer id="com.siftergames">
+    <name>Sifter</name>
+  </developer>
+  <content_rating type="oars-1.1" />
+  <screenshots>
+    <screenshot type="default">
+      <image>https://www.siftergames.com/flathub/library.png</image>
+      <caption>Your whole library in one place, scored on your side</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.siftergames.com/flathub/game-detail.png</image>
+      <caption>Design Risk score with the reasons behind it</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://www.siftergames.com/flathub/discover.png</image>
+      <caption>Discover games that respect players</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.3.2" date="2026-07-28" />
+  </releases>
+</component>

--- a/com.siftergames.desktop.yml
+++ b/com.siftergames.desktop.yml
@@ -1,0 +1,88 @@
+# Flatpak manifest for the Sifter desktop app — repackages the released,
+# versioned .deb (the same binary every other Linux user runs) rather than
+# building from source, since the source repo is private. This is the
+# standard Flathub pattern for proprietary apps (Discord, Slack, etc.).
+#
+# The url + sha256 below are ONE FACT — bump them together, never apart.
+# Both come from the Desktop release workflow: the versioned artifact it
+# uploads to desktop/releases/<version>/, and the checksum it prints on the
+# "== sha256 for packaging/flatpak ==" line. Currently pinned to 0.3.2,
+# verified 2026-07-28 by downloading the published file and re-hashing it.
+#
+# Validation: run the "Validate Flatpak" GitHub workflow (it also fires on
+# any PR touching this directory). It builds, installs, and headlessly boots
+# the sandboxed app on an Ubuntu runner — no local Linux machine needed.
+# See README.md here for the submission walkthrough and honest limits.
+#
+# Runtime note: Tauri v2 needs GTK3 + webkit2gtk-4.1. The GNOME runtime has
+# historically shipped both; if Flathub's builder reports webkit2gtk-4.1
+# missing from this runtime version, the fallback is building webkitgtk as a
+# module or pinning an older runtime — resolve at submission time against
+# Flathub's current guidance for Tauri apps.
+
+app-id: com.siftergames.desktop
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+command: sifter-desktop
+
+finish-args:
+  # The webview + launcher UI.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # Loads the live site; launches hand off via portal-opened URLs.
+  - --share=network
+  # Read-only visibility into the install records the library scanner reads
+  # (see desktop/src-tauri/library-scan): Steam (native/Flatpak/Snap),
+  # Heroic (native/Flatpak), Lutris (native/Flatpak). Read-only on purpose —
+  # Sifter never writes into another launcher's data.
+  - --filesystem=~/.local/share/Steam:ro
+  - --filesystem=~/.steam:ro
+  - --filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/Steam:ro
+  - --filesystem=~/snap/steam/common/.local/share/Steam:ro
+  - --filesystem=~/.config/heroic:ro
+  - --filesystem=~/.var/app/com.heroicgameslauncher.hgl/config/heroic:ro
+  - --filesystem=~/.config/lutris/games:ro
+  - --filesystem=~/.var/app/net.lutris.Lutris/config/lutris/games:ro
+
+modules:
+  - name: sifter-desktop
+    buildsystem: simple
+    build-commands:
+      # Unpack the released .deb (data tarball compression varies by
+      # bundler version — match any).
+      - ar x Sifter-linux.deb
+      - tar -xf data.tar.*
+      - install -Dm755 usr/bin/sifter-desktop /app/bin/sifter-desktop
+      # Desktop entry + icons must be renamed to the Flatpak app-id.
+      - |
+        desktop_file=$(ls usr/share/applications/*.desktop | head -1)
+        sed -i 's/^Icon=.*/Icon=com.siftergames.desktop/' "$desktop_file"
+        # AppStream compose hard-requires a valid XDG category, and older
+        # Sifter .debs (pre-0.3.2) shipped a desktop file without one.
+        if grep -q '^Categories=' "$desktop_file"; then
+          sed -i 's/^Categories=.*/Categories=Game;/' "$desktop_file"
+        else
+          printf 'Categories=Game;\n' >> "$desktop_file"
+        fi
+        install -Dm644 "$desktop_file" /app/share/applications/com.siftergames.desktop.desktop
+      - |
+        for dir in usr/share/icons/hicolor/*/apps; do
+          size=$(basename "$(dirname "$dir")")
+          icon=$(ls "$dir"/*.png 2>/dev/null | head -1) || continue
+          [ -n "$icon" ] && install -Dm644 "$icon" "/app/share/icons/hicolor/$size/apps/com.siftergames.desktop.png"
+        done
+      - install -Dm644 com.siftergames.desktop.metainfo.xml -t /app/share/metainfo
+    sources:
+      - type: file
+        # Immutable per-version artifact published by the Desktop release
+        # workflow (desktop/releases/<version>/ — never overwritten, unlike
+        # desktop/latest/). Bump the version in this URL AND the sha256
+        # together; they are one fact.
+        url: https://vqwhap5sw1u1nujs.public.blob.vercel-storage.com/desktop/releases/0.3.2/Sifter-linux.deb
+        sha256: 4cf6477ab6546a5dee828fdafd79e2ca3069c512402a8654be8e489cddcb32a0
+        dest-filename: Sifter-linux.deb
+      - type: file
+        path: com.siftergames.desktop.metainfo.xml


### PR DESCRIPTION
Flatpak manifest and AppStream metainfo for Sifter, a desktop game-library app. The manifest repackages the released, versioned .deb (pinned by immutable URL + sha256) since the source repo is private.

<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [ ] Please describe the application briefly. < Please insert the description here >
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. < Please insert the video here >
- [ ] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [ ] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [ ] I am an _(please keep whichever is applicable and remove the rest)_ author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
