### PR TITLE
Add io.github.volkinstridov.MathMark

### DIFF
--- a/io.github.volkinstridov.MathMark.yml
+++ b/io.github.volkinstridov.MathMark.yml
@@ -1,0 +1,45 @@
+# Сборка пакета Flatpak.
+#
+# Себе:
+#   flatpak run org.flatpak.Builder --force-clean --user --repo=repo build \
+#       desktop/io.github.volkinstridov.MathMark.yml
+#
+# Тот же файл подаётся на Flathub, поэтому исходники берутся не из папки
+# рядом, а архивом с GitHub по метке — иначе их серверы не смогут собрать.
+
+app-id: io.github.volkinstridov.MathMark
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: mathmark
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+  # только «Документы»: там лежит папка по умолчанию ~/Documents/math.
+  # Доступ ко всей домашней папке Flathub пропускает лишь по особому
+  # разрешению, а ради читалки просить его незачем.
+  - --filesystem=xdg-documents
+  # печать шпоры
+  - --socket=cups
+
+modules:
+  - name: mathmark
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 desktop/mathmark-launcher /app/bin/mathmark
+      - mkdir -p /app/lib/mathmark /app/share/mathmark
+      - cp -r desktop/mathmark/. /app/lib/mathmark/
+      - cp -r shared/reader shared/prompt shared/i18n /app/share/mathmark/
+      - install -Dm644 desktop/io.github.volkinstridov.MathMark.desktop
+        /app/share/applications/io.github.volkinstridov.MathMark.desktop
+      - install -Dm644 desktop/data/io.github.volkinstridov.MathMark.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.volkinstridov.MathMark.svg
+      - install -Dm644 desktop/data/io.github.volkinstridov.MathMark.metainfo.xml
+        /app/share/metainfo/io.github.volkinstridov.MathMark.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/VolkinstridoV/mathmark/archive/refs/tags/v1.0.1.tar.gz
+        sha256: 092b074530cf22006b2d0404035ffb88a87c42e1ddd257719ec57b814496a673


### PR DESCRIPTION
MathMark is a reader for maths written in Markdown, for the desktop and for Android. It renders LaTeX formulas with KaTeX offline and lets you mark problems and topics; marking changes exactly one byte in the file, so the notes stay editable from an editor or a terminal at the same time.

Source: https://github.com/VolkinstridoV/mathmark
License: MIT
I am the author and the maintainer.

Notes for the reviewers:

* The app id follows the `io.github.<user>.<App>` form — I do not own a domain.
* Permissions are deliberately narrow: `--filesystem=xdg-documents` only. The default folder is `~/Documents/math`; the app reads plain `.md` files from it and writes a single byte back when a task is marked. No network access is requested — the formula engine (KaTeX) is bundled.
* `--socket=cups` is used for printing a cheat sheet, which is one of the app's stated features.
* `flatpak-builder-lint manifest` passes. On `repo` it reports only the two screenshot-mirroring findings that are expected outside Flathub's own builders; the screenshot URLs are reachable and return HTTP 200.
* The build takes its sources from a tagged release archive with a sha256.