### PR TITLE
Add software.sevensummits.screensavor

### DIFF
--- a/software.sevensummits.screensavor.yml
+++ b/software.sevensummits.screensavor.yml
@@ -1,0 +1,19 @@
+app-id: software.sevensummits.screensavor
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: software.sevensummits.screensavor
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --talk-name=org.gnome.Mutter.IdleMonitor
+modules:
+  - name: screensavers
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/7summits-ryan/screen-savor.git
+        tag: v0.1.0
+        commit: 6ee8f3747399c970c4fe8f15cd34a6c37c803be3


### PR DESCRIPTION
## New Submission: Screen Savor

**App ID:** `software.sevensummits.screensavor`

### Description
Screen Savor is a fun, lightweight screensaver application for GNOME desktops built with GTK4 and Libadwaita.

### Features
- **Multiple Screensavers**: DVD Logo, Matrix Rain, and Color Pulse visualizers
- **Idle Detection**: Automatically activates after a configurable idle timeout via GNOME's IdleMonitor (D-Bus)
- **Settings UI**: Configure idle timeout, enable/disable the daemon, and pick a default screensaver
- **Wayland Native**: Built for modern GNOME desktops

### Source Repository
https://github.com/7summits-ryan/screen-savor

### License
GPL-3.0-or-later

### Checklist
- [x] App ID matches a domain I own (`7summits.software`)
- [x] AppStream metainfo is included
- [x] Desktop file is included
- [x] App icon is included (256x256 PNG)
- [x] Source is publicly hosted on GitHub
- [x] Manifest uses a pinned git tag and commit hash
- [x] License file (COPYING) is included in the repository