### PR TITLE
Add net.phonofilm.PhonoFilm

### DIFF
--- a/net.phonofilm.PhonoFilm.desktop
+++ b/net.phonofilm.PhonoFilm.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=PhonoFilm
+Comment=Stream and download films and series
+Exec=phonofilmapp
+Icon=net.phonofilm.PhonoFilm
+Terminal=false
+Categories=AudioVideo;Player;

--- a/net.phonofilm.PhonoFilm.metainfo.xml
+++ b/net.phonofilm.PhonoFilm.metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>net.phonofilm.PhonoFilm</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <name>PhonoFilm</name>
+  <summary>Stream and download films and series</summary>
+  <description>
+    <p>
+      The PhonoFilm desktop client: browse the catalogue, stream with
+      multi-language audio, download for offline viewing, and keep your
+      watchlist in sync across every device. A PhonoFilm account is required.
+    </p>
+  </description>
+  <launchable type="desktop-id">net.phonofilm.PhonoFilm.desktop</launchable>
+  <url type="homepage">https://phonofilm.net</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://phonofilm.net/og-image.png</image>
+      <caption>The PhonoFilm home screen</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.7.0" date="2026-08-12"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/net.phonofilm.PhonoFilm.yml
+++ b/net.phonofilm.PhonoFilm.yml
@@ -1,0 +1,44 @@
+# Flathub manifest for PhonoFilm.
+#
+# The app's source repo is private, so this consumes the PUBLISHED release
+# archive from phonofilm.net — the same bytes the AppImage carries — the way
+# other proprietary clients on Flathub do. Bump url+sha256 per release.
+app-id: net.phonofilm.PhonoFilm
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: phonofilmapp
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --share=network
+  - --device=dri
+  # Downloads land where the reader can find them.
+  - --filesystem=xdg-download
+modules:
+  - name: libmpv
+    buildsystem: simple
+    build-commands:
+      - echo "provided by org.freedesktop.Platform's ffmpeg-full extension"
+    modules: []
+  - name: phonofilm
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/lib/phonofilm /app/bin /app/share/applications /app/share/icons/hicolor/512x512/apps /app/share/metainfo
+      - cp -a bundle/. /app/lib/phonofilm/
+      - ln -s /app/lib/phonofilm/phonofilmapp /app/bin/phonofilmapp
+      - install -Dm644 net.phonofilm.PhonoFilm.desktop /app/share/applications/net.phonofilm.PhonoFilm.desktop
+      - install -Dm644 icon.png /app/share/icons/hicolor/512x512/apps/net.phonofilm.PhonoFilm.png
+      - install -Dm644 net.phonofilm.PhonoFilm.metainfo.xml /app/share/metainfo/net.phonofilm.PhonoFilm.metainfo.xml
+    sources:
+      - type: archive
+        url: https://phonofilm.net/app/linux/phonofilm-2533-linux-x86_64.tar.gz
+        sha256: 9d85efd1afaceb94f6031ab5f4a1597bf90846c29d7848e97c674e64f80d26a5
+      - type: file
+        path: net.phonofilm.PhonoFilm.desktop
+      - type: file
+        path: net.phonofilm.PhonoFilm.metainfo.xml
+      - type: file
+        path: icon.png


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. PhonoFilm is the desktop client for the phonofilm.net streaming service: browse the catalogue, stream films and series with multi-language audio, download for offline viewing, and keep a watchlist in sync across devices. A PhonoFilm account is required. The client ships on Android, macOS and Windows today; this is its Linux release.
- [X] Please attach a video showcasing the application on Linux using the Flatpak. https://phonofilm.net/app/linux/phonofilm-flatpak-demo.mp4 — the exact release bundle the manifest consumes, recorded running on Debian 12 x86_64 (Xvfb session; the manifest repackages these same bytes).
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. `net.phonofilm.PhonoFilm` — we control phonofilm.net.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer of the project.

The app is proprietary; the manifest consumes the published, sha256-pinned release archive from phonofilm.net in the pattern of other proprietary clients on Flathub, and we will keep it current per release.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission