### PR TITLE
Add io.github.KlowdfurrRad.TrayAuth

### DIFF
--- a/io.github.KlowdfurrRad.TrayAuth.yml
+++ b/io.github.KlowdfurrRad.TrayAuth.yml
@@ -1,0 +1,82 @@
+# Flathub submission manifest for TrayAuth.
+#
+# Identical to ../io.github.KlowdfurrRad.TrayAuth.yml except the app source: Flathub builds
+# from a tagged commit, not a working directory. Keep the two in step when either changes.
+
+app-id: io.github.KlowdfurrRad.TrayAuth
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet8
+
+command: trayauth
+
+build-options:
+  append-path: /usr/lib/sdk/dotnet8/bin
+  append-ld-library-path: /usr/lib/sdk/dotnet8/lib
+  env:
+    DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
+
+finish-args:
+  # Avalonia's Linux backend is X11 (runs under XWayland on GNOME).
+  - --socket=x11
+  # The bundled wl-copy needs the real Wayland socket: it is how a background app is allowed
+  # to take the clipboard at all on Wayland.
+  - --socket=wayland
+  - --share=ipc
+  - --device=dri
+  # The tray icon: StatusNotifierItem over DBus, drawn by the shell.
+  - --talk-name=org.kde.StatusNotifierWatcher
+  # The vault key lives in the keyring (Secret Service API).
+  - --talk-name=org.freedesktop.secrets
+  # Deliberately NO --filesystem: file dialogs go through the portal, exports land wherever
+  # the user picks, and the vault lives in the app's own XDG_CONFIG_HOME.
+
+modules:
+  # Clipboard for a background app on Wayland; the host's copy is invisible to the sandbox.
+  - name: wl-clipboard
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/bugaevc/wl-clipboard.git
+        tag: v2.2.1
+        commit: 3eb912c274042cd5deed6b478b39908a12f37498
+
+  # Provides secret-tool, which the app shells out to for keyring storage of the vault key.
+  - name: libsecret
+    buildsystem: meson
+    config-opts:
+      - -Dmanpage=false
+      - -Dgtk_doc=false
+      - -Dintrospection=false
+      - -Dvapi=false
+      - -Dcrypto=disabled
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz
+        sha256: 163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20
+
+  - name: trayauth
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/bin /app/lib/trayauth
+      # Offline restore: every package comes from ./nuget-sources.
+      # Self-contained because the dotnet8 extension exists only at build time.
+      - dotnet publish src/TrayAuth.Desktop/TrayAuth.Desktop.csproj -c Release -r linux-x64
+        --self-contained true -p:PublishSingleFile=false -p:DebugType=none
+        --source ./nuget-sources -o /app/lib/trayauth
+      - ln -s /app/lib/trayauth/trayauth /app/bin/trayauth
+      - install -Dm644 packaging/flatpak/io.github.KlowdfurrRad.TrayAuth.desktop
+        -t /app/share/applications
+      - install -Dm644 packaging/linux/trayauth.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.KlowdfurrRad.TrayAuth.svg
+      - install -Dm644 packaging/flatpak/io.github.KlowdfurrRad.TrayAuth.metainfo.xml
+        -t /app/share/metainfo
+    sources:
+      - type: git
+        url: https://github.com/KlowdfurrRad/TrayAuth.git
+        tag: desktop-v0.2.0-alpha-1
+        commit: 150da1a31ff24b9583d353e4d63c1334e5bf6421
+      - nuget-sources.json

--- a/nuget-sources.json
+++ b/nuget-sources.json
@@ -1,0 +1,240 @@
+[
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia/11.2.0/avalonia.11.2.0.nupkg",
+        "sha512":  "29abeea9da4de98d44c6e65d201a01203fe0c4fdef3103237f5f03a50d2c447d51e88d86f75933ce2edfb46a526dbb2af9c458608905d0a9009237eac7a56573",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.angle.windows.natives/2.1.22045.20230930/avalonia.angle.windows.natives.2.1.22045.20230930.nupkg",
+        "sha512":  "82bb927cff47738cd13ee87f93664eed203fe0586c807c0fb2215e743b01d787c1ab8285512c82a3f891dbd303a20eb1feb24fdfe09a9edd91d9de65ce96f4d7",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.angle.windows.natives.2.1.22045.20230930.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.buildservices/0.0.29/avalonia.buildservices.0.0.29.nupkg",
+        "sha512":  "9485e64c84b087beaf0803c049e9c057216b889bb8d452f0339149dbde65b2c9f1cca2f2b119c3d1eb8c6eb135f582edc72516095bb6be9a2d3b530d3aa3d639",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.buildservices.0.0.29.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.desktop/11.2.0/avalonia.desktop.11.2.0.nupkg",
+        "sha512":  "1ad0f6e37e74de8fea5adba66cb05a343c45e32d88f1a15148d397c2bcc7af2fe74ca1c216ff9feaeae0cd51da40f8b4ba611bafd6f4c45bbb1785a8cf1d6f54",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.desktop.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.freedesktop/11.2.0/avalonia.freedesktop.11.2.0.nupkg",
+        "sha512":  "266197f6b100a1e916aaa454212be3ca102bb93693af1377ae092b2549b11d50950c12ae418362b3e7a4ab450c1287c73ab3b971c23a42784deb764fe023cf52",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.freedesktop.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.native/11.2.0/avalonia.native.11.2.0.nupkg",
+        "sha512":  "19e1202136e698389d46a856e5cee5c17071ed68ae8dcab3535b0239087d2f20e417e4ef80fe15a7aa60b20faaabe8bfc3d4cfd93a9853dbce4f6997d019f886",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.native.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.remote.protocol/11.2.0/avalonia.remote.protocol.11.2.0.nupkg",
+        "sha512":  "ff668650dc50b4ac0e1dbe322dbb02abc10527e8d42badcc1a4ce7cd77545406bf53ba6bc3dc00604f3bb79ecd2f6e6553e95978c62eac3d428cae8ed855e88e",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.remote.protocol.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.skia/11.2.0/avalonia.skia.11.2.0.nupkg",
+        "sha512":  "186d119fc05f52b351f49ddaacdacf5c3a51327878ca2dbe5dff8dbff9a8270dfb423b9e776ed5db2fc0856dd203d2ac06b8bc4fe24272d07bb3a93d9cdcbe64",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.skia.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.themes.fluent/11.2.0/avalonia.themes.fluent.11.2.0.nupkg",
+        "sha512":  "6f294c561a5e12b05d7ca19c56a6d81a2e243d5fa390d64fa293b2a81056c689db744463d67257f9c3d33a1a2848e4152986957574a2820ac264a99468481b8c",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.themes.fluent.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.win32/11.2.0/avalonia.win32.11.2.0.nupkg",
+        "sha512":  "29c91b2775ab6160d6c2d9cab68fd48fa99b3b8ddd94c60aa27c97b7d876086ef18db7287a576c89cddbb4914c9d2c1c2807563e53cadc4bf061025334e87214",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.win32.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/avalonia.x11/11.2.0/avalonia.x11.11.2.0.nupkg",
+        "sha512":  "952a66eef72103e3a4beba34f7fa877257519269542b22931d0b390441f7aa47c4226814c91b176a70e532f687973757129536d6aae2a5d660f931273e75ba40",
+        "dest":  "nuget-sources",
+        "dest-filename":  "avalonia.x11.11.2.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp/7.3.0.2/harfbuzzsharp.7.3.0.2.nupkg",
+        "sha512":  "9628aeb042563ce1640a79a2577af8f6e3c0bd0a6b6de89a530a44b21ffa7deacf256c86d368221199811ec7f6f18683383bbfe8ebe07ce4236dbdda229c2572",
+        "dest":  "nuget-sources",
+        "dest-filename":  "harfbuzzsharp.7.3.0.2.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.linux/7.3.0.2/harfbuzzsharp.nativeassets.linux.7.3.0.2.nupkg",
+        "sha512":  "0ea026b5cc9b52b8bc44139ea22cbb58d2613b660ffc3410bf90c08aff5fd1c32b71db33602892c633e370fc72af85810fb0128d9c1ca81ddad079c98d160c3f",
+        "dest":  "nuget-sources",
+        "dest-filename":  "harfbuzzsharp.nativeassets.linux.7.3.0.2.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.macos/7.3.0.2/harfbuzzsharp.nativeassets.macos.7.3.0.2.nupkg",
+        "sha512":  "8a97410cd28f2613f67cea9236d6f2921165e5644fce5a3fcd05ca11b670fc596ba4b422871ad0792cf59572ea6f05ae68028cb10983f1547b4edfe81caecb1a",
+        "dest":  "nuget-sources",
+        "dest-filename":  "harfbuzzsharp.nativeassets.macos.7.3.0.2.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.webassembly/7.3.0.3-preview.2.2/harfbuzzsharp.nativeassets.webassembly.7.3.0.3-preview.2.2.nupkg",
+        "sha512":  "576cd59d109a8a2c2c83eb6d674f44c47a21b74d379f9894f1be7c268e332732c2cf2106bb24c86dfd470941d46fa16c007b4923ef38feb7d97d9209b0d4df44",
+        "dest":  "nuget-sources",
+        "dest-filename":  "harfbuzzsharp.nativeassets.webassembly.7.3.0.3-preview.2.2.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/harfbuzzsharp.nativeassets.win32/7.3.0.2/harfbuzzsharp.nativeassets.win32.7.3.0.2.nupkg",
+        "sha512":  "88c7980861dfe3dd50e1e4730fa152ba37386def115ed2aee2a859c2bf9f33c9612d750982c093cb9e09893047d0f5bd20168f83914a09c311ebb5c5b37136cd",
+        "dest":  "nuget-sources",
+        "dest-filename":  "harfbuzzsharp.nativeassets.win32.7.3.0.2.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/microcom.runtime/0.11.0/microcom.runtime.0.11.0.nupkg",
+        "sha512":  "c00731176e34ea7b936ad58a38639843c790b027b714ed5d3ea828b85ea94b14a502ded52ca7f60bb10c0ac0e744bd6e62fdcce0108ebaaf9731c408eece031e",
+        "dest":  "nuget-sources",
+        "dest-filename":  "microcom.runtime.0.11.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/8.0.29/microsoft.aspnetcore.app.runtime.linux-x64.8.0.29.nupkg",
+        "sha512":  "8cf6a63df88c74f4101b5521df7bf647db25d62126b2d31dfb5df8ec5d4e33fddd671cf91d6f412d5a28ceb99a1caf0491b05f8e488563b3d22710849ac56d1a",
+        "dest":  "nuget-sources",
+        "dest-filename":  "microsoft.aspnetcore.app.runtime.linux-x64.8.0.29.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.host.linux-x64/8.0.29/microsoft.netcore.app.host.linux-x64.8.0.29.nupkg",
+        "sha512":  "40c41c97fb4a7e9af295bc2aae99e5747e19b08918844d4d340e5f0b30be31a9008a5744d4a7ae5bffa3739f293ef1d987b876321825d3fac0f627db5ee64bf2",
+        "dest":  "nuget-sources",
+        "dest-filename":  "microsoft.netcore.app.host.linux-x64.8.0.29.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/8.0.29/microsoft.netcore.app.runtime.linux-x64.8.0.29.nupkg",
+        "sha512":  "f90482dc76f2e9b6e20dfc889a8e6067949a7deebcfd29b13026038bea3e49e9587960e3c9c71af6081fd8f249f05c45f3651a6ce3757f36b910e168ecf27cdf",
+        "dest":  "nuget-sources",
+        "dest-filename":  "microsoft.netcore.app.runtime.linux-x64.8.0.29.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.platforms/5.0.0/microsoft.netcore.platforms.5.0.0.nupkg",
+        "sha512":  "8493fe11648c7ecc20b6530490d30fd63744961345c0501a7a10b11046661da09b783ddceb8b3208ae52a72a8a94cafdce8dc1bd6073c32081e30d0e7407f174",
+        "dest":  "nuget-sources",
+        "dest-filename":  "microsoft.netcore.platforms.5.0.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/qrcoder/1.6.0/qrcoder.1.6.0.nupkg",
+        "sha512":  "4979a63cc47b6b012cae0a80b3c61b43bb37b66e0a97e1abe35814f0f881e8ebc4bb4c356084ebe0a0399abe94c4ae85246375bebe378de4e2411344e34d9e7f",
+        "dest":  "nuget-sources",
+        "dest-filename":  "qrcoder.1.6.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/sixlabors.imagesharp/3.1.12/sixlabors.imagesharp.3.1.12.nupkg",
+        "sha512":  "b3093e4e529ff9e02bbb4e482396beffda0db7174a64a71a04146d31b69dc349a3ab5f6ae8197856a8255a72a712abf0e36a25dec83b0da70c1b1b0ac9b041ec",
+        "dest":  "nuget-sources",
+        "dest-filename":  "sixlabors.imagesharp.3.1.12.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/skiasharp/2.88.8/skiasharp.2.88.8.nupkg",
+        "sha512":  "52b0661b38146357ee5f92153d9223b03d4e043db8c811773470725a81f4ec0171fc22a644ee70636f8793ac60432222a5395777615ca63b4d44d5095a331b35",
+        "dest":  "nuget-sources",
+        "dest-filename":  "skiasharp.2.88.8.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.linux/2.88.8/skiasharp.nativeassets.linux.2.88.8.nupkg",
+        "sha512":  "c1cee7bb4adfd02c023804d312c59326e37859b012ff00ff245882e77f5da62df79672e0bc82b5576d8fcb23296d69e4309dcb65f44cc4474be5bc2e4be005ce",
+        "dest":  "nuget-sources",
+        "dest-filename":  "skiasharp.nativeassets.linux.2.88.8.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.macos/2.88.8/skiasharp.nativeassets.macos.2.88.8.nupkg",
+        "sha512":  "eac30f293b6da9cb2260b59abc99ffc4124669be585a26080b333ac3decce150afd490133c595cbea33cb63c34e6565d3bed28c2630c8431aac5ddc3acf1f1df",
+        "dest":  "nuget-sources",
+        "dest-filename":  "skiasharp.nativeassets.macos.2.88.8.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.webassembly/2.88.8/skiasharp.nativeassets.webassembly.2.88.8.nupkg",
+        "sha512":  "18f19a940f21e458c78fb65d3988fcf7fa3ef87ac266568d938a4c47f89806b6790da851a0db49bf412df9b43d0a8ae461d067def875602bff2670a7d7bf1b89",
+        "dest":  "nuget-sources",
+        "dest-filename":  "skiasharp.nativeassets.webassembly.2.88.8.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/skiasharp.nativeassets.win32/2.88.8/skiasharp.nativeassets.win32.2.88.8.nupkg",
+        "sha512":  "cf469d9b57e03bd775035db8da878241c7bfca0917195665fccf8f73de4d8b5bdf95613421c2fc3dc12c88d05163fa7e8f4cc7ca382cb4288302258ccfe88be8",
+        "dest":  "nuget-sources",
+        "dest-filename":  "skiasharp.nativeassets.win32.2.88.8.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/system.io.filesystem.accesscontrol/5.0.0/system.io.filesystem.accesscontrol.5.0.0.nupkg",
+        "sha512":  "45a6b5446faa06612e90974bd7d542d9a1480c0583c0237e8732ffbceff1b70a6e12c23792145e7613bd00041bda26745b83d73008ee71a46da5c7a40a4568d3",
+        "dest":  "nuget-sources",
+        "dest-filename":  "system.io.filesystem.accesscontrol.5.0.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/system.io.pipelines/8.0.0/system.io.pipelines.8.0.0.nupkg",
+        "sha512":  "57eb6a11e84f40a48b57b1dc5786a01aa9852122b7d15363490d8a12c9a458bf99a8ddf4c0c0247be98559c2b42e769a10bda2c5a9817735484d960dc652eb12",
+        "dest":  "nuget-sources",
+        "dest-filename":  "system.io.pipelines.8.0.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/system.security.accesscontrol/5.0.0/system.security.accesscontrol.5.0.0.nupkg",
+        "sha512":  "ae6b03ad029d3eb6818a6c8bb56cf4904013fa535a67b8e621b783a029dd88aa2e471e002cbc7d720381ad8bc8c6b93111a08f6ce2d271af6d974bf4d02b6c81",
+        "dest":  "nuget-sources",
+        "dest-filename":  "system.security.accesscontrol.5.0.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/system.security.principal.windows/5.0.0/system.security.principal.windows.5.0.0.nupkg",
+        "sha512":  "44a920aaaf22b2172d41319bb57ab2b8e1a4531d5f02192a6f53a81d875125195b60ba0b5a44a45981d137fd7b0f3a65b12959b5fd97afc0578cd84ef27467cd",
+        "dest":  "nuget-sources",
+        "dest-filename":  "system.security.principal.windows.5.0.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/tmds.dbus.protocol/0.20.0/tmds.dbus.protocol.0.20.0.nupkg",
+        "sha512":  "602cf251f034d41a4feef63f0d77c3005553f88abd5ba9cf941d0f731369aa1c0a8844e89686f7fd3a1ad8e02068b5c3b4dd3e719fdb40cb603b9ca3b0e22e8e",
+        "dest":  "nuget-sources",
+        "dest-filename":  "tmds.dbus.protocol.0.20.0.nupkg"
+    },
+    {
+        "type":  "file",
+        "url":  "https://api.nuget.org/v3-flatcontainer/zxing.net/0.16.10/zxing.net.0.16.10.nupkg",
+        "sha512":  "adf82d9edf981df544b2b7bfda59c81a8611f5ae9d53511fab9fac6f94a845452e59b7fed9d2b6cf84a409fc31509e8e14d78f39c8b8777a0a16cdb551b70dbd",
+        "dest":  "nuget-sources",
+        "dest-filename":  "zxing.net.0.16.10.nupkg"
+    }
+]


### PR DESCRIPTION
TrayAuth is a TOTP authenticator that lives in the system tray: the tray menu lists every
account with its live code, and clicking one copies it. Codes follow RFC 4226/6238 and are
verified against the published RFC test vectors for SHA1, SHA256 and SHA512.

- Source: https://github.com/KlowdfurrRad/TrayAuth
- License: MIT
- The app makes no network connections of any kind - no account, no sync, no telemetry.

### Notes for reviewers

**Two bundled modules.** The app shells out to `wl-copy` and `secret-tool`, and host binaries
are not visible from inside the sandbox, so both are built as modules:

- `wl-clipboard` - on Wayland a background app cannot take the clipboard through the toolkit;
  only the data-control protocol allows it, which is what `wl-copy` uses. The tray menu's
  copy-a-code action depends on this, so `--socket=wayland` is requested for that reason
  alone (the UI itself is X11/XWayland via Avalonia).
- `libsecret` - provides `secret-tool`, used to keep the vault's AES key in the keyring via
  `--talk-name=org.freedesktop.secrets` rather than in a file.

**No filesystem permissions are requested.** Import and export both go through the file chooser
portal, and the vault lives in the app's own config directory.

**`--talk-name=org.kde.StatusNotifierWatcher`** is the tray icon itself, which is the app's
primary interface.

**Start-on-login is hidden inside Flatpak.** The sandbox blocks `~/.config/autostart`, so
rather than offer a switch that silently does nothing, the menu item is omitted when
`/.flatpak-info` exists. The Background portal is the intended fix later.

**Offline build.** `nuget-sources.json` pins all 34 NuGet packages with SHA-512. The .NET
`RuntimeFrameworkVersion` is pinned in the project file so the resolved package closure cannot
drift from what the dotnet8 SDK extension requests at build time.

Screenshots are taken from throwaway demo accounts, not a real vault.
