### PR TITLE
Add software._7summits.ScreenSavor

### DIFF
--- a/software._7summits.ScreenSavor.yml
+++ b/software._7summits.ScreenSavor.yml
@@ -1,0 +1,25 @@
+id: software._7summits.ScreenSavor
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: software._7summits.ScreenSavor
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  # Idle detection. GNOME implements neither ext-idle-notify-v1 nor
+  # org.freedesktop.ScreenSaver.GetSessionIdleTime (it returns NotSupported), and the
+  # Inhibit portal only reports the session screensaver, not a configurable timeout.
+  - --talk-name=org.gnome.Mutter.IdleMonitor
+modules:
+  - name: screen-savor
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/7summits-ryan/screen-savor.git
+        tag: v0.1.1
+        commit: cc9f3e341447e662a45fe1ba5c8c48d8b04026bc
+        x-checker-data:
+          type: git
+          tag-pattern: '^v([\d.]+)$'


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [X] Please describe the application briefly. Screen Savor is a lightweight screensaver application for GNOME desktops, built with GTK4 and Libadwaita. It ships three full-screen visualizers — DVD Logo, Matrix Rain and Color Pulse — which can be launched on demand or started automatically after a configurable period of inactivity. Source: https://github.com/7summits-ryan/screen-savor
- [X] Please attach a video showcasing the application on Linux using the Flatpak.

  https://github.com/user-attachments/assets/e07ce754-04ef-481f-9424-1e64d3614ff3

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author to the project.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

---

A note on the one non-obvious permission, `--talk-name=org.gnome.Mutter.IdleMonitor`:

The app needs to know when the session has been idle for a user-configurable interval. On GNOME that is the only interface that provides it:

- `ext-idle-notify-v1` would need no extra permission at all, but Mutter does not implement it (`libmutter` exports only `zwp_idle_inhibit_manager_v1` / `zwp_idle_inhibitor_v1`).
- `org.freedesktop.ScreenSaver.GetSessionIdleTime` introspects on the session bus but returns `org.freedesktop.DBus.Error.NotSupported`; on GNOME that name is only an inhibit proxy.
- `org.freedesktop.portal.Inhibit.CreateMonitor` needs no sandbox hole, but `StateChanged` only reports the session screensaver becoming active, not an arbitrary timeout.

Happy to switch if there is a preferred approach I have missed.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
