### PR TITLE
Add org.meduzamusic.MeduzaMusic

### DIFF
--- a/org.meduzamusic.MeduzaMusic.yml
+++ b/org.meduzamusic.MeduzaMusic.yml
@@ -1,0 +1,48 @@
+app-id: org.meduzamusic.MeduzaMusic
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: meduza-music
+
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --share=network
+  - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.ayatana.statusbar
+  - --filesystem=/tmp
+  - --filesystem=xdg-run/meduza-music:create
+
+build-options:
+  append-path: /usr/lib/sdk/rust-stable/bin
+  build-args:
+    - --share=network
+  env:
+    CARGO_HOME: /run/build/meduza-music/cargo
+
+modules:
+  - name: mpv
+    buildsystem: simple
+    build-commands:
+      - echo "mpv provided by runtime or system"
+    sources: []
+
+  - name: meduza-music
+    buildsystem: simple
+    build-commands:
+      - cargo build --release --verbose
+      - install -Dm755 target/release/meduza-music /app/bin/meduza-music
+      - install -Dm644 org.meduzamusic.MeduzaMusic.desktop /app/share/applications/org.meduzamusic.MeduzaMusic.desktop
+      - install -Dm644 org.meduzamusic.MeduzaMusic.metainfo.xml /app/share/metainfo/org.meduzamusic.MeduzaMusic.metainfo.xml
+      - install -Dm644 assets/icon_512.png /app/share/icons/hicolor/512x512/apps/org.meduzamusic.MeduzaMusic.png
+      - install -Dm644 assets/icon_128.png /app/share/icons/hicolor/128x128/apps/org.meduzamusic.MeduzaMusic.png
+    sources:
+      - type: git
+        url: https://github.com/akilaisadev/meduza-music.git
+        tag: v1.0.0


### PR DESCRIPTION
### New Application Submission

- **App ID**: `org.meduzamusic.MeduzaMusic`
- **Name**: Meduza Music
- **Summary**: Fast, native, lightweight desktop YouTube Music player for Linux built with Rust, egui, and MPV.
- **Upstream Repository**: https://github.com/akilaisadev/meduza-music
- **License**: MIT