### PR TITLE
Add org.stratumauth.Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Stratum
+
+Cross-platform two-factor authentication desktop client (TOTP/HOTP/Steam/mOTP/Yandex), built with Avalonia, GPL-3.0.
+
+- Source: https://github.com/cyf112233/stratum_desktop
+- The build runs fully offline: NuGet packages come from `nuget-offline.tar.gz` in the v1.0.0 GitHub Release.

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "name": "Stratum",
+  "keep-upstream-to-date": true
+}

--- a/org.stratumauth.Desktop.metainfo.xml
+++ b/org.stratumauth.Desktop.metainfo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.stratumauth.Desktop</id>
+  <name>Stratum</name>
+  <summary>Two-factor authenticator</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <description>
+    <p>Cross-platform two-factor authentication desktop client.</p>
+    <p>Supports TOTP/HOTP/Steam/mOTP/Yandex codes, encrypted backups, categories, icon packs, QR code import and importing from 16 other authenticator apps.</p>
+  </description>
+  <launchable type="desktop-id">org.stratumauth.Desktop.desktop</launchable>
+  <url type="homepage">https://github.com/cyf112233/stratum_desktop</url>
+  <url type="bugtracker">https://github.com/cyf112233/stratum_desktop/issues</url>
+  <releases>
+    <release version="1.0.0" date="2026-08-04"/>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-torture">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-blood">none</content_attribute>
+    <content_attribute id="violence-blood-discoloration">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="weapons">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-graphic">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="language-strong">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+    <content_attribute id="game-simulation">none</content_attribute>
+    <content_attribute id="game-gambling">none</content_attribute>
+    <content_attribute id="game-racing">none</content_attribute>
+    <content_attribute id="game-fighting">none</content_attribute>
+  </content_rating>
+</component>

--- a/org.stratumauth.Desktop.yml
+++ b/org.stratumauth.Desktop.yml
@@ -1,0 +1,27 @@
+app-id: org.stratumauth.Desktop
+runtime: org.freedesktop.Platform//24.08
+sdk: org.freedesktop.Sdk//24.08
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.dotnet10
+command: stratum
+rename-icon: org.stratumauth.Desktop
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=xdg-data
+  - --talk-name=org.freedesktop.secrets
+modules:
+  - name: stratum
+    buildsystem: simple
+    build-commands:
+      - bash packaging/flathub/build.sh
+    sources:
+      - type: git
+        url: https://github.com/cyf112233/stratum_desktop.git
+        tag: v1.0.0
+      - type: archive
+        url: https://github.com/cyf112233/stratum_desktop/releases/download/v1.0.0/nuget-offline.tar.gz
+        sha256: 5db2f626af28a84d024964c3fea9d39137e88ac6e1df0f68ec77e33ade265c3e
+        dest: nuget-offline


### PR DESCRIPTION
Add **Stratum** — a cross-platform two-factor authentication desktop client (TOTP/HOTP/Steam/mOTP/Yandex), built with Avalonia, GPL-3.0.

- Source: https://github.com/cyf112233/stratum_desktop
- Offline NuGet bundle is fetched from the v1.0.0 GitHub Release (`nuget-offline.tar.gz`), the build runs fully offline.
- Verified locally: `flatpak-builder` offline build succeeds (x86_64), app launches, database uses SQLCipher with key in the OS keyring.
