### PR TITLE
Add com.github.andreascape.ciak

### DIFF
--- a/com.github.andreascape.ciak.json
+++ b/com.github.andreascape.ciak.json
@@ -1,0 +1,97 @@
+{
+  "app-id": "com.github.andreascape.ciak",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
+  "command": "ciak",
+  "finish-args": [
+    "--share=network",
+    "--socket=wayland",
+    "--socket=fallback-x11",
+    "--share=ipc",
+    "--device=dri",
+    "--env=PYTHONPATH=/app/lib/python3.13/site-packages",
+    "--filesystem=xdg-run/dconf",
+    "--talk-name=ca.desrt.dconf"
+  ],
+  "modules": [
+    {
+      "name": "python3-pip-deps",
+      "buildsystem": "simple",
+      "build-commands": [
+        "pip3 install --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} httpx certifi h11 h2 hpack hyperframe sniffio priority anyio httpcore idna"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl",
+          "sha256": "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl",
+          "sha256": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl",
+          "sha256": "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/d0/9e/984486f2d0a0bd2b024bf4bc1c62688fcafa9e61991f041fb0e2def4a982/h2-4.2.0-py3-none-any.whl",
+          "sha256": "479a53ad425bb29af087f3458a61d30780bc818e4ebcf01f0b536ba916462ed0"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl",
+          "sha256": "157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl",
+          "sha256": "b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl",
+          "sha256": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/5e/5f/82c8074f7e84978129347c2c6ec8b6c59f3584ff1a20bc3c940a3e061790/priority-2.0.0-py3-none-any.whl",
+          "sha256": "6f8eefce5f3ad59baf2c080a664037bb4725cd0a790d53d59ab4059288faf6aa"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl",
+          "sha256": "b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl",
+          "sha256": "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
+        },
+        {
+          "type": "file",
+          "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+          "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+        }
+      ]
+    },
+    {
+      "name": "ciak",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dprofile=release"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/andrea-scape/ciak.git",
+          "tag": "v0.1.1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Please confirm your submission meets all the criteria

- [x] I have read the [App Requirements](https://github.com/flathub/flathub/wiki/App-Requirements) and [App Maintenance](https://github.com/flathub/flathub/wiki/App-Maintenance) docs.
- [x] This app is not already in the Flathub repository (or this is a submission to update the manifest).
- [x] The app is **open source** (GPL-3.0-or-later).
- [x] The app ID follows [reverse-DNS naming](https://github.com/flathub/flathub/wiki/App-Requirements#app-id).
- [x] The app uses **stable, publicly accessible releases** (git tag v0.1.1).

## About the app

Ciak is a movie and TV show tracker for Linux, built with GTK4 and libadwaita. It lets you keep a local watchlist, rate shows, and track your watched history. Metadata comes from TMDB. Everything stays on your computer in a local SQLite database.

## Technical details

- App ID: com.github.andreascape.ciak
- Runtime: org.gnome.Platform//50
- License: GPL-3.0-or-later
- Source: https://github.com/andrea-scape/ciak
- Homepage: https://github.com/andrea-scape/ciak