### PR TITLE
Add io.github.baakhoff.BiD

### DIFF
--- a/io.github.baakhoff.BiD.metainfo.xml
+++ b/io.github.baakhoff.BiD.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.baakhoff.BiD</id>
+  <name>BiD</name>
+  <summary>Mixer for Audient iD audio interfaces</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <description>
+    <p>
+      Unofficial control panel and mixer for the Audient iD series USB audio
+      interfaces on Linux: mixes and cues, routing, loopback, VU meters and
+      the full monitor section, over the interface's spare USB port so audio
+      keeps playing while the mixer is open.
+    </p>
+    <p>
+      Verified on the iD24; the iD4, iD14, iD22, iD44 and iD48 are inherited
+      from the device list and welcome testing. The host needs a one-line
+      udev rule for USB access, described in the project README.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.baakhoff.BiD.desktop</launchable>
+  <url type="homepage">https://github.com/baakhoff/BiD</url>
+  <url type="bugtracker">https://github.com/baakhoff/BiD/issues</url>
+  <developer id="io.github.baakhoff">
+    <name>baakhoff</name>
+  </developer>
+  <categories>
+    <category>Audio</category>
+    <category>Mixer</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.2.2" date="2026-07-31"/>
+  </releases>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/baakhoff/BiD/master/Desktop/screenshot.png</image>
+      <caption>The mixer: strips with meters, the mix tabs, and the monitor section</caption>
+    </screenshot>
+  </screenshots>
+</component>

--- a/io.github.baakhoff.BiD.yml
+++ b/io.github.baakhoff.BiD.yml
@@ -1,0 +1,52 @@
+app-id: io.github.baakhoff.BiD
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: BiD
+rename-desktop-file: bid.desktop
+rename-icon: bid
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  # raw USB access for the control interface; the host still needs the
+  # udev rule from the README so the device node is writable
+  - --device=all
+  # the StatusNotifier tray
+  - --talk-name=org.kde.StatusNotifierWatcher
+modules:
+  - name: glfw
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DBUILD_SHARED_LIBS=ON
+      - -DGLFW_BUILD_EXAMPLES=OFF
+      - -DGLFW_BUILD_TESTS=OFF
+      - -DGLFW_BUILD_DOCS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/glfw/glfw/releases/download/3.4/glfw-3.4.zip
+        sha256: b5ec004b2712fd08e8861dc271428f048775200a2df719ccf575143ba749a3e9
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+
+  - name: bid
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      # imgui arrives as a declared source: no network during the build
+      - -DFETCHCONTENT_SOURCE_DIR_IMGUI_EXTERNAL=/run/build/bid/imgui
+    post-install:
+      - install -Dm644 ../io.github.baakhoff.BiD.metainfo.xml
+        /app/share/metainfo/io.github.baakhoff.BiD.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/baakhoff/BiD/archive/refs/tags/v0.2.2.tar.gz
+        sha256: 2c404d252d7cd682b71f925531ba1d17fc2e4fe6fc285a3c95fab5a7b8b1d652
+      - type: archive
+        url: https://github.com/ocornut/imgui/archive/refs/tags/v1.92.4.tar.gz
+        sha256: 0e175d4d941112532549b418ced0bd546abe9024ecb9b5f431f8a67a2197b0ba
+        dest: imgui
+      - type: file
+        path: io.github.baakhoff.BiD.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. BiD is an unofficial mixer and control panel for Audient iD USB audio interfaces on Linux: mixes and cues, routing, loopback, VU meters and the full monitor section, talking over the interface's spare USB port so audio keeps playing while the mixer is open.
- [X] Please attach a video showcasing the application on Linux using the Flatpak. https://github.com/baakhoff/BiD/raw/master/Desktop/demo.webm — recorded on KDE Plasma/Wayland from the native build: this machine has no flatpak tooling, so the manifest's first build is this PR's CI. Happy to re-record from the Flatpak after a successful bot build if wanted.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author of the project.

### Notes for reviewers

- Upstream: https://github.com/baakhoff/BiD (MIT); I maintain both the app and this packaging.
- The build is offline-clean: imgui is a declared source handed to CMake's FetchContent, glfw builds as a module against the 24.08 runtime.
- USB note: the control interface needs a one-line udev rule on the host (documented in the README and surfaced by the app's connect dialog). The app runs and shows its full UI without it; only the hardware connection needs the rule.
- Tray icon via StatusNotifier (`--talk-name=org.kde.StatusNotifierWatcher`); without a tray the app simply quits on close.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission