### PR TITLE
Add com.velumvpn.app

### DIFF
--- a/com.velumvpn.app/com.velumvpn.app.metainfo.xml
+++ b/com.velumvpn.app/com.velumvpn.app.metainfo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.velumvpn.app</id>
+
+  <name>VelumVPN</name>
+  <summary>VPN-клиент для обхода блокировок в России</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <description>
+    <p>
+      VelumVPN — VPN-клиент на основе mihomo (Clash Meta) для пользователей в России.
+      Три режима маршрутизации: только заблокированные сайты, все зарубежные, весь трафик через VPN.
+    </p>
+    <p>Возможности:</p>
+    <ul>
+      <li>Автоматическое обновление геобаз заблокированных ресурсов РФ</li>
+      <li>Три режима маршрутизации трафика</li>
+      <li>Страница диагностики соединений в реальном времени</li>
+      <li>Добавление собственных правил через интерфейс</li>
+      <li>Поддержка Telegram, GitHub, Discord</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">velumvpn.desktop</launchable>
+
+  <url type="homepage">https://velum.uno</url>
+  <url type="bugtracker">https://github.com/Jidos86/VelumVPN/issues</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Главный экран — статус подключения и режимы маршрутизации</caption>
+      <image>https://raw.githubusercontent.com/Jidos86/VelumVPN/main/docs/MainMenu.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Мои правила — добавление сайтов и приложений</caption>
+      <image>https://raw.githubusercontent.com/Jidos86/VelumVPN/main/docs/MyRules.png</image>
+    </screenshot>
+
+  </screenshots>
+
+  <releases>
+    <release version="1.1.18" date="2026-08-01">
+      <description>
+        <p>Исправления для Linux и Steam Deck</p>
+        <ul>
+          <li>Linux — иконка приложения в лаунчере и таскбаре</li>
+          <li>Linux — TUN-режим использует gVisor вместо mixed</li>
+          <li>Геоданные — переключено на прямые ссылки GitHub</li>
+          <li>Правила маршрутизации — добавлены ru-blocked-community и re-filter</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+
+  <categories>
+    <category>Network</category>
+    <category>Security</category>
+  </categories>
+
+  <keywords>
+    <keyword>vpn</keyword>
+    <keyword>proxy</keyword>
+    <keyword>mihomo</keyword>
+    <keyword>clash</keyword>
+  </keywords>
+</component>

--- a/com.velumvpn.app/com.velumvpn.app.yml
+++ b/com.velumvpn.app/com.velumvpn.app.yml
@@ -1,0 +1,69 @@
+app-id: com.velumvpn.app
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '23.08'
+command: velumvpn-wrapper
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=all
+  - --filesystem=home
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --system-talk-name=org.freedesktop.NetworkManager
+  - --system-talk-name=org.freedesktop.PolicyKit1
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+
+modules:
+  - name: velumvpn
+    buildsystem: simple
+    build-commands:
+      # Распаковываем pacman-пакет
+      - bsdtar -xf velumvpn.pkg.tar.xz opt usr
+
+      # Копируем приложение
+      - mkdir -p /app/lib/velumvpn
+      - cp -r opt/VelumVPN/. /app/lib/velumvpn/
+
+      # Иконки
+      - |
+        for size in 16x16 24x24 32x32 48x48 64x64 128x128 256x256 512x512; do
+          src="opt/VelumVPN/resources/icons/${size}.png"
+          if [ -f "$src" ]; then
+            install -Dm644 "$src" "/app/share/icons/hicolor/${size}/apps/com.velumvpn.app.png"
+          fi
+        done
+
+      # Desktop-файл (переименовываем в com.velumvpn.app)
+      - install -Dm644 usr/share/applications/velumvpn.desktop /app/share/applications/com.velumvpn.app.desktop
+      - desktop-file-edit --set-key=Icon --set-value=com.velumvpn.app /app/share/applications/com.velumvpn.app.desktop
+
+      # AppStream метаданные
+      - install -Dm644 com.velumvpn.app.metainfo.xml /app/share/metainfo/com.velumvpn.app.metainfo.xml
+
+      # Права на ядро mihomo
+      - chmod +sx /app/lib/velumvpn/resources/sidecar/mihomo || true
+
+      # Скрипт-обёртка
+      - install -Dm755 velumvpn-wrapper.sh /app/bin/velumvpn-wrapper
+
+    sources:
+      - type: file
+        url: https://github.com/Jidos86/VelumVPN/releases/download/1.1.18/VelumVPN_x64.pkg.tar.xz
+        sha256: 0de3a467a3421ef28cbdb841945799ff61cec7f3242bea869b2f532f903ffcb4
+        dest-filename: velumvpn.pkg.tar.xz
+
+      - type: file
+        path: com.velumvpn.app.metainfo.xml
+
+      - type: script
+        dest-filename: velumvpn-wrapper.sh
+        commands:
+          - exec /app/lib/velumvpn/velumvpn "$@"


### PR DESCRIPTION
VelumVPN is a VPN client for bypassing internet restrictions in Russia, based on mihomo (Clash Meta) core.

- Three routing modes: blocked-only, all-foreign, all-through-VPN
- Auto-updating geo databases of blocked resources
- Custom rules via UI (no config editing needed)
- Supports Windows and Linux (including Steam Deck)

License: MIT
Homepage: https://velum.uno
Source: https://github.com/Jidos86/VelumVPN