### PR TITLE
Add io.github.justlinuxnoob.ArchiveFree

### DIFF
--- a/io.github.justlinuxnoob.ArchiveFree.yml
+++ b/io.github.justlinuxnoob.ArchiveFree.yml
@@ -1,0 +1,68 @@
+id: io.github.justlinuxnoob.ArchiveFree
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: archivefree
+
+# The GNOME runtime already provides Python 3, PyGObject, GTK 4 and libadwaita,
+# so the only thing we have to bundle is 7-Zip — which is what makes the
+# Flatpak support 7z, RAR, ISO and encrypted ZIP with nothing else installed.
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # An archive manager is only useful if it can reach the user's files, and
+  # people keep archives everywhere. This matches what other archive tools do.
+  - --filesystem=host
+  # Archives opened from a mounted phone, network share or USB stick.
+  - --filesystem=xdg-run/gvfs
+  # Lets the app become the default archive handler on the host.
+  - --talk-name=org.freedesktop.FileManager1
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - '*.a'
+  - '*.la'
+
+modules:
+  - name: sevenzip
+    buildsystem: simple
+    build-commands:
+      - make -j "${FLATPAK_BUILDER_N_JOBS:-1}" -C CPP/7zip/Bundles/Alone2
+        -f ../../cmpl_gcc.mak
+      - install -Dm755 CPP/7zip/Bundles/Alone2/b/g/7zz /app/bin/7zz
+      # ArchiveFree probes for 7zz, 7z, 7za and 7zr in that order; the alias
+      # keeps anything that looks for the traditional name working too.
+      - ln -s 7zz /app/bin/7z
+    sources:
+      - type: archive
+        url: https://7-zip.org/a/7z2501-src.tar.xz
+        sha256: ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
+        strip-components: 0
+    cleanup:
+      - /share/doc
+
+  - name: archivefree
+    buildsystem: simple
+    build-commands:
+      - install -d /app/share/archivefree/integration
+      - cp -r archivefree /app/share/archivefree/
+      - install -Dm644 data/integration/archivefree-extension.py
+        /app/share/archivefree/integration/archivefree-extension.py
+      - install -Dm755 packaging/flatpak/archivefree-launcher /app/bin/archivefree
+      - install -Dm644 data/io.github.justlinuxnoob.ArchiveFree.desktop
+        /app/share/applications/io.github.justlinuxnoob.ArchiveFree.desktop
+      - install -Dm644 data/io.github.justlinuxnoob.ArchiveFree.metainfo.xml
+        /app/share/metainfo/io.github.justlinuxnoob.ArchiveFree.metainfo.xml
+      - install -Dm644
+        data/icons/hicolor/scalable/apps/io.github.justlinuxnoob.ArchiveFree.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.justlinuxnoob.ArchiveFree.svg
+    sources:
+      - type: git
+        url: https://github.com/justlinuxnoob/archivefree.git
+        tag: v0.5.1
+        commit: abee20eef18cae9f589a1adf0ffeb21d87c997f1


### PR DESCRIPTION
## ArchiveFree

A GTK4/libadwaita archive manager. It opens an archive in a window so you can
see what is inside and choose what to extract, rather than unpacking everything
the moment you double-click.

- **Upstream:** https://github.com/justlinuxnoob/archivefree
- **Licence:** GPL-3.0-or-later
- I am the upstream author.

### Checks

- Builds from a pinned tag (`v0.5.1`) with `flatpak-builder`
- `appstreamcli validate` and `desktop-file-validate` pass in upstream CI
- Four screenshots in the metainfo
- No network access, no telemetry, no adverts, no accounts

### Bundled dependency

7-Zip 25.01, built from official source (LGPL-2.1). This is what makes 7z, RAR,
ISO, CAB and encrypted ZIP work with nothing else installed. The non-free
`unrar` is deliberately **not** bundled — RAR support goes through 7-Zip
precisely to keep everything redistributable.

### Filesystem permission — `--filesystem=host`

The linter flags this and I want to justify it up front rather than have you ask.

ArchiveFree is an archive manager. Its core function is to open an archive the
user double-clicked, which can be anywhere on the filesystem, and to extract its
contents to a destination the user picks, which can also be anywhere. Both ends
are chosen at the moment of use, so there is no fixed set of paths to declare
in advance.

The portal alternatives do not fit. `OpenFile` provides a single read-only
handle, whereas extraction has to create an arbitrary tree of files and
directories under a user-chosen folder. And the archive being opened is chosen
by the file manager through the MIME association, not by a portal dialog inside
the app.

This is the same permission granted to the other archive managers on Flathub,
including `org.gnome.FileRoller`.

If you would prefer the narrower `--filesystem=home` plus `/media` and
`/run/media`, I am happy to change it. The one functional cost is that
"undo" in Preferences reads the host's `mimeinfo.cache` under `/run/host` to
find out which application handled archives *before* ArchiveFree took over, so
it can hand them back to exactly that app. Without host access it still removes
our associations cleanly, but can no longer name the previous handler for
applications installed under `/usr`. The code already degrades gracefully.

### Screenshots

The metainfo references four screenshots hosted in the upstream repository at
the `v0.1.1` tag, so the URLs are stable. The two related linter findings
(`appstream-external-screenshot-url`, `appstream-screenshots-not-mirrored-in-ostree`)
resolve once Flathub's build service mirrors them.
