### PR TITLE
Add io.github.navknight.wattle

### DIFF
--- a/io.github.navknight.wattle.yaml
+++ b/io.github.navknight.wattle.yaml
@@ -1,0 +1,25 @@
+app-id: io.github.navknight.wattle
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: wattle
+
+# org.gnome.Platform 50 already bundles WebKitGTK 6.0 and its GStreamer
+# plugins (good/bad/libav, for WebRTC and media codecs), so no separate
+# WebKitGTK build module is needed.
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-download
+
+modules:
+  - name: wattle
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/Navknight/Wattle.git
+        tag: v0.1.1


### PR DESCRIPTION
## Wattle

A native GNOME desktop client for WhatsApp Web, built with GTK4, libadwaita, and WebKitGTK.

- Homepage: https://github.com/Navknight/Wattle
- Source manifest: https://github.com/Navknight/Wattle/blob/master/flatpak/io.github.navknight.wattle.yaml
- License: GPL-3.0-or-later

Features: multiple accounts, native notifications, permissions manager, keyboard shortcuts, a downloads manager, an app lock, per-account customization, and CLI control of a running instance.