### PR TITLE
Add me.faizraza.dayly

### DIFF
--- a/me.faizraza.dayly.desktop
+++ b/me.faizraza.dayly.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+# The same listing name as the Microsoft Store, so Dayly is called one thing across
+# every store it ships in.
+Name=Dayly - Time Tracker
+Comment=Local-only time tracker that lives in your tray
+# The wrapper installed at /app/bin/dayly, not the binary under /app/dayly — launching
+# the binary directly would skip zypak and Chromium would fail to start its sandbox.
+Exec=dayly
+Icon=me.faizraza.dayly
+Terminal=false
+Type=Application
+Categories=Utility;
+# Matches the WM_CLASS Electron reports, so the shell groups the running window with
+# this entry instead of showing a second, unnamed icon.
+StartupWMClass=Dayly
+X-GNOME-UsesNotifications=true

--- a/me.faizraza.dayly.metainfo.xml
+++ b/me.faizraza.dayly.metainfo.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <!-- Matches `appId` in electron-builder.yml, so every platform uses one identifier. -->
+  <id>me.faizraza.dayly</id>
+
+  <!-- The same listing name as the Microsoft Store reservation. -->
+  <name>Dayly - Time Tracker</name>
+  <summary>Local-only time tracker that lives in your tray</summary>
+
+  <!-- The licence of this metadata file, not of the app. -->
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="me.faizraza">
+    <name>Muhammad Faiz Raza</name>
+  </developer>
+
+  <launchable type="desktop-id">me.faizraza.dayly.desktop</launchable>
+
+  <description>
+    <p>
+      Dayly tracks working hours from the system tray. Start the timer when you begin,
+      pause it when you stop, and see the day's total without opening a window.
+    </p>
+    <p>
+      Everything stays on this machine in a single SQLite file. There is no account to
+      create, no cloud to sync with, and no telemetry — Dayly opens no network sockets
+      at all.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Start, pause and resume from the tray, with the day's total always visible</li>
+      <li>Idle detection that asks what to do with time away from the machine</li>
+      <li>Automatic pause when the machine sleeps or locks</li>
+      <li>A daily target, with progress shown against it</li>
+      <li>History by day, week and month, with segments you can correct after the fact</li>
+      <li>Export to CSV or JSON, and a one-file backup you can copy anywhere</li>
+      <li>An optional always-on-top mini window for a glanceable total</li>
+    </ul>
+  </description>
+
+  <!--
+    These resolve only once docs/screenshots/ is committed and pushed to main. The mini
+    window shot is deliberately absent: at 496x248 it is under Flathub's 620x351 floor
+    and would fail the linter.
+  -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/faizrazadec/dayly/main/docs/screenshots/panel.png</image>
+      <caption>The tray panel, showing today's total and progress against the daily target</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/faizrazadec/dayly/main/docs/screenshots/history.png</image>
+      <caption>History by month, with per-day segments that can be corrected</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/faizrazadec/dayly/main/docs/screenshots/settings.png</image>
+      <caption>Settings: appearance, daily target and idle detection</caption>
+    </screenshot>
+  </screenshots>
+
+  <releases>
+    <release version="0.1.0" date="2026-07-28">
+      <description>
+        <p>First public release.</p>
+      </description>
+    </release>
+  </releases>
+
+  <!-- Empty element means every OARS category is "none": no violence, no data sharing. -->
+  <content_rating type="oars-1.1" />
+
+  <url type="homepage">https://github.com/faizrazadec/dayly</url>
+  <url type="bugtracker">https://github.com/faizrazadec/dayly/issues</url>
+  <url type="vcs-browser">https://github.com/faizrazadec/dayly</url>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#e8eaf0</color>
+    <color type="primary" scheme_preference="dark">#20242e</color>
+  </branding>
+</component>

--- a/me.faizraza.dayly.yml
+++ b/me.faizraza.dayly.yml
@@ -1,0 +1,94 @@
+# Flathub manifest for Dayly.
+#
+# This repackages the published .deb rather than building from source. Flathub builds
+# with no network access, so a source build would mean vendoring every npm dependency
+# into the manifest via flatpak-node-generator and regenerating it on each release. The
+# .deb is already the artifact CI produces and publishes, so repackaging it keeps one
+# build path instead of two that can disagree.
+#
+# The submission copy lives at the root of a branch named after the app id in a fork of
+# github.com/flathub/flathub. This copy is the one that is maintained.
+#
+# The id matches `appId` in electron-builder.yml exactly, lower case included, so that
+# every platform identifies Dayly by the same string.
+app-id: me.faizraza.dayly
+
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+
+# Supplies zypak, which lets Chromium's sandbox work inside the Flatpak sandbox without
+# the setuid helper. The branch has to match runtime-version above.
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+
+command: dayly
+
+# Dayly ships a single locale, so the split would produce an empty extension.
+separate-locales: false
+
+finish-args:
+  # Display. fallback-x11 rather than x11 so an X socket is only requested when there
+  # is no Wayland session to use.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # The tray is the entire UI surface: without a StatusNotifierItem host Dayly has no
+  # icon to click. This is the one permission the app genuinely cannot work without.
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # End-of-day reminders.
+  - --talk-name=org.freedesktop.Notifications
+
+  # Deliberately no --share=network. Dayly opens no sockets, and the update check is
+  # already gated off in a Flatpak build (LinuxPlatform keys `supportsAutoUpdate` on
+  # $APPIMAGE, which is unset here), so the store is the only updater. Opening the
+  # Releases page goes through the portal and needs no socket of our own.
+
+modules:
+  - name: dayly
+    buildsystem: simple
+    build-commands:
+      # The .deb is an ar archive holding a tarball; neither needs a package manager.
+      - ar x dayly.deb
+      - tar -xf data.tar.xz
+
+      - mkdir -p /app/dayly
+      - cp -a opt/Dayly/. /app/dayly/
+
+      # zypak replaces the setuid sandbox helper, and shipping an unused setuid binary
+      # trips the Flathub linter.
+      - rm -f /app/dayly/chrome-sandbox
+      # electron-updater's feed descriptor. The updater never runs in this build, so the
+      # file would only ever mislead someone reading the package.
+      - rm -f /app/dayly/resources/app-update.yml
+
+      # Launches through zypak rather than exec'ing the binary directly.
+      - install -Dm755 dayly.sh /app/bin/dayly
+
+      # Everything user-visible is renamed to the app id, which Flathub requires.
+      - install -Dm644 me.faizraza.dayly.desktop /app/share/applications/me.faizraza.dayly.desktop
+      - install -Dm644 me.faizraza.dayly.metainfo.xml /app/share/metainfo/me.faizraza.dayly.metainfo.xml
+      # Installed at its true size: electron-builder emits only the 1024x1024 icon, and
+      # declaring it as any other size would be a lie the linter catches.
+      - install -Dm644 usr/share/icons/hicolor/1024x1024/apps/dayly.png
+        /app/share/icons/hicolor/1024x1024/apps/me.faizraza.dayly.png
+
+    sources:
+      - type: file
+        url: https://github.com/faizrazadec/dayly/releases/download/v0.1.0/dayly_0.1.0_amd64.deb
+        sha256: 4c77c469f60fa35b0451d33d983a7dc167c5daba36c4a195dc7d6e239ab21e92
+        dest-filename: dayly.deb
+
+      - type: script
+        dest-filename: dayly.sh
+        commands:
+          - exec zypak-wrapper.sh /app/dayly/dayly "$@"
+
+      - type: file
+        path: me.faizraza.dayly.desktop
+
+      - type: file
+        path: me.faizraza.dayly.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. < Dayly is a local-only desktop time tracker that lives in the system tray. Start and pause the timer from the tray, set a daily target, and correct past segments in a history view. Everything stays on the machine in a single SQLite file — no account, no cloud, no telemetry, and the app opens no network sockets. Electron + TypeScript, MIT licensed, upstream at https://github.com/faizrazadec/dayly >
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. < Pending — see note below >
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. < `me.faizraza.dayly` — reverse-DNS of faizraza.me, a domain I control; it matches the `appId` already used in the project's electron-builder config >
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an _(please keep whichever is applicable and remove the rest)_ author/developer to the project.

---

**Note on the video:** it is not attached yet and I am working on it. My development machine is macOS on aarch64 while the packaged `.deb` this manifest repackages is amd64, so I cannot yet run the Flatpak locally to record it. I will post the video as a comment before asking for this to be looked at.

**Packaging notes**

The manifest repackages the published `.deb` rather than building from source. Dayly is an Electron app, so a source build would mean vendoring every npm dependency via flatpak-node-generator and regenerating it each release; the `.deb` is already the artifact CI produces and publishes, which keeps a single build path.

Built on `org.electronjs.Electron2.BaseApp` 25.08 with zypak. `chrome-sandbox` is removed since zypak replaces the setuid helper, and electron-updater's `app-update.yml` is removed because the updater is gated off in this build.

**Permissions** — deliberately minimal, notably **no `--share=network`**. Dayly opens no sockets and its update check is disabled under Flatpak, so the store is the only updater. Beyond display access it requests only:

- `org.kde.StatusNotifierWatcher` — the tray is the entire UI surface; without it there is no icon to click
- `org.freedesktop.Notifications` — end-of-day reminders

`appstreamcli validate` and `desktop-file-validate` both pass cleanly.

Known limitation: launch-at-login is not wired to the Background portal yet, so that setting has no effect under Flatpak. I plan to address it in a follow-up rather than request a permission the app cannot currently use.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
