### PR TITLE
Add io.github.gitgusilva.gitbox

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "only-arches": ["x86_64"],
+  "automerge-flathubbot-prs": true
+}

--- a/gitbox.sh
+++ b/gitbox.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Launcher installed as /app/bin/gitbox (the manifest's `command`).
+#
+# zypak-wrapper, from org.electronjs.Electron2.BaseApp, redirects Chromium's
+# sandbox onto the Flatpak sandbox — that is what replaces the --no-sandbox the
+# deb's desktop entry passes, without giving up sandboxing.
+#
+# --ozone-platform-hint=auto makes Electron pick Wayland when a compositor is
+# there and X11 otherwise, matching the --socket=wayland/--socket=fallback-x11
+# pair in the manifest.
+exec zypak-wrapper /app/gitbox/gitbox --ozone-platform-hint=auto "$@"

--- a/io.github.gitgusilva.gitbox.desktop
+++ b/io.github.gitgusilva.gitbox.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Type=Application
+Name=GitBox
+GenericName=Git Client
+Comment=Browse history, stage changes and manage branches in your Git repositories
+Comment[pt_BR]=Navegue pelo histórico, prepare mudanças e gerencie branches nos seus repositórios Git
+Comment[es]=Explora el historial, prepara cambios y gestiona ramas en tus repositorios Git
+Exec=gitbox %U
+Icon=io.github.gitgusilva.gitbox
+Terminal=false
+Categories=Development;RevisionControl;
+Keywords=git;vcs;version control;commit;branch;merge;diff;repository;
+Keywords[pt_BR]=git;vcs;controle de versão;commit;branch;merge;diff;repositório;
+MimeType=x-scheme-handler/gitbox;
+# Electron reports the productName as the X11 class; without this the running
+# window is not matched to this entry (no icon in the dash, duplicate entries).
+StartupWMClass=GitBox
+StartupNotify=true

--- a/io.github.gitgusilva.gitbox.metainfo.xml
+++ b/io.github.gitgusilva.gitbox.metainfo.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- AppStream metadata: what the software centres (GNOME Software, KDE
+     Discover, the Flathub website) show for GitBox. Validate any edit with
+     appstreamcli validate before committing. -->
+<component type="desktop-application">
+  <id>io.github.gitgusilva.gitbox</id>
+
+  <name>GitBox</name>
+  <summary>Fast, self-contained Git client</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-3.0-or-later</project_license>
+
+  <developer id="io.github.gitgusilva">
+    <name>Gustavo Will</name>
+  </developer>
+
+  <launchable type="desktop-id">io.github.gitgusilva.gitbox.desktop</launchable>
+
+  <description>
+    <p>
+      GitBox is a desktop Git client that talks to repositories through a native
+      libgit2 addon instead of shelling out to a git binary — cloning, fetching,
+      pulling and pushing over HTTPS and SSH all work without git installed.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Commit history with a branch graph, multi-branch filtering and Monaco-powered diffs</li>
+      <li>Several repositories open at once as tabs, grouped into colour-coded projects</li>
+      <li>An integrated terminal for the times a command is faster than a click</li>
+      <li>Side-by-side merge conflict resolution in a window of its own</li>
+      <li>Per-host credentials in an encrypted store, plus pull requests and repository statistics</li>
+      <li>Themes built on design tokens, with an in-app editor and a community theme registry</li>
+      <li>English, Brazilian Portuguese and Spanish interfaces</li>
+    </ul>
+  </description>
+
+  <content_rating type="oars-1.1" />
+
+  <url type="homepage">https://gitgusilva.github.io/gitbox/</url>
+  <url type="bugtracker">https://github.com/gitgusilva/gitbox/issues</url>
+  <url type="vcs-browser">https://github.com/gitgusilva/gitbox</url>
+  <url type="contribute">https://github.com/gitgusilva/gitbox/blob/main/CONTRIBUTING.md</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://gitgusilva.github.io/gitbox/screenshots/history.png</image>
+      <caption>Commit history with the branch graph and a file diff</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gitgusilva.github.io/gitbox/screenshots/changes.png</image>
+      <caption>Staging individual hunks before committing</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gitgusilva.github.io/gitbox/screenshots/merge-editor.png</image>
+      <caption>Resolving a merge conflict side by side</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gitgusilva.github.io/gitbox/screenshots/projects.png</image>
+      <caption>Repositories grouped into colour-coded projects</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gitgusilva.github.io/gitbox/screenshots/statistics.png</image>
+      <caption>Contribution statistics for a repository</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://gitgusilva.github.io/gitbox/screenshots/settings.png</image>
+      <caption>Appearance settings with the theme editor</caption>
+    </screenshot>
+  </screenshots>
+
+  <recommends>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </recommends>
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#c7d2fe</color>
+    <color type="primary" scheme_preference="dark">#1e1b4b</color>
+  </branding>
+
+  <releases>
+    <release version="1.3.1" date="2026-08-10">
+      <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.3.1</url>
+      <description>
+        <p>Packages are about half their previous size: the vendored libraries were shipped as full source and object trees, though they are linked into the native addon at build time.</p>
+      </description>
+    </release>
+    <release version="1.3.0" date="2026-07-31">
+      <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.3.0</url>
+      <description>
+        <p>The diff viewer can be detached into its own window, and the theme system gained an in-app editor.</p>
+      </description>
+    </release>
+    <release version="1.2.0" date="2026-07-29">
+      <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.2.0</url>
+      <description>
+        <p>Native branch merging through libgit2, with conflict resolution in a separate window.</p>
+      </description>
+    </release>
+    <release version="1.1.7" date="2026-07-28">
+      <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.1.7</url>
+      <description>
+        <p>Fixes for remote authentication and the commit history filter.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.github.gitgusilva.gitbox.metainfo.xml
+++ b/io.github.gitgusilva.gitbox.metainfo.xml
@@ -19,9 +19,10 @@
 
   <description>
     <p>
-      GitBox is a desktop Git client that talks to repositories through a native
-      libgit2 addon instead of shelling out to a git binary — cloning, fetching,
-      pulling and pushing over HTTPS and SSH all work without git installed.
+      GitBox is a desktop Git client. Cloning, fetching, pulling and pushing run
+      through a native libgit2 addon carrying its own TLS and SSH stack, rather
+      than through the git command line, so remotes work over HTTPS and SSH with
+      nothing else to configure.
     </p>
     <p>Features:</p>
     <ul>
@@ -83,6 +84,12 @@
   </branding>
 
   <releases>
+    <release version="1.3.2" date="2026-08-10">
+      <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.3.2</url>
+      <description>
+        <p>Editors, diff tools and the terminal are resolved on the host, so the Settings pickers list what you actually have installed and the integrated terminal opens your login shell.</p>
+      </description>
+    </release>
     <release version="1.3.1" date="2026-08-10">
       <url type="details">https://github.com/gitgusilva/gitbox/releases/tag/v1.3.1</url>
       <description>

--- a/io.github.gitgusilva.gitbox.yml
+++ b/io.github.gitgusilva.gitbox.yml
@@ -53,7 +53,43 @@ finish-args:
   - --filesystem=/run/media
   - --filesystem=/media
 
+  # The user's editor, diff tool and shell live on the host, not in the runtime.
+  # ui/electron/src/host.js runs them through flatpak-spawn --host, which talks
+  # to this name; without it the Settings pickers list nothing, "open in
+  # terminal" has nothing to launch, and the integrated terminal falls back to
+  # the runtime's /bin/bash with none of the user's toolchains on PATH.
+  - --talk-name=org.freedesktop.Flatpak
+
 modules:
+  # Clone, fetch, pull and push go through the native libgit2 addon, but the
+  # local plumbing — staging, diffs, stashes, tags, submodules, amend, revert —
+  # still runs the git CLI, and org.freedesktop.Platform carries no git. Without
+  # this module those commands fail with ENOENT inside the sandbox: the deb this
+  # app is built from silently relies on the distribution having git installed.
+  #
+  # Trimmed to what the app calls: no Tcl/Tk (git-gui), no gettext catalogues, no
+  # Perl or Python scripts. curl and expat stay, because `git submodule add` and
+  # `git submodule update --remote` do reach the network through the CLI.
+  - name: git
+    buildsystem: simple
+    build-commands:
+      # NO_RUST because the Freedesktop SDK carries no cargo, and the Rust parts
+      # of git are an optimisation the C implementations still cover.
+      #
+      # INSTALL_SYMLINKS matters more than it looks: git installs 179 dashed
+      # built-ins into libexec/git-core, and without it each one is a full 4 MB
+      # copy of the same binary — 600 MB of duplicate git in the image.
+      - make -j$(nproc) prefix=/app NO_RUST=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1 NO_PYTHON=1 all
+      - make prefix=/app NO_RUST=1 NO_TCLTK=1 NO_GETTEXT=1 NO_PERL=1 NO_PYTHON=1 INSTALL_SYMLINKS=1 install
+    cleanup:
+      - /share/man
+      - /share/doc
+      - /libexec/git-core/git-cvsserver
+    sources:
+      - type: archive
+        url: https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.55.0.tar.xz
+        sha256: 457fdb04dc8728e007d4688695e6912e6f680727920f2a40bf11eacc17505357
+
   - name: gitbox
     buildsystem: simple
     build-commands:
@@ -75,8 +111,8 @@ modules:
 
     sources:
       - type: file
-        url: https://github.com/gitgusilva/gitbox/releases/download/v1.3.1/GitBox-1.3.1-amd64.deb
-        sha256: 24e792eceaab1e2dfb4419d599ffecc109702f86705e1c78ca06648b67e75e68
+        url: https://github.com/gitgusilva/gitbox/releases/download/v1.3.2/GitBox-1.3.2-amd64.deb
+        sha256: 902f62c1cfd46e12d6d71d1e74b3040e76344539b3ca0447bc2620dc1d33368c
         # Lets Flathub's external-data-checker open the version-bump PR on this
         # manifest by itself whenever a new GitHub Release appears.
         x-checker-data:

--- a/io.github.gitgusilva.gitbox.yml
+++ b/io.github.gitgusilva.gitbox.yml
@@ -1,0 +1,93 @@
+# Flatpak manifest for GitBox — the file Flathub builds from.
+#
+# The app id is NOT the electron-builder appId (com.gitbox.app). Flathub only
+# accepts an id under a domain or code-hosting account you control, and the
+# project lives at github.com/gitgusilva/gitbox, so the Flatpak is published as
+# io.github.gitgusilva.gitbox. The deb/rpm/pacman/Windows packages keep their
+# own id; nothing outside this directory refers to it.
+#
+# GitBox is repackaged from the .deb that .github/workflows/build-linux.yml
+# already publishes to the GitHub Release, rather than compiled here. Building
+# from source inside flatpak-builder would mean vendoring three npm trees plus
+# the libgit2/mbedTLS/OpenSSL/libssh2 tarballs that core/addon/vendor/
+# build-libgit2.sh fetches, all offline — for a bit-for-bit identical binary.
+app-id: io.github.gitgusilva.gitbox
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+
+# Supplies zypak, which lets Chromium's sandbox work inside the Flatpak sandbox,
+# plus the shared libraries an Electron binary expects but the bare Platform
+# does not carry.
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+
+command: gitbox
+
+# Electron ships its own translations inside the app bundle; letting
+# flatpak-builder split them into a .Locale extension only hides them.
+separate-locales: false
+
+finish-args:
+  # Wayland first, XWayland only when there is no Wayland compositor. The
+  # wrapper passes --ozone-platform-hint=auto to match: without it Electron
+  # would default to X11 and find no socket at all under a Wayland session.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # clone/fetch/pull/push, the update check, and the OAuth sign-in flows.
+  - --share=network
+
+  # git over SSH. The addon links libssh2 and authenticates through the agent,
+  # so the agent socket is what makes key-based remotes work; the keys
+  # themselves are read from ~/.ssh via the home filesystem below.
+  - --socket=ssh-auth
+
+  # Repositories live wherever the user keeps them, and GitBox has to read and
+  # write working trees, ~/.gitconfig and ~/.ssh. Narrower than --filesystem=host:
+  # /etc, /usr and other apps' data stay out of reach.
+  - --filesystem=home
+  # Repos on external drives or secondary mounts.
+  - --filesystem=/run/media
+  - --filesystem=/media
+
+modules:
+  - name: gitbox
+    buildsystem: simple
+    build-commands:
+      # flatpak-builder has no deb extractor; unpack it by hand.
+      - ar x GitBox-*-amd64.deb
+      - tar -xf data.tar.xz
+
+      - mkdir -p /app/gitbox
+      - cp -a opt/GitBox/. /app/gitbox/
+      # The setuid Chromium sandbox helper cannot work inside Flatpak (no setuid
+      # bit survives, and zypak replaces it). Left in place it only trips the
+      # "you must run as root" bailout.
+      - rm -f /app/gitbox/chrome-sandbox
+
+      - install -Dm755 gitbox.sh /app/bin/gitbox
+      - install -Dm644 io.github.gitgusilva.gitbox.desktop /app/share/applications/io.github.gitgusilva.gitbox.desktop
+      - install -Dm644 io.github.gitgusilva.gitbox.metainfo.xml /app/share/metainfo/io.github.gitgusilva.gitbox.metainfo.xml
+      - install -Dm644 usr/share/icons/hicolor/512x512/apps/gitbox.png /app/share/icons/hicolor/512x512/apps/io.github.gitgusilva.gitbox.png
+
+    sources:
+      - type: file
+        url: https://github.com/gitgusilva/gitbox/releases/download/v1.3.1/GitBox-1.3.1-amd64.deb
+        sha256: 24e792eceaab1e2dfb4419d599ffecc109702f86705e1c78ca06648b67e75e68
+        # Lets Flathub's external-data-checker open the version-bump PR on this
+        # manifest by itself whenever a new GitHub Release appears.
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/gitgusilva/gitbox/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: .assets[] | select(.name == "GitBox-" + $version + "-amd64.deb") | .browser_download_url
+
+      - type: file
+        path: gitbox.sh
+      - type: file
+        path: io.github.gitgusilva.gitbox.desktop
+      - type: file
+        path: io.github.gitgusilva.gitbox.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. **GitBox is a desktop Git client. Cloning, fetching, pulling and pushing run through a native libgit2 addon carrying its own TLS and SSH stack rather than through the git command line, so remotes work over HTTPS and SSH with nothing else to configure. It shows commit history with a branch graph, stages individual hunks, resolves merge conflicts side by side, opens several repositories as tabs, and is themeable and localized (English, Brazilian Portuguese, Spanish). Source: https://github.com/gitgusilva/gitbox — Homepage: https://gitgusilva.github.io/gitbox/ — License: LGPL-3.0-or-later.**
- [X] Please attach a video showcasing the application on Linux using the Flatpak. **A two-minute tour of the Flatpak on Fedora 44 / GNOME 49 (Wayland): https://github.com/gitgusilva/gitbox/releases/download/v1.3.2/gitbox-flatpak-demo.mp4 — the commit graph, a commit's detail tabs, the project and branch menus, creating a branch, a side-by-side diff, staging, a commit, a fetch over HTTPS, a merge that conflicts and is resolved in the merge editor, the command log, the statistics view and settings, including a theme installed from the project's theme registry. Recorded by `flatpak/demo/record.sh` in the app repository, so it can be reproduced.**
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. **The project is hosted at `github.com/gitgusilva/gitbox` and its homepage is `gitgusilva.github.io/gitbox`, so the id is `io.github.gitgusilva.gitbox`.**
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

---

### Packaging notes

The manifest repackages `GitBox-1.3.2-amd64.deb`, the artifact the project's own tag build publishes to its GitHub Release, pinned by sha256. Building from source inside `flatpak-builder` would mean vendoring three npm dependency trees plus the libgit2, mbedTLS, OpenSSL and libssh2 tarballs the project's build script fetches, all resolvable offline, to produce the same binary.

`x-checker-data` is set up so the external-data-checker can follow new releases, and `flathub.json` sets `only-arches: ["x86_64"]` — the upstream build currently publishes x86_64 Linux artifacts only.

A second module builds **git** from the kernel.org tarball. The libgit2 addon owns the network, but the local plumbing — staging, diffs, stashes, tags, submodules, amend, revert — still shells out to `git`, and `org.freedesktop.Platform` carries none. Without it the app can browse a repository but every write fails with `spawn git ENOENT`. It is trimmed to what the app calls (`NO_TCLTK`, `NO_GETTEXT`, `NO_PERL`, `NO_PYTHON`, and `NO_RUST` since the SDK has no cargo); curl and expat stay because `git submodule add` and `git submodule update --remote` do reach the network through the CLI. Bumping it is manual — the `x-checker-data` on the app source tracks GitBox releases only.

The app runs under `zypak-wrapper` on top of `org.electronjs.Electron2.BaseApp`, so Chromium keeps its sandbox; the `chrome-sandbox` setuid helper is removed during build.

### Permissions needing an exception

**`--filesystem=home`** — GitBox is a Git client, so it has to open working trees wherever the user keeps them, and read `~/.gitconfig` and `~/.ssh`. There is no portal that gives a Git client durable read-write access to a repository the user picks, and a repository is a directory whose contents change under the app constantly. `--filesystem=host` was deliberately avoided; only `home` plus `/media` and `/run/media` for repositories on external drives are requested.

**`--socket=ssh-auth`** — this is what makes Git over SSH work. The bundled libssh2 authenticates through the user's SSH agent; without the agent socket, SSH remotes fail for anyone whose key is not passphrase-less.

**`--talk-name=org.freedesktop.Flatpak`** — a Git client launches the user's own tools: the external editor for a commit message, the configured diff/merge tool, and a terminal in the repository. Those live on the host, not in the runtime, so `ui/electron/src/host.js` runs them through `flatpak-spawn --host`. Without it the tool pickers in Settings list nothing, "open in terminal" has nothing to launch, and the built-in terminal falls back to the runtime's `/bin/bash` with none of the user's toolchains on `PATH`. The code degrades rather than fails when the permission is refused: the first denied call flips an internal flag and every lookup then reports "not found", so revoking it with `flatpak override --no-talk-name` leaves a working app with empty pickers — verified both ways.

### Testing

Built and run locally against `org.freedesktop.Platform` 25.08. Verified inside the sandbox that the native addon loads and performs real repository operations (history, diffs, staging, fetch over HTTPS) against a repository under `$HOME`. `appstreamcli validate` and `desktop-file-validate` pass; `flatpak-builder-lint` reports only the three permissions above plus `appstream-external-screenshot-url`, since the screenshots are not mirrored to `dl.flathub.org` yet.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
