### PR TITLE
Add com.jeremyperson.LlamaAmp

### DIFF
--- a/com.jeremyperson.LlamaAmp.yml
+++ b/com.jeremyperson.LlamaAmp.yml
@@ -1,0 +1,59 @@
+app-id: com.jeremyperson.LlamaAmp
+runtime: org.gnome.Platform
+runtime-version: '48'
+sdk: org.gnome.Sdk
+command: llama-amp
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  # Internet radio streams + ListenBrainz scrobbling
+  - --share=network
+  # ALSA direct output mode needs raw audio device access
+  - --device=all
+  # Music libraries: user music dir plus common external-drive mount points
+  - --filesystem=xdg-music
+  - --filesystem=/media:ro
+  - --filesystem=/mnt:ro
+  # MPRIS media keys / lock-screen controls
+  - --own-name=org.mpris.MediaPlayer2.llamaamp
+  # Track-change notifications and the tray icon
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+modules:
+  - name: fonts
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 DSEG7-Classic/DSEG7Classic-Regular.ttf /app/share/fonts/DSEG7Classic-Regular.ttf
+      - install -Dm644 DSEG7-Classic/DSEG7Classic-Bold.ttf /app/share/fonts/DSEG7Classic-Bold.ttf
+      - install -Dm644 DSEG-LICENSE.txt /app/share/doc/llama-amp/DSEG-LICENSE.txt
+      - install -Dm644 'Orbitron[wght].ttf' '/app/share/fonts/Orbitron[wght].ttf'
+      - install -Dm644 OFL.txt /app/share/doc/llama-amp/Orbitron-OFL.txt
+    sources:
+      - type: archive
+        url: https://github.com/keshikan/DSEG/releases/download/v0.46/fonts-DSEG_v046.zip
+        sha256: a6c2f43520971ca8067262e78d49025e605f749bf716ec5394bad9a0ee1c238c
+      - type: file
+        url: https://github.com/google/fonts/raw/8b0a1d0f5983c89bc2b93f1b5fb55f9e252744b5/ofl/orbitron/Orbitron%5Bwght%5D.ttf
+        sha256: f42db2dd16e642258e35782916eceb1dcdbea06fb958d77ad71dc5963587e8fd
+        dest-filename: Orbitron[wght].ttf
+      - type: file
+        url: https://raw.githubusercontent.com/google/fonts/8b0a1d0f5983c89bc2b93f1b5fb55f9e252744b5/ofl/orbitron/OFL.txt
+        sha256: ab609b0e110d622435ff337cdf233288556e011bbf9bd0550be98846c0630819
+  - name: llama-amp
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 musicPlayer.py /app/share/llama-amp/musicPlayer.py
+      # Beside the script (tray/notification/placeholder lookups) and in
+      # hicolor under the app-id (shell/app grid)
+      - install -Dm644 llama-amp.svg /app/share/llama-amp/llama-amp.svg
+      - install -Dm644 llama-amp.svg /app/share/icons/hicolor/scalable/apps/com.jeremyperson.LlamaAmp.svg
+      - install -Dm755 packaging/flatpak/llama-amp.sh /app/bin/llama-amp
+      - install -Dm644 packaging/flatpak/com.jeremyperson.LlamaAmp.desktop /app/share/applications/com.jeremyperson.LlamaAmp.desktop
+      - install -Dm644 packaging/flatpak/com.jeremyperson.LlamaAmp.metainfo.xml /app/share/metainfo/com.jeremyperson.LlamaAmp.metainfo.xml
+    sources:
+      - type: git
+        url: https://github.com/jeremyperson/llama-amp.git
+        tag: v1.4
+        commit: dbd7fba985bead73db425bf19581b53d0c72a734


### PR DESCRIPTION
### Llama Amp

A Winamp-inspired music player for Linux with a modern flat theme. Single-file Python/GTK3/GStreamer app: gapless playback, ReplayGain, 10-band EQ with a live spectrum analyzer, internet radio (SHOUTcast/Icecast), MPRIS2, ListenBrainz scrobbling, and a bit-perfect ALSA direct-output mode.

- **Upstream**: https://github.com/jeremyperson/llama-amp (MIT)
- **I am the upstream author** and will maintain the Flathub package.
- Builds from the pinned `v1.4` tag; bundled fonts (DSEG7 Classic, Orbitron — both SIL OFL 1.1) come from pinned, checksummed sources.
- AppStream metainfo, desktop entry, and icon are installed from upstream (`packaging/flatpak/`); `appstreamcli validate` passes.

### Permissions rationale

- `--share=network` — internet radio streaming and optional ListenBrainz scrobbling
- `--device=all` — the optional "ALSA direct output" mode opens raw `hw:` devices for bit-perfect playback, bypassing PulseAudio; the default output path uses the pulseaudio socket
- `--filesystem=xdg-music`, `/media:ro`, `/mnt:ro` — music libraries commonly live in the music dir or on mounted drives
- `--own-name=org.mpris.MediaPlayer2.llamaamp` — MPRIS2 media keys / lock-screen controls
- `--talk-name=org.freedesktop.Notifications` / `org.kde.StatusNotifierWatcher` — track-change notifications and the tray icon
- Note: the app's update checker detects Flatpak and disables itself entirely — updates are store-managed.

### Checklist

- [x] I have read the [App Requirements](https://docs.flathub.org/docs/for-app-authors/requirements) and [Submission guides](https://docs.flathub.org/docs/for-app-authors/submission)
- [x] The app builds from pinned sources (git tag + commit; archives with sha256)
- [x] The app ID matches the upstream domain ownership convention (io/com.github pattern not required; I control the repository and the app is published under my name)
- [x] License is MIT; bundled fonts are SIL OFL 1.1 with licenses installed
- [x] MetaInfo validates with `appstreamcli validate`