### PR TITLE
Add io.github.tsteppy.FingerprintSetup

### DIFF
--- a/io.github.tsteppy.FingerprintSetup.json
+++ b/io.github.tsteppy.FingerprintSetup.json
@@ -1,0 +1,37 @@
+{
+    "app-id": "io.github.tsteppy.FingerprintSetup",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "fingerprint-setup",
+    "finish-args": [
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--device=dri",
+        "--system-talk-name=net.reactivated.Fprint"
+    ],
+    "modules": [
+        {
+            "name": "fingerprint-setup",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 fingerprint-setup /app/bin/fingerprint-setup",
+                "mkdir -p /app/lib",
+                "cp -r src/fingerprint_setup /app/lib/fingerprint_setup",
+                "install -Dm644 data/io.github.tsteppy.FingerprintSetup.desktop /app/share/applications/io.github.tsteppy.FingerprintSetup.desktop",
+                "install -Dm644 data/io.github.tsteppy.FingerprintSetup.metainfo.xml /app/share/metainfo/io.github.tsteppy.FingerprintSetup.metainfo.xml",
+                "install -Dm644 LICENSE /app/share/licenses/io.github.tsteppy.FingerprintSetup/LICENSE",
+                "install -Dm644 data/icons/io.github.tsteppy.FingerprintSetup.svg /app/share/icons/hicolor/scalable/apps/io.github.tsteppy.FingerprintSetup.svg"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/tsteppy/fingerprintsetup.git",
+                    "tag": "v0.1.0",
+                    "commit": "1d3dc683e83a5a6c94ccb54aab4fea62ce1c8112"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
**Fingerprint Setup** — enrol fingerprints on Linux that actually work, and find out whether they do.

Source: https://github.com/tsteppy/fingerprintsetup (GPL-3.0-or-later)

### What it does

Laptop fingerprint readers image a small patch of a finger — often around 5x4mm — so a press only matches if it lands on skin the enrolment covered. Enrolling every press the same way is the usual reason fingerprint login feels unreliable, and neither `fprintd-enroll` nor GNOME Settings gives any positional guidance.

On the reader that motivated this, eight presses at one position measured a **60% false-reject rate**; the same eight spread deliberately across the fingertip measured **10%**.

So the app does two things nothing else on Linux does:

- **Coaches each enrolment press to a different part of the fingertip**, showing progress on a coverage map.
- **Tests the enrolment afterwards** — ten verifications, six natural and four deliberately offset — and reports how it actually performs, so the user knows before they rely on it.

It also provides a fingerprint manager for desktops that ship none (Cinnamon, XFCE, MATE).

It talks to **fprintd**, so it works with any supported reader rather than one specific device.

### Notes for reviewers

- **It never writes PAM configuration.** It reports status and shows the correct command for the detected distribution for the user to run themselves in a terminal. There is no `subprocess`, no shell-out, and no write-mode file access anywhere in the source.
- Because Flathub does not permit `host-etc` access, the sandboxed build cannot read the host's PAM stack, so it reports the on/off state as *unknown* rather than claiming a state it did not verify. The distribution is still detected from `/run/host/os-release`, so the right command is still offered.
- The coverage map is labelled "Positions completed" — fprintd never reports where a press physically landed, so the app deliberately does not imply it measured anything.
- Permissions requested are `--system-talk-name=net.reactivated.Fprint` (without it the app cannot see the reader) plus the standard GTK socket/ipc/dri set. Nothing else.
- `flatpak-builder-lint manifest` reports no findings. `repo` reports only the two screenshot-mirroring items, which I understand are resolved by Flathub's own build.
- 54 tests, none of which require a fingerprint reader; the whole UI also runs against an in-memory device via `--simulate`.

Built and run locally on the GNOME 50 runtime against real hardware (an EgisTec EH576).