### PR TITLE
Add io.github.nglmercer.qpwgraph-rs

### DIFF
--- a/io.github.nglmercer.qpwgraph-rs.yml
+++ b/io.github.nglmercer.qpwgraph-rs.yml
@@ -1,0 +1,43 @@
+app-id: io.github.nglmercer.qpwgraph-rs
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.llvm18
+command: qpwgraph-rs
+finish-args:
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --socket=session-bus
+  - --talk-name=org.pipewire.Pulse
+  - --filesystem=xdg-config/qpwgraph-rs:create
+  - --share=ipc
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/pkgconfig
+  - /share/gir-1.0
+  - '*.a'
+  - /man
+modules:
+  - name: qpwgraph-rs
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin
+      env:
+        CARGO_HOME: /run/build/qpwgraph-rs/cargo
+        LIBCLANG_PATH: /usr/lib/sdk/llvm18/lib
+        BINDGEN_EXTRA_CLANG_ARGS: "-I/usr/include/x86_64-linux-gnu"
+    build-commands:
+      - cargo build --release --locked -p pw-graph-app --features pipewire
+      - install -Dm755 target/release/qpwgraph-rs /app/bin/qpwgraph-rs
+      - install -Dm644 io.github.nglmercer.qpwgraph-rs.desktop /app/share/applications/io.github.nglmercer.qpwgraph-rs.desktop
+      - install -Dm644 io.github.nglmercer.qpwgraph-rs.metainfo.xml /app/share/metainfo/io.github.nglmercer.qpwgraph-rs.metainfo.xml
+      - install -Dm644 io.github.nglmercer.qpwgraph-rs.svg /app/share/icons/hicolor/scalable/apps/io.github.nglmercer.qpwgraph-rs.svg
+    sources:
+      - type: git
+        url: https://github.com/nglmercer/qpwgraph-rs.git
+        commit: f07d2d3b1bccd1684417ef66e04cde2e50d85e26
+      - cargo-sources.json


### PR DESCRIPTION
## Description

Rust/egui patchbay for PipeWire, with optional ALSA Sequencer MIDI support.

## Checklist

- [x] App builds and runs locally with flatpak-builder
- [x] App ID follows reverse-DNS format: `io.github.nglmercer.qpwgraph-rs`
- [x] Runtime: `org.freedesktop.Platform` version `25.08`
- [x] SDK extensions: `rust-stable`, `llvm18`
- [x] Metainfo file included in source repository
- [x] Desktop file included in source repository
- [x] SVG icon included in source repository
- [x] Screenshots included in metainfo
- [x] Cargo sources generated for offline build

## Linter Notes

- `finish-args-arbitrary-dbus-access`: Session bus access is required for PipeWire integration
- `finish-args-unnecessary-xdg-config-qpwgraph-rs-create-access`: Config directory is needed for app settings (patchbay files, preferences)