### PR TITLE
Add fr.echonuit.VigieChiroCompanion

### DIFF
--- a/fr.echonuit.VigieChiroCompanion.metainfo.xml
+++ b/fr.echonuit.VigieChiroCompanion.metainfo.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>fr.echonuit.VigieChiroCompanion</id>
+  <name>VigieChiro Companion</name>
+  <summary>Préparer et déposer les nuits d'enregistrement de chiroptères</summary>
+  <developer id="fr.echonuit">
+    <name>Echonuit</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+
+  <description>
+    <p>
+      Compagnon du protocole Vigie-Chiro : importer une nuit depuis la carte SD d'un enregistreur
+      passif, vérifier sa cohérence, écouter et valider les espèces détectées, puis préparer le
+      dépôt sur la plateforme Vigie-Chiro.
+    </p>
+    <p>Les données restent sur votre ordinateur : aucun compte, aucun serveur intermédiaire.</p>
+  </description>
+
+  <launchable type="desktop-id">fr.echonuit.VigieChiroCompanion.desktop</launchable>
+  <url type="homepage">https://companion.echonuit.fr/</url>
+  <url type="bugtracker">https://github.com/echonuit/vigiechiro-pr-companion/issues</url>
+  <url type="vcs-browser">https://github.com/echonuit/vigiechiro-pr-companion</url>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://raw.githubusercontent.com/echonuit/vigiechiro-pr-companion/main/.github/assets/apercu-accueil.png</image>
+      <caption>L'accueil et ses activités : sites, import, écoute et validation, carte.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/echonuit/vigiechiro-pr-companion/main/.github/assets/apercu-import-assistant.png</image>
+      <caption>L'import d'une nuit depuis la carte SD d'un enregistreur passif.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/echonuit/vigiechiro-pr-companion/main/.github/assets/apercu-sons-validation.png</image>
+      <caption>L'écoute et la validation des espèces détectées.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://raw.githubusercontent.com/echonuit/vigiechiro-pr-companion/main/.github/assets/apercu-multisite.png</image>
+      <caption>La carte des sites et le tableau des passages.</caption>
+    </screenshot>
+  </screenshots>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="2.185.0" date="2026-08-12">
+      <description></description>
+    </release>
+    <release version="2.34.4" date="2026-07-22">
+      <description/>
+    </release>
+    <release version="2.34.2" date="2026-07-22"/>
+  </releases>
+</component>

--- a/fr.echonuit.VigieChiroCompanion.yml
+++ b/fr.echonuit.VigieChiroCompanion.yml
@@ -1,0 +1,113 @@
+app-id: fr.echonuit.VigieChiroCompanion
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  # L'extension VERSIONNÉE, et non `…Extension.openjdk` tout court. Sa documentation dit
+  # ce qu'est la non versionnée : « the current latest (NON-LTS) version ». Elle suit donc
+  # le Java qui change tous les six mois, et sur la branche 25.08 elle rendait déjà un
+  # jdk-26. Le produit, lui, est en 25 LTS partout : `maven.compiler.release` vaut 25, les
+  # workflows déclarent java-version 25, et le fat-jar publié porte un bytecode 69.
+  # Le Flatpak était ainsi le SEUL emballage à s'exécuter sur un JDK qu'aucun test ne
+  # traverse - et cela importe d'autant plus que le lanceur passe
+  # `--sun-misc-unsafe-memory-access=allow`, dont le retrait est daté par la version du
+  # JDK (#2747) : à laisser flotter, l'échéance arrive ici sans que rien ne l'annonce.
+  - org.freedesktop.Sdk.Extension.openjdk25
+command: vigiechiro-runner
+rename-desktop-file: VigieChiroCompanion.desktop
+
+finish-args:
+  # Affichage. Wayland en premier, X11 en repli : le parc des naturalistes est hétérogène.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # Lecture audio des séquences (écoute et validation des cris).
+  - --socket=pulseaudio
+
+  # API Vigie-Chiro (dépôt, résultats Tadarida) et consultation des versions publiées.
+  - --share=network
+
+  # Espace de travail, et RIEN d'autre du dossier personnel. `Workspace.parDefaut()` code ce
+  # chemin en dur, on peut donc n'accorder que lui : ni le reste de Documents, ni le home.
+  # `:create` laisse l'application créer le dossier au premier lancement.
+  - --filesystem=~/Documents/VigieChiro-Companion:create
+
+  # LE point qui décide de l'utilité du paquet : les cartes SD. udisks2 les monte sous
+  # /run/media/<utilisateur>/<étiquette> (Ubuntu, Fedora récents) ou /media/<utilisateur>/…
+  # (Debian, dérivées plus anciennes). Sans ces deux accès, l'application s'ouvre mais ne peut
+  # RIEN importer - c'est-à-dire qu'elle ne sert à rien.
+  - --filesystem=/run/media
+  - --filesystem=/media
+
+modules:
+  - name: openjdk
+    buildsystem: simple
+    build-commands:
+      # Le chemin porte le numéro de l'extension. La destination, elle, ne change pas :
+      # l'extension versionnée installe aussi dans /app/jre, donc le lanceur plus bas
+      # reste inchangé.
+      - /usr/lib/sdk/openjdk25/install.sh
+
+  - name: vigiechiro
+    buildsystem: simple
+    build-commands:
+      # On extrait le .deb PUBLIÉ plutôt que de construire depuis les sources : les builds Flathub
+      # sont hors ligne, et une résolution Maven y est impossible sans déclarer chaque dépendance
+      # transitive en source vérifiée. Même choix que Gluon Scene Builder, pour la même raison.
+      - mkdir -p paquet
+      - ar p vigiechiro.deb data.tar.zst | tar --use-compress-program=unzstd -xf -
+        -C paquet
+      # Le fat-jar embarque déjà JavaFX et ses natifs Linux : contrairement à Scene Builder, aucun
+      # SDK JavaFX séparé n'est nécessaire.
+      - install -Dm644 paquet/opt/vigiechirocompanion/lib/app/vigiechiro-*-shaded.jar
+        /app/lib/vigiechiro.jar
+      - install -Dm644 paquet/opt/vigiechirocompanion/lib/VigieChiroCompanion.png
+        /app/share/icons/hicolor/256x256/apps/fr.echonuit.VigieChiroCompanion.png
+      - install -Dm755 vigiechiro-runner /app/bin/vigiechiro-runner
+      - install -Dm644 fr.echonuit.VigieChiroCompanion.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 paquet/opt/vigiechirocompanion/lib/vigiechirocompanion-VigieChiroCompanion.desktop
+        /app/lib/VigieChiroCompanion.desktop
+      # `Categories` d'abord : jpackage écrit `Categories=Unknown`, valeur INVALIDE que
+      # desktop-file-edit refuse - il valide le fichier à chaque appel, donc toute autre édition
+      # échouerait avant d'y arriver. (Défaut présent aussi dans le .deb installé normalement.)
+      - desktop-file-edit --remove-key=Categories /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-edit --set-key=Categories --set-value='Science;Biology;' /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-edit --remove-key=Comment /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-edit --set-key=Comment --set-value='Préparer et déposer les nuits
+        de chiroptères' /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-edit --set-key=Exec --set-value='vigiechiro-runner' /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-edit --set-icon=fr.echonuit.VigieChiroCompanion /app/lib/VigieChiroCompanion.desktop
+      - desktop-file-install /app/lib/VigieChiroCompanion.desktop --dir=/app/share/applications
+
+    sources:
+      - type: file
+        dest-filename: vigiechiro.deb
+        url: https://github.com/echonuit/vigiechiro-pr-companion/releases/download/v2.185.0/vigiechirocompanion_2.185.0_amd64-x64.deb
+        sha256: 6fa16f3ca801bffbc7730ea5f8e2b6ad40bdfe9ade585588c5e76a0b38c31387
+        # Le robot de Flathub détecte les nouvelles versions et ouvre la mise à jour tout seul :
+        # c'est ce qui rend la maintenance quasi nulle une fois le paquet accepté.
+        x-checker-data:
+          type: json
+          # `is-main-source` : désigne ce .deb comme LA source qui porte la version de
+          # l'application. Sans cette marque, le vérificateur met à jour l'URL et
+          # l'empreinte mais laisse l'entrée <release> du fichier AppStream figée -
+          # c'est ainsi qu'elle est restée bloquée sur la 2.26.0 pendant huit versions.
+          is-main-source: true
+          url: https://api.github.com/repos/echonuit/vigiechiro-pr-companion/releases/latest
+          version-query: .tag_name | ltrimstr("v")
+          timestamp-query: .published_at
+          url-query: .assets[] | select(.name=="vigiechirocompanion_" + $version +
+            "_amd64-x64.deb") | .browser_download_url
+
+      - type: file
+        path: fr.echonuit.VigieChiroCompanion.metainfo.xml
+
+      - type: script
+        dest-filename: vigiechiro-runner
+        commands:
+          # `--enable-native-access` et `--sun-misc-unsafe-memory-access` : mêmes options que
+          # l'installeur jpackage (JNI SQLite, natifs JavaFX, Unsafe de Guice/Guava).
+          - exec /app/jre/bin/java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow
+            -cp /app/lib/vigiechiro.jar fr.univ_amu.iut.Launcher "$@"


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. VigieChiro Companion is a desktop tool for the French **Vigie-Chiro** bat monitoring programme, run by the Muséum national d'Histoire naturelle. Volunteer naturalists leave passive ultrasound recorders in the field overnight; this application imports a night straight from the recorder's SD card, checks it for consistency, prepares the listening sequences, lets the volunteer listen to and validate the detected species, and prepares the upload to the Vigie-Chiro platform. Free software (GPL-3.0-or-later), works offline apart from that upload, and keeps every file on the user's own machine: no account, no intermediate server.
- [x] Please attach a video showcasing the application on Linux using the Flatpak. https://echonuit.fr/media/vigiechiro-flatpak.mp4
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission

---

### What the video shows

It was recorded from the package built out of the manifest in this pull request, running as a
Flatpak. Starting from an empty workspace, it declares a monitoring square and a listening point,
then imports a night from a **real recorder SD card** mounted by `udisks2` under `/media`. The
application finds 4289 WAV files spread over three nights, reports each night's completeness,
imports the one that is selected, and ends on a transformed passage whose sequences can be
listened to, with waveform and spectrogram.

That sequence is the argument for the one unusual permission below.

### About the permissions

`--filesystem=/media` and `--filesystem=/run/media` decide whether the application is useful at
all. Field recorders store their nights on SD cards; `udisks2` mounts them under
`/media/<user>/<label>` on Debian and Ubuntu, and under `/run/media/<user>/<label>` on Fedora and
derivatives. Without both, the application opens but cannot import anything. Neither is a
subdirectory grant, so `finish-args-absolute-run-media-path` does not apply.

Everything else is deliberately narrow. Rather than `--filesystem=home`, the manifest grants only
`~/Documents/VigieChiro-Companion:create`, because the workspace path is hard-coded. Checked
inside the sandbox: `$HOME` shows 3 entries instead of 76, and `~/Documents` shows only
`VigieChiro-Companion`.

### About the build

The manifest extracts the published `.deb` rather than building from source: Flathub builds have
no network, and resolving Maven dependencies there would mean declaring every transitive
dependency as a verified source. Same choice as
[Gluon Scene Builder](https://github.com/flathub/com.gluonhq.SceneBuilder), a directly comparable
JavaFX precedent. Our fat jar already bundles JavaFX and its Linux natives, so no separate JavaFX
SDK is needed.

The SDK extension is pinned to `org.freedesktop.Sdk.Extension.openjdk25`, the LTS one, rather than
the unversioned extension which tracks the latest non-LTS release: the product is built and
tested on Java 25 throughout, and we would rather not ship on a JDK we never test.

`x-checker-data` is declared, so version bumps will be picked up by Flathub's bot. That block is
already exercised upstream by a workflow running the very same `flatpak-external-data-checker`,
which then builds the Flatpak and **starts it** before proposing the update.

### Checks run before submitting

- `flatpak-builder-lint manifest` : no errors.
- `appstreamcli validate` : passes.
- Built and started locally from this manifest; screenshots mirror and the `screenshots/x86_64`
  ostree ref is committed.
