### PR TITLE
Add mx.unam.fciencias.aztlan.GTrophies

### DIFF
--- a/mx.unam.fciencias.aztlan.GTrophies.json
+++ b/mx.unam.fciencias.aztlan.GTrophies.json
@@ -1,0 +1,28 @@
+{
+    "app-id": "mx.unam.fciencias.aztlan.GTrophies",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "gtrophies",
+    "finish-args": [
+        "--device=dri",
+        "--socket=fallback-x11",
+        "--socket=wayland",
+        "--share=ipc",
+        "--share=network"
+    ],
+    "modules": [
+        {
+            "name": "gtrophies",
+            "buildsystem": "meson",
+            "sources" : [
+                {
+                    "type": "git",
+                    "url": "https://aztlan.fciencias.unam.mx/gitlab/canek/gtrophies.git",
+                    "commit": "a655168915567b201001bbabf3a8eb0a2f6aaf8b",
+                    "tag": "1"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [X] Please describe the application briefly.
        GTrophies is a GNOME application to retrieve, store and consult trophies achieved in games for the PlayStation family of gaming devices using accounts in the PlayStation Network.
- [X] Please attach a video showcasing the application on Linux using the Flatpak.
        https://github.com/user-attachments/assets/8b7941f3-5f3e-4bbe-b55c-12007c6a3077
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. I need help with this, I will elaborate more below.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am the author of the project.

### About the Application ID

I'm a professor at [UNAM](https://www.unam.mx/), a University in Mexico (with domain `unam.mx`). Obviously I'm not the owner of the `unam.mx` domain; however, I'm the owner (or, more precisely, I'm in charge) of a sub-sub-domain: [Aztlan in the Faculty of Sciences](https://aztlan.fciencias.unam.mx/~canek/) (`aztlan.fciencias.unam.mx`). This is my personal server as a professor at UNAM, I even host a [GitLab instance](https://aztlan.fciencias.unam.mx/gitlab/) on it. The Git repository for GTrophies [it's at this instance](https://aztlan.fciencias.unam.mx/gitlab/canek/gtrophies).

I tried to use the [website verification](https://aztlan.fciencias.unam.mx/.well-known/org.flathub.VerifiedApps.txt), but it didn't work, or at least `flatpak-builder-lint` was not happy about it:

```json
{
    "errors": [
        "appid-url-not-reachable"
    ],
    "info": [
        "appid-url-not-reachable: Tried https://unam.mx | Request exception: SSLError | Message: HTTPSConnectionPool(host='unam.mx', port=443): Max retries exceeded with url: / (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1032)')))"
    ],
    "message": "See https://docs.flathub.org/linter for details and exceptions"
}
```

So, I would like to ask for help in what is the appropriate procedure going forward.

If you could manually verify that I'm in charge of `aztlan.fciencias.unam.mx`, please just tell me what should I put in my server and in which path, and I shall do it.

If that's not possible, I could try changing my application id to be associated to my GitHub account; but I would **_really_** prefer to use my own domain.

**UPDATE**: Originally I didn't crossed the checkmark, since `flatpak-builder-lint` gave me the above error. However, the automatic bot added the `pr-check-blocked` label, so I checked to unblock it. I don't know if this is the correct action.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
