### PR TITLE
Add io.github.navknight.wattle

### DIFF
--- a/io.github.navknight.wattle.yaml
+++ b/io.github.navknight.wattle.yaml
@@ -1,0 +1,25 @@
+app-id: io.github.navknight.wattle
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: wattle
+
+# org.gnome.Platform 50 already bundles WebKitGTK 6.0 and its GStreamer
+# plugins (good/bad/libav, for WebRTC and media codecs), so no separate
+# WebKitGTK build module is needed.
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --filesystem=xdg-download
+
+modules:
+  - name: wattle
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/Navknight/Wattle.git
+        tag: v0.1.1


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Wattle is a WhatsApp Web client for GNOME, built with GTK4, libadwaita and WebKitGTK. I built it because I wanted something that felt native on my desktop instead of running WhatsApp Web in a browser tab or an Electron wrapper. It supports multiple accounts, native notifications, a permissions manager, keyboard shortcuts, a downloads manager, an app lock, and CLI control of a running instance.
- [ ] Please attach a video showcasing the application on Linux using the Flatpak. Will add a recording shortly — flagging this box as pending rather than checking it falsely.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer to the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission