### PR TITLE
Add org.stratumauth.Desktop

### DIFF
--- a/org.stratumauth.Desktop/flathub.json
+++ b/org.stratumauth.Desktop/flathub.json
@@ -1,0 +1,4 @@
+{
+  "name": "Stratum",
+  "keep-upstream-to-date": true
+}

--- a/org.stratumauth.Desktop/org.stratumauth.Desktop.yaml
+++ b/org.stratumauth.Desktop/org.stratumauth.Desktop.yaml
@@ -1,0 +1,27 @@
+app-id: org.stratumauth.Desktop
+runtime: org.freedesktop.Platform//24.08
+sdk: org.freedesktop.Sdk//24.08
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet10
+command: stratum
+rename-icon: org.stratumauth.Desktop
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-data
+  - --talk-name=org.freedesktop.secrets
+modules:
+  - name: stratum
+    buildsystem: simple
+    build-commands:
+      - bash packaging/flathub/build.sh
+    sources:
+      - type: git
+        url: https://github.com/cyf112233/stratum_desktop.git
+        tag: v1.0.0
+      - type: archive
+        url: https://github.com/cyf112233/stratum_desktop/releases/download/v1.0.0/nuget-offline.tar.gz
+        sha256: 5db2f626af28a84d024964c3fea9d39137e88ac6e1df0f68ec77e33ade265c3e
+        dest: nuget-offline


### PR DESCRIPTION
Add **Stratum** — a cross-platform two-factor authentication desktop client (TOTP/HOTP/Steam/mOTP/Yandex), built with Avalonia, GPL-3.0.

- Source: https://github.com/cyf112233/stratum_desktop
- Offline NuGet bundle is fetched from the v1.0.0 GitHub Release (`nuget-offline.tar.gz`), the build runs fully offline.
- Verified locally: `flatpak-builder` offline build succeeds (x86_64), app launches, database uses SQLCipher with key in the OS keyring.
