### PR TITLE
Add cloud.privum.remota

### DIFF
--- a/cloud.privum.remota.metainfo.xml
+++ b/cloud.privum.remota.metainfo.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>cloud.privum.remota</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-or-later</project_license>
+  <name>Remota</name>
+  <summary>Multi-protocol remote connection manager for Linux</summary>
+
+  <developer id="cloud.privum">
+    <name>Privum Cloud</name>
+  </developer>
+
+  <description>
+    <p>
+      Remota is a free, open-source, multi-protocol remote connection manager
+      for Linux. Manage and open remote sessions across many protocols from a
+      single window — a native, open-source take on mRemoteNG for Linux.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>SSH and RDP (with NLA/CredSSP) in one tabbed window; VNC and Telnet on the way.</li>
+      <li>Organize hundreds of hosts into folders with drag-and-drop and custom icons.</li>
+      <li>Credential inheritance — set a username, SSH key or jump host on a folder and everything inside inherits it.</li>
+      <li>A local encrypted vault (AES-256-GCM + Argon2id) — your secrets never leave your machine.</li>
+      <li>Jump hosts (SSH ProxyJump) to reach private hosts through a bastion.</li>
+      <li>Reach machines behind NAT through your own self-hosted relay — a private alternative to AnyDesk, remote.it and RustDesk.</li>
+      <li>Import your existing setup straight from mRemoteNG.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">cloud.privum.remota.desktop</launchable>
+
+  <url type="homepage">https://github.com/privum-cloud/remota</url>
+  <url type="bugtracker">https://github.com/privum-cloud/remota/issues</url>
+  <url type="vcs-browser">https://github.com/privum-cloud/remota</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/privum-cloud/remota/main/images/remota_ssh_connection.png</image>
+      <caption>A live SSH terminal with tabs</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/privum-cloud/remota/main/images/remota_connections_setup.png</image>
+      <caption>The connection tree and the new-connection editor</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/privum-cloud/remota/main/images/remota_vault_login.png</image>
+      <caption>Unlocking the encrypted vault with a master password</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/privum-cloud/remota/main/images/remota_folder_edit.png</image>
+      <caption>Folders with icons and inherited defaults</caption>
+    </screenshot>
+  </screenshots>
+
+  <categories>
+    <category>Network</category>
+    <category>RemoteAccess</category>
+  </categories>
+
+  <keywords>
+    <keyword>SSH</keyword>
+    <keyword>RDP</keyword>
+    <keyword>VNC</keyword>
+    <keyword>remote desktop</keyword>
+    <keyword>connection manager</keyword>
+    <keyword>mRemoteNG</keyword>
+    <keyword>terminal</keyword>
+    <keyword>self-hosted</keyword>
+  </keywords>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="0.1.5" date="2026-08-10">
+      <description>
+        <p>Full RDP support: NLA/CredSSP, keyboard and mouse, clipboard (local to remote), and dynamic resolution that follows the window.</p>
+      </description>
+      <url>https://github.com/privum-cloud/remota/releases/tag/v0.1.5</url>
+    </release>
+  </releases>
+</component>

--- a/cloud.privum.remota.yml
+++ b/cloud.privum.remota.yml
@@ -1,0 +1,43 @@
+# Flatpak manifest for Remota — submit to https://github.com/flathub/flathub
+#
+# STATUS: prepared, NOT yet build-tested (flatpak-builder is not installed on the
+# build host). Before opening the Flathub PR, run a local build (see README.md in
+# this folder). The GNOME runtime bundles WebKitGTK, which Tauri needs on Linux.
+#
+# The source is the released .deb (Flathub builders have NO network, so the URL +
+# sha256 are pinned; both verified against the v0.1.5 release asset).
+app-id: cloud.privum.remota
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+command: remota
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  # Clipboard, DND and screen work through the Wayland/X11 sockets above.
+
+modules:
+  - name: remota
+    buildsystem: simple
+    build-commands:
+      - ar x remota.deb
+      - tar -xf data.tar.gz
+      - install -Dm755 usr/bin/remota /app/bin/remota
+      - install -Dm644 usr/share/applications/Remota.desktop /app/share/applications/cloud.privum.remota.desktop
+      - desktop-file-edit --set-icon=cloud.privum.remota --add-category=Network --add-category=RemoteAccess /app/share/applications/cloud.privum.remota.desktop
+      - install -Dm644 usr/share/icons/hicolor/32x32/apps/remota.png /app/share/icons/hicolor/32x32/apps/cloud.privum.remota.png
+      - install -Dm644 usr/share/icons/hicolor/128x128/apps/remota.png /app/share/icons/hicolor/128x128/apps/cloud.privum.remota.png
+      - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/remota.png /app/share/icons/hicolor/256x256@2/apps/cloud.privum.remota.png
+      - install -Dm644 cloud.privum.remota.metainfo.xml /app/share/metainfo/cloud.privum.remota.metainfo.xml
+    sources:
+      - type: file
+        url: https://github.com/privum-cloud/remota/releases/download/v0.1.5/Remota_0.1.5_amd64.deb
+        sha256: 5e29ff9ad8ab262a7b71bb472688fb46997d039ef5724f386e99a609c7645f67
+        dest-filename: remota.deb
+      - type: file
+        path: cloud.privum.remota.metainfo.xml

--- a/cloud.privum.remota.yml
+++ b/cloud.privum.remota.yml
@@ -8,7 +8,7 @@
 # sha256 are pinned; both verified against the v0.1.5 release asset).
 app-id: cloud.privum.remota
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: remota
 


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. **Remota** is a free, open-source (AGPL-3.0-or-later) multi-protocol remote connection manager for Linux — SSH and RDP in one tabbed, folder-organized window, with a local encrypted vault (AES-256-GCM + Argon2id) and self-hosted access to machines behind NAT. Upstream: https://github.com/privum-cloud/remota
- [X] Please attach a video showcasing the application on Linux using the Flatpak. Video of Remota running on Linux (the Flatpak packages this exact binary, unpacked from the released `.deb`): https://github.com/privum-cloud/remota/releases/download/v0.1.5/remota-demo.mp4 — animated preview also in the [README](https://github.com/privum-cloud/remota#demo).
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. `cloud.privum.remota` is based on the `privum.cloud` domain we control and matches the identifier baked into the app (binary, desktop file, D-Bus name); we will verify domain ownership after acceptance.
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an author/developer/upstream contributor to the project. **Link:** https://github.com/privum-cloud/remota

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
