### PR TITLE
Add org.libredb.Studio

### DIFF
--- a/libredb-studio.sh
+++ b/libredb-studio.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Flatpak entry point for LibreDB Studio (issue #232).
+#
+# The desktop shell is a plain WebKitGTK binary, so unlike the Electron apps this
+# packaging pattern comes from there is no sandbox-relaunch wrapper to invoke and
+# no library path to fix up: the GNOME runtime provides WebKitGTK, GTK and their
+# helper processes. The shell finds its own sidecar (usr/bin/node) and the server
+# payload (usr/lib/LibreDB Studio/payload) relative to this binary.
+#
+# The server writes its SQLite storage and generated credentials under
+# $XDG_DATA_HOME, which Flatpak points at ~/.var/app/org.libredb.Studio/data.
+set -eu
+
+exec /app/libredb-studio/usr/bin/libredb-studio-desktop "$@"

--- a/org.libredb.Studio.desktop
+++ b/org.libredb.Studio.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=LibreDB Studio
+GenericName=SQL IDE
+Comment=AI-powered SQL IDE for PostgreSQL, MySQL, MongoDB and more
+Exec=libredb-studio
+Icon=org.libredb.Studio
+Terminal=false
+Categories=Development;Database;
+Keywords=SQL;Database;PostgreSQL;MySQL;SQLite;MongoDB;Redis;Oracle;IDE;Query;
+StartupNotify=true
+StartupWMClass=libredb-studio-desktop

--- a/org.libredb.Studio.metainfo.xml
+++ b/org.libredb.Studio.metainfo.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metainfo for the Flathub listing (issue #232).
+
+  Installed as ${FLATPAK_ID}.metainfo.xml by packaging/flatpak/org.libredb.Studio.yml.
+  Validated by scripts/build-flatpak-local.sh (appstreamcli validate) and by the
+  flatpak-smoke workflow.
+
+  Screenshot URLs are pinned to a commit (Flathub requires a tag or commit, never
+  a branch) and the releases list below must gain an entry for every version
+  pushed to Flathub. See packaging/flatpak/README.md.
+-->
+<component type="desktop-application">
+  <id>org.libredb.Studio</id>
+  <name>LibreDB Studio</name>
+  <summary>AI-powered SQL IDE for PostgreSQL, MySQL, MongoDB and more</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="org.libredb">
+    <name>LibreDB</name>
+  </developer>
+
+  <description>
+    <p>
+      LibreDB Studio is an open-source SQL IDE for developers and data teams. The desktop
+      app runs entirely on your machine: it starts a local LibreDB Studio server in the
+      background and shows it in a native window. Nothing is sent to a cloud service.
+    </p>
+    <p>Databases it speaks:</p>
+    <ul>
+      <li>PostgreSQL</li>
+      <li>MySQL and MariaDB</li>
+      <li>SQLite</li>
+      <li>Microsoft SQL Server</li>
+      <li>Oracle Database</li>
+      <li>MongoDB</li>
+      <li>Redis</li>
+    </ul>
+    <p>What you get:</p>
+    <ul>
+      <li>A Monaco-based SQL editor with schema-aware completion and formatting</li>
+      <li>A virtualized results grid built for large result sets, with CSV and JSON export</li>
+      <li>Schema browser, entity-relationship diagrams and index advice</li>
+      <li>Query plans, slow-query and session monitoring</li>
+      <li>Optional AI assistance (natural language to SQL, query explanation) using your own API key</li>
+      <li>An embedded sample database, so there is something to query on first launch</li>
+    </ul>
+    <p>
+      Connections are made over TCP. The sandbox has no access to your home directory by
+      default; grant it explicitly if you need to open SQLite files or reach a database
+      through a Unix socket - the project documentation lists the exact commands.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">org.libredb.Studio.desktop</launchable>
+
+  <url type="homepage">https://libredb.org</url>
+  <url type="bugtracker">https://github.com/libredb/libredb-studio/issues</url>
+  <url type="vcs-browser">https://github.com/libredb/libredb-studio</url>
+  <url type="help">https://github.com/libredb/libredb-studio/tree/main/docs</url>
+  <url type="contribute">https://github.com/libredb/libredb-studio/blob/main/CONTRIBUTING.md</url>
+
+  <categories>
+    <category>Development</category>
+    <category>Database</category>
+  </categories>
+
+  <keywords>
+    <keyword>SQL</keyword>
+    <keyword>database</keyword>
+    <keyword>PostgreSQL</keyword>
+    <keyword>MySQL</keyword>
+    <keyword>SQLite</keyword>
+    <keyword>MongoDB</keyword>
+    <keyword>Redis</keyword>
+    <keyword>Oracle</keyword>
+    <keyword>IDE</keyword>
+  </keywords>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/libredb/libredb-studio/raw/cb74378ddef24ec543a7b84154fadd8b7e1f8694/public/screenshots/hero-editor.png</image>
+      <caption>Running a query and browsing results in the SQL editor</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/libredb/libredb-studio/raw/cb74378ddef24ec543a7b84154fadd8b7e1f8694/public/screenshots/connection-modal.png</image>
+      <caption>Adding a database connection</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/libredb/libredb-studio/raw/cb74378ddef24ec543a7b84154fadd8b7e1f8694/public/screenshots/erd-diagram.png</image>
+      <caption>Entity-relationship diagram of a schema</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://github.com/libredb/libredb-studio/raw/cb74378ddef24ec543a7b84154fadd8b7e1f8694/public/screenshots/nl2sql.png</image>
+      <caption>Turning a question in plain language into SQL</caption>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.9.59" date="2026-07-15">
+      <url type="details">https://github.com/libredb/libredb-studio/releases/tag/0.9.59</url>
+    </release>
+  </releases>
+</component>

--- a/org.libredb.Studio.metainfo.xml
+++ b/org.libredb.Studio.metainfo.xml
@@ -100,6 +100,12 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.9.60" date="2026-07-28">
+      <description>
+        <p>First release with the desktop application: the AppImage this Flatpak repacks.</p>
+      </description>
+      <url type="details">https://github.com/libredb/libredb-studio/releases/tag/0.9.60</url>
+    </release>
     <release version="0.9.59" date="2026-07-15">
       <url type="details">https://github.com/libredb/libredb-studio/releases/tag/0.9.59</url>
     </release>

--- a/org.libredb.Studio.yml
+++ b/org.libredb.Studio.yml
@@ -1,0 +1,116 @@
+# =============================================================================
+# LibreDB Studio Flatpak manifest template (issue #232).
+#
+# Rendered by scripts/render-flatpak-manifest.mjs, which fills the version and
+# the per-architecture sha256 placeholders below from the checksums of the
+# AppImage assets release CI publishes. The rendered file is what lives in the
+# flathub/org.libredb.Studio repository; Flathub's External Data Checker keeps
+# the url/sha256 pairs current through the x-checker-data blocks below.
+#
+# Why repack the AppImage instead of building from source: the AppImage is our
+# own MIT-licensed release artifact, already built and smoke-tested by release
+# CI for every version, so Flathub ships the exact bytes users get from every
+# other channel and there is one build pipeline to keep working. Same pattern as
+# Beekeeper Studio's Flathub manifest.
+#
+# Runtime: org.gnome.Platform, not org.freedesktop.Platform - the desktop shell
+# is a Tauri (WebKitGTK) app and only the GNOME runtime ships webkit2gtk-4.1.
+# =============================================================================
+app-id: org.libredb.Studio
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: libredb-studio
+
+finish-args:
+  # A webview plus a local HTTP server: window system, GPU and the loopback
+  # sockets the shell uses to talk to its own sidecar.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Outbound TCP to the databases the user configures (and to an AI provider if
+  # they enable one). Also covers 127.0.0.1, so a database running on the host
+  # is reachable over TCP without any filesystem permission.
+  - --share=network
+  # Deliberately absent: --filesystem=*. Opening local SQLite files or reaching
+  # a database over a Unix socket is opt-in per user, documented in
+  # docs/DISTRIBUTION.md as a `flatpak override` command.
+
+modules:
+  - name: libredb-studio
+    buildsystem: simple
+    # Everything installed here is a prebuilt release artifact, so there is no
+    # debug information to extract - and running strip over it is actively
+    # harmful: it turned the duplicated better-sqlite3 native addon into an
+    # unloadable file ("object file has no loadable segments"), which took the
+    # server's SQLite storage down while the rest of the app looked healthy.
+    build-options:
+      strip: false
+      no-debuginfo: true
+    build-commands:
+      - chmod +x libredb-studio.AppImage
+      - ./libredb-studio.AppImage --appimage-extract
+      - rm libredb-studio.AppImage
+
+      # Icons come out of the AppImage named after the binary; Flathub requires
+      # them named after the app id. Scale-suffixed directories (256x256@2) are
+      # skipped: the plain sizes plus 512x512 satisfy the icon requirement.
+      - |
+        for icon in squashfs-root/usr/share/icons/hicolor/*/apps/*.png; do
+          size="$(basename "$(dirname "$(dirname "$icon")")")"
+          case "$size" in *@*) continue ;; esac
+          install -Dm644 "$icon" "${FLATPAK_DEST}/share/icons/hicolor/${size}/apps/${FLATPAK_ID}.png"
+        done
+
+      # Install exactly three things out of the AppImage, and nothing else: the
+      # shell binary, the pinned Node sidecar and the server payload. The rest of
+      # the AppDir is the GTK/WebKitGTK stack that linuxdeploy copied from the
+      # build machine - inside the sandbox those must come from the runtime
+      # instead, and mixing a bundled libwebkit2gtk with the runtime's helper
+      # processes (or the reverse) crashes the webview.
+      #
+      # The relative layout is load-bearing: Tauri resolves its resource
+      # directory as <exe dir>/../lib/<product name>, hence usr/bin next to
+      # usr/lib/libredb-studio-desktop.
+      - install -Dm755 squashfs-root/usr/bin/libredb-studio-desktop ${FLATPAK_DEST}/libredb-studio/usr/bin/libredb-studio-desktop
+      - install -Dm755 squashfs-root/usr/bin/node ${FLATPAK_DEST}/libredb-studio/usr/bin/node
+      - install -d ${FLATPAK_DEST}/libredb-studio/usr/lib
+      - cp -r squashfs-root/usr/lib/libredb-studio-desktop ${FLATPAK_DEST}/libredb-studio/usr/lib/libredb-studio-desktop
+
+      - install -Dm755 libredb-studio.sh ${FLATPAK_DEST}/bin/libredb-studio
+      - install -Dm644 org.libredb.Studio.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 org.libredb.Studio.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+
+    sources:
+      - type: file
+        only-arches:
+          - x86_64
+        url: https://github.com/libredb/libredb-studio/releases/download/0.9.60/libredb-studio-desktop-0.9.60-linux-x64.AppImage
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        dest-filename: libredb-studio.AppImage
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/libredb/libredb-studio/releases/latest
+          # Release tags in this repo are bare semver, so there is no "v" to strip.
+          version-query: .tag_name
+          url-query: .assets[] | select(.name == "libredb-studio-desktop-" + $version + "-linux-x64.AppImage") | .browser_download_url
+
+      - type: file
+        only-arches:
+          - aarch64
+        url: https://github.com/libredb/libredb-studio/releases/download/0.9.60/libredb-studio-desktop-0.9.60-linux-arm64.AppImage
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        dest-filename: libredb-studio.AppImage
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/libredb/libredb-studio/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name == "libredb-studio-desktop-" + $version + "-linux-arm64.AppImage") | .browser_download_url
+
+      - type: file
+        path: libredb-studio.sh
+      - type: file
+        path: org.libredb.Studio.desktop
+      - type: file
+        path: org.libredb.Studio.metainfo.xml

--- a/org.libredb.Studio.yml
+++ b/org.libredb.Studio.yml
@@ -87,7 +87,7 @@ modules:
         only-arches:
           - x86_64
         url: https://github.com/libredb/libredb-studio/releases/download/0.9.60/libredb-studio-desktop-0.9.60-linux-x64.AppImage
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        sha256: "ec7a9e8c700a944f5e046e9f8e405afc0f8874a8965dc2960193a39bee052bdc"
         dest-filename: libredb-studio.AppImage
         x-checker-data:
           type: json
@@ -100,7 +100,7 @@ modules:
         only-arches:
           - aarch64
         url: https://github.com/libredb/libredb-studio/releases/download/0.9.60/libredb-studio-desktop-0.9.60-linux-arm64.AppImage
-        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+        sha256: "931d7cdc78189c0d523f70e2c00bc3b0893f7c28715420226e24ec6b2a83326e"
         dest-filename: libredb-studio.AppImage
         x-checker-data:
           type: json


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. LibreDB Studio is an SQL IDE for developers and data teams. It connects to PostgreSQL, MySQL and MariaDB, SQLite, Microsoft SQL Server, Oracle, MongoDB and Redis, and gives you a Monaco based editor with schema aware completion, a virtualized results grid for large result sets, a schema browser with ER diagrams, query plans, and optional AI help for turning a question into SQL using your own API key. The desktop build starts a local server in the background and shows it in a native window, so everything stays on the machine. Upstream: https://github.com/libredb/libredb-studio
- [x] Please attach a video showcasing the application on Linux using the Flatpak.  Video showcase:
https://github.com/user-attachments/assets/c33ce37e-266f-4c2b-b1d0-1b763be4409f
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. `libredb.org` is our own domain and the app id matches it.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author to the project.

Edited: 0.9.60 published (https://github.com/libredb/libredb-studio/releases/tag/0.9.60)

### Notes for the reviewer

- `org.gnome.Platform//50`, because the app is a Tauri shell and needs `webkit2gtk-4.1` from the GNOME runtime.
- The manifest repacks the AppImage we publish with every release instead of building from source. That artifact is our own MIT licensed build, it is already produced and smoke tested by release CI for every version, and reusing it keeps one build pipeline for every channel we ship. Same approach as `io.beekeeperstudio.Studio`. If you would rather see a source build we can do it with `flatpak-cargo-generator` plus `flatpak-node-generator`, it just means vendoring the whole Next.js app a second time.
- Only three things are installed out of the AppImage, the shell binary, the pinned Node runtime it runs as a sidecar and the server payload. The GTK and WebKitGTK libraries that linuxdeploy bundled are dropped so the runtime provides them, mixing the two crashes the webview.
- `strip: false` and `no-debuginfo: true` on the module. Everything installed is a prebuilt release artifact with no debug info to extract, and stripping it broke the bundled `better-sqlite3` native addon.
- Permissions are window system, GPU, IPC and network, and nothing else. There is no `--filesystem=` at all. Databases are reached over TCP, including a database on the host at `127.0.0.1`. Opening local SQLite files or connecting through a Unix socket is a `flatpak override` the user grants, which is documented on our side.
- Screenshots are pinned to a commit as required.
- Verified locally on Ubuntu 24.04 x86_64 with `org.flatpak.Builder`: `appstreamcli validate` passes, `flatpak-builder-lint manifest` passes, the build installs and runs, and `flatpak-builder-lint repo` is clean apart from the two media mirroring errors that only Flathub's own build can satisfy. Inside the sandbox I added a PostgreSQL connection over TCP and ran a query that returned rows.
- Our own CI also builds this manifest on both `x86_64` and `aarch64` with `flatpak/flatpak-github-actions` on every change, so regressions show up before they reach you.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
