### PR TITLE
Add io.github.yarden2012.pkgfind

### DIFF
--- a/io.github.yarden2012.pkgfind.desktop
+++ b/io.github.yarden2012.pkgfind.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=pkgfind
+GenericName=Package Search
+Comment=Search Flatpak, Fedora RPM, Homebrew and distrobox containers at once
+Exec=pkgfind
+Icon=io.github.yarden2012.pkgfind
+Terminal=false
+Categories=System;PackageManager;
+Keywords=package;install;software;flatpak;rpm;ostree;brew;homebrew;distrobox;search;
+StartupNotify=true

--- a/io.github.yarden2012.pkgfind.metainfo.xml
+++ b/io.github.yarden2012.pkgfind.metainfo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.yarden2012.pkgfind</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <name>pkgfind</name>
+  <summary>Search every package source at once</summary>
+
+  <developer id="io.github.yarden2012">
+    <name>yarden2012</name>
+  </developer>
+
+  <description>
+    <p>
+      pkgfind puts one search box over every place an app can come from, then
+      shows a single ranked list that tells you where each result lives and
+      whether it is already installed. Instead of checking a store, then a
+      separate search for each package manager, you type once.
+    </p>
+    <p>It searches, and installs straight from the results:</p>
+    <ul>
+      <li>Flatpak remotes such as Flathub</li>
+      <li>Fedora RPM packages through rpm-ostree, or dnf on traditional systems</li>
+      <li>Homebrew</li>
+      <li>The package manager inside each distrobox container</li>
+    </ul>
+    <p>
+      It was built first for atomic Fedora systems such as Bazzite, Silverblue
+      and Kinoite, and also runs on ordinary Linux distributions. Every source
+      selects itself: only the ones whose tool is actually present are searched.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.github.yarden2012.pkgfind.desktop</launchable>
+
+  <url type="homepage">https://github.com/yarden2012/rolo/tree/main/pkgfind</url>
+  <url type="bugtracker">https://github.com/yarden2012/rolo/issues</url>
+  <url type="vcs-browser">https://github.com/yarden2012/rolo</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/yarden2012/rolo/main/flathub/screenshot-1.png</image>
+      <caption>A single ranked list of results across every package source</caption>
+    </screenshot>
+  </screenshots>
+
+  <categories>
+    <category>System</category>
+    <category>PackageManager</category>
+  </categories>
+
+  <keywords>
+    <keyword>package</keyword>
+    <keyword>install</keyword>
+    <keyword>software</keyword>
+    <keyword>flatpak</keyword>
+    <keyword>rpm</keyword>
+    <keyword>homebrew</keyword>
+  </keywords>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="0.5.2" date="2026-08-03">
+      <description>
+        <p>Broader package-manager support and a range of fixes.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.github.yarden2012.pkgfind.svg
+++ b/io.github.yarden2012.pkgfind.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#3584e4"/>
+  <g fill="none" stroke="#ffffff" stroke-width="8" stroke-linecap="round">
+    <circle cx="55" cy="55" r="27"/>
+    <path d="M75.5 75.5 L100 100"/>
+  </g>
+  <g fill="#ffffff" opacity="0.95">
+    <path d="M55 40 L69 48 L55 56 L41 48 Z"/>
+    <path d="M40 50.5 L53.5 58.2 L53.5 72 L40 64.3 Z" opacity="0.75"/>
+    <path d="M70 50.5 L56.5 58.2 L56.5 72 L70 64.3 Z" opacity="0.55"/>
+  </g>
+</svg>

--- a/io.github.yarden2012.pkgfind.yaml
+++ b/io.github.yarden2012.pkgfind.yaml
@@ -1,0 +1,50 @@
+# Flathub manifest for pkgfind.
+#
+# The application code is pulled from the pkgfind-v0.5.2 release tarball; the
+# desktop file, metainfo and icon (which carry the Flathub-style app id) are
+# provided alongside this manifest. The app id in the source is rewritten at
+# build time so nothing in the upstream repo has to change.
+app-id: io.github.yarden2012.pkgfind
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: pkgfind
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # pkgfind drives the host's package managers through the portal. This is a
+  # broad permission and the main thing Flathub review will scrutinise.
+  - --talk-name=org.freedesktop.Flatpak
+
+modules:
+  - name: pkgfind
+    buildsystem: simple
+    build-commands:
+      # App code, from the release tarball.
+      - install -Dm644 -t /app/lib/pkgfind
+        pkgfind/pkgfind.py pkgfind/app.py pkgfind/backends.py
+      # Match the GtkApplication id to the Flathub app id so the window
+      # associates with the desktop entry and icon.
+      - sed -i 's/dev\.rolo\.pkgfind/io.github.yarden2012.pkgfind/' /app/lib/pkgfind/app.py
+      - install -Dm755 pkgfind/flatpak/pkgfind-launcher /app/bin/pkgfind
+      # Desktop entry, metainfo and icon carrying the Flathub app id.
+      - install -Dm644 io.github.yarden2012.pkgfind.desktop
+        /app/share/applications/io.github.yarden2012.pkgfind.desktop
+      - install -Dm644 io.github.yarden2012.pkgfind.metainfo.xml
+        /app/share/metainfo/io.github.yarden2012.pkgfind.metainfo.xml
+      - install -Dm644 io.github.yarden2012.pkgfind.svg
+        /app/share/icons/hicolor/scalable/apps/io.github.yarden2012.pkgfind.svg
+    sources:
+      - type: archive
+        url: https://github.com/yarden2012/rolo/archive/refs/tags/pkgfind-v0.5.2.tar.gz
+        sha256: e595554d898b05ca393a06a304b4db40b78f51a2c8f27620230918515f5647a2
+        strip-components: 1
+      - type: file
+        path: io.github.yarden2012.pkgfind.desktop
+      - type: file
+        path: io.github.yarden2012.pkgfind.metainfo.xml
+      - type: file
+        path: io.github.yarden2012.pkgfind.svg


### PR DESCRIPTION
Submitting **pkgfind**, a GTK4/libadwaita app that puts one search box over every package source on the system (Flatpak, Fedora RPM via rpm-ostree/dnf, Homebrew, and distrobox containers) and installs straight from the results.

- App ID: `io.github.yarden2012.pkgfind`
- License: MIT
- Source: https://github.com/yarden2012/rolo/tree/main/pkgfind

Note for reviewers: the app drives the host package managers through `--talk-name=org.freedesktop.Flatpak`. Happy to discuss the permission model.