### PR TITLE
Add io.github.fablefoundry.LinuxCommandGuide

### DIFF
--- a/io.github.fablefoundry.LinuxCommandGuide.yml
+++ b/io.github.fablefoundry.LinuxCommandGuide.yml
@@ -1,0 +1,26 @@
+app-id: io.github.fablefoundry.LinuxCommandGuide
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+command: LinuxCommandGuide
+
+finish-args:
+  # GUI only: no network access, no filesystem access beyond the app's own
+  # sandboxed config dir (favorites/theme/recents), which needs no extra
+  # permission to begin with.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+modules:
+  - name: linux-command-guide
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: git
+        url: https://github.com/fablefoundry/LinuxCommandGuide.git
+        tag: v2.0.1
+        commit: 47b2961daa21a04f1c907cd78eadec9f2259db18


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Linux Command Guide is a beginner-friendly Linux command reference and learning app (Qt6/C++). It covers 217 commands across Arch, Debian, Fedora, Linux Mint, Ubuntu, and universal commands that work everywhere, each with a full plain-English explanation, syntax breakdown, real-world examples, and complete flag/exit-code reference, plus a Getting Started section for beginners, a searchable glossary, and a side-by-side distro command comparison view.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. < TODO: to be added >
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an _(please keep whichever is applicable and remove the rest)_ author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:**

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
