### PR TITLE
Add com.mskazemi.YazSes

### DIFF
--- a/com.mskazemi.YazSes.metainfo.xml
+++ b/com.mskazemi.YazSes.metainfo.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata for the Flathub listing.
+
+  This file is the listing. It is what a user reads in GNOME Software or KDE Discover
+  before deciding to install, and it is indexed as a web page on flathub.org — so the
+  limitations below belong here rather than only in the README. A Flatpak that cannot
+  type into other windows, on a user who never read the caveat, is a one-star review.
+-->
+<component type="desktop-application">
+  <id>com.mskazemi.YazSes</id>
+  <name>YazSes</name>
+  <summary>Offline voice dictation that types into the focused app</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>Apache-2.0</project_license>
+
+  <developer id="com.mskazemi">
+    <name>Mohsen Seyedkazemi Ardebili</name>
+  </developer>
+
+  <description>
+    <p>
+      YazSes is offline voice dictation. Hold a key, speak, release — your words are
+      transcribed on your own CPU and typed into whatever window has focus: editor,
+      browser, terminal or chat.
+    </p>
+    <p>
+      After installation and a one-time model download, speech recognition runs locally.
+      Audio and transcripts are not sent to any cloud service, and there is no account,
+      API key, GPU or subscription.
+    </p>
+    <p>It also works on recordings:</p>
+    <ul>
+      <li>Transcribe an audio or video file to text, SRT, WebVTT, Markdown or JSON</li>
+      <li>Label who said what, using speaker models that run on your machine</li>
+      <li>Capture a whole meeting hands-free and get a speaker-labelled transcript</li>
+      <li>Optionally write minutes with a local language model you supply</li>
+    </ul>
+    <p>Known limitations, so they are not a surprise after installing:</p>
+    <ul>
+      <li>
+        The first run downloads a speech model (a few hundred megabytes) and needs a
+        network connection. Transcription itself works with networking disabled.
+      </li>
+      <li>
+        The shipped models are tuned for English. Other languages need a multilingual
+        model selected explicitly, and accuracy varies.
+      </li>
+      <li>
+        Hold-to-talk needs permission to read keyboard events. If your system declines
+        that permission, the daemon starts and looks healthy but never hears the key.
+      </li>
+      <li>
+        Typing into other applications depends on the sandbox permissions granted to this
+        build. Where injection is not permitted, dictated text is placed on the clipboard
+        instead, and you paste it yourself.
+      </li>
+      <li>Desktop only — there is no mobile version.</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.mskazemi.YazSes.desktop</launchable>
+
+  <url type="homepage">https://mskazemi.com/yazses/</url>
+  <url type="bugtracker">https://github.com/MSKazemi/yazses/issues</url>
+  <url type="vcs-browser">https://github.com/MSKazemi/yazses</url>
+  <url type="help">https://mskazemi.com/yazses/troubleshooting/</url>
+
+  <categories>
+    <category>Utility</category>
+    <category>Accessibility</category>
+    <category>AudioVideo</category>
+  </categories>
+
+  <keywords>
+    <keyword>dictation</keyword>
+    <keyword>speech to text</keyword>
+    <keyword>voice typing</keyword>
+    <keyword>transcription</keyword>
+    <keyword>offline</keyword>
+    <keyword>accessibility</keyword>
+    <keyword>whisper</keyword>
+  </keywords>
+
+  <supports>
+    <control>keyboard</control>
+  </supports>
+
+  <content_rating type="oars-1.1"/>
+
+  <releases>
+    <release version="2.17.0" date="2026-08-09"/>
+  </releases>
+</component>

--- a/com.mskazemi.YazSes.yml
+++ b/com.mskazemi.YazSes.yml
@@ -1,0 +1,119 @@
+# Flatpak manifest for YazSes.
+#
+# App ID: com.mskazemi.YazSes — chosen because mskazemi.com is a domain the maintainer
+# controls, which is what Flathub requires. It is PERMANENT: an app ID cannot be changed
+# after publication without shipping a whole new app and orphaning every install.
+#
+# Why Flatpak at all, when a Snap already exists: the Snap cannot do hold-to-talk under
+# strict confinement (issue #44 — raw keyboard capture denied, no raw-input plug on the
+# store build). Flatpak can grant device access to /dev/input, which is the single
+# capability that decides whether this package is usable or decorative.
+#
+# Build:
+#   flatpak-builder --user --install --force-clean build com.mskazemi.YazSes.yml
+#
+# The python3-* module list is generated, not hand-written — regenerate it by running
+# the Flatpak workflow with 'regenerate' checked and committing the artifact it uploads.
+# It uses req2flatpak, pinned to Python 3.11 / x86_64-manylinux2014 to match this runtime.
+# flatpak-pip-generator cannot be used: it reads platform tags by running
+# `from packaging import tags` inside org.kde.Sdk, whose Python has no `packaging` module.
+
+app-id: com.mskazemi.YazSes
+# KDE runtime rather than GNOME: it carries Qt 6, which PySide6 (the voice-activity
+# overlay and the tray icon) needs. Pulling PySide6 through pip against the GNOME runtime
+# means building Qt in the sandbox, which is enormous and fragile.
+runtime: org.kde.Platform
+runtime-version: '6.7'
+sdk: org.kde.Sdk
+command: yazses
+
+# Make the setuptools installed into /app win over the SDK's own.
+#
+# pip builds an sdist's metadata in an in-process hook run by /usr/bin/python,
+# which imports setuptools from the SDK's /usr/lib/python3.11/site-packages.
+# Installing a newer one into ${FLATPAK_DEST} therefore changed nothing on its
+# own — the first attempt failed with the identical error. PYTHONPATH is
+# searched before system site-packages, so this is what actually makes the
+# newer setuptools the one that parses evdev's PEP 639 licence field.
+build-options:
+  env:
+    PYTHONPATH: /app/lib/python3.11/site-packages
+
+finish-args:
+  # --- Microphone. Without this there is no audio at all. -----------------------------
+  - --socket=pulseaudio
+
+  # --- Hold-to-talk. THE make-or-break permission. ------------------------------------
+  # evdev reads key events from /dev/input/event*. There is no portal for global
+  # hold-to-talk: the whole interaction is "notice a key being held while another
+  # application has focus", which is by definition outside the sandbox's own window.
+  # This is what the Snap could not get, and why that package cannot dictate.
+  - --device=input
+
+  # --- Text injection into the focused window. The contested one. ---------------------
+  # ydotool/xdotool synthesise input into applications outside the sandbox. Reviewers are
+  # right to look hard at this: it is precisely what sandboxing exists to prevent, and a
+  # granted --socket=x11 plus device access is close to full input control of the session.
+  #
+  # If Flathub declines these, the package still works: set
+  #   [injection] backend = "clipboard"
+  # in config.toml and the transcript is placed on the clipboard for the user to paste.
+  # That is a real degradation and it must be documented in the app description rather
+  # than discovered by users. Do not quietly ship a build that cannot type and call it
+  # the same product.
+  - --socket=x11
+  - --socket=wayland
+  - --share=ipc
+
+  # --- Model download on first run, and nothing else. ---------------------------------
+  # Network is needed once, to fetch the speech model from Hugging Face. Inference never
+  # uses it. This is the one place the "nothing leaves your machine" claim needs its
+  # caveat stated out loud.
+  - --share=network
+
+  # --- Where the model cache and the user's config live. ------------------------------
+  - --filesystem=xdg-config/yazses:create
+  - --filesystem=xdg-cache/yazses:create
+  - --filesystem=xdg-data/yazses:create
+  # Reading recordings the user asks to transcribe. host-os/home is deliberately NOT
+  # requested: `yazses transcribe` takes a path the user chose, so the portal is enough
+  # for the GUI case and this covers the common CLI case without opening the home dir.
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+modules:
+  - name: portaudio
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
+        sha256: 47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def
+
+  # Modern setuptools, installed BEFORE the dependency modules.
+  #
+  # The SDK ships a setuptools too old to parse a PEP 639 SPDX `license` string,
+  # and `evdev` uses one. It publishes no wheels — only an sdist — so pip must
+  # build its metadata with whatever setuptools is present, and the old one dies
+  # with "invalid pyproject.toml config: `project.license`". evdev is not
+  # optional: it is how hold-to-talk reads the key while another app has focus.
+  - name: python3-setuptools
+    buildsystem: simple
+    build-commands:
+      # --ignore-installed matters: without it pip tries to uninstall the SDK's
+      # setuptools first, and that lives in read-only /usr, so the whole module
+      # dies with Errno 30 before installing anything — even though --prefix
+      # points at /app.
+      - pip3 install --no-index --find-links="file://${PWD}"
+          --prefix=${FLATPAK_DEST} --ignore-installed setuptools
+      # Proves PYTHONPATH actually put the new one first. Without this a failure
+      # surfaces later, inside evdev, where it is far harder to read.
+      - python3 -c "import setuptools; print('setuptools', setuptools.__version__,
+          setuptools.__file__); assert int(setuptools.__version__.split('.')[0]) >= 77" 
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl
+        sha256: 51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670
+
+  # Generated by req2flatpak — see the header. Kept in a separate file so a
+  # dependency bump is a regenerated file rather than a hand-edited diff nobody can review.
+  - python3-yazses.json

--- a/python3-yazses.json
+++ b/python3-yazses.json
@@ -1,0 +1,264 @@
+{
+    "name": "python3-package-installation",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --no-build-isolation annotated-doc anyio av certifi cffi click coloredlogs cryptography ctranslate2 evdev faster-whisper filelock flatbuffers fsspec h11 hf-xet httpcore httpx huggingface-hub humanfriendly idna markdown-it-py mdurl mpmath numpy onnxruntime packaging platformdirs protobuf pycparser pygments python-xlib pyyaml rich setuptools shellingham six sounddevice sympy tokenizers tqdm typer typing-extensions wheel yazses"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl",
+            "sha256": "117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl",
+            "sha256": "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl",
+            "sha256": "8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl",
+            "sha256": "62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f7/a4/4399daaf8f7dfee9d7c3327fdb0426ee041cc63edc358b93911ceb2bfc7a/cffi-2.1.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "34e261f78cb6ceaaa36f42f2613f4380d94d9c759a9c73c769ee6e0247364632",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl",
+            "sha256": "e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl",
+            "sha256": "612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl",
+            "sha256": "82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/82/a6/26d5d004717b923f6c46ab8495bb07b42f7a1003faefc6767c4f37bc9b57/ctranslate2-4.6.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "0a52715fd86c1b1a339b6f9f99449d375a2486f1a87c1066460f4c4e7491924c",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz",
+            "sha256": "2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/05/99/49ee85903dee060d9f08297b4a342e5e0bcfca2f027a07b4ee0a38ab13f9/faster_whisper-1.2.1-py3-none-any.whl",
+            "sha256": "79a66ad50688c0b794dd501dc340a736992a6342f7f95e5811be60b5224a26a7"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl",
+            "sha256": "7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl",
+            "sha256": "7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl",
+            "sha256": "b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl",
+            "sha256": "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+            "sha256": "d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl",
+            "sha256": "2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl",
+            "sha256": "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/de/d8/95b735e183957c1f26d94c52977f09d466d55119cbbc1558ea4975e4c216/huggingface_hub-1.27.0-py3-none-any.whl",
+            "sha256": "7df6827c2f956c60fbaa64646e979e566db76f619dd0a9729dfb8c5a3eb4f68d"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl",
+            "sha256": "1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+            "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl",
+            "sha256": "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+            "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl",
+            "sha256": "a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/8a/12/ddbf34a866fd0022883bc14cbec3aa2429d54783fa0c90f1fcbc14206249/onnxruntime-1.16.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "sha256": "3e253e572021563226a86f1c024f8f70cdae28f2fb1cc8c3a9221e8b1ce37db5",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl",
+            "sha256": "d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/49/e2/4e6eee633809c376c024821b91ade709cbfd040ec53939ffbcc292aa7eee/platformdirs-4.11.2-py3-none-any.whl",
+            "sha256": "7f89089b6ea71bda7962953edcf784b2e2d9d285b40ad88be2bb75c6e9d82ab4"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl",
+            "sha256": "74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+            "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl",
+            "sha256": "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl",
+            "sha256": "c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl",
+            "sha256": "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl",
+            "sha256": "51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl",
+            "sha256": "7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+            "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl",
+            "sha256": "30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl",
+            "sha256": "e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+            "sha256": "5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4",
+            "only-arches": [
+                "x86_64"
+            ]
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl",
+            "sha256": "7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl",
+            "sha256": "53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+            "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl",
+            "sha256": "3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/18/0c/840cd1038f68a751350347fa3c666bd692c8f98718aadb2d28e1d44ee666/yazses-2.18.2-py3-none-any.whl",
+            "sha256": "84c648e4f0244749ddcf9c4d1d107428cb126b7801f15b5ba29783c8fe5c618b"
+        }
+    ]
+}


### PR DESCRIPTION
**[YazSes](https://github.com/MSKazemi/yazses)** — offline hold-to-talk voice dictation. Hold a key, speak, release, and the transcript is typed into whatever application has focus. Transcription runs on-device with faster-whisper: no cloud, no API key, no subscription. Apache-2.0.

Disclosure: I am the maintainer.

## Builds

`flatpak-builder` runs green in the project's own CI on every change to `packaging/flatpak/**` — modules, `build-finish`, and a bundle. `appstreamcli validate` passes on the metainfo.

## The permissions, stated up front

I would rather argue these here than have them found in review.

| Permission | Why |
|---|---|
| `--socket=pulseaudio` | the microphone; without it there is no audio at all |
| `--device=input` | **hold-to-talk.** `evdev` reads `/dev/input/event*`. There is no portal for "notice a key being held while *another* application has focus" — the interaction is by definition outside our own window |
| `--socket=x11` / `--socket=wayland` | typing the transcript into the focused window. This is the contested one, and reviewers are right to look hard at it: synthesising input into applications outside the sandbox is what sandboxing exists to prevent |
| `--share=network` | a one-time speech-model download from Hugging Face. Inference never uses the network |
| `--filesystem=xdg-config/cache/data/yazses` | config and the model cache |
| `--filesystem=xdg-documents`, `xdg-download` | reading recordings the user asks to transcribe. `host` and `home` are deliberately **not** requested |

**If the input/injection permissions are declined, I would rather ship a degraded build honestly than argue.** Setting `[injection] backend = "clipboard"` puts the transcript on the clipboard for the user to paste; that is a real reduction in what the app does, and it would go in the app description rather than a footnote. What I will not do is ship a build that cannot type and describe it as the same product.

This is also the one capability Snap could not grant — the store build cannot do hold-to-talk at all — which is why Flatpak matters for this app specifically.

## Dependencies

`python3-yazses.json` is **generated, not hand-written** (`req2flatpak`, pinned to Python 3.11 / x86_64 to match `org.kde.Sdk//6.7`); 45 sources, each with a sha256. Regenerating it is a CI job in the upstream repo, so a dependency bump arrives as a regenerated file rather than a hand-edited diff.

`org.kde.Platform` rather than the GNOME runtime because it carries Qt 6 for the tray icon and voice-activity overlay.

The app ID uses `mskazemi.com`, a domain I control and which serves the project's documentation.