### PR TITLE
Add io.github.blindrun.OutpostChat

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,0 +1,4572 @@
+[
+  {
+    "type": "file",
+    "url": "https://github.com/electron/electron/releases/download/v43.2.0/SHASUMS256.txt",
+    "sha256": "823ec97893f00c3ab2a4d44811bc75f7dd582ff6086407109a179c2184c5702d",
+    "dest-filename": "SHASUMS256.txt-43.2.0",
+    "dest": "flatpak-node/cache/electron"
+  },
+  {
+    "type": "file",
+    "url": "https://github.com/electron/electron/releases/download/v43.2.0/electron-v43.2.0-linux-arm64.zip",
+    "sha256": "50e1cdefbf8590e0d89b0276314a99c7b98e8eed732204c6f1a1c2a38376ed87",
+    "dest-filename": "electron-v43.2.0-linux-arm64.zip",
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://github.com/electron/electron/releases/download/v43.2.0/electron-v43.2.0-linux-armv7l.zip",
+    "sha256": "e5cf445bda3ef071bbe9f16dfbabbca61b24b528f2dcbdff227e98fb349c99e8",
+    "dest-filename": "electron-v43.2.0-linux-armv7l.zip",
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://github.com/electron/electron/releases/download/v43.2.0/electron-v43.2.0-linux-x64.zip",
+    "sha256": "f77ca6ed67bbc68702b69b56ad499bca6ae090705ade7d04f0ac545e409dec68",
+    "dest-filename": "electron-v43.2.0-linux-x64.zip",
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+    "sha512": "66bd55b3b13db6908d8591c301b1555dcda0115086f51a8f0e3ae7a39f9b76007a2d102ebe0c8c1c9bade0d095c98c2d02279aa4ccdcddf890dc24938bbe4046",
+    "dest-filename": "55b3b13db6908d8591c301b1555dcda0115086f51a8f0e3ae7a39f9b76007a2d102ebe0c8c1c9bade0d095c98c2d02279aa4ccdcddf890dc24938bbe4046",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/bd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+    "sha512": "8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+    "dest-filename": "eb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+    "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "dest-filename": "0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+    "sha512": "17e9ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+    "dest-filename": "ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/e9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
+    "sha512": "de4481b46f0e6dc4d57d76a79b9bd527a52704b115995b1193533ebc6a82b8c055f972c26c962e5907ee97ec88cb41900ec4a52b490712b8841e7ed23e4e049c",
+    "dest-filename": "81b46f0e6dc4d57d76a79b9bd527a52704b115995b1193533ebc6a82b8c055f972c26c962e5907ee97ec88cb41900ec4a52b490712b8841e7ed23e4e049c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/44"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+    "sha512": "8cd4fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
+    "dest-filename": "fc9f01f57fd5f91842135da43c205fca76c92f2243857c1d82bf0ba6b2f79589dce949cfa6be185331d0064981773be36ae3d949ef2facb0e0d15eed3af8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/d4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+    "sha512": "299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+    "dest-filename": "26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/9f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+    "sha512": "44a2ff3be8c6a1724cc6bc7fe7bef5cb59f4c532a616e39818ede0326c32a4133aaec1f4928bb49acc3075703626b848904e31c82eeff6f1a4d27e8d3f380ec5",
+    "dest-filename": "ff3be8c6a1724cc6bc7fe7bef5cb59f4c532a616e39818ede0326c32a4133aaec1f4928bb49acc3075703626b848904e31c82eeff6f1a4d27e8d3f380ec5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/a2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+    "sha512": "5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+    "dest-filename": "6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
+    "sha512": "75f65ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+    "dest-filename": "5ea31eba02f74fb5bda50fc3ac208421d764e9d063424540df04720a1a96e6a2966da36fc0f274a96182e879d3c81e9aa479b959fe4f0e5741b2ecf62ec9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/f6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+    "sha512": "c209bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
+    "dest-filename": "bd1219768e97aa3f7cf0ffb9a8de4447169e4c10386a01dc32d5f4c69070309e418e56c829bd084bf01e67d6a95bd358d5de7fdb23465f669e65580d64e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+    "sha512": "d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
+    "dest-filename": "4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/3a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+    "sha512": "f503ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
+    "dest-filename": "ad35f7dc385fdcd6c78c0839e37246f747d587706df8b64cbe147a4d28a096d3073fb1c60bc0cb4efa9b721947cc5b4fdbfe7e2a46200b95a14773d3a3ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+    "sha512": "575249d564d152a1c7ace4a1e7dee151170ca9529518bfde6b792fd204a711db04674ffe5723e084cd6530d19cd34cfb088428ad2bdb2a9b89931bee1dbbdd6e",
+    "dest-filename": "49d564d152a1c7ace4a1e7dee151170ca9529518bfde6b792fd204a711db04674ffe5723e084cd6530d19cd34cfb088428ad2bdb2a9b89931bee1dbbdd6e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+    "sha512": "218a831a24d769be859e20209d2759c2059ba26c69cbd16d62f2cab3bc0252cd9af119084c6f831463b50ccf5cafe137fd18000d1a458eb295689d73eac8ed12",
+    "dest-filename": "831a24d769be859e20209d2759c2059ba26c69cbd16d62f2cab3bc0252cd9af119084c6f831463b50ccf5cafe137fd18000d1a458eb295689d73eac8ed12",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/8a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+    "sha512": "ed84f453fcded2d17640e05b135e60299c32e6dbe01b22d18911cbce195b3a97fb053d37da805277485a66a5e7e56ea5dba58b96edddcb1ce333edbadfcff3d9",
+    "dest-filename": "f453fcded2d17640e05b135e60299c32e6dbe01b22d18911cbce195b3a97fb053d37da805277485a66a5e7e56ea5dba58b96edddcb1ce333edbadfcff3d9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+    "sha512": "72851fba831e201ec1f3f34c7a4c5a0f32e16989a9d0764d3c48d8466f60a11a2ef146480b7cf6d6cd2c2fd016a02c38106f3be90c8ede462b73ad56345f41ff",
+    "dest-filename": "1fba831e201ec1f3f34c7a4c5a0f32e16989a9d0764d3c48d8466f60a11a2ef146480b7cf6d6cd2c2fd016a02c38106f3be90c8ede462b73ad56345f41ff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+    "sha512": "fa82f71cf151219d52b762b9d255825e28a82204a8c73cfb475277b85ea778edb2975b209a9818e975c91f805da680e4316ce741379817aa1634364b09d43879",
+    "dest-filename": "f71cf151219d52b762b9d255825e28a82204a8c73cfb475277b85ea778edb2975b209a9818e975c91f805da680e4316ce741379817aa1634364b09d43879",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/82"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+    "sha512": "3833a8bf4b0630931fde33e89ce9201aa3e49d3b2ef83750ee40fefa0cfc688f9a14c38c1c56d6000dad6aa5d755374ff8e4ce411ff39c6bd2a6691e23459361",
+    "dest-filename": "a8bf4b0630931fde33e89ce9201aa3e49d3b2ef83750ee40fefa0cfc688f9a14c38c1c56d6000dad6aa5d755374ff8e4ce411ff39c6bd2a6691e23459361",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+    "sha512": "b74f6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
+    "dest-filename": "6f48ddcc75fb32087a057134421ff894b46ece2740ac8f307c72302629cfef6bf90881e0c8fd3c6c8a0767704ff86deef7e26d1cbc863035a5788b65ea03",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/4f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+    "sha512": "e0101f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
+    "dest-filename": "1f7f29183a03bee67cc1598c04dd6f74b0180b26850f45659c2fcc25ca233c201f22a49cf750c27d29741dd512905e92a9f13bad9fcd0766d5acbb6bbbeb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/10"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+    "sha512": "210dc46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab",
+    "dest-filename": "c46d3cc6c488a06f5237a8f65cd6b5899c7d019922afe506136a5130c1e16fc810cb4807b6e333f495efe1ca2ede7067d9565215020e0166a6fc581c0aab",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+    "sha512": "2925609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b",
+    "dest-filename": "609909b33303e59ad9633a899aca847cf56e05ca70808b713c3cfb3bbe60d53def38853faf18f2a425f4e19265ecd31d2301a6bd53cb96f1b6dfc92d9f5b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+    "sha512": "9c49f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4",
+    "dest-filename": "f007efb5bb99550ccd94238735fb947e15868a7da0334b83a87287229a3566de7430dd3bb31f950db2872b71305b8677ab6e5c878f8038f6a5db22265da4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+    "sha512": "2f72e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1",
+    "dest-filename": "e08a62c75ed1a45a290a9ec3e0d3f545c7d38665a0be78dd6ee2bf8e0755d1a87de6781200542db3af559d307f911e69d192a962400387349fc4d23fded1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/72"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+    "sha512": "050e5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
+    "dest-filename": "5a64d482a63ec3e8ada4b2b4424e62912c4a673ef58388b3dfa06ca167efbc62d88af5dff70c128f260af2df9f57fcfd4f7ebbb2630be7bf0163b8488422",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/0e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+    "sha512": "1ac0822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+    "dest-filename": "822190c4fe9de2f7abed12ac7eedd054197adcef37922b7c303c721a453852fbd3a15885d1ab3b3877a93549553c83dd43acd456c56506869e4a5d06f654",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+    "sha512": "0e1f2f02c577ea2839c1af4e5f8a57bcc73d0f755e89b7f0db08b1d0253060e0cb0fc9e48fd52c2e3012af8f673e0fb678acf184157ebfb2fca57bd3e1eeb7f5",
+    "dest-filename": "2f02c577ea2839c1af4e5f8a57bcc73d0f755e89b7f0db08b1d0253060e0cb0fc9e48fd52c2e3012af8f673e0fb678acf184157ebfb2fca57bd3e1eeb7f5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/1f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+    "sha512": "1fff8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb",
+    "dest-filename": "8bf94913577dee7f8f4f1f9a420140553cd8f69c30574cdfaa4b574ec32ca0db897709c89c89c080edc6be1ccbc9059705825e6bf1ef9147a7a5b1be0bcb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+    "sha512": "291633c5ea5cd781bf084a4419cdd89fe24a680793eb7b26943afebe307c8d17e04c1048f70463fe791010efae715f29f08f5b7ca2d6a77eee1e016b6e7b4fbf",
+    "dest-filename": "33c5ea5cd781bf084a4419cdd89fe24a680793eb7b26943afebe307c8d17e04c1048f70463fe791010efae715f29f08f5b7ca2d6a77eee1e016b6e7b4fbf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+    "sha512": "6b5c1f97268bd2d1ed25298b48e5726d8872db6bd18a1e1e76e861ae472382b5869d17eb66da2f2761518f1b93b64923e3b3bf6da7f447ce905393ae629cfc7c",
+    "dest-filename": "1f97268bd2d1ed25298b48e5726d8872db6bd18a1e1e76e861ae472382b5869d17eb66da2f2761518f1b93b64923e3b3bf6da7f447ce905393ae629cfc7c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/5c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+    "sha512": "32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest-filename": "3e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+    "sha512": "4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+    "dest-filename": "e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+    "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest-filename": "505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+    "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
+    "sha512": "d959f25a4aac3f9bf95db0612f7b43e52cb1f2234f058b2853b918e12d9fcfbc20f118ff9f3b5628253318a685453bf45f07f7fc7d39f024752afb5dff7951a3",
+    "dest-filename": "f25a4aac3f9bf95db0612f7b43e52cb1f2234f058b2853b918e12d9fcfbc20f118ff9f3b5628253318a685453bf45f07f7fc7d39f024752afb5dff7951a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+    "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+    "dest-filename": "56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+    "sha512": "4b6b3768ecad88a74545dba5c36a8f139d4cce3cd53a2b29a5c56fee354547e2b0d24c70bc5ac371803487b35da9b9a3d0790c2176166a88fb7e58bc920c757a",
+    "dest-filename": "3768ecad88a74545dba5c36a8f139d4cce3cd53a2b29a5c56fee354547e2b0d24c70bc5ac371803487b35da9b9a3d0790c2176166a88fb7e58bc920c757a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/6b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+    "sha512": "356d9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+    "dest-filename": "9c5fc9b543b28f03b6b933650b41e676c11e6a2393c06f0e4bd1438cc5d8a8564f4f319d21d539b264490f62b0af6230e51480aeb0ebb576510a00079707",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+    "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+    "dest-filename": "940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+    "sha512": "39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest-filename": "bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+    "sha512": "faafedec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa",
+    "dest-filename": "edec492fd440d8da5e8675ae8b2e25f5e2b53d4d5db459ade87de426c0f1596ce328f435eb2db3a315a69c9645ca5a27486a8a7000e6d00eac16b46523aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+    "sha512": "9477badb3bdb4c1e5e100054562fc0c1587464a63dacc3038669be79ecaeb9441b437f89f9f38d550399ca3f8376bbc3e01637dee6278b2449e142486922807f",
+    "dest-filename": "badb3bdb4c1e5e100054562fc0c1587464a63dacc3038669be79ecaeb9441b437f89f9f38d550399ca3f8376bbc3e01637dee6278b2449e142486922807f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+    "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest-filename": "9e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+    "sha512": "04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+    "dest-filename": "e011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+    "sha512": "00aa5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
+    "dest-filename": "5a6251e7f2de1255b3870b2f9be7e28a82f478bebb03f2f6efadb890269b3b7ca0d3923903af2ea38b4ad42630b49336cd78f2f0cf1abc8b2a68e35a9e58",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+    "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
+    "dest-filename": "63e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+    "sha512": "774208fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
+    "dest-filename": "08fc63bdb9ff657d41c7d8142c8f1cd125905db2382c0625b806f85693fdeaa0ac1016320354dd7d3df5fc1760ffafd3c2313b4b5a3615085ae9798533b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+    "sha512": "11d7a9fd7f5f1aa54d9b328156c0d820eb43fb3d6db9ecd5ef42c18dd0acb7d4eabbbea5b27bd1899ea84e27359fefc12305fa4031803bde0f3783764800efb7",
+    "dest-filename": "a9fd7f5f1aa54d9b328156c0d820eb43fb3d6db9ecd5ef42c18dd0acb7d4eabbbea5b27bd1899ea84e27359fefc12305fa4031803bde0f3783764800efb7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+    "sha512": "8467d5ccfc6d85b7f7fb6ca383f441b3ad1c074161a814bfcef755ff8c27e3f0663746cd30c1cf73857f05b1627aa7f54ca0061801e76387928da8c29747f65e",
+    "dest-filename": "d5ccfc6d85b7f7fb6ca383f441b3ad1c074161a814bfcef755ff8c27e3f0663746cd30c1cf73857f05b1627aa7f54ca0061801e76387928da8c29747f65e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/67"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+    "sha512": "49c43822ebc8105d533253fb66dfaf8c9ffff7394f6f64837315b13376e4f2ceade8619d27b28ed5d09c4e274e3c929e3d6df42c4ff6713ef00b23e1a3dfd6c6",
+    "dest-filename": "3822ebc8105d533253fb66dfaf8c9ffff7394f6f64837315b13376e4f2ceade8619d27b28ed5d09c4e274e3c929e3d6df42c4ff6713ef00b23e1a3dfd6c6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+    "sha512": "13e5d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+    "dest-filename": "d0091c126da6a20a1b6fea4e83c2073e6f1f81b3abee2891c7979928c7f05a29b8625f3a903b02b870edb6c84946a763829a3c15853dc79b18323c69c97d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+    "sha512": "83f911e76d208801589125d3cdc985de4a90abbc22f05e8de92cde0e066ba9304df951dd9a058ec93743d720fb0004c321dff25cbbee3f7e02c56e3afc1c0277",
+    "dest-filename": "11e76d208801589125d3cdc985de4a90abbc22f05e8de92cde0e066ba9304df951dd9a058ec93743d720fb0004c321dff25cbbee3f7e02c56e3afc1c0277",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+    "sha512": "ab6867ecc6e8da714d9157a43e21c5c7a35fa37854466112ded7c19fe9393eac65d919263f7406a995211ffabd3dc87fe06d3935184f8c39558f53bcab84f1bf",
+    "dest-filename": "67ecc6e8da714d9157a43e21c5c7a35fa37854466112ded7c19fe9393eac65d919263f7406a995211ffabd3dc87fe06d3935184f8c39558f53bcab84f1bf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/68"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+    "sha512": "53567fa1bef557f6d77d5001bcdaff2ae99fe55c9e4110449ba4f16f43d0e92ed5e46a41337c3809bab3ff13c389c479b4dd2ebc389f9e0f02fb9a8409e1b0c9",
+    "dest-filename": "7fa1bef557f6d77d5001bcdaff2ae99fe55c9e4110449ba4f16f43d0e92ed5e46a41337c3809bab3ff13c389c479b4dd2ebc389f9e0f02fb9a8409e1b0c9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+    "sha512": "dbf90db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980",
+    "dest-filename": "0db1c3e1a5cc6b3a280c6736e2585eddcfc8a585bfe72075371326625d65e97aafdabbca89f1585d7ed324b72de7ec68fa1c819a9501bca2204d07700980",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+    "sha512": "bfea7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72",
+    "dest-filename": "7aa2782cae9d324c66c95e38313e8c36f832fddc30123f891708329bf3f6f046db7d384177c218209240e418dce0716cb65da1786bc9d98250bbb8496c72",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+    "sha512": "4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest-filename": "5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+    "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest-filename": "db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/a9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+    "sha512": "f88c7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
+    "dest-filename": "7363d05939077f5ee60f466aef1158c5fe7aa3e64813e2412aed5a1fac3a0cd4cc6846311692b082dc4b4b8b9f5355ac314c09fea2b27015072ba84375fa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/8c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+    "sha512": "d51e45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b",
+    "dest-filename": "45868fa306ad030f276dfbfbc75a3e4a24d24229d01128e0b06547a7f3823906b796a0ba912c0347d54f3b789cb5b620123ed3271aa249ab466c2e844f3b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+    "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+    "dest-filename": "b6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+    "sha512": "efb3d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+    "dest-filename": "d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+    "sha512": "05278d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest-filename": "8d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/27"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+    "sha512": "44ea0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0",
+    "dest-filename": "0bf788c91f675454c2f663fe4f10335a48781e39d48389c5324bb8b3705eb71bab1373f1538cbb9be1bf0897d4bc4b46de39f62dd13680e6abc52bec34c0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+    "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+    "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+    "sha512": "1503783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest-filename": "783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+    "sha512": "3f40b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
+    "dest-filename": "b2b0d0d0eebb55c3840842d9be311c55ebabca152be5b10bc6617656477a855348e530a1d9659830f1efbc0d26a1e140ca32a9e49d10d0cfec6e41743f66",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+    "sha512": "291b3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+    "dest-filename": "3b5950ca83ce8f5a2b80aa10eb0109d35d92ab69570273abc574bd78aab67f0dc5b0b91a3b5688985da9573bb4b918aa6a622544c026e01437f134728905",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/1b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+    "sha512": "a490e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8",
+    "dest-filename": "e1e7fe30ac49d75ff556459bebb8018793329daf8eb3d753a54cf37e56b0139565a148a7b03422757eeb423b90bb7890779cf305640d4b798b5c15ba19d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+    "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+    "sha512": "65006f8b50dca49e060ea6a78ee719d878f7c043b9a590d2f3d0566e472bbddc64b09a2bc140c365a997f65745929f5ac369660432e090e6c40380d6349f4561",
+    "dest-filename": "6f8b50dca49e060ea6a78ee719d878f7c043b9a590d2f3d0566e472bbddc64b09a2bc140c365a997f65745929f5ac369660432e090e6c40380d6349f4561",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+    "sha512": "f91d3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+    "dest-filename": "3cfe82349e5def7cf72a7ed651a72b64b015c3cce52f781abf341571d2c529d5ac70ccf42b2a29cdc79c9de6cc4fbbc8f5c08cbc01f9d543ee5e15d85ae9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+    "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest-filename": "903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+    "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest-filename": "305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+    "sha512": "696df9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+    "dest-filename": "f9c9933a05bff8a099599dc307d8b0a866d2574d1c444b5eef137868462a305369161da24a1644810e70d1f9c9bd27ef5085799113221fbf4a638bd7a309",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+    "sha512": "e2dbedb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e",
+    "dest-filename": "edb5ea571b555a606ad189b93913025dd6de2e76e9d239531d2d200bea621dd62c78dfca0fc0f64c00b638d450a28ee90ed4bd2dc0d706b1dcd2edd1e00e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/db"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+    "sha512": "ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest-filename": "2f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+    "sha512": "f109902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest-filename": "902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+    "sha512": "672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest-filename": "83ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+    "sha512": "4f4348b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+    "dest-filename": "48b90a674ef14301336e1cde6ba0fc12046f37ac5b2e3be3175c7f7fdcdd5e15b9f8c1c3e3b6dbe330b10f589d11194620404edc1a04b7b4dc5ba8218cee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/43"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+    "sha512": "db130298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+    "dest-filename": "0298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
+    "sha512": "3b7cc95055181c92a0ccfaa2a07c5fc730739520b5797092afbf6031204a04fe408238e99abc9d32c30ba2d120f5f009177eaf7549dc6fee27751371a0f76549",
+    "dest-filename": "c95055181c92a0ccfaa2a07c5fc730739520b5797092afbf6031204a04fe408238e99abc9d32c30ba2d120f5f009177eaf7549dc6fee27751371a0f76549",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+    "sha512": "cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+    "dest-filename": "f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/81"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+    "sha512": "b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+    "dest-filename": "b87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+    "sha512": "28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest-filename": "7f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+    "sha512": "6ac2c555f596b49f746723941ccaa4eff4b6c3682e40ac542368ad8f777dd800c78715126c23068b57f5701709ef13354e8fa913f2a16f0a35cae35b3043ca78",
+    "dest-filename": "c555f596b49f746723941ccaa4eff4b6c3682e40ac542368ad8f777dd800c78715126c23068b57f5701709ef13354e8fa913f2a16f0a35cae35b3043ca78",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+    "sha512": "51e26615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
+    "dest-filename": "6615f3ab0104bc38958f678aad807c961316b4f3cfccb4ae54132a091851faedc0c45e4652be23a2291099e178a3d33c48dc9102818b37a0ac7e022cd004",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
+    "sha512": "25cd7d5cf57dcbdfb66c07593e45ee54d18d204141abda681c2eb597c2afe8574aec3446dfe21cd2b7ab0b40d739a787373f325b47e0fc99c5f0641138e17930",
+    "dest-filename": "7d5cf57dcbdfb66c07593e45ee54d18d204141abda681c2eb597c2afe8574aec3446dfe21cd2b7ab0b40d739a787373f325b47e0fc99c5f0641138e17930",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
+    "sha512": "6b528ce617aa4b7810099ce2cd7108f118c9cb7415a2050b3dd792927b7beae2c3a41216fc70c6b0c83f5e03f4ae23fa3c8f423ac46f1484ca2860ea03c7c9c4",
+    "dest-filename": "8ce617aa4b7810099ce2cd7108f118c9cb7415a2050b3dd792927b7beae2c3a41216fc70c6b0c83f5e03f4ae23fa3c8f423ac46f1484ca2860ea03c7c9c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+    "sha512": "83fd9b9fc6136af63872e4b917e8ce4bbce665b5d7055f0a67cc8729f26314fa0ab7306aae909d34fc41777b6a741c0fec155dd251b37fb064dacd0a7ac599e1",
+    "dest-filename": "9b9fc6136af63872e4b917e8ce4bbce665b5d7055f0a67cc8729f26314fa0ab7306aae909d34fc41777b6a741c0fec155dd251b37fb064dacd0a7ac599e1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/fd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+    "sha512": "66157133d88638d52964623517174c4602635055e2ec060655ae4fc0a94ed6d575ff8cc3c5099f2a95ce1d5ced2ab77a2fdacb7058c446f8b531fdafc724e48a",
+    "dest-filename": "7133d88638d52964623517174c4602635055e2ec060655ae4fc0a94ed6d575ff8cc3c5099f2a95ce1d5ced2ab77a2fdacb7058c446f8b531fdafc724e48a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+    "sha512": "6cedf2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+    "dest-filename": "f2d7462292e53052e0d441133829fc0d90a867a553bb20f75bb2b7a3c0df7f000049cf34d0e06787c32ccd4ab54efad107dff369db9e5adec559a590e3be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+    "sha512": "f34cefae01bb6515c3fad0f42322efae737d9febde4b169d311b0c682f7028a3f78946ed0bbac633cf9d56e0a639bd11af0c2ff04496e1ac2751987d1dba757c",
+    "dest-filename": "efae01bb6515c3fad0f42322efae737d9febde4b169d311b0c682f7028a3f78946ed0bbac633cf9d56e0a639bd11af0c2ff04496e1ac2751987d1dba757c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+    "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest-filename": "d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+    "sha512": "a2810673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
+    "dest-filename": "0673a1cfdbac57abf37e18218e4f424a08b0c6aead9b41466b43b832ac989900d27ff180d3c53a5005718c9fe59b2105cd569c96ca69bb2985480909f23a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/81"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+    "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+    "dest-filename": "6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+    "sha512": "76d2544dea73316dcb9bf34fc517f7c0fe3ae365168632f6b10c5cfb29b660c8f59bf1f6cc33503a57b369fce41f09fab0cb2d8c74f01ba89042c72d0d6fdbd4",
+    "dest-filename": "544dea73316dcb9bf34fc517f7c0fe3ae365168632f6b10c5cfb29b660c8f59bf1f6cc33503a57b369fce41f09fab0cb2d8c74f01ba89042c72d0d6fdbd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+    "sha512": "d9b9a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
+    "dest-filename": "a546934a0714ff09198f3a5c88490a4d8fea92798bdcca6fee4f4271d9b30e94a2ed4b2d5998bb95c5210a2b2a2bfcde7286fa7f6621b5a04dc311831214",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+    "sha512": "7b79d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest-filename": "d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+    "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest-filename": "47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+    "sha512": "1d6701a0de8d8a57aab52c9d2b616a1db4bf2e80ddda9aab9d01cbc89cc18f890ea7f932d8c58c37af78c4e7e42bcfd29d4b16d831fb11fc9597274a0ac9b567",
+    "dest-filename": "01a0de8d8a57aab52c9d2b616a1db4bf2e80ddda9aab9d01cbc89cc18f890ea7f932d8c58c37af78c4e7e42bcfd29d4b16d831fb11fc9597274a0ac9b567",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/67"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+    "sha512": "8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest-filename": "d6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+    "sha512": "526ffe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
+    "dest-filename": "fe17132bf422125a1d1b8b966fd22383fb8705879a8b7a4b35aa1028a4a540270dddae029b2b24a2929ef01a10cbd073de6a36b43f950b66bc4b92789456",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+    "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+    "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest-filename": "5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/da"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+    "sha512": "66011e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+    "dest-filename": "1e6578f7d2af88d0437e09b492a48c8f689e475500f5f19d66faed455db01e4fde26af5cf0e74ab8aba8e2882e38ecd97f61370861201fb621aa7adc1708",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+    "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest-filename": "90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+    "sha512": "807c00d4ef4b0c870aba730a84e6d2fc78a6c2d7a13b59cf50408a02ee53a4a81a3b5f5f716125e1b96259ed635b1545bc85f3b498e34382fc5d0d4453d7fb27",
+    "dest-filename": "00d4ef4b0c870aba730a84e6d2fc78a6c2d7a13b59cf50408a02ee53a4a81a3b5f5f716125e1b96259ed635b1545bc85f3b498e34382fc5d0d4453d7fb27",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+    "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest-filename": "d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+    "sha512": "e608b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4",
+    "dest-filename": "b2d8f90b618d5c3f7f69d7b11c87edb19694d12fd1cbb2939f1209b42fa0b005705382c2b9a2ed09b7362e7a9c64690fedbe1085209e6e5e8d0eaccd83c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+    "sha512": "bca6ad021e129557e06eff98b66862463844309b18a6c1b5636acc42d47e49549bcadb120f5606cc321cac026674579cf3cbbff95a069b19e5fbcd202f5b5109",
+    "dest-filename": "ad021e129557e06eff98b66862463844309b18a6c1b5636acc42d47e49549bcadb120f5606cc321cac026674579cf3cbbff95a069b19e5fbcd202f5b5109",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+    "sha512": "a115c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+    "dest-filename": "c0a6ae78113463e1e3221731a71d61b2fb3a39adab9d8eec4dd1bf07eecfd1536a16d16becc7d3b400244dfe446af44f15bbf45eb24181e68de38be1731d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+    "sha512": "797bc61b067908bd7b652c0759dddb6e093b514a45e88147b4fe7b35861a90fbc73acf060e00dee4a248dfa8c82730e427a7898eecd103c78141be9290ab9ed2",
+    "dest-filename": "c61b067908bd7b652c0759dddb6e093b514a45e88147b4fe7b35861a90fbc73acf060e00dee4a248dfa8c82730e427a7898eecd103c78141be9290ab9ed2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+    "sha512": "110b05ccc509902286af578faa56000e42149875b5b37657af962acbac1b1ab7d40a986997699a33f932388440d87a4fdc06854136570f895d8de93e9dc71d74",
+    "dest-filename": "05ccc509902286af578faa56000e42149875b5b37657af962acbac1b1ab7d40a986997699a33f932388440d87a4fdc06854136570f895d8de93e9dc71d74",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/0b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+    "sha512": "6090da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+    "dest-filename": "da0896449c199c6f0d777ef74033d03034e2703b3ac4e29a8ca81ab99c5884a9752a1f094ae01fb7a54c3a24dbdf48fb57d39c451ed632ff59e2d357860b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+    "sha512": "ca1950800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2",
+    "dest-filename": "50800ea69ce25428eb11505b2025d402be42a1733f2d9591b91c141f45e619cb8e8ec0b718f9989ad26b5d1ec3a8f72fe13fe0b130dd1353d431a0eb46e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/19"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+    "sha512": "85c8376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+    "dest-filename": "376667a94b7d3fec1485a91be8a370ce310bbb223ab13b99c20edfb333d5d68dbdf75a0ef388d4fe42fa9bb9cdfe816a733b4d89b9b5729361b866fa3539",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+    "sha512": "38ed291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest-filename": "291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+    "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest-filename": "cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+    "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest-filename": "4fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/21"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+    "sha512": "f5f4a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest-filename": "a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+    "sha512": "b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest-filename": "9f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/34"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+    "sha512": "9c117e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
+    "dest-filename": "7e175ac06550aefe9eeb8f3800f986f895f617ae997b6ba56626b53cc05f48d422af3ff4303cd6479ce9706d3918e9dbed148cc5312c905db2e84d03d1a4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+    "sha512": "9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest-filename": "74ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/54"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+    "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+    "dest-filename": "9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/3e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+    "sha512": "0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest-filename": "ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+    "sha512": "65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest-filename": "9187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+    "sha512": "ead7d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2",
+    "dest-filename": "d9f756ceafb6ce5e72bb3d10c21812dad47e14d3cd181cd6804362ac30694b13345b938e27b1917613521e45cdefb491cf55b2826207456da18eda58ddf2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+    "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+    "dest-filename": "79fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+    "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+    "sha512": "e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest-filename": "4d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+    "sha512": "d5c0cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest-filename": "cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+    "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest-filename": "0307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+    "sha512": "4f651b7db044177db089ea5722c3254d6f7e743602eb0321fedfef600e2db8e30aa96cff9f7bebd4d152c508b23fece4da65eca0c03f8bfeea57a2cabadd6dd4",
+    "dest-filename": "1b7db044177db089ea5722c3254d6f7e743602eb0321fedfef600e2db8e30aa96cff9f7bebd4d152c508b23fece4da65eca0c03f8bfeea57a2cabadd6dd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+    "sha512": "9320ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+    "dest-filename": "ae10e5a326a66e0db447ccbf15f77373421c0807bd681564b2cd5a3e28f648fa99d03cfc6e71d92b399be42d19eb7f9511b1033e209d3d0f0dbd71100b20",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+    "sha512": "753c5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41",
+    "dest-filename": "5cbcf5ea3ef5c1429ab9754afa9843095f8a08105bfa6f0a26dc50f02910ecb888e324600daa106ea009fd73545024874029abf7dc40fae44db2b3ef3b41",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+    "sha512": "4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest-filename": "240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/58"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+    "sha512": "57edb7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
+    "dest-filename": "b7b0332bd765a7cfb893703789af73ba008c659ef4ff6e66800003ff5dd6b7e42f74a7de7df69d05d5e1d1fcdd4a20b592a1654088e3058c105769748cc6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+    "sha512": "bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest-filename": "4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+    "sha512": "93dd88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest-filename": "88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+    "sha512": "93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest-filename": "c6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/fb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+    "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest-filename": "a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+    "sha512": "54b82121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
+    "dest-filename": "2121634ce842d0ce8ef3c26720d0d99357258a623bc878cf37ca3a74c110d39949eb33aefc7d06dc281a3a9f6089105d2cce81bfff2b60f932a56bcf402d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/b8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+    "sha512": "887aea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb",
+    "dest-filename": "ea7b9b21bc151c15b999abdcce40706878e85926ee91406ac3a4181e9d49bf026f85dc9336320423fab2b767ad357f3acbe602d95ad00f1f638169255ccb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+    "sha512": "827583d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61",
+    "dest-filename": "83d78261dc5cd2dc23e117403134e27c0b1a9e6e53d3003cc8dfcaf4c2df19c9097979da72ef99b2b74f041b6a0abe9ca2a92aacc7e5a4cfdbed91b4ea61",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+    "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest-filename": "4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
+    "sha512": "e81ded2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3",
+    "dest-filename": "ed2ed16ab504b87a46abbcb54c67e5fe565bd07a46dee2d69491ffeb8553b777f874336adf0119bfa572dc3c4b238ccb0582b1604ab85023171256b073f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+    "sha512": "14552d64ca6867c46a1d2dd77971261d62c0e2d847f99c42bf694e88f227d5773b0b1aea856ccd483cc3fbf7214bfcdb61ece68b058b7500b4f497502a6b613b",
+    "dest-filename": "2d64ca6867c46a1d2dd77971261d62c0e2d847f99c42bf694e88f227d5773b0b1aea856ccd483cc3fbf7214bfcdb61ece68b058b7500b4f497502a6b613b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+    "sha512": "c291d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+    "dest-filename": "d8ce1c625502fe215d3904b1365e7df8cd6d52db6de1be3b6a934fa0b0faf077ff0934b5c981964cfe23c5b18735c72a6117ee8ce84bdd13913d3011a40c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+    "sha512": "002ffb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81",
+    "dest-filename": "fb2687c9bd91abae779635a12725e38b531f89946b7bb4d6b4c198913d3e0c635c267ca8eddbee8eda9daecf6fac92597c39966624c36a7a47bb90a6cd81",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/2f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+    "sha512": "098e9cac6ab7d77317f06930bc1eedce0a7df6f8d0c58d7efb9cb5d3f04a37f1947c7a9668e19030d66406fa92cec64a5a4fe28f01e55b3ce42ee96c18786359",
+    "dest-filename": "9cac6ab7d77317f06930bc1eedce0a7df6f8d0c58d7efb9cb5d3f04a37f1947c7a9668e19030d66406fa92cec64a5a4fe28f01e55b3ce42ee96c18786359",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+    "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+    "dest-filename": "7905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+    "sha512": "34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+    "dest-filename": "3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+    "sha512": "642960e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
+    "dest-filename": "60e80698bda9af60413cd9ddc8c9ddef49222343ea1d823693cd1b8edeceeda0274529cce86f68b4cc287b244f245a7d7bcaf016854571bea1b051a96c44",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+    "sha512": "5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+    "dest-filename": "967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/63"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+    "sha512": "9ba175477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6",
+    "dest-filename": "75477cfc8e395fda29901d2d907b3e6c8ca590cdbbae86e27f14a605459bcf1373ee1dc48c559cdfb0b84654e91f776d286cbe5258405ec394a196ab8dc6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/a1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+    "sha512": "cf039374bdeb150fe545d0679ed295397ea4e5c289c047351dd8a54fbd41584bbb278d605c8076311a7ebf176e3d2c1924f581c44cefe321f5c182c91941d7e1",
+    "dest-filename": "9374bdeb150fe545d0679ed295397ea4e5c289c047351dd8a54fbd41584bbb278d605c8076311a7ebf176e3d2c1924f581c44cefe321f5c182c91941d7e1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+    "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+    "dest-filename": "4790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+    "sha512": "d3f06718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
+    "dest-filename": "6718209fc943240697838168a16a720017d2666611c1814844ab3bdff9a7613462e83fa4da888e6817ca326f7238e4ff8f727aea8a149fd353349741b9f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+    "sha512": "4ccf5806fc82f38671137ae07de7f151689028b8a5b2d0fa93b3d31adeb07dbb5717c8b12092ce2f7558c95ff3f9988f2ec57102c280155c1695679bd98f18cb",
+    "dest-filename": "5806fc82f38671137ae07de7f151689028b8a5b2d0fa93b3d31adeb07dbb5717c8b12092ce2f7558c95ff3f9988f2ec57102c280155c1695679bd98f18cb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+    "sha512": "a43a3796ef0985f8ea96ce8690c8296a1b05f640b26b2860ca48f22cc3454ca5aba5574042d6320789ae00c5a8cc10788a0fddb56026b0cc4b108f30bb3f8361",
+    "dest-filename": "3796ef0985f8ea96ce8690c8296a1b05f640b26b2860ca48f22cc3454ca5aba5574042d6320789ae00c5a8cc10788a0fddb56026b0cc4b108f30bb3f8361",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/3a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+    "sha512": "74c22789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+    "dest-filename": "2789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+    "sha512": "b6a357ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798",
+    "dest-filename": "57ad2efca0c384ef734cc4ae0430b42c428c167fc8caa281fd83bc4f6af453ef4e91e9b91027a0d8d937bb42e91a66cba5c5adf4c10edb934a66e1788798",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/a3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+    "sha512": "268e9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
+    "dest-filename": "9d274e029928eece7c09492de951e5a677f1f47df4e59175e0c198be7aad540a6a90c0287e78bb183980b063df758b615a878875044302c78a938466ec88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+    "sha512": "3a478368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
+    "dest-filename": "8368067f6d00b1785028ccce793ca70a534c8930f1a27cbc15e108238adbbee4ca007d240de25b0b25e5d9d5bf30d31fbf12675ae8c6605d2d63bec6a99e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+    "sha512": "fc85ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest-filename": "ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+    "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest-filename": "38b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+    "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest-filename": "3e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+    "sha512": "5123e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+    "dest-filename": "e431e113df5ace3226abb013481d928b1a0bca73f2eb8e87c09c194eb6d7f96a346faa2440f10b1e9db728a1cb4ae9de93b3a6aa657040f976e42ad86242",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+    "sha512": "8f911cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5",
+    "dest-filename": "1cb67907eda99f57fab91e09a86a5d60d901c5251ada3ad9b1d09a48aa4c6106123f9494a5d67329438e6155aaf03444cea161229a7759e102b4447c6ec5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+    "sha512": "cf4c9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+    "dest-filename": "9623ee050ebaf0792f199ade048f91dd266932d79f8bd9ee96827dfe88ae5f5b36fa4f77e1345ab6f8c79345bd3ae1ce96af837fc2fd03cd04e33731cd19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+    "sha512": "be92d012cf952c2af59d4d015d2d3b99a628170943007d209e042ebadb71230bad0c510c1ead9b957fbcbe98310dd2b72753f08c22627a9efb3a2b536782e5d4",
+    "dest-filename": "d012cf952c2af59d4d015d2d3b99a628170943007d209e042ebadb71230bad0c510c1ead9b957fbcbe98310dd2b72753f08c22627a9efb3a2b536782e5d4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+    "sha512": "5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest-filename": "d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+    "sha512": "ee8d70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617",
+    "dest-filename": "70100d91c8c3fb22eec635b6bdbdcd11596180089382641257d862568a9d22915fb070eb2056e63db84f023e2c908641854a586e4a464f6af37bbb573617",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/8d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+    "sha512": "381c0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+    "dest-filename": "0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/1c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+    "sha512": "db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest-filename": "8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+    "sha512": "b44047a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+    "dest-filename": "47a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+    "sha512": "299c58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
+    "dest-filename": "58a350549160f64d514baf4310a0cf2f5148a0583dcb943f376bfef906a0bee2a1341dbd55a39bf516071f68d5ef7d7cebfb912143a8a783f09a0628d397",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+    "sha512": "14ffa9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027",
+    "dest-filename": "a9f1107c396a45dd86410ab3f982d0039ad5c0a41e4030b9febddc80f8fcb10a3ac2b34d268f2528cecb0edf77300de4f7c0d19d2f127933ffd8aad1c027",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+    "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest-filename": "73b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+    "sha512": "bcb05608a6feecb5ac5fe4db7f358e930d16f359b7efbb72c7784ec1e0538cee370976674464b5fc93d6b36d1faf43e06720d793a44e62bca5b04c9c2bcada0c",
+    "dest-filename": "5608a6feecb5ac5fe4db7f358e930d16f359b7efbb72c7784ec1e0538cee370976674464b5fc93d6b36d1faf43e06720d793a44e62bca5b04c9c2bcada0c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+    "sha512": "db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+    "dest-filename": "ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+    "sha512": "38c70f36fa9308552735a06599d82afa57cda98ee04e24a63510e3637b805d1cae75e299119c6edc22ed8cc42bc78cd9c425f66ff9a936a4edc2e08981784793",
+    "dest-filename": "0f36fa9308552735a06599d82afa57cda98ee04e24a63510e3637b805d1cae75e299119c6edc22ed8cc42bc78cd9c425f66ff9a936a4edc2e08981784793",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+    "sha512": "3b9973f75c5239ea173fa0ee9721df965a6af84834d0c5a2b5921bb4f7e8484bea207765e607dc63a858cc35a78f4a83e6dcf9d8f234f2ef6a52f49579405e1f",
+    "dest-filename": "73f75c5239ea173fa0ee9721df965a6af84834d0c5a2b5921bb4f7e8484bea207765e607dc63a858cc35a78f4a83e6dcf9d8f234f2ef6a52f49579405e1f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/99"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+    "sha512": "661ab76bec852ab63048196e2f81fd5cfde6df2e6ebd0901ff4f42c03aee0a246647f5096279fd5b8478f2bcb4b860bbd1a7933ca2f29c1b6c70ff5e7c515c3f",
+    "dest-filename": "b76bec852ab63048196e2f81fd5cfde6df2e6ebd0901ff4f42c03aee0a246647f5096279fd5b8478f2bcb4b860bbd1a7933ca2f29c1b6c70ff5e7c515c3f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+    "sha512": "0e52fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+    "dest-filename": "fe5f03b2dcdc4043cc6e0b4a243e02b8ea2b953402b4d5837b46e79806aa85786b018d5f5798203301d82dfbaebb6c297990f87d12a28a0f09da3c6d48ec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+    "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest-filename": "0449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest-filename": "89808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+    "sha512": "0593abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2",
+    "dest-filename": "abde74501ce9ed5234eb1fcf8b879e2c98a1e81f2babf167b557c0d2315ae5e40da66a538ec2e2519ca4438d29e4a1e061e1ab7a0701276f923b265df5c2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+    "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+    "dest-filename": "9a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+    "sha512": "0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest-filename": "f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+    "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+    "sha512": "791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+    "dest-filename": "81e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+    "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest-filename": "87dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+    "sha512": "46fc3072bb8d8c8d67713e7145a91ec92f4b7fc95c22dbf7e0a0fe6a27fe547f6476e0327d8062a46875db6ef8c6d7a720f675d7dfd1f4175305af200304a1d0",
+    "dest-filename": "3072bb8d8c8d67713e7145a91ec92f4b7fc95c22dbf7e0a0fe6a27fe547f6476e0327d8062a46875db6ef8c6d7a720f675d7dfd1f4175305af200304a1d0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/fc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+    "sha512": "7a611c2eea26b768f4defc43e78822541e12c538e7b2a914ebddb164e6571c3568632ca9126f9bde3a624dc73e09ffa6ca8a1cfbf2f2d33d358ea78d1d58091b",
+    "dest-filename": "1c2eea26b768f4defc43e78822541e12c538e7b2a914ebddb164e6571c3568632ca9126f9bde3a624dc73e09ffa6ca8a1cfbf2f2d33d358ea78d1d58091b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/61"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+    "sha512": "bb2b2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
+    "dest-filename": "2e9b2aef9145f4ad7fdd115aadf200b7b13073778ce859f2de4b6f676f9de299d69756f2c83585d323618dab368cbaf69c371e2e250f3e6f7cd7474a6481",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+    "sha512": "6fd11bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+    "dest-filename": "1bf21d9e56a344f1e76f29dc2a92b63a3bb900c2623c91c9c1bf535272895825ba39f57505d27a05abe9716c2d72376d1b982d160446c30b91ffec049bd0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+    "sha512": "886f866257517f6050d140d401de8943f470cda432ea65e6b24fc8ce56326a5e00e12345c39e0c787e3fb4b905e08e56a161bd490c2ea96cd2f7d8da1501c1b9",
+    "dest-filename": "866257517f6050d140d401de8943f470cda432ea65e6b24fc8ce56326a5e00e12345c39e0c787e3fb4b905e08e56a161bd490c2ea96cd2f7d8da1501c1b9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+    "sha512": "de8b943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
+    "dest-filename": "943a9421b60adb39ad7b27bfaec4e4e92136166863fbfc0868477f80fbfd5ef6c92bcde9468bf757cc4632bdbc6e6c417a5a7db2a6c7132a22891459f56a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+    "sha512": "ecf887b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
+    "dest-filename": "87b4b965e4b767288330d74d08fbcc495d1e605b6430598913ea226f6b46d78ad64a6bf5ccad26dd9a0debd979da89dcfd42e99dd153da32b66517d57db0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+    "sha512": "cbe58a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde",
+    "dest-filename": "8a165051f011979ec3652071463d99b20dfdc314ca0b85a7e5027c99815eab1bac6ef89c1eb13a3643d47a5f0626b66c001429009377b7e6311da1e87fde",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cb/e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+    "sha512": "4e334f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68",
+    "dest-filename": "4f6e537807001631753cb3d004cf82664319c3d4d34bedb34e63f00a533c9a99cdfbf4558049485cfcad692f69e855bf9799928b2faf1c8f32ec88e00c68",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+    "sha512": "552eec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
+    "dest-filename": "ec8dce8a47b7b5ba4445850498e4b336b8158050f88e3dafc0de690a9a23304a64455084edd31ba3fbf95eb209c2bfe74f204625933adcc9782ab881cc70",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+    "sha512": "3cb8105d0e87d8558269e45a93cbef935196e3ada5331079b37266ebbdcdf36cc8e2faad5543ee65d7df7596cf0c546853c900848b5616d3c25a23e9a78fc40e",
+    "dest-filename": "105d0e87d8558269e45a93cbef935196e3ada5331079b37266ebbdcdf36cc8e2faad5543ee65d7df7596cf0c546853c900848b5616d3c25a23e9a78fc40e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3c/b8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+    "sha512": "293aa7c6c806890e99033642565247e5e3a34a7be5c84831d66f1b91125f3a198646a7e8e4a2ef98094009092b8c4b4e43807bc05f537522c8b3d3bdd0c5fdc4",
+    "dest-filename": "a7c6c806890e99033642565247e5e3a34a7be5c84831d66f1b91125f3a198646a7e8e4a2ef98094009092b8c4b4e43807bc05f537522c8b3d3bdd0c5fdc4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/3a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+    "sha512": "5aec802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+    "dest-filename": "802d18d63c31adb7fc3326269d3b901763ef2167cd215697ba3328af82b691116ef9d57dd26e146f1b778b28e60dfbc544bea2dc7f7c1d9ede386784b848",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+    "sha512": "04d83d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
+    "dest-filename": "3d10ddc30f71ac0d75fb01af0ee29f76b2bca3926cd86209a04c073a080e2e18b103cc57f13b1ba0bb6d5a90ec697171e2120b18902ea73ec42f2cb2e612",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+    "sha512": "f29d00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
+    "dest-filename": "00524e173838087b04a2d25f04a63b3e1159d688aecda03204194d07844efe67263c0f520c63ba1dbb9951ac55c683bd4bd79286f10acf9ae9b8e514ed74",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+    "sha512": "7c6c4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest-filename": "4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+    "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+    "dest-filename": "2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/fd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+    "sha512": "bc78dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+    "dest-filename": "dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/78"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+    "sha512": "d1ad45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa",
+    "dest-filename": "45e25ef7fd915939a9099d0dc5be4276fa0493416cffaf6284e4e7436344f13e6e61e0692a91659f338ed3ec7b1b9ceb5c255105e1ea42572eaeed0dcafa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+    "sha512": "e20974df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787",
+    "dest-filename": "74df09f7863d473f7cb381d23b777942905f79176d4fcf804f1af2878a7c90cc02d1e426a9c02f32222d11879f0310c43f4a0b82d37c058f693433f98787",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+    "sha512": "f4b9224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3",
+    "dest-filename": "224f08d487aad3e79e43b44f6b4d7f81281c8f7eb333100b67944b5d130af73647dfc228a1a9ed9b5800e0f8e4118edf6097a20276607f6450c2180b52a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+    "sha512": "9b0a9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+    "dest-filename": "9e5b95ec036a807a31b8ea061d10d6b15e3c7da2744d09f9fb2f476eb8fe210ae4c88bf40eecf0cad3b2897e9d5dfa2cd63ebcc4243712a816b439942b88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+    "sha512": "08784f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
+    "dest-filename": "4f87e50d1c3d864d735884f58b9d4f0e347748fb90c8fb811820039a883eb7ac7798959bf287c3fe8a7e7df7d4d348581462e294023cd123899d87fa7ed8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/78"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+    "sha512": "19dd94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
+    "dest-filename": "94641243917958ec66c9c5fb04f3f9ef2a45045351b7f1cd6c88de903fa6bd3d3f4c98707c1a7a6c71298c252a05f0b388aedf2e77fc0fb688f2b381bafa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+    "sha512": "f59c88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512",
+    "dest-filename": "88d3c3ecbdd425dabfdb0481ae6e955d477451f6c63a44389614fade036d42fc41654219a0a36d1466536364c31936e6eeb0b840428ce403439de49db512",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+    "sha512": "e36b415702d69da42f5b9cdce076d9ad3b9671c1020997c18bdd850eec2dab16ac1fe25b3c1dff14e29bd66db6d8ae364785b1bb1cf332c4ecc1fce0b52bbae1",
+    "dest-filename": "415702d69da42f5b9cdce076d9ad3b9671c1020997c18bdd850eec2dab16ac1fe25b3c1dff14e29bd66db6d8ae364785b1bb1cf332c4ecc1fce0b52bbae1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/6b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+    "sha512": "60cdff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3",
+    "dest-filename": "ff213876309e4cb7368ce36f5a9e1fb1da388b563a882c5e26e28c90075f16ec681e6bb05fa9d1ffc0630aedd0e232086fffa586ef39d6330503cc9897a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+    "sha512": "701ce79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+    "dest-filename": "e79d0f4a8c9a94ebb079d91302eb908c6ab2b6eb4d161676e471a8b05aadf1cbfe61685265b21827a63a2f31527e1df7f8f5df06127d1bf3b0b9a43435d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/1c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+    "sha512": "051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+    "dest-filename": "d5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+    "sha512": "bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+    "dest-filename": "82d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+    "sha512": "63bfca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0",
+    "dest-filename": "ca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+    "sha512": "f08f138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
+    "dest-filename": "138d6e4a30e2ac6504efa318ee4886bb7e80303d618eb6cfbaa3bb208f3e35fea303f55407103c62e8f06f2b6974317526a99c8da542be4f6b5069a125bf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+    "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest-filename": "6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+    "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+    "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest-filename": "f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+    "sha512": "6b607d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
+    "dest-filename": "7d6342a535797dbbfbec5bab1322ef6f184a5f2aedb0455ea5d47dd711ab3fd20508cc6cc1a0ffc8a2e4dc5106e6f495992c7dc23b1ca7d374d89456b1eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/60"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+    "sha512": "b811d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+    "dest-filename": "d4dcbddccec232617297f3c7ddac6a2fc5d482a13183459e92617b524712d95331e0e4fffae87b7aba85251eef4466877e8a75e12a8dea420c17513ff2d7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+    "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest-filename": "1aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+    "sha512": "3a8fb4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+    "dest-filename": "b4444155e7dfebcf781f24d2908819707c7692112975a5c1b200142c9e721f58e16de89363e600a883653a30b67ffc81980fe9c0f2723e9934a144445e68",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+    "sha512": "8c7f4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2",
+    "dest-filename": "4486d2888ee5d9d9c5b19974bc64ff345f20b789ab10c4c0d5f23ce1349a5f0dbed56d02d55b85afb31cfd419bf357e1b862849f05454a0cecb12f38bfb2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+    "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest-filename": "90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/ac"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+    "sha512": "9ff4a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
+    "dest-filename": "a19ef0e2e851db6d57ef8aba3e5a88e2173bfeb3c30f30705ccd578f7d4a4324bc282d3d21b759786300426e2f29240bde104767907c8fc933ff9b345fc2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+    "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest-filename": "153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+    "sha512": "32f8d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe",
+    "dest-filename": "d7ce4cff04e7f2543906d2814eb41c475f6bb780a6cc1c817f7576e566c803dc158e14b987a2f229658ec1ca425d02372a442062d5660135d102f7223bbe",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+    "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest-filename": "80bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+    "sha512": "3053bf433bed00e9896e484e6824ef6c670537d2fd6fe26e9c8b03c1a2a58d239d70b31e6b7349d64f54b33feb8dd7d25d3ab875fcdf792ed6e29e1838000778",
+    "dest-filename": "bf433bed00e9896e484e6824ef6c670537d2fd6fe26e9c8b03c1a2a58d239d70b31e6b7349d64f54b33feb8dd7d25d3ab875fcdf792ed6e29e1838000778",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/53"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+    "sha512": "0b9b63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
+    "dest-filename": "63942fc70ad5543a2dca595a24778bc755588e9868ed2f0221e0cbb33e8fe73184d5fe9d6eaeddd19cccf62165c374a106247de4e7e28fc6da91b14606b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+    "sha512": "c98aebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+    "dest-filename": "ebb169eb5cc71db27bbfed83180287ccd64b692f9072eef6617f5e42ad78a3596ac461992ce405c1b9d6a57d25892e59de9ff4142540796a807492a65418",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/8a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+    "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+    "dest-filename": "00c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+    "sha512": "a95b6f3317976d57a3d1c4162aa5524801e629910702fc5d17c1c4501156b6cf21fb1128e66fe51223da92ec99dc19c2063383f22db893334e88e2cb82c4b184",
+    "dest-filename": "6f3317976d57a3d1c4162aa5524801e629910702fc5d17c1c4501156b6cf21fb1128e66fe51223da92ec99dc19c2063383f22db893334e88e2cb82c4b184",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/5b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+    "sha512": "c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
+    "dest-filename": "7f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/74"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+    "sha512": "47033b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+    "dest-filename": "3b3283e88cfc6c381627c9dda1cb46f1b48955ae284db3da63e5252f63c673d6c41c406dad1b5852afc3c3c5f80407c44d28386a6c896ba086ab48d0cdb1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+    "sha512": "7b4be8b48a69e14a36009612cd51d5eb109c6b0ba27b3dc3cea0c06eb4dcdd8c4192994de9ef9d335dd97887199c383f4294ae536cdf677af3c18f2e9049da5f",
+    "dest-filename": "e8b48a69e14a36009612cd51d5eb109c6b0ba27b3dc3cea0c06eb4dcdd8c4192994de9ef9d335dd97887199c383f4294ae536cdf677af3c18f2e9049da5f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+    "sha512": "f793eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
+    "dest-filename": "eed505d0bebb86121bfad9708c3b7326f741ac70e08296fac853008cd0f60e5cade4685de5dec207c71ef54e125f71b3363b902ee923b701609211f5b899",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+    "sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+    "dest-filename": "6ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+    "sha512": "df847b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732",
+    "dest-filename": "7b1d39c6d172097014a7e5784377b9cd14f45c5d8459ac10763b68dd2aa60e0e5752cc102acec5a865862f76e932ef7b68612fc44aac4fbe40dffc5d1732",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+    "sha512": "02cb82cdf7c61c9c9b49a46b9abe5e1ebf359b0254de48f0e8cfaea6b5af09788d78df52386c10dc99fc8dbf26dd9ea2cd58249e7d51d054c21003f642b2d8ff",
+    "dest-filename": "82cdf7c61c9c9b49a46b9abe5e1ebf359b0254de48f0e8cfaea6b5af09788d78df52386c10dc99fc8dbf26dd9ea2cd58249e7d51d054c21003f642b2d8ff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/cb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+    "sha512": "2c863dd7483d4c8d77612f7996b305aecf119bfbbf8ab8077935a8282a2d79e274e02509f767847e3d2b567fbb54a30f06950f894a0129f84dc8b236dc413f28",
+    "dest-filename": "3dd7483d4c8d77612f7996b305aecf119bfbbf8ab8077935a8282a2d79e274e02509f767847e3d2b567fbb54a30f06950f894a0129f84dc8b236dc413f28",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+    "sha512": "203c5f95e2e699b4ac91f5925004e23759df9f6ac3baf9cc3aa6f909647dda221fa2303451dfae94e000110e7b2cfafdad69acade5327f9970c9aa3eec634d57",
+    "dest-filename": "5f95e2e699b4ac91f5925004e23759df9f6ac3baf9cc3aa6f909647dda221fa2303451dfae94e000110e7b2cfafdad69acade5327f9970c9aa3eec634d57",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+    "sha512": "ac125e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+    "dest-filename": "5e2390970259b2d6957eeb5ed607d27add4e9771acc71c5d9fd9d6c98b1e17ce9505d114b765b8f414620e080bdae4ffddfc604e61a002435c3ed1acd492",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+    "sha512": "829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+    "dest-filename": "4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+    "sha512": "b5760e8bd479ed48ffd99db948eb394514b3abcf3a301423da063c74f2fec65fe4bfab3a4af072a0a7c0b6f7d5784ba19ed583823776a3da7695be1354f033d0",
+    "dest-filename": "0e8bd479ed48ffd99db948eb394514b3abcf3a301423da063c74f2fec65fe4bfab3a4af072a0a7c0b6f7d5784ba19ed583823776a3da7695be1354f033d0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+    "sha512": "5e7d30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c",
+    "dest-filename": "30dccb6243ace8cf6bc5c9456bb9a08be773bf0f052f90478ebe3faeba5326d019141985a6058572125a996922e163a643d2e95f537681adad9a553e317c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+    "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+    "dest-filename": "f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+    "sha512": "82c5de726f365103654c1511246baa396cb55b0d3c4b791951caf768e252d363e4d312ed91f7940150b4bb4c6181da271667bcd1e752254209caebcbffbdb9d1",
+    "dest-filename": "de726f365103654c1511246baa396cb55b0d3c4b791951caf768e252d363e4d312ed91f7940150b4bb4c6181da271667bcd1e752254209caebcbffbdb9d1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/c5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+    "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+    "sha512": "244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+    "dest-filename": "46cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+    "sha512": "a062dee3a308ac246a5fbcad3d47fae84018bdd78c219627dd66a872aa8a640c6b06992a1df2ffaaf4f227f6d3939f80a870a35e6aefdc2116832dfaf3385152",
+    "dest-filename": "dee3a308ac246a5fbcad3d47fae84018bdd78c219627dd66a872aa8a640c6b06992a1df2ffaaf4f227f6d3939f80a870a35e6aefdc2116832dfaf3385152",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/62"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+    "sha512": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest-filename": "888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest-filename": "a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+    "sha512": "c8ca8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
+    "dest-filename": "8606ab57c9e3757b74c662f80d803559de3f385b873090e5d0b30821a25e803e065669f7fd9676ef37b3076093a25ecbc63d7b634d8244882f49db0bfd12",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/ca"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+    "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest-filename": "c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+    "sha512": "df074689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec",
+    "dest-filename": "4689d672ab93c1d3ce172c44b94e9392440df08d7025216321ba6da445cbffe354a7d9e990d1dc9c416e2e6572de8f02af83a12cbdb76554bf8560472dec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+    "sha512": "620bd44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+    "dest-filename": "d44dfc2ac9ced45d532b07e4889ac5584a64d2f17fed4abb5d35930898cfa7efe413ae2457c978a6d2606b4d735eab3545d0a5868073de8b2562145acd0f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/0b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+    "sha512": "b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest-filename": "6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/5a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+    "sha512": "199b63c66fc9ff84d2c6e2f714d6230a62e4b414e7230feb56629223229e6006699890768a0f556ae082e71b1af3618d29528302aa4e9f7295ccdb74ce6ad4d2",
+    "dest-filename": "63c66fc9ff84d2c6e2f714d6230a62e4b414e7230feb56629223229e6006699890768a0f556ae082e71b1af3618d29528302aa4e9f7295ccdb74ce6ad4d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+    "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "dest-filename": "2cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/59"
+  },
+  {
+    "type": "inline",
+    "contents": "01c00565b799b2a2ad8d1d419358e4ef36d8c3fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"integrity\": \"sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==\", \"time\": 0, \"size\": 44526, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-9.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ba2e0f724389afe9916b645aa486202f4dd28493d3be6ed3399afa0fcaea",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "02382899d29c800e1c9a1bab7a79342179741836\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz\", \"integrity\": \"sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==\", \"time\": 0, \"size\": 461946, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0c7a29210a4aa9c71ad92b46cc1cf6c6dc91d749a4f77099315431478ff6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/37"
+  },
+  {
+    "type": "inline",
+    "contents": "03beb9ddad49176deb64a0d5d14fee037432192f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz\", \"integrity\": \"sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==\", \"time\": 0, \"size\": 1558, \"metadata\": {\"url\": \"https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4b4efa891c8a52c39e43b2f62af7a690f61e546a84380471c6091500134d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "046742ddcf7a9dd650a67a25492f7b42043fec75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"integrity\": \"sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==\", \"time\": 0, \"size\": 2017, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ca47ff09ac9d048c991a5d94c9ef412ffa5496c2ab672947137bfb61e829",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/69"
+  },
+  {
+    "type": "inline",
+    "contents": "062c157a258c356eb5d0ff406805815d4fbd2c7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"integrity\": \"sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==\", \"time\": 0, \"size\": 8996, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "453bd89145eccf9d67f5797fb09e5a017b5b13f1ac45cb7b70bda45940ec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "067fbc2fc960f70859479dbcb175ef9d7e4f1292\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"integrity\": \"sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==\", \"time\": 0, \"size\": 6074, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "18f75527ac37299e70f06aad31fb38c55d9ffb7d576a3961d46b9f85720a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "087fa1caedd1cac5e2a0df8256b7bac99d91c883\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz\", \"integrity\": \"sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==\", \"time\": 0, \"size\": 10354, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4db5d2095048400e1b65c118d99a808aeea0ba244ab7cdaf1fc8f17f733d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/3a"
+  },
+  {
+    "type": "inline",
+    "contents": "08f70474f0a819721a36f4141d951f4775819862\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"integrity\": \"sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==\", \"time\": 0, \"size\": 15520, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "575503a996b3678372373e36b1adcb0ecf0c5e27804be136f2f9b46a57fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "09c678964a5885453de438c2b508d0a9bbae1e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz\", \"integrity\": \"sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==\", \"time\": 0, \"size\": 2732, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5221448e8c3990b22267bb8a1f5cd80dc3cf431aeed10551e17b86620a2d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/cd"
+  },
+  {
+    "type": "inline",
+    "contents": "09f138beba2de0d7ab0331db6c60fa3139d16923\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz\", \"integrity\": \"sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==\", \"time\": 0, \"size\": 7051, \"metadata\": {\"url\": \"https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "45cb5e1b2a9fcc6c9e54b5bb03bb45c04d6c50d2b9910b2f5a983b9cecfe",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "0b042650b04498dbdbf81f0343b3b2847ed53f19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz\", \"integrity\": \"sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==\", \"time\": 0, \"size\": 6189, \"metadata\": {\"url\": \"https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3536d502e0ff43519488f819126f2cfa55b2ac4d93e35e83bc5ce806cef3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/07"
+  },
+  {
+    "type": "inline",
+    "contents": "0c1cf298fba3626323078ac44e073351c23715c2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz\", \"integrity\": \"sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==\", \"time\": 0, \"size\": 4387, \"metadata\": {\"url\": \"https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3fe7e830982304d7d26088289037bd2a037f35f7c004a4fc0d36f6d24b35",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/c5"
+  },
+  {
+    "type": "inline",
+    "contents": "0c753b404a6f805e02925ff19092d8bc079e07e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz\", \"integrity\": \"sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==\", \"time\": 0, \"size\": 18461, \"metadata\": {\"url\": \"https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4b8cc1e73588d291d2f68237ed9b99cae45e16d3a2b0d6e39076cc7bdb29",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/0c"
+  },
+  {
+    "type": "inline",
+    "contents": "0d4d873606d0bfe53dbba5264734e4a646c2e669\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tar/-/tar-7.5.22.tgz\", \"integrity\": \"sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==\", \"time\": 0, \"size\": 471090, \"metadata\": {\"url\": \"https://registry.npmjs.org/tar/-/tar-7.5.22.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b8cfae2fa88592146c0571f9a5013dd016dc15a17e75afc11d2eaf70e513",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "0e56ca535acf8433c58508cbe5087a65db39a46d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz\", \"integrity\": \"sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==\", \"time\": 0, \"size\": 6290, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "481ca7eeb393e2fb68fd72d6d364f08e6c5986bf134c7dd78546ef9e4191",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2b/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "11a5b941f5a6b10a63ea5e9e26fea947f3927fbf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz\", \"integrity\": \"sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==\", \"time\": 0, \"size\": 47751, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "66db19710a240b6ccc78a2d0e9768e7d20b2d3d0162c41c50e831e07c612",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/59"
+  },
+  {
+    "type": "inline",
+    "contents": "13a4ebca831696b5a3cc9d8bbc89c5f2d9c31003\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"integrity\": \"sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==\", \"time\": 0, \"size\": 2030, \"metadata\": {\"url\": \"https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2937f0abc26f9973382cb3afa8b4b1d233a6a47ad4f3c5917ddb4997cddb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/12"
+  },
+  {
+    "type": "inline",
+    "contents": "159cbc14ae2101062a05bdc8d9ece1d5b0b73b97\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz\", \"integrity\": \"sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==\", \"time\": 0, \"size\": 4608, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ad9f74c9e8998e1f85a916fde8658ebe3692c500e207e60efed24b4a2f90",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/87"
+  },
+  {
+    "type": "inline",
+    "contents": "167d6a163262a44c1cbbe9c3dfdbc73e69037186\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz\", \"integrity\": \"sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==\", \"time\": 0, \"size\": 2812, \"metadata\": {\"url\": \"https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "37d67591b1434fa3f4c75bbbb228cfbdae2310c5cfe94fa626935e5a22c2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/26"
+  },
+  {
+    "type": "inline",
+    "contents": "16c447d9067175bead72b1203150f5a467a91c78\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz\", \"integrity\": \"sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==\", \"time\": 0, \"size\": 2234, \"metadata\": {\"url\": \"https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d8752773e2be8ff244bc63d0f84ad951e7bb0cfe9ef06e130b57fdeb53ba",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "19c64071be660c591b186e67b434f94f4a359ce7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz\", \"integrity\": \"sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==\", \"time\": 0, \"size\": 13800, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b4bddca1df9d1a5db8fc8bd09d22078228fd3c1f50ad12a3c9886499c03f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/91"
+  },
+  {
+    "type": "inline",
+    "contents": "1ad5e60331f6634b7da563e23a5182bdd0f46183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"integrity\": \"sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\", \"time\": 0, \"size\": 3656, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aefda99ca03a1004596e312ea5d597c682502fb85fe4283d6c1079cacd8f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/f8"
+  },
+  {
+    "type": "inline",
+    "contents": "1b308231d47933b4057e9f70a81dd62f2dd8ec7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz\", \"integrity\": \"sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==\", \"time\": 0, \"size\": 24079, \"metadata\": {\"url\": \"https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e0dcccdd2dfc3e89509c9b8049a20b6337cfb9f43915fc28d1e8b68a760",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "1b47529f329948540a1e64b03a3d2a22095873c0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz\", \"integrity\": \"sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==\", \"time\": 0, \"size\": 1015, \"metadata\": {\"url\": \"https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b3d5fbbe79a2c6cd5b94ec69720d4f24fc018b06a7746ba9ac2191471286",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/06"
+  },
+  {
+    "type": "inline",
+    "contents": "1c5e1811a130694cfac7ea6639d95ed4e3f79177\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz\", \"integrity\": \"sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==\", \"time\": 0, \"size\": 6355, \"metadata\": {\"url\": \"https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b973fb10d0d62b5962532a6e5691f81dd1c20b63fcce513967941450a82",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/7f"
+  },
+  {
+    "type": "inline",
+    "contents": "1d58e25734b3951feafbf567d5e945d11d0096ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz\", \"integrity\": \"sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==\", \"time\": 0, \"size\": 16825, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "47ba321b37f695a79668b4434d63f6dcb7f98dc2447a78e96305be133d4d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/6c"
+  },
+  {
+    "type": "inline",
+    "contents": "1f00a148568369ebe861d3225db2c24cbdd7fd51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"integrity\": \"sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==\", \"time\": 0, \"size\": 9799, \"metadata\": {\"url\": \"https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "af28f1133468f98432a0caf94d8a9e1a4f1bcd830398a06a4e51d9d17bcd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/da"
+  },
+  {
+    "type": "inline",
+    "contents": "205276628e2bac010bcfded4bc8e4595d5853c3f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz\", \"integrity\": \"sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==\", \"time\": 0, \"size\": 5591, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b93a55ccc4e49f1f202fb8da7ee9e687e3a2a49ec42d4759cf6b22a7a96a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/39"
+  },
+  {
+    "type": "inline",
+    "contents": "208fc0230d6282f97661a6d69e374bc7904c535e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz\", \"integrity\": \"sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==\", \"time\": 0, \"size\": 37710, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1bf4b81351e5756289759aaff7ac4b5bd671012f517b3ad861a2e0392df6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "22a56a4cd0414d0b3690becdec4e1ebf13f0e0dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"integrity\": \"sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==\", \"time\": 0, \"size\": 1951, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6149661c453e9896445eb249a914c680462121e4f460635ec401d9394202",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/73"
+  },
+  {
+    "type": "inline",
+    "contents": "234b2b002e11d7447393d4adb3e4f2c73d7d0605\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz\", \"integrity\": \"sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==\", \"time\": 0, \"size\": 10834, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8a44b32d69a5591845c94cb9672fdd649aeb30591590834cefc04ee63fb3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/30"
+  },
+  {
+    "type": "inline",
+    "contents": "248b7519cc16e8e6a291a945319ccbc0a17bebeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz\", \"integrity\": \"sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==\", \"time\": 0, \"size\": 427320, \"metadata\": {\"url\": \"https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea4dd358e11afe9ef68c643b6a7f643c748872d2b708f7af6649062338da",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/53"
+  },
+  {
+    "type": "inline",
+    "contents": "2555d3b0c40bf4adef50f36e46fafebc3570f43c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz\", \"integrity\": \"sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==\", \"time\": 0, \"size\": 16280, \"metadata\": {\"url\": \"https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e29b27364c96f1a8a4675a38daf5b13d449e23090a5a40d16fd31cd5c150",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/49"
+  },
+  {
+    "type": "inline",
+    "contents": "25685b71276e0bbf230b952f058dca235d321f38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz\", \"integrity\": \"sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==\", \"time\": 0, \"size\": 32529, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "23d4e85b74dcb88b6bf1f7a3fba3c6b6a3c715191f86fb9e59d2bd61068d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/c6"
+  },
+  {
+    "type": "inline",
+    "contents": "258a9d7dda2b000ca764a5d38903c6a6e3ac5db7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz\", \"integrity\": \"sha512-Wn9sPYIVFRFl5HmwMJkARCCf7rqK/EurkfQ/rJZ14mHP3iYTjZSIOSVonEAnhWeAXwtw7zOekGRlc6yTtZ0t+g==\", \"time\": 0, \"size\": 21147, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e0a5dd37937f6fc99476efd5a49fbec7b78fbbad5a33614195d972a33b1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "26846e3e1a8d5d85f8c8129099f31500fa5e9283\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/undici/-/undici-7.29.0.tgz\", \"integrity\": \"sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==\", \"time\": 0, \"size\": 397276, \"metadata\": {\"url\": \"https://registry.npmjs.org/undici/-/undici-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e92b9ab4ed555765234d3dde254568bb8c8f0514a08797950c293b461949",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/12"
+  },
+  {
+    "type": "inline",
+    "contents": "28512f2f3de55bd2dcfee4dc8b2152990fc59e19\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"integrity\": \"sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==\", \"time\": 0, \"size\": 5179, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6799e52a12dedc4a8cca2afd9ff0a0f444219aece66ac340a7aaf4c02923",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "29006c75f5093f4a80cf9a534fd4940910b113d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz\", \"integrity\": \"sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==\", \"time\": 0, \"size\": 5788, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b9a1c2e048cca34847c9ced69637739ea6399ce5db7c68e1d6afa05c85ae",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "29f6f56d53a6cc5cf482ed443c60f2a900a0d93f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz\", \"integrity\": \"sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==\", \"time\": 0, \"size\": 2915, \"metadata\": {\"url\": \"https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d947695d5fef896bb84d57ecc3141429beb60968981dcdfd897299f74af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/14"
+  },
+  {
+    "type": "inline",
+    "contents": "2a66929a98d00add15f3f9651adccf72e8542b9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"integrity\": \"sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==\", \"time\": 0, \"size\": 5203, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "464a09af299a6607875146c73e357016c5cb1808f31cb066f94d226bc3dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "2bdf558ae872100445d39c9d6fac55b69312f3f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"integrity\": \"sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==\", \"time\": 0, \"size\": 5596, \"metadata\": {\"url\": \"https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c5ae5884dcf7678189db49acdbd1fee0fdb92a113a81dc0e2caf59f11279",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "2e229e55b8873a58370202403101507b79bb9f25\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz\", \"integrity\": \"sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==\", \"time\": 0, \"size\": 1897, \"metadata\": {\"url\": \"https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8c2e4d1165ebc3bd07e913a9fbec73804b8812d163d4e8df93f52ba10f9a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/77"
+  },
+  {
+    "type": "inline",
+    "contents": "2fb1f84a89da15b1d20cda74fb66ba7be81bf1d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz\", \"integrity\": \"sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==\", \"time\": 0, \"size\": 25624, \"metadata\": {\"url\": \"https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ee9e4a12a27d15ac423724c93899f5753de0ee526f6866bb394c93570ee4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/83/a8"
+  },
+  {
+    "type": "inline",
+    "contents": "311590c5f5fff488a62c956d36a4bfa405779127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz\", \"integrity\": \"sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==\", \"time\": 0, \"size\": 180002, \"metadata\": {\"url\": \"https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "32c48c847df485cd23d95d2e9bef120c31052b0452925cc069e73fac64e0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "329bf717774657a85f01cdc1fcf22abb2ca27c72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz\", \"integrity\": \"sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==\", \"time\": 0, \"size\": 6726, \"metadata\": {\"url\": \"https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8568ed9674b12676bf259ba59067883528ffae7c339cf041b7c076744829",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "32f031e68c7f223de75e68dd480b08147512f556\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz\", \"integrity\": \"sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==\", \"time\": 0, \"size\": 315640, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9043468767e0c56dd9f471bf490a9dbd69791bd99c61ac2373a4bf254fe7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/b1"
+  },
+  {
+    "type": "inline",
+    "contents": "3312183314e6e4baed751558184c5f088b873636\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz\", \"integrity\": \"sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==\", \"time\": 0, \"size\": 2231, \"metadata\": {\"url\": \"https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "030cc762b50dee13f56a04bc253a00ae3503dd2b7656ca3d33da61908a95",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/4a"
+  },
+  {
+    "type": "inline",
+    "contents": "3354861afeee5a3b226696e30c8b93f402d8f0e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz\", \"integrity\": \"sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==\", \"time\": 0, \"size\": 25794, \"metadata\": {\"url\": \"https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7b2f0fa362e627de610a516b01c5402d87a8803d1696e1230ffed2762a7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/56"
+  },
+  {
+    "type": "inline",
+    "contents": "343923512bb0ad67c0cad9b79866a8f4653bb4fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-6.0.1.tgz\", \"integrity\": \"sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==\", \"time\": 0, \"size\": 3349, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dfaf9c9f68c37e777aa402dd46cbd05f3344e68006cb1c2338606d9eddf5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/a4"
+  },
+  {
+    "type": "inline",
+    "contents": "350ed8e2e4287ecffa70e50a4400a8319aff06c2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz\", \"integrity\": \"sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==\", \"time\": 0, \"size\": 6119, \"metadata\": {\"url\": \"https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ca9bac98ad7734a20e80059032786956989fd2b1bf8d23cff6469bd2f8c2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/93"
+  },
+  {
+    "type": "inline",
+    "contents": "3577f0a6ffc7b4d7a011801a9f63fc6a22ec6679\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz\", \"integrity\": \"sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==\", \"time\": 0, \"size\": 15591, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7b67a74b911e0588e465757144cb919b1aa0b334c563980c64c4f0ed10b1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "35fa7b6385be7d38bd824e927089a7ec1e198b47\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz\", \"integrity\": \"sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==\", \"time\": 0, \"size\": 30612, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "53dd7b5a6cac9479c12a1f8f88e5595d357e3d2f0c85a80596e6c62dc586",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "364997eb9cfd890191bd5ef6a4d36b28eefe04a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz\", \"integrity\": \"sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==\", \"time\": 0, \"size\": 4431, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6a2298196c9cd65881a7267db2824adff4d9c24f0ed6d3a2ca4c81d3e235",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/60"
+  },
+  {
+    "type": "inline",
+    "contents": "3843564a59d93133fac7d1ce00eae6b37bb8cf67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz\", \"integrity\": \"sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==\", \"time\": 0, \"size\": 4584, \"metadata\": {\"url\": \"https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a34aeaf29195f5f9401c15f6857af1bd76c7606e0b093aab991c9bb6dc49",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "38576a1adf8cbbdd07182c380de6d1021bb0a533\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz\", \"integrity\": \"sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==\", \"time\": 0, \"size\": 3851, \"metadata\": {\"url\": \"https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9e124541d1bd7686c80038ca3b6ed601e64e680a83edccdf47801f6e21e6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "397b27f709fdfc1064f037683dff530b8797050d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz\", \"integrity\": \"sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==\", \"time\": 0, \"size\": 6944, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2f341048e538d1202f2e9aa373938188e96869a99f4d06f42218a1d852c4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/06"
+  },
+  {
+    "type": "inline",
+    "contents": "3a335be62977bd5c9773c7e41da25d1a6a47cc3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"integrity\": \"sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==\", \"time\": 0, \"size\": 28613, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b41f4759346e1d3b6651322d78c7983a4a546cdd6c18c3eb56c944571e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "3ae8968f33b0f29b75885e2675855bd85914f14c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/retry/-/retry-0.12.0.tgz\", \"integrity\": \"sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==\", \"time\": 0, \"size\": 10431, \"metadata\": {\"url\": \"https://registry.npmjs.org/retry/-/retry-0.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9a559510ea40d7e5a78b72d7673ae60db5288c6fd078c06d9ee1b49d9882",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/e4"
+  },
+  {
+    "type": "inline",
+    "contents": "3ba94d414b4f205dc2f2b607d8ad921e91c20bde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-5.7.2.tgz\", \"integrity\": \"sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==\", \"time\": 0, \"size\": 17872, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-5.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "326bbe3e88c981f3f2700e89f091f4f912cf110ae44023316ea62051848d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "3bd257e336bd122dc2b3e7d617d2f9627fa72e3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz\", \"integrity\": \"sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==\", \"time\": 0, \"size\": 2552, \"metadata\": {\"url\": \"https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "367acc572c1c8511d78b8bb723ba67429c954e7281592c8a833a52882080",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "3caeb6fc769783481bc1fc009486114f50b4df60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz\", \"integrity\": \"sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==\", \"time\": 0, \"size\": 3433, \"metadata\": {\"url\": \"https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "62dce9a2b6aa41a8097ad49b67b6a27e8bb8ed3eb0d2c8390c5e47f81e55",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/a4"
+  },
+  {
+    "type": "inline",
+    "contents": "3cdbf69dadcb56348a8ff1c1cdcad493057103d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz\", \"integrity\": \"sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==\", \"time\": 0, \"size\": 3387, \"metadata\": {\"url\": \"https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "67c972c58898526f6fcef84802f01306a300bc840e9107e05f7db9b1f12e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/c4"
+  },
+  {
+    "type": "inline",
+    "contents": "3e1f8aa853af6960e1a881ffe691dc2494393991\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/once/-/once-1.4.0.tgz\", \"integrity\": \"sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==\", \"time\": 0, \"size\": 1979, \"metadata\": {\"url\": \"https://registry.npmjs.org/once/-/once-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "423d7e791f7fedd6bef784f0f467761c619f209ce9c788f08b63e968a880",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "3f75dcd8395c00123f2751290cf554a151f365c5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz\", \"integrity\": \"sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==\", \"time\": 0, \"size\": 4199, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "71b2d1452a6c218b9b534041f2e2b4b9ce6235c552e2515e16f03820d00e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/80"
+  },
+  {
+    "type": "inline",
+    "contents": "404631371bc60fc5d707e0ffaf61fe52063a5ae5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz\", \"integrity\": \"sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==\", \"time\": 0, \"size\": 1405830, \"metadata\": {\"url\": \"https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b559813de222517cdc12c45caa1fb240556f92e0352186fda7288d31cfb8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "4092130d8ec8f18af10c9c3ab5f39bd7e58bd1d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz\", \"integrity\": \"sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==\", \"time\": 0, \"size\": 5944, \"metadata\": {\"url\": \"https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6b5f901e14b049b2e340d9f19d64bc3a4440272cb7bc50d2227d76805d70",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/91"
+  },
+  {
+    "type": "inline",
+    "contents": "424424bf943ac060b021ce3d522e0cc1236ee893\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz\", \"integrity\": \"sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==\", \"time\": 0, \"size\": 22554, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b44adf2cf9f8f21fd1a61916b15412d3e1c794de2531459600a92ef82b66",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/2d"
+  },
+  {
+    "type": "inline",
+    "contents": "42e8df9629694ce0dd35c127fb6b29b0563fe62c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz\", \"integrity\": \"sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==\", \"time\": 0, \"size\": 62870, \"metadata\": {\"url\": \"https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2dad145840379a55189a92dc8361bd5fce4bb4842980d0f37b1ff01da058",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/64"
+  },
+  {
+    "type": "inline",
+    "contents": "448980b96c09ed65195efbf60c774b0f214f617b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz\", \"integrity\": \"sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==\", \"time\": 0, \"size\": 30541, \"metadata\": {\"url\": \"https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "708131fd7b70288ec630f44721ae379d4c8e2cf29afcca0017003c6c42d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/bc"
+  },
+  {
+    "type": "inline",
+    "contents": "44cd0b1b3bb58b3f65c1feda85642adfabb22c1c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz\", \"integrity\": \"sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==\", \"time\": 0, \"size\": 5537, \"metadata\": {\"url\": \"https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "407397fb4d570f9126e6ba00bd4221d5f1c2544480fc89a28fab37df52b8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "467103dbd76f3e27bac05e17740f8a8b85a6b3e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz\", \"integrity\": \"sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==\", \"time\": 0, \"size\": 3717629, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8776bf77e9381c00c68207c684e7b6ac54bb44cfbcaf1f39b550b63cbd07",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "4b7371f24456bcf965bd356e51e6c0ef3d3821f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz\", \"integrity\": \"sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==\", \"time\": 0, \"size\": 6805, \"metadata\": {\"url\": \"https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "82f929c07a477d1e206b4d2303edd2bde0e352436b4ddefe3fe94cbfa84d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/ce"
+  },
+  {
+    "type": "inline",
+    "contents": "4b7cd88c78120c3e6e31751fb60460bfba192996\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz\", \"integrity\": \"sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==\", \"time\": 0, \"size\": 9864, \"metadata\": {\"url\": \"https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "147aa05aad52a311d27a85d14ed9f42098cf08300db77021589ae7919c40",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "4c6458d0ed8dc6e1da9abb20e67e2f7a0340d41c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz\", \"integrity\": \"sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==\", \"time\": 0, \"size\": 32112, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "626b833e294790284cd337a1d18d9dcfa6033cfd0cb3c40d822fb2878e38",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/de"
+  },
+  {
+    "type": "inline",
+    "contents": "4ca1dc5968526e4aac494fc8f65c48a048f44e5f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/got/-/got-11.8.6.tgz\", \"integrity\": \"sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==\", \"time\": 0, \"size\": 67729, \"metadata\": {\"url\": \"https://registry.npmjs.org/got/-/got-11.8.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e08f3dfa5d00cabec76b3a947effc9e3d49e62b94e985db850a84c753e5d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/11"
+  },
+  {
+    "type": "inline",
+    "contents": "4d28bf1a2b925691ade5e3c9c2eca4e67150280e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz\", \"integrity\": \"sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==\", \"time\": 0, \"size\": 17325, \"metadata\": {\"url\": \"https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "976d338167b5c91b39d2951d214877b93a3f5205092b5c2e776de105830d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/45"
+  },
+  {
+    "type": "inline",
+    "contents": "4d7fc4bb7de578288baa3bee3f4ae373df1f0266\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron/-/electron-43.2.0.tgz\", \"integrity\": \"sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==\", \"time\": 0, \"size\": 194259, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron/-/electron-43.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d3a2c008079215eb3403ca89373b0cfd30b64a4f928462d199327cbbc673",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/fd"
+  },
+  {
+    "type": "inline",
+    "contents": "500a86d2d37be84ad19b8c07881dacfde3ffcc5e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"integrity\": \"sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\", \"time\": 0, \"size\": 18477, \"metadata\": {\"url\": \"https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "238807144536cb82d714f2a1374ef3c3a03fbbfd4fa234ff083114a25f63",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/63"
+  },
+  {
+    "type": "inline",
+    "contents": "5021d88b4d4a6267562b21338b1b19d400dbad75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz\", \"integrity\": \"sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==\", \"time\": 0, \"size\": 53775, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1a022dc0913129a3ad668420edd5a0ad2cc6a57c5cf4a9752a38a8ab8c80",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/8a"
+  },
+  {
+    "type": "inline",
+    "contents": "5025fc821e00072d0e863cdc15ae06a7d0cac569\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz\", \"integrity\": \"sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==\", \"time\": 0, \"size\": 4330, \"metadata\": {\"url\": \"https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "83c239ea0882a0dddefc86f1c7369353143c88c774de6d54a48434e1269f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "5071a43f9ce91d17fee4062020c1f07c89b0b38b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz\", \"integrity\": \"sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==\", \"time\": 0, \"size\": 3951, \"metadata\": {\"url\": \"https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87872271dbd3eedfe22f6e99c8a69638509f45eef118ed4ecf7c58e372d4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/11"
+  },
+  {
+    "type": "inline",
+    "contents": "5148e76a98ebca0061a0013fe83122bbdd2b0636\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"integrity\": \"sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==\", \"time\": 0, \"size\": 150393, \"metadata\": {\"url\": \"https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ef4d8877589473848fd9bf548c44e0a4b9e0b52f57d138c51b77a9fe6c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/2d"
+  },
+  {
+    "type": "inline",
+    "contents": "516c35a4e0c72405901ec4b2aad1fe61bbc5dc2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz\", \"integrity\": \"sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==\", \"time\": 0, \"size\": 4581, \"metadata\": {\"url\": \"https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "593e58ef36fbcb5f9f8984f0e15359c68c3442ce040cfe42a2eff8de571b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/eb"
+  },
+  {
+    "type": "inline",
+    "contents": "52c4b31b713be2be1a09219d80a8d964bd5ee142\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz\", \"integrity\": \"sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==\", \"time\": 0, \"size\": 4494, \"metadata\": {\"url\": \"https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b26c31e0da3d9323f2596c2a445ed29a5583dc964d85ab673976029ed2d9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/ed"
+  },
+  {
+    "type": "inline",
+    "contents": "54692f9439030ea2c2c32aa9671f5c44dbace583\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz\", \"integrity\": \"sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==\", \"time\": 0, \"size\": 4927, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "62dbc9511af786c8c4a740679257471743aa49353a2dfec1eeb7a273aa66",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "54cce2187ab1cc714efa00ce0bef4e235d608503\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz\", \"integrity\": \"sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==\", \"time\": 0, \"size\": 101396, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cd7674b822df1345c9c34d1a695ac98c2b5e5dd34568a18c67c4e675fbc5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/94"
+  },
+  {
+    "type": "inline",
+    "contents": "55dc518ad4ed2a09b7c89ca41ae70c63b34d4aeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz\", \"integrity\": \"sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==\", \"time\": 0, \"size\": 2313, \"metadata\": {\"url\": \"https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6fe07a61a892f6f6531a5c2b91b04027042da092d88fd7fc49eea54646d0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/eb"
+  },
+  {
+    "type": "inline",
+    "contents": "5725a8b9756f42d0477df9a478a240302f1eb2f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz\", \"integrity\": \"sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==\", \"time\": 0, \"size\": 8110, \"metadata\": {\"url\": \"https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0aaef637f012513ca7b7eca7959e6c40b888a50bbb93b50ab0809258813e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/79"
+  },
+  {
+    "type": "inline",
+    "contents": "57386f8da5993ca63daeb026123dc2a337e8dc3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz\", \"integrity\": \"sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==\", \"time\": 0, \"size\": 6360, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "83ff575f37d312f1649df4fc617026d1cc47dc9609df732c6b403fed5983",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/08"
+  },
+  {
+    "type": "inline",
+    "contents": "57c41e183178bfcd928d0972c11c95cfed177a67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/undici/-/undici-6.28.0.tgz\", \"integrity\": \"sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==\", \"time\": 0, \"size\": 295110, \"metadata\": {\"url\": \"https://registry.npmjs.org/undici/-/undici-6.28.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a10098985fc5d5778763c84c111e791667bddfdbee985566461d59551b65",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/db"
+  },
+  {
+    "type": "inline",
+    "contents": "586ef380d7bc535bcc2adb1d700dab73012b72c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz\", \"integrity\": \"sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==\", \"time\": 0, \"size\": 73972, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cbc6649f11de3ace7a33d2b87588072d82973673c2fe9cd893d6f5522dca",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/83/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "5911e16b8e6a81c7190c4c3f624c453bb1d60d24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz\", \"integrity\": \"sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==\", \"time\": 0, \"size\": 44403, \"metadata\": {\"url\": \"https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cd727b5dc4f1a2e6bb7deaefb020f0aeb2132c516f75be84a139b1fbf94f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/df"
+  },
+  {
+    "type": "inline",
+    "contents": "59235edf7a1e8614b263822c258c0cab9b63e42a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz\", \"integrity\": \"sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==\", \"time\": 0, \"size\": 24482, \"metadata\": {\"url\": \"https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d8cd07a98122dee66d2dddd6cf13ec07d58661b9c16aa1283da271977212",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/33"
+  },
+  {
+    "type": "inline",
+    "contents": "59433e19f4aa894db22c771aeee46790f3829a91\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz\", \"integrity\": \"sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==\", \"time\": 0, \"size\": 49937, \"metadata\": {\"url\": \"https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cb6f59cf06a8dfb8a4312f2d4ee79f7ce42afcf923439d637567568031bb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/31"
+  },
+  {
+    "type": "inline",
+    "contents": "596d0838d69d40374d1e68327b7ffef20ada0390\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"integrity\": \"sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "489c0e6a9e4cbd64a8acd4fbfda113e9dfdd114f464830471fda53fff0cd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/c4"
+  },
+  {
+    "type": "inline",
+    "contents": "59c9e50e387d0dd1e8141e3371932d65ae75fba2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"integrity\": \"sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\", \"time\": 0, \"size\": 9742, \"metadata\": {\"url\": \"https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7bd13a4fbca4723a579cab6019efcd5e03ff32581fd276a8f79738dc7a68",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/18"
+  },
+  {
+    "type": "inline",
+    "contents": "5b47f212fe504b3658e482fb881c82c2016419c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"integrity\": \"sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\", \"time\": 0, \"size\": 9804, \"metadata\": {\"url\": \"https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b2ef5a84c2eaaa7d05e56b8cf6c031a281ad250ad82994ffd1323d790201",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/a1"
+  },
+  {
+    "type": "inline",
+    "contents": "5c2daaa21e43d1f7be77d2e83fc50fc0880d3368\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz\", \"integrity\": \"sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==\", \"time\": 0, \"size\": 83605, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c43cb43d33c94194830f62decc25626d377ceda4183614d4743fb9ffd7ee",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/d8"
+  },
+  {
+    "type": "inline",
+    "contents": "5d2feb20b8086f2e14a49906df15bcf6181f96a8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz\", \"integrity\": \"sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==\", \"time\": 0, \"size\": 4426, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8ff85a5beb38108b18dfb2c44c8851b26232c3479c3e2337507b7ac2d23b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/44"
+  },
+  {
+    "type": "inline",
+    "contents": "5df5bdc438047ef5912ac5c0cceda7d48c8cca10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz\", \"integrity\": \"sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==\", \"time\": 0, \"size\": 9821, \"metadata\": {\"url\": \"https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "78c8ffe678eee45c958a2be44ac6501650d6372ed2cf8c22b7a8e3c62423",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "5e621ade89e852910872fb351d7f3083c1bcb416\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"integrity\": \"sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==\", \"time\": 0, \"size\": 2668, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "be90b3954e2f6e7b35b521e65a5016fd963aa11c3d6c88ccd9e0b61c069e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/ad"
+  },
+  {
+    "type": "inline",
+    "contents": "5eeba38c32699bfe5489c58d29ded948619a20bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"integrity\": \"sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==\", \"time\": 0, \"size\": 2263, \"metadata\": {\"url\": \"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87042931e5944467d47331c350feb4384bf9143ab6ceebf7108a55905843",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "6129c0520f5904686a2ec4b39e25d1b0e003d0bd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz\", \"integrity\": \"sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==\", \"time\": 0, \"size\": 2180, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9f26fc841e03de019e6637c442b754c5ddfbc958f993ad8423e3dd041692",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/f6"
+  },
+  {
+    "type": "inline",
+    "contents": "62fc2f09977ec3ec2f3b218de1da6948b5ef56a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz\", \"integrity\": \"sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e05e41ce38b1de47d720428a14c9b0c12d84930460e815e4b4e08ee724d5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/00"
+  },
+  {
+    "type": "inline",
+    "contents": "634c86eb52ae5b3308789a753cb496e7922865eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/temp/-/temp-0.9.4.tgz\", \"integrity\": \"sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==\", \"time\": 0, \"size\": 5744, \"metadata\": {\"url\": \"https://registry.npmjs.org/temp/-/temp-0.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4084b4199df6728727c8c1ef60479569196173bfac5d2548c005d6fdf19d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/15"
+  },
+  {
+    "type": "inline",
+    "contents": "64a582dffa3bb0ed7ab1744a5ff46d0adb226ae8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz\", \"integrity\": \"sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==\", \"time\": 0, \"size\": 4101, \"metadata\": {\"url\": \"https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5191a0c12d46dc1642126a7c79ac5b744e6f31560e96058cc7bf29781390",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/d6"
+  },
+  {
+    "type": "inline",
+    "contents": "64c7a3a0f94b9bddc92702fa72506dfaf25a7cc3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"integrity\": \"sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==\", \"time\": 0, \"size\": 1654, \"metadata\": {\"url\": \"https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2407adde9d05bdd552950df201bc4af8db37f56e8a766823f9a3893a2107",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "6520cc209e4043bd45b276ef4ea46de092057728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"integrity\": \"sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==\", \"time\": 0, \"size\": 6157, \"metadata\": {\"url\": \"https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a5acf52705a1beb66603196f4bc44e583052d0f1d5a23dfb5316da1811d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/d7"
+  },
+  {
+    "type": "inline",
+    "contents": "65a38d846d3c6571c7029bf7c010f3f361e02619\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz\", \"integrity\": \"sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==\", \"time\": 0, \"size\": 6059, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0e27b0257fb5f041ac774321372e8d3b9b40a4631e6d7a0f2d0051ec2a34",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/8e"
+  },
+  {
+    "type": "inline",
+    "contents": "66b7fc5a9735644c140313da9f7b8d74b44a932b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz\", \"integrity\": \"sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==\", \"time\": 0, \"size\": 12308, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cd9c8c5d7644f3453ef6a7e43f425203b6df831f6983aaa433c11871887f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "6784529eed7dfe768a00bb8f26ac938d794f0dbe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz\", \"integrity\": \"sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==\", \"time\": 0, \"size\": 7231, \"metadata\": {\"url\": \"https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "24dfbb2c45c3b8a6e8d28b441cf345581a0030bd27ca640f5eb08a0236ec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/82"
+  },
+  {
+    "type": "inline",
+    "contents": "68f564140c592c4f1e64586672d73993310c8c32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"integrity\": \"sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==\", \"time\": 0, \"size\": 1894, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "393eb6f1cdd50a93cb92ed56af16a93821a9263f732f369d831c48199a58",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/c1"
+  },
+  {
+    "type": "inline",
+    "contents": "690407eb990c221b8dd857f8a8cf8afa34684ab2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz\", \"integrity\": \"sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==\", \"time\": 0, \"size\": 14677, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "400cfcda0abd9b153139f605abc14a1297504d4db7c375f520ebc61bc1e9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/8d"
+  },
+  {
+    "type": "inline",
+    "contents": "6b34e8f0115245837a7cf95cb285ae69911fd5ef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz\", \"integrity\": \"sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==\", \"time\": 0, \"size\": 3018, \"metadata\": {\"url\": \"https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ad46d55ca529175e31495e24424ec24ed59ce48817f490f64c05d7211bb9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/6b"
+  },
+  {
+    "type": "inline",
+    "contents": "6b84b8f37c618e3624796e18c35d85e15b6f7d98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"integrity\": \"sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==\", \"time\": 0, \"size\": 5338, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c2c4e4cf88f6f5a26a474eec1eb28a1a0c087f156fa82df974013a50081f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/65"
+  },
+  {
+    "type": "inline",
+    "contents": "6e6cb181797b0667513cb0e46f631211fd3eb343\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"integrity\": \"sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5e4a83442d291d5de897ec5988a37d07269e97c52ea66182b3be08b6b990",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/0f"
+  },
+  {
+    "type": "inline",
+    "contents": "6ee2e82d38dedcac927b1b393ca71b413aa2d426\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz\", \"integrity\": \"sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==\", \"time\": 0, \"size\": 4317, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8879c3cd1412a0890461590276aa13d0344cb4e09494a4b3d854a7c7660a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "7028aae816823ee10f757eb0868d6efcfe696acd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/progress/-/progress-2.0.3.tgz\", \"integrity\": \"sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==\", \"time\": 0, \"size\": 6000, \"metadata\": {\"url\": \"https://registry.npmjs.org/progress/-/progress-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "54dc621a54fe11094875185a4e7049b202a604ff7216c95aa8b52dccbe87",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/f0"
+  },
+  {
+    "type": "inline",
+    "contents": "71f3a98ea666ec2377ca1046c8e671b6b655e91a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-7.2.3.tgz\", \"integrity\": \"sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==\", \"time\": 0, \"size\": 15444, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-7.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6643cd3b9873fb99797c42a3d1709213997f83c9fee6a35449be578f8550",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/35"
+  },
+  {
+    "type": "inline",
+    "contents": "725625676c79b1a85d648e98e3acb275dc553491\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz\", \"integrity\": \"sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==\", \"time\": 0, \"size\": 18233, \"metadata\": {\"url\": \"https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f89fcccccf7642d9d99bde52fc8902caf354dc36c2997ba70b5b6eb67c02",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "734461ac35b786308e653c9529b59d3d692eee87\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz\", \"integrity\": \"sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==\", \"time\": 0, \"size\": 24198, \"metadata\": {\"url\": \"https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8fbb72bfc03310bdf22a69288993688ad6ae76401cbe0e939548f16c39e9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/5f"
+  },
+  {
+    "type": "inline",
+    "contents": "7590d644854430ceb3d166d6a10b762f962fd1f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"integrity\": \"sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==\", \"time\": 0, \"size\": 1506, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0ff11cd5c49f9abb3792227a2806421aeb4003688278322146dd805a2cea",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/31"
+  },
+  {
+    "type": "inline",
+    "contents": "763581e9c630fa5d969e57574916c4fd2d975ea5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json5/-/json5-2.2.3.tgz\", \"integrity\": \"sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==\", \"time\": 0, \"size\": 50318, \"metadata\": {\"url\": \"https://registry.npmjs.org/json5/-/json5-2.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e89f8bf36bf4f4865512579b711f7cba1f7f3a4cc4d8b133abb9793b0ea9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/24"
+  },
+  {
+    "type": "inline",
+    "contents": "7641368474869040e3961b45f849d8efca03e063\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"integrity\": \"sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\", \"time\": 0, \"size\": 39740, \"metadata\": {\"url\": \"https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "339b9832e323abb280eb874ec64f59486423026430be7b1c2ec42ca7e1b7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
+  },
+  {
+    "type": "inline",
+    "contents": "78009203a4d6c0d136d30689531b9fd0616bade0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz\", \"integrity\": \"sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==\", \"time\": 0, \"size\": 3254, \"metadata\": {\"url\": \"https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9594cf5ec7b6b73d63a930b49bf7075e8a5c29cdc43776e641af762a7710",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/90"
+  },
+  {
+    "type": "inline",
+    "contents": "788dde1a1bccf85bd1e8ec4e441c806507e926c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz\", \"integrity\": \"sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==\", \"time\": 0, \"size\": 4662, \"metadata\": {\"url\": \"https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7c199fba9261b92a884e4e207b05388761c224a6f43097aeca01664cd8a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/73"
+  },
+  {
+    "type": "inline",
+    "contents": "79df6aeacb3a61b65cca811e9740a8ab7b741819\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz\", \"integrity\": \"sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==\", \"time\": 0, \"size\": 2677, \"metadata\": {\"url\": \"https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b9e22026b9c7d32f01eebcaae1ba78a0c50fff9f6daa3c7fd8351e1f2f84",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "7a5332ed80674fb40d1d266cf912b83a81e92849\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz\", \"integrity\": \"sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==\", \"time\": 0, \"size\": 32085, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "78c6e4f62f566a7470892bcba249cb773218bc3396c274080f4fd8c8d691",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/0a"
+  },
+  {
+    "type": "inline",
+    "contents": "7a96398bcb23418943af4f6b2a22a767399e981b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"integrity\": \"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==\", \"time\": 0, \"size\": 13449, \"metadata\": {\"url\": \"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e25f670d26bc26d1cb236efef449fc8718223fd484c4107ba797934cb10c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/1f"
+  },
+  {
+    "type": "inline",
+    "contents": "7a9a77dba41e943a7bffb71813740b59450f1f6e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz\", \"integrity\": \"sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==\", \"time\": 0, \"size\": 10968, \"metadata\": {\"url\": \"https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6cbcccb53a97ca56a3f515079dad26301f0ca0937c940661aa824ba8282d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/0a"
+  },
+  {
+    "type": "inline",
+    "contents": "7c442e6fcb2e842a764f9b558be2907f1e4db8d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"integrity\": \"sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==\", \"time\": 0, \"size\": 8620, \"metadata\": {\"url\": \"https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "35cb8b23ae64f5467e4748e13214ac6208cf6c4330e3bc5a2a28b7b96aac",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/ed"
+  },
+  {
+    "type": "inline",
+    "contents": "7c4f3167ca676e48dd5c05fd462dd80b6a1d5f92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz\", \"integrity\": \"sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==\", \"time\": 0, \"size\": 4356, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5988b2031fd875c9c89cf51b451820b3c045c93af7d1a7fff57fe118584c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/cf"
+  },
+  {
+    "type": "inline",
+    "contents": "7c57ead6e2d98083adf099564d4f0adaf8fd7cd0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz\", \"integrity\": \"sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==\", \"time\": 0, \"size\": 8111, \"metadata\": {\"url\": \"https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99a8ac8d9fe0f2ad4894aa959445cb3e3c9b6cd11883956769678b196ced",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/b5"
+  },
+  {
+    "type": "inline",
+    "contents": "7ca1aaff10735a730d04e84a69646d25e5c28145\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"integrity\": \"sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==\", \"time\": 0, \"size\": 26992, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "53e431efe5d40277f768cec075f9e7f618f2296715654a7b953121078b1e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/14"
+  },
+  {
+    "type": "inline",
+    "contents": "7cfe84f78520262599c8e5d269394a49cb17e870\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.8.5.tgz\", \"integrity\": \"sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==\", \"time\": 0, \"size\": 29399, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.8.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b35aa26fd53c39287596a93949ad69fc2a94fe33b5998605d9f1507cca37",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/bd"
+  },
+  {
+    "type": "inline",
+    "contents": "7e2a22a1dc1bde1f24ae9dc32cb4b615355a77f2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"integrity\": \"sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==\", \"time\": 0, \"size\": 217611, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f3e26b8c50880e9350336dbc39f707c1ba35f75dbadc9598933ea528a990",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "7e54b6ac0d3d5a74bdfa2fef6993c130903eaf48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz\", \"integrity\": \"sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==\", \"time\": 0, \"size\": 8504, \"metadata\": {\"url\": \"https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9c312bb275081a100a2f4ee0049329b3d966da3c1f0fb4e9e828e10b1be5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/63"
+  },
+  {
+    "type": "inline",
+    "contents": "7ef605811d4b05bf705339a8b030fcb98e529b26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz\", \"integrity\": \"sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==\", \"time\": 0, \"size\": 2378, \"metadata\": {\"url\": \"https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9659af8603efdbb4be9503333d179292a7c4f2d02e409f8842e12f55a5b7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/99"
+  },
+  {
+    "type": "inline",
+    "contents": "80651016cac75d59625ec270d9f2e78649974122\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz\", \"integrity\": \"sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==\", \"time\": 0, \"size\": 3464, \"metadata\": {\"url\": \"https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0d7ba846044fe5a2fa1d8341f6a7f56438ae9161709a548cbda5f1fd7c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/2f"
+  },
+  {
+    "type": "inline",
+    "contents": "808365d5b6377e5042b3cae0ad7b68c52be5cdc1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz\", \"integrity\": \"sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==\", \"time\": 0, \"size\": 33668, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "25bb9615aa16691191832dc6466eb46a9cc028781c1801cc71d928fb4d4a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/45"
+  },
+  {
+    "type": "inline",
+    "contents": "822595d2f9563ecb020d9c2f8d2523b2558e5926\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz\", \"integrity\": \"sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==\", \"time\": 0, \"size\": 4488, \"metadata\": {\"url\": \"https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b5852a37a1c7a8587e01794c63ffc105ace222e8c117e0b7d8fceeb1b31a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/2b"
+  },
+  {
+    "type": "inline",
+    "contents": "828a49082589bb7e28409ba68d20e6f50c654fe7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz\", \"integrity\": \"sha512-KZ8mhXvWv2rIEgMbWZ4y33bDHyUKMXnx4M0sTyPNK/vcB81ImdeY9Ggdqy0SWbMDgmbqyQ+phgejh6V3R2QuSg==\", \"time\": 0, \"size\": 31787, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ae9493f705375fdcf031e500c69f0a44117123f93dfb2a7806c8cecd4441",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "828bbfb4bd4c72071665ec181d950d9febf3f5a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz\", \"integrity\": \"sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==\", \"time\": 0, \"size\": 20211, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c6b3eea46fb06d8467de0e0e24978997e3538b1b7fb168eb21cfeb09d716",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "84001e5db6b95e23a5edd389d31721786f7c00df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-5.0.0.tgz\", \"integrity\": \"sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==\", \"time\": 0, \"size\": 3346, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7df889e5858b4dc876354f0b10e3efbf53f9384649c8e9238d86fbe3bea5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/db"
+  },
+  {
+    "type": "inline",
+    "contents": "85795dea1ecf7c402ce8472ecdc63256cebb23d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"integrity\": \"sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==\", \"time\": 0, \"size\": 139293, \"metadata\": {\"url\": \"https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0acdca37b8cc7145aae47941a4acde6fc2dd876377875417fbd0e59dba97",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "85d8d5cbd3c51a2a6c63ae73638fff5de819f75e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz\", \"integrity\": \"sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==\", \"time\": 0, \"size\": 11288, \"metadata\": {\"url\": \"https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0972e27b472e887ee3688d264ce83c680c164c7a6485354a4781e6d71253",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/db"
+  },
+  {
+    "type": "inline",
+    "contents": "8666d22189f104ccc5ef690862922914e4966b58\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz\", \"integrity\": \"sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==\", \"time\": 0, \"size\": 2003, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9c712a5e8a00354e98f9eee025a14a8f8053ed29c4ade503136800b6c9ad",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/83"
+  },
+  {
+    "type": "inline",
+    "contents": "87a4a7985d99182254f2259d6de8bebbcf0d6847\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"integrity\": \"sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==\", \"time\": 0, \"size\": 2021, \"metadata\": {\"url\": \"https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "43bc4bbdabf8ae0454ee7075000f4ba27acf124106cdb71a445723bbc8c9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/5c"
+  },
+  {
+    "type": "inline",
+    "contents": "881d3158e8981edf330a0aa9948a6e58a89fd4a0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz\", \"integrity\": \"sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==\", \"time\": 0, \"size\": 4014, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e2a6284e759231bc5e31fb0a378c5e22d4e10ad3f06818081bf46670577a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "8ac90d1fafd79650deb369ba4d50ee1f9b910235\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz\", \"integrity\": \"sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==\", \"time\": 0, \"size\": 15784, \"metadata\": {\"url\": \"https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "90b1f197bbd6fcf22d48eaf1a3e2bf1a29509254b184b8695383da01bc4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/21"
+  },
+  {
+    "type": "inline",
+    "contents": "8bb73f8792bf02f9f388cb0c7c40eb42886f88e4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz\", \"integrity\": \"sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==\", \"time\": 0, \"size\": 22336, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ef61e7a29ce5b4fb8d4176fafa5f5fe17e0e9640f6e5db82941937013315",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "8c084c7ae5707b44c8c6538a46398ea4595e9711\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz\", \"integrity\": \"sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==\", \"time\": 0, \"size\": 7677, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4823d25a60802304e58edaa16fb53111bb559d3aa89a535a31db203d673c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/e2"
+  },
+  {
+    "type": "inline",
+    "contents": "8c9867c5176f8e3d29632ef41a0b78c6e1f302d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz\", \"integrity\": \"sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==\", \"time\": 0, \"size\": 16062, \"metadata\": {\"url\": \"https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0614f2da9878f227d7db0c06e275306653755994fc1191b06b8fc625b090",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/79"
+  },
+  {
+    "type": "inline",
+    "contents": "8d127c7f6038e76b2f6cb2d1f34cbac59fe49191\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"integrity\": \"sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==\", \"time\": 0, \"size\": 4831, \"metadata\": {\"url\": \"https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "469da539f6f336e366cb9edec72814077ffd341100a28dfb8cca1408d9af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/73"
+  },
+  {
+    "type": "inline",
+    "contents": "8e70c1566d2a126d311d3224316e888924d7606c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"integrity\": \"sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8a67a6a69c573e507dac8723fa56c0451c1ebb42aa08925c3bd37a8435c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "8f498db3c301f6f442fccce923dbf96a93ff776f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"integrity\": \"sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==\", \"time\": 0, \"size\": 145420, \"metadata\": {\"url\": \"https://registry.npmjs.org/plist/-/plist-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2073ae784c88534a43261e1b45ea995702ed5b9c3b921f22c6957e6c9be9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "900766ea19fc0eec87a064661058740680e217d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz\", \"integrity\": \"sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==\", \"time\": 0, \"size\": 42688, \"metadata\": {\"url\": \"https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8d5cf0bcdf28a774809fa42c20f489c30c453fea103305d75b565454da7f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/44"
+  },
+  {
+    "type": "inline",
+    "contents": "90933b1926f6c04fba0ef5802b503bdeec2b46d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz\", \"integrity\": \"sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==\", \"time\": 0, \"size\": 4434, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ed036cc76081b7f1bfb3aa59d491eb3b3602c9381ec8d81435ceecf56b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/15"
+  },
+  {
+    "type": "inline",
+    "contents": "90a871a7296e5692e62f51b6b762fea6e067831e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz\", \"integrity\": \"sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==\", \"time\": 0, \"size\": 12383, \"metadata\": {\"url\": \"https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "70d30f776e14a8776301cc7c601c8284929f4a99ef0d53e20fa7637a1755",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/9e"
+  },
+  {
+    "type": "inline",
+    "contents": "90dde44d78c8028fcf6b6c0e69eb6f1be0ccfd9a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz\", \"integrity\": \"sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==\", \"time\": 0, \"size\": 13982, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b82d5390dafe5342dc87e485df15e6f36a0851d0b7582705c3f6e0175267",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/48"
+  },
+  {
+    "type": "inline",
+    "contents": "9126afeaddd66043090e27254115e0983fdfddc4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz\", \"integrity\": \"sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==\", \"time\": 0, \"size\": 4109, \"metadata\": {\"url\": \"https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "40755fd116126afd216c71b0e32d65209a5aa5258585607fca59e411384a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/48"
+  },
+  {
+    "type": "inline",
+    "contents": "917282b6fa4e934f5b711f50e109d90a924ef1e1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz\", \"integrity\": \"sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==\", \"time\": 0, \"size\": 1182, \"metadata\": {\"url\": \"https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6193555b4444d9152a470646047c4d5a86bb2cd122fa569dacd5a059e13f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/d2"
+  },
+  {
+    "type": "inline",
+    "contents": "91a196ae012f18774044f612769a0024ea8e8f43\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz\", \"integrity\": \"sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==\", \"time\": 0, \"size\": 6677, \"metadata\": {\"url\": \"https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "956075e3a75f25d2401347585c1393cfe83e0af66899f306f7ec8018b6cf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/a5"
+  },
+  {
+    "type": "inline",
+    "contents": "91cf859a57821d613590397910a610fa21e3daec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"integrity\": \"sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e41f2c2713684e6e809753f5b2a642d98d5d19a1c17c03d0788531cebf88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/7f"
+  },
+  {
+    "type": "inline",
+    "contents": "93a155478d5243faeda776a11ebc832145ffee14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"integrity\": \"sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==\", \"time\": 0, \"size\": 4429, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea55e4e584609a1f0ba14a730391c0b04141931864f08f4172886bec44f9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
+  },
+  {
+    "type": "inline",
+    "contents": "98ccaee5f8ce2817a09b90e28ebe806a75f4a606\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"integrity\": \"sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==\", \"time\": 0, \"size\": 2868, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d04e75208dec117f72a95a5989f81fac7565a530fd22f70ea5e3abc377c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/62"
+  },
+  {
+    "type": "inline",
+    "contents": "9a2092c66416a6b34ca232046989392af6eb0f96\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz\", \"integrity\": \"sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==\", \"time\": 0, \"size\": 4372, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b90e45414a9e52cdf1e4a96698065357795b9400d7af079b0a75ee8fd76d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/6a"
+  },
+  {
+    "type": "inline",
+    "contents": "9a4e87b3f2e8eb0907e316be8dba0594b01ca7e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz\", \"integrity\": \"sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==\", \"time\": 0, \"size\": 27712, \"metadata\": {\"url\": \"https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b4a9e82e8fd0e8187e8b3d72ac1f9a7572aac1df6422c0ff1d69726f9dec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/65"
+  },
+  {
+    "type": "inline",
+    "contents": "9ac64a980e2a0ca49985b6c7e8dcc5e7f94c6a69\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz\", \"integrity\": \"sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==\", \"time\": 0, \"size\": 4111, \"metadata\": {\"url\": \"https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4313d559739f2998050c4b1bcfc5ffa04c9bcef5bf4c0b25e564c7a33601",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/07"
+  },
+  {
+    "type": "inline",
+    "contents": "9b081a9be63cf4abe9180e060516b93eb7a8d95e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"integrity\": \"sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==\", \"time\": 0, \"size\": 7907, \"metadata\": {\"url\": \"https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f36d855e73b72c900bef7ba44a2a553de3d77b218493b4ddb6ae6fce516",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "9b0c40676cebe440ae2416b5aaed90b42ad69034\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz\", \"integrity\": \"sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==\", \"time\": 0, \"size\": 226859, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8437188635c1a731713d7ab55eeb0abdf518ebfc38573f57b01ddeb5f7dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "9b7921fbbab985e4c4285dd651cce693e9e10dde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz\", \"integrity\": \"sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==\", \"time\": 0, \"size\": 6655, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2451561f054e0e7e27d5df87c6fa6f2ba6a68cc3a01b777b5157f8d18497",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/5b"
+  },
+  {
+    "type": "inline",
+    "contents": "9c8a850b9eef6b34ef0ed7687dee7ce92ac997b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"integrity\": \"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==\", \"time\": 0, \"size\": 2967, \"metadata\": {\"url\": \"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bd8af8e4938b9fee217abddb09ce52db330434e323c828aeabe5bd909ae7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/a7"
+  },
+  {
+    "type": "inline",
+    "contents": "9d190979fafab00d83ce2ce9ab4c90792fcf30ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz\", \"integrity\": \"sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==\", \"time\": 0, \"size\": 2429, \"metadata\": {\"url\": \"https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "79d1f3eb5c41918fc08954ff9aa28e78b24b8a640157c52724bd9fc7a4b2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/62"
+  },
+  {
+    "type": "inline",
+    "contents": "9efd18a561eea788bc847946f2966a225ae44dde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz\", \"integrity\": \"sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==\", \"time\": 0, \"size\": 2783, \"metadata\": {\"url\": \"https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "94eb7a5af2f86dfcab6f8eebcc327f7a014c17456460d210967e2466a7d5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "a16ba0b3711194e36abfc3c93e56563b0857ef6a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz\", \"integrity\": \"sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==\", \"time\": 0, \"size\": 118534, \"metadata\": {\"url\": \"https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "33ed7e82f2b1a8b951a8c5940696548e5cf8ddb78db75e882304a0b3f57b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/79"
+  },
+  {
+    "type": "inline",
+    "contents": "a2a6c3cb423fcec73db84de16e1624cb944cbbd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"integrity\": \"sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==\", \"time\": 0, \"size\": 18724, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime/-/mime-2.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2a0f2a6cea25e2b56b9059fe234a67034533d0170fb8c63247f93c2c37c2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "a2c6730db5276a4f496908a3aaeb4791116d3cba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz\", \"integrity\": \"sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==\", \"time\": 0, \"size\": 8079, \"metadata\": {\"url\": \"https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "519103a79db19d6d95ed157de08cbd809b32139119e6d02adaf2deeb017a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5f/40"
+  },
+  {
+    "type": "inline",
+    "contents": "a2c6b13ca421d20668e3669d1845b0d1d92f12d6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"integrity\": \"sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==\", \"time\": 0, \"size\": 25747, \"metadata\": {\"url\": \"https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5cb3f47ba8a17b62a575c388705c516448f9426b5f1e0bbbbe6f21f223d8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/3f"
+  },
+  {
+    "type": "inline",
+    "contents": "a2eee1bac32146d808526b7277f214aa51aa1d54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz\", \"integrity\": \"sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==\", \"time\": 0, \"size\": 1882, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3e8c6b6c875addf2057fb5fa152fff0fab217f78a8e51c0aa457a925bf12",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/dd"
+  },
+  {
+    "type": "inline",
+    "contents": "a2f3e9c64be21344803609f4e669ac7073621a1b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz\", \"integrity\": \"sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==\", \"time\": 0, \"size\": 9141554, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a7d97b9db8ab7a9936cede6325ef66063a510e16dc2e8bca79217ec8fe24",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "a389d3567858196e22be63c4bc7e9dfd47375183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz\", \"integrity\": \"sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==\", \"time\": 0, \"size\": 14287, \"metadata\": {\"url\": \"https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f3d991647a77c6d90d2646904dc777dfcf6724822b5181965f940aa75ae7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "a481f9f5caade7d1e25e2005bd586788297ee48b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"integrity\": \"sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==\", \"time\": 0, \"size\": 2258, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8af21194b7c666dcff699b874730170edc9a2670a4d17bf4186649ee9fa7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/96"
+  },
+  {
+    "type": "inline",
+    "contents": "a4825a3537f883d93b2da1cab0b74cea68de0c9b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz\", \"integrity\": \"sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==\", \"time\": 0, \"size\": 10590, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ff4abda1d723df94c6c3a93dab8f673d675ba3da978ecc496a884cc1ca8a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/41"
+  },
+  {
+    "type": "inline",
+    "contents": "a4e302a96332d176614e0d0cebed06805008297e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz\", \"integrity\": \"sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==\", \"time\": 0, \"size\": 25591, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b27322aa8e0aa28aa436380c95dc1efd18b7ed694fc7dabb39f9f6fc97c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/50"
+  },
+  {
+    "type": "inline",
+    "contents": "a4ee88f0d35669a5fbc15bc2d7c9227675212da1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"integrity\": \"sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==\", \"time\": 0, \"size\": 9822, \"metadata\": {\"url\": \"https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4c69aba00431d506e9b53306eba6929ed6581502d7e8c77cb340635745a1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/66"
+  },
+  {
+    "type": "inline",
+    "contents": "a594df06e22af03ff1c6531b6a46dbc61fc0e72c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"integrity\": \"sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==\", \"time\": 0, \"size\": 6465, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ae718527d2b9bf7fa981d80037d5b2f7b34f0e34a76fdd3bc9b604b90077",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/f8"
+  },
+  {
+    "type": "inline",
+    "contents": "a96912c2955a276f6fb51f289824cc00ab2000c1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz\", \"integrity\": \"sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==\", \"time\": 0, \"size\": 58304, \"metadata\": {\"url\": \"https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aaafc99323d81b9dbe93a123e6d46ce50bf4ac7efc7f86e02952242506ca",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/be"
+  },
+  {
+    "type": "inline",
+    "contents": "ab07e82d2dbf1e8335d08c667924e00504d8a9bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz\", \"integrity\": \"sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==\", \"time\": 0, \"size\": 5266, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5387e38555d4ade6743dd68435e50854b8e40c97f255ecf0bda6f4e34883",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "ac0d531594dceaf640056a94b254bad7987a6806\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sax/-/sax-1.6.1.tgz\", \"integrity\": \"sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==\", \"time\": 0, \"size\": 16800, \"metadata\": {\"url\": \"https://registry.npmjs.org/sax/-/sax-1.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "392983726a7da73adf0bdd31dd19dd1d6ea9497a7728de9c45c796022efa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/3d"
+  },
+  {
+    "type": "inline",
+    "contents": "ad2c41b699ad1d285bdacf4119420f09ab0daffa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz\", \"integrity\": \"sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==\", \"time\": 0, \"size\": 3519, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f2a8bd190f22671c866441ba3c09df2b7cc1088ad65bfa1ff1f42906fe4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "ad5b09501473307a390d236ad572f17d331c0d32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz\", \"integrity\": \"sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==\", \"time\": 0, \"size\": 44639, \"metadata\": {\"url\": \"https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "37dc5438037a2e91479fad3afae6e28cdeab35edd4fec4e6b725f4520420",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/6d"
+  },
+  {
+    "type": "inline",
+    "contents": "af3d5ac851b31d793dd2d2dea4ad5947ee06c35c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz\", \"integrity\": \"sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==\", \"time\": 0, \"size\": 226720, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c9a64f72abd820109b8efb144d6a608c65e20fc6d788116ce11d6ad5e633",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/82"
+  },
+  {
+    "type": "inline",
+    "contents": "afdb061a71abe8500f6a02abb577d6c635ad6436\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz\", \"integrity\": \"sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==\", \"time\": 0, \"size\": 8148, \"metadata\": {\"url\": \"https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3562ef3eab71f341053fecdd114d60b8b85bcbf4e2aa2a0ac3725dffd59d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "b10e797ef8b06e0d3eedecce48eac8b4d40a4ca9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz\", \"integrity\": \"sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==\", \"time\": 0, \"size\": 8185, \"metadata\": {\"url\": \"https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d01f1c025c259065360fdcb05a94989eb2dd69e2004e3ebb8bb3484c8d4e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/7e"
+  },
+  {
+    "type": "inline",
+    "contents": "b20b1d636832ef08d38aceb6103aa4584c800fc1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz\", \"integrity\": \"sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==\", \"time\": 0, \"size\": 15151, \"metadata\": {\"url\": \"https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bdfa5ddf727069eac8a23761bb83e0befe6e18626e3b77a96a8fa8ef4d38",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "b3867782eee3da7d53505bbb6847faaa9a5924ee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pump/-/pump-3.0.4.tgz\", \"integrity\": \"sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==\", \"time\": 0, \"size\": 3806, \"metadata\": {\"url\": \"https://registry.npmjs.org/pump/-/pump-3.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b7197dbc6e9d94f1799c2a8f30479d064e6bc8b729680b718cb3f239cb54",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "b7b2c53e78216e19ccd892db974a1382354d600e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"integrity\": \"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\", \"time\": 0, \"size\": 4483, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e01e6bce59ac02f0d20fc97382749190cb73f6006f9526fc7fb1ec79dd4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/26"
+  },
+  {
+    "type": "inline",
+    "contents": "b80b8ae25a2a10c0c5b6691530dbf72e2c5f7a6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"integrity\": \"sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\", \"time\": 0, \"size\": 5849, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c2ea22c4bf9c5ddcd0333850e543442de3364478847c7ebc382b1ff3a70d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "b81623f5bfed041aedf3dc60497aab4f8f0d1361\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz\", \"integrity\": \"sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==\", \"time\": 0, \"size\": 16920, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7d0ac147818ea1892350f9c3f49b22c27f3d1f279ead6de0f28c314c285d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/08"
+  },
+  {
+    "type": "inline",
+    "contents": "b835b23b3f1fd4279f6db7954b0a7deca7c62ae6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz\", \"integrity\": \"sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==\", \"time\": 0, \"size\": 4068, \"metadata\": {\"url\": \"https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a2b741aec6bd4dd94223969fdf1afbd63e8b8cbafb7cd5d5029acb3181e1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/74"
+  },
+  {
+    "type": "inline",
+    "contents": "b90f8e54c94da02989f18777eee73af9278fb00e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz\", \"integrity\": \"sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==\", \"time\": 0, \"size\": 2756, \"metadata\": {\"url\": \"https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "483598f2f71313734ffeeba67883f6e17e9a0f7e14abb904bac587630683",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/b4"
+  },
+  {
+    "type": "inline",
+    "contents": "bc36e636fa3ed3bfc55b9a02a226c10e33b71201\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz\", \"integrity\": \"sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==\", \"time\": 0, \"size\": 1568, \"metadata\": {\"url\": \"https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5a622259e8f1b6efc5409a6654f2df18b31cbd389638bce81bc2e0160dee",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/a7"
+  },
+  {
+    "type": "inline",
+    "contents": "bcc94283cb3f1228bea4770aa0688dcd1791a3d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz\", \"integrity\": \"sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==\", \"time\": 0, \"size\": 1609, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c06d275269c6d6b921feebc2470f62b1c8f36f3a86affdc737fe608cc3fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/8d"
+  },
+  {
+    "type": "inline",
+    "contents": "bd9c03022848ffc26bd5d84dd961f1a5df429988\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz\", \"integrity\": \"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==\", \"time\": 0, \"size\": 199644, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b2abd228ca638980cfe42d12d418a89da30648e35d497277d5713e38c7ed",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/33"
+  },
+  {
+    "type": "inline",
+    "contents": "bdd19e30c505d2a8d3a73582414f523f73840ef0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz\", \"integrity\": \"sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==\", \"time\": 0, \"size\": 7774, \"metadata\": {\"url\": \"https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7080af956e3c31396dbe85dd286a41888df1b90a5c2a6c65ba0d6a5464b9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/df"
+  },
+  {
+    "type": "inline",
+    "contents": "c0f57ec5579380abe0aea95565833a529a477bb8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz\", \"integrity\": \"sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==\", \"time\": 0, \"size\": 87152, \"metadata\": {\"url\": \"https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "303d809759cacfacc465b075f4cc6a5d71e47fd1187d9de4719edd376736",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/08"
+  },
+  {
+    "type": "inline",
+    "contents": "c19348f331a014f6bc61730fae6e7900233642bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz\", \"integrity\": \"sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==\", \"time\": 0, \"size\": 2469, \"metadata\": {\"url\": \"https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a105e3f3b6ccfc2beed11576834b20e4729aec847effbde4599b6860802b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/db"
+  },
+  {
+    "type": "inline",
+    "contents": "c32c69ab6c8ba19de74e387e5c163c2520ba8e72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"integrity\": \"sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==\", \"time\": 0, \"size\": 2169, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c10bf71d66461aba0899e81d7a146332c45dbbacb1693c38fc2e4e578e39",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/c9"
+  },
+  {
+    "type": "inline",
+    "contents": "c36a4344f60f78677eb2a507571ca18431f911b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"integrity\": \"sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==\", \"time\": 0, \"size\": 1503, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b652af7d985d655c33bbc6261689ea2f5a550b485dde76ad3aefbe2591eb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/af"
+  },
+  {
+    "type": "inline",
+    "contents": "c3784050b42a96f65af103f19af80319bedfc5cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz\", \"integrity\": \"sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==\", \"time\": 0, \"size\": 4409, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "264481d7837b331d367ed401431d4045546de1c18aa8c591c37a7da98de7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/64"
+  },
+  {
+    "type": "inline",
+    "contents": "c4b4b6b896ef855c65b3bd621ca505e1a76a0915\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz\", \"integrity\": \"sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==\", \"time\": 0, \"size\": 136914, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "40235d701b0ddef3fb2bcc8d21e069e9d308f04f615dd3630a5bedf07ffa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/93"
+  },
+  {
+    "type": "inline",
+    "contents": "c4f8ad2aea9690bc5d90c6fce2f370ccf7dd118e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz\", \"integrity\": \"sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==\", \"time\": 0, \"size\": 4820, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "51151580349c403e9dfbbdd5e40201a21b074f7cdf8417861f9ee32280c4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "c5afc2fc15efcac8fffd79449e4fb03aad38d40b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz\", \"integrity\": \"sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==\", \"time\": 0, \"size\": 3003, \"metadata\": {\"url\": \"https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ccfa15939a7e202fbf5f81851089cfae8190c30a79267a650aae85b8d52",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "c5fb26985990c098bab0a72bd50068f3b84a62f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz\", \"integrity\": \"sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==\", \"time\": 0, \"size\": 16300, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a1ce38da01571c9114e58fadd7c2774b85ded892829d447b47cc624a4418",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/7d"
+  },
+  {
+    "type": "inline",
+    "contents": "c724baa464622e99f67cd486cf902ab4070333cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"integrity\": \"sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==\", \"time\": 0, \"size\": 4474, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c68ba9a1320725050b57ca9c7fbc237e694f1f4a6cb94104f7e3e654f7f4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "c77a08443f9be6000534ff48ff4924e9fdd8ebb2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz\", \"integrity\": \"sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==\", \"time\": 0, \"size\": 3357, \"metadata\": {\"url\": \"https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4ead7ee719c83964143f0cf588e2b7cdd8a117c7ac5b02cc8a433c10d703",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/0e"
+  },
+  {
+    "type": "inline",
+    "contents": "c8a5706006c7272b34109041e53fbf4865386e30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"integrity\": \"sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\", \"time\": 0, \"size\": 11577, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "375aec77f76404d91225e72006a0105b2a6ec04bb02cfa365ebcd4a0232b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "c8d87730c433a4a1671e6952c24df984b4811155\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz\", \"integrity\": \"sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==\", \"time\": 0, \"size\": 22625, \"metadata\": {\"url\": \"https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "662005cd57fba832014f34d3e45ae6070bfd4ddce3acfe9525a092dbbe27",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "c8dc69aa53afdcd39b445f0c8cd5ac47dee550bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"integrity\": \"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==\", \"time\": 0, \"size\": 6664, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c147816be94e86ed9bbb4b9e20409e4791a8991fcfd41d7a44489dedd29b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/90"
+  },
+  {
+    "type": "inline",
+    "contents": "c9e3d6e08d73510bffcdcc6883ddeba6a0cd516c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"integrity\": \"sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==\", \"time\": 0, \"size\": 2068, \"metadata\": {\"url\": \"https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5296f26e207d1371c8f95bf082321237691bc5e5db64b66d0ffd6ffa99ab",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "caf2cef9e57fd1035961a49a5c778d77a56cc57e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"integrity\": \"sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==\", \"time\": 0, \"size\": 2618, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ce47a91aa4c10cda303c5b693122434fcebd897428fb2d4b7b305796453a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "cc92285241ca975434ae5bbf041cd810ab7d5c3e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz\", \"integrity\": \"sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d45062af43674e433f967d20768d308ed6ce195be6acadfb7cfd21d11e67",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "ccf891d44b5231050430281b8f8b7373dbe1bd23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"integrity\": \"sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d241faeb3fea9ec8318fd93dd55eb70a87cc8a6e3f849ccef9863882b4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "cd5580f645fb3ca98dfc09db01fe7a82550df78e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz\", \"integrity\": \"sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==\", \"time\": 0, \"size\": 39537, \"metadata\": {\"url\": \"https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9bac1ea488bfbd4bf6b9532b78063301d4c06388d3919fe9cc00b0ed689f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/c6"
+  },
+  {
+    "type": "inline",
+    "contents": "cd9778c443eb202955f61afde92f0297963d8fcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"integrity\": \"sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c662626ec8eafafa54476678b9f71799a74ee368f2b7845a6ec9f9174a4d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/1f"
+  },
+  {
+    "type": "inline",
+    "contents": "ce0190e6df90ccc1a9357350e6cd69fb98d27da8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz\", \"integrity\": \"sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==\", \"time\": 0, \"size\": 6067, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9648614194cfe05bcf87e96e6d1a9d596eff2ccd2be75d5a63840ff5c5fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/33"
+  },
+  {
+    "type": "inline",
+    "contents": "cf18bad9e243e05bc08340a0670e330f54cf0b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz\", \"integrity\": \"sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==\", \"time\": 0, \"size\": 2190, \"metadata\": {\"url\": \"https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c03134d3b6216050d19cb8276cd28d5ae942c859d0bc3758b53face0594c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/bb"
+  },
+  {
+    "type": "inline",
+    "contents": "d04bf98c4456aeda2a0b458ee15e7b791a21335e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"integrity\": \"sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==\", \"time\": 0, \"size\": 8913, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3823be4be0216c6b586c2eeec514837e4811d9f2cf65ab1e5bda679f7fdf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/35"
+  },
+  {
+    "type": "inline",
+    "contents": "d1769d66951775b353aed9264eca46fe8f9e06fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz\", \"integrity\": \"sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==\", \"time\": 0, \"size\": 1310397, \"metadata\": {\"url\": \"https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0825f52cf5b13e8a63b6bea1c5c1547f6753c2a82e8b6b5d2bcd5000246",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "d32904c7e60ee11a7cc3af0143e5e473c36a9f9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.7.4.tgz\", \"integrity\": \"sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==\", \"time\": 0, \"size\": 28442, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.7.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c335f15c5e60271d167b8468ee446614a76a1bee37e0fcc08643dc5818a4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/ed"
+  },
+  {
+    "type": "inline",
+    "contents": "d5462faa35bff0216713716dc03138cc969bdd60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz\", \"integrity\": \"sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==\", \"time\": 0, \"size\": 8059, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a7f609296af013f459dea95f5b86155b1d4d3fa7dc9ec423562d0c55294f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "d67c09f0c62a0a3dbe4d7c7d06d7b61f78d79ced\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz\", \"integrity\": \"sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==\", \"time\": 0, \"size\": 7812, \"metadata\": {\"url\": \"https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "55189be39944cf4128880be8c6f5ac22c5f81fc4c5852b8dd3d192842037",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "d712d41325d51afeb0fce7351d650884d3ac77e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-5.1.0.tgz\", \"integrity\": \"sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==\", \"time\": 0, \"size\": 28908, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2bb29a71b4389f5f4ed58b78db53a74114c69552ee98ca33e2afde6d1887",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/92"
+  },
+  {
+    "type": "inline",
+    "contents": "d729690b718bc80f5c383b054ab9d42301e7a0c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz\", \"integrity\": \"sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==\", \"time\": 0, \"size\": 48046, \"metadata\": {\"url\": \"https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4db75acf58fe8c33adfbf09ff50989bbbbac4bc6caa6bbfe4d0af07a18c7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "d7af0dccbb92c22336f80fc25356846c3a282481\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz\", \"integrity\": \"sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==\", \"time\": 0, \"size\": 7873, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "43b89d1c15ce8a3c5d1add3132f3c3d0fc8ae221a195e331cb84d785ed88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/65"
+  },
+  {
+    "type": "inline",
+    "contents": "d7f65475b438093e8952272a9fe0d5ca6db26942\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz\", \"integrity\": \"sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==\", \"time\": 0, \"size\": 2638, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c9d3ab62f2cf84cc398a67aa348ac4a8b98b8f0a4777a60c319bc0250fca",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/d7"
+  },
+  {
+    "type": "inline",
+    "contents": "d995864e6fb972527db53a003835e2dc1af0e036\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz\", \"integrity\": \"sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==\", \"time\": 0, \"size\": 29130, \"metadata\": {\"url\": \"https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1365f7225500841e836be4b3a69d7fda5de91c58bed7f871dd5f06148e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/17"
+  },
+  {
+    "type": "inline",
+    "contents": "d9b43a9a600028ee2be2bf6eb3005f697ec4ace0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz\", \"integrity\": \"sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==\", \"time\": 0, \"size\": 117068, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ffe6d031118c280f930d5a8ba11df17d931b6f09825617541d35aea437bc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/82"
+  },
+  {
+    "type": "inline",
+    "contents": "d9d308d9a488ff2be7ce561eec05edae6e5aa7ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"integrity\": \"sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5a271b1898a503a6f8a6b2361235fd7539e9ae1aa5622d3e78124d1a0c34",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/9d"
+  },
+  {
+    "type": "inline",
+    "contents": "db85e73952c1119351e672d9281ecc05d698b218\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz\", \"integrity\": \"sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==\", \"time\": 0, \"size\": 10593, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1fd4b5f086823584bd93210faf20eb842d3f2b6fbaa246cac541ea904772",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/17"
+  },
+  {
+    "type": "inline",
+    "contents": "dce2b0f75ed9856e7f27b5a7ac1f62ec3466f18f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz\", \"integrity\": \"sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==\", \"time\": 0, \"size\": 5049, \"metadata\": {\"url\": \"https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e51aeab9f2ed39d1416132dca81cf2f580dc5de2fd02b9a85d1df3b191f3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/10"
+  },
+  {
+    "type": "inline",
+    "contents": "dcf769524365383f6df36d778ead11e29045e495\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz\", \"integrity\": \"sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==\", \"time\": 0, \"size\": 1949, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5573a63509099c8f965cee0e85671d503d30fbc6e8cef78a3de92574677d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/68"
+  },
+  {
+    "type": "inline",
+    "contents": "dd38b0ea179012dd3455f0bc242f4694b0d8bc50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz\", \"integrity\": \"sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==\", \"time\": 0, \"size\": 4352, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2899d14d6bc80984cf8c90d47500d411da5d6dde4e18a12040ebd7fcbd03",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "dd71d391c9de9e8ac0b89e228a72e904bf34b9fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz\", \"integrity\": \"sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==\", \"time\": 0, \"size\": 26650, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3a65eccea4ca04855d7844772466a7bd372d2aafee069252572fec3cc2bb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "ddb18874d80de9cf6f921c311c7d0cf2b9d60327\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"integrity\": \"sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==\", \"time\": 0, \"size\": 2768, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05a8af0a671c32b41850c1223429fe74449cfcb4c7cac54a9c7c213dfcae",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "ddc9491e936f0880db20eb5b479fdbfe8a2537fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz\", \"integrity\": \"sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==\", \"time\": 0, \"size\": 8728, \"metadata\": {\"url\": \"https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "93f15ef8a50ee08113cdd2668575c7a9157d292acfb12d746775cf347db3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/61"
+  },
+  {
+    "type": "inline",
+    "contents": "ddf5b461ef421da62efbb6531c3f2d69e0450e7a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jake/-/jake-10.9.4.tgz\", \"integrity\": \"sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==\", \"time\": 0, \"size\": 40521, \"metadata\": {\"url\": \"https://registry.npmjs.org/jake/-/jake-10.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fba3ee303f9dc37372dfddac99519c973fd848836b9aa0a5f4bea7267da2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "de6678a1c4a0ad5f2b54460b3a863d854db20625\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz\", \"integrity\": \"sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==\", \"time\": 0, \"size\": 9489, \"metadata\": {\"url\": \"https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1a87c90cd59a4bf06f52e30c511bf53242eb0913f15adc62c3e20ab4e433",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/93"
+  },
+  {
+    "type": "inline",
+    "contents": "dec4fa36f7c4ab7cb0d2f0d60af0fb0f07fb1666\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"integrity\": \"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\", \"time\": 0, \"size\": 2625, \"metadata\": {\"url\": \"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c9aa1c46bf0c67511379e97bd07fca87532422f2506214f94db8861160d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "df494e0c7697c3599dc3823233bcc1679aaace81\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"integrity\": \"sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==\", \"time\": 0, \"size\": 8998, \"metadata\": {\"url\": \"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4fb51f0d6958df4998537c738c83e14af659c6a2ac678defad66458c5358",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/0c"
+  },
+  {
+    "type": "inline",
+    "contents": "dfc095b983a77202312a4ce77cc7f9a7b0355b22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"integrity\": \"sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\", \"time\": 0, \"size\": 3210, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0913a74f5e223a4fe6108493dd3b03c2d47259df459926160659513c9ad3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "e52296458da2d5932936b1fd659d875bfdec73ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz\", \"integrity\": \"sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==\", \"time\": 0, \"size\": 14405, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "24084655f33001f02707d177db2ae7d1e414822fe1a207e1bbab9c7c7354",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/da"
+  },
+  {
+    "type": "inline",
+    "contents": "e5c8d688b6f4deb438d53af0e0f8186131929506\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"integrity\": \"sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==\", \"time\": 0, \"size\": 2246, \"metadata\": {\"url\": \"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e7e8934679b7b49b8240b1f2dcb66c25a5bd17f9629f8fe0ea634cab93c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "e5ee13734d082e76f338e1c7b6037f8b482ac34c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz\", \"integrity\": \"sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==\", \"time\": 0, \"size\": 2822, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "426d9e205dc4ed0aff7c534b89733c3b5d09e37bfcde46b86d3b0e2dab70",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/87"
+  },
+  {
+    "type": "inline",
+    "contents": "e907c0e842454b436f48aa6285eeb5add8438988\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"integrity\": \"sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==\", \"time\": 0, \"size\": 1878, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "34b8f549d763f9583ffbafa18d2b62d1ce4c0aa482ae63a65de156b49543",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/df"
+  },
+  {
+    "type": "inline",
+    "contents": "eb55e357db5ffa3616b9f331bb2b01cd24a60d41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"integrity\": \"sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==\", \"time\": 0, \"size\": 1676, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "532a4c7bf52c908d567ded2bb11b0f3282f0733d0d079a5291c2f72e0077",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/fd"
+  },
+  {
+    "type": "inline",
+    "contents": "ee74a0bbba7904e68168e039b27b255427396b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"integrity\": \"sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==\", \"time\": 0, \"size\": 5583, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9df6136179e75a89f9d3914f7535bf2a6318e5c002f7257fc49bc7b83ece",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/8e"
+  },
+  {
+    "type": "inline",
+    "contents": "ee88913f76915af25e64aca1fc488d82b849056b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz\", \"integrity\": \"sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==\", \"time\": 0, \"size\": 2039, \"metadata\": {\"url\": \"https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6179aff4f4b91a00b02f4ca53b423cd3ece0add9a11a64f5e022c5e88bae",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/73"
+  },
+  {
+    "type": "inline",
+    "contents": "f1083394f1c7ac7e42b46a1f625f1b28f779b75c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz\", \"integrity\": \"sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==\", \"time\": 0, \"size\": 3294, \"metadata\": {\"url\": \"https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "20c9647db7103db5c74e092939ab38cf0fdfadcaa40b9de72a21a61c9014",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/16"
+  },
+  {
+    "type": "inline",
+    "contents": "f49a35b62fd925f40ce87761b764297787761c3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"integrity\": \"sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\", \"time\": 0, \"size\": 1816, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "483e6b07a338fc56daa546a5c7d73c769d72f488be87ff50117370bdf004",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/db"
+  },
+  {
+    "type": "inline",
+    "contents": "f4de916161c81da3f77da9a28fd35b7e69ce2f6f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz\", \"integrity\": \"sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==\", \"time\": 0, \"size\": 2950, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e150ac6f42a5580bba9d83a4666eb08d0f103c059c66a93d9b599f7c8c7f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/77"
+  },
+  {
+    "type": "inline",
+    "contents": "f50fd6341d7979300e25539737e9b053a5eec139\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz\", \"integrity\": \"sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==\", \"time\": 0, \"size\": 462516, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dc82460bd04623f5dc8d867c8cabab7644c93483d26a7bf2e039a420edd1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "f68506aa7598cd19a4f14b283770c11b37a3f9a0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz\", \"integrity\": \"sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==\", \"time\": 0, \"size\": 2428, \"metadata\": {\"url\": \"https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "81e939b8cfc06f7898abade8c43b8e3b2e22185d1d59aa852874a712aecc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/e0"
+  },
+  {
+    "type": "inline",
+    "contents": "f7d3f7650411766b35b2def93ef5f39cc51e1e33\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"integrity\": \"sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==\", \"time\": 0, \"size\": 207830, \"metadata\": {\"url\": \"https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "31f9aa29658115263d61505a3e09112e36d5129f905de7c0188cf6ebe425",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "f9e8cc4e9266c00877133a3f846e87e94f02e1d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"integrity\": \"sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==\", \"time\": 0, \"size\": 12860, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8b676d3aa47926784ae93445ccbb67ab3cd5cde01ed2fb99100c51c73d52",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/51"
+  },
+  {
+    "type": "inline",
+    "contents": "fa30007cb866f40fed46c7af169611b11677ee84\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz\", \"integrity\": \"sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==\", \"time\": 0, \"size\": 4405, \"metadata\": {\"url\": \"https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7949b7ba6f3c8dbcd41a7f6076440f44a2af7f6b517ef1a5e8414b098f5e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/12"
+  },
+  {
+    "type": "inline",
+    "contents": "fb1be7f69d4ecf636c0348cbebd02d75a02b5d24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"integrity\": \"sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==\", \"time\": 0, \"size\": 2765, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ace9a1dfbea06eafdda3044e21e830e5cbd76a5eb5a794acdc111e0c31e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "fc1beb25b4ec3568f3f97849a16f14d629543639\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz\", \"integrity\": \"sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==\", \"time\": 0, \"size\": 6656, \"metadata\": {\"url\": \"https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0f0e169c6775789d51142945f770287198b1d2457ebb4a67be111458aa70",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/ab"
+  },
+  {
+    "type": "inline",
+    "contents": "fd81d7ed78a018d57d6d1911b059b8726077994e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-6.3.1.tgz\", \"integrity\": \"sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==\", \"time\": 0, \"size\": 19093, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-6.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e3daaea93f68bf9dcdd7e978b6dd8f43627145028c05ccc5d6187e7a25d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "fe1de1ff680c8d916c7726262158d78f4d91f892\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz\", \"integrity\": \"sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==\", \"time\": 0, \"size\": 2231, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "da67432c2cf29c75daef6eda49ba57e2e83b8962cb126f332ef78931ea1a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/85"
+  },
+  {
+    "type": "script",
+    "commands": [
+      "case \"$FLATPAK_ARCH\" in",
+      "\"i386\")",
+      "  export ELECTRON_BUILDER_ARCH_ARGS=\"--ia32\"",
+      "  ;;",
+      "\"x86_64\")",
+      "  export ELECTRON_BUILDER_ARCH_ARGS=\"--x64\"",
+      "  ;;",
+      "\"arm\")",
+      "  export ELECTRON_BUILDER_ARCH_ARGS=\"--armv7l\"",
+      "  ;;",
+      "\"aarch64\")",
+      "  export ELECTRON_BUILDER_ARCH_ARGS=\"--arm64\"",
+      "  ;;",
+      "esac"
+    ],
+    "dest-filename": "electron-builder-arch-args.sh",
+    "dest": "flatpak-node"
+  },
+  {
+    "type": "script",
+    "commands": [
+      "version=$(node --version | sed \"s/^v//\")",
+      "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+      "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+      "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+      "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+    ],
+    "dest-filename": "setup_sdk_node_headers.sh",
+    "dest": "flatpak-node"
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "bash flatpak-node/setup_sdk_node_headers.sh"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621\"",
+      "ln -s \"../SHASUMS256.txt-43.2.0\" \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621/SHASUMS256.txt\""
+    ],
+    "dest": "flatpak-node/cache/electron"
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621\"",
+      "ln -s \"../electron-v43.2.0-linux-arm64.zip\" \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621/electron-v43.2.0-linux-arm64.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621\"",
+      "ln -s \"../electron-v43.2.0-linux-armv7l.zip\" \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621/electron-v43.2.0-linux-armv7l.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621\"",
+      "ln -s \"../electron-v43.2.0-linux-x64.zip\" \"9c4e224684594fb9a8cbda18d3e2b7bf0c3c023d1462402a4031f8b4cc25e621/electron-v43.2.0-linux-x64.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-arm64.zip\"",
+      "ln -s \"../electron-v43.2.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-arm64.zip/electron-v43.2.0-linux-arm64.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-armv7l.zip\"",
+      "ln -s \"../electron-v43.2.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-armv7l.zip/electron-v43.2.0-linux-armv7l.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-x64.zip\"",
+      "ln -s \"../electron-v43.2.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv43.2.0electron-v43.2.0-linux-x64.zip/electron-v43.2.0-linux-x64.zip\""
+    ],
+    "dest": "flatpak-node/cache/electron",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+    "sha512": "c09f117906c7c6c01f5e1adff62c65d1a61b668ad1b8e5a904dce6f292fc7ed992c50c7fc27243e4483ceb5370254fdccf2d955c521e6c27999d9ac8f6b92d21",
+    "dest-filename": "117906c7c6c01f5e1adff62c65d1a61b668ad1b8e5a904dce6f292fc7ed992c50c7fc27243e4483ceb5370254fdccf2d955c521e6c27999d9ac8f6b92d21",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/9f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@capacitor/core/-/core-8.5.0.tgz",
+    "sha512": "09ae24aeda87d61a2d863b412307f62764d6ec8858ab5ba3a7c41e22d4e226884db2a8a3f236b60d8607dc353497c466c4259a040153180d9380e80e30248db1",
+    "dest-filename": "24aeda87d61a2d863b412307f62764d6ec8858ab5ba3a7c41e22d4e226884db2a8a3f236b60d8607dc353497c466c4259a040153180d9380e80e30248db1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+    "sha512": "452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
+    "dest-filename": "db4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+    "sha512": "be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
+    "dest-filename": "fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+    "sha512": "73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
+    "dest-filename": "6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+    "sha512": "12cb2102e724966a6e5007e40013f124d8738fdbf6b06ec9bb31432f830bd68250495d78b2aae94d89ec68eb9d300c3dc8e696e77354dd041395442846ce1ccf",
+    "dest-filename": "2102e724966a6e5007e40013f124d8738fdbf6b06ec9bb31432f830bd68250495d78b2aae94d89ec68eb9d300c3dc8e696e77354dd041395442846ce1ccf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/cb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+    "sha512": "2f5ba080d400ab2636d6c99063c0259723986dcbfd31ef536b1c2e2f2b4bd51f1c93d9db60f9902cdc040e2de938518031ae45f08da7522d89739f56e5ac3194",
+    "dest-filename": "a080d400ab2636d6c99063c0259723986dcbfd31ef536b1c2e2f2b4bd51f1c93d9db60f9902cdc040e2de938518031ae45f08da7522d89739f56e5ac3194",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/5b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+    "sha512": "64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
+    "dest-filename": "ff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+    "sha512": "afd807a61b42b3ed4cec9d29c3a4a7fe187f5a96bf890ace3a4acd02554b17f807abefc22661c858a2945217568dc0fa0886bc89d6abb290ac012897097bc553",
+    "dest-filename": "07a61b42b3ed4cec9d29c3a4a7fe187f5a96bf890ace3a4acd02554b17f807abefc22661c858a2945217568dc0fa0886bc89d6abb290ac012897097bc553",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/af/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+    "sha512": "95983c7ea22fdafec5176dfb6f0320cc664426f18befdfece649c9fe2e859ac185e175e5cdc719e236fe4eb148c6d492c45b48a5db20acf65e324d48f4015cc9",
+    "dest-filename": "3c7ea22fdafec5176dfb6f0320cc664426f18befdfece649c9fe2e859ac185e175e5cdc719e236fe4eb148c6d492c45b48a5db20acf65e324d48f4015cc9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/95/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+    "sha512": "e75067c7da4d88c44a49436d05fc9290d27dbcc53d1e1dc8d68cc377a8323cf63369709f9e9b547046715c66059feba5d9db5c3148aa191d586a2d8ad74ba84f",
+    "dest-filename": "67c7da4d88c44a49436d05fc9290d27dbcc53d1e1dc8d68cc377a8323cf63369709f9e9b547046715c66059feba5d9db5c3148aa191d586a2d8ad74ba84f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+    "sha512": "4e6fa06df0b4687bb5b4103f26f290877d92d0ae988021e4880178fd6eb15f42b446636e73de1578ae35f5d26813ae51e5a4719a8fa7a194125ab00c17ac9bea",
+    "dest-filename": "a06df0b4687bb5b4103f26f290877d92d0ae988021e4880178fd6eb15f42b446636e73de1578ae35f5d26813ae51e5a4719a8fa7a194125ab00c17ac9bea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+    "sha512": "24ccc3282097abddd871c1b9833de1bceb35a1744a01fd176297ce4bcf1efb066b0bc22e823ea3ebcf3aeefad8664be90c3a4a9ff2a828e45386672132917a4c",
+    "dest-filename": "c3282097abddd871c1b9833de1bceb35a1744a01fd176297ce4bcf1efb066b0bc22e823ea3ebcf3aeefad8664be90c3a4a9ff2a828e45386672132917a4c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/cc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+    "sha512": "b8c2f6d63d8ae537cf1aeb4ac6e6fe33e9cb8d922b5a35d0e46af1e2509efe78a64e3f41e0beb7cc7a635cb978cb42f799c9b686d11021bd3aa021bfb337ab37",
+    "dest-filename": "f6d63d8ae537cf1aeb4ac6e6fe33e9cb8d922b5a35d0e46af1e2509efe78a64e3f41e0beb7cc7a635cb978cb42f799c9b686d11021bd3aa021bfb337ab37",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+    "sha512": "9dabd28ae4cca20be742866833fbfe977656a39d3f353c121d2ce1780071fd10a79943da2b0abda92a3806bd8e611b36d7e173f2e16a21364cdc7e28a4e074fd",
+    "dest-filename": "d28ae4cca20be742866833fbfe977656a39d3f353c121d2ce1780071fd10a79943da2b0abda92a3806bd8e611b36d7e173f2e16a21364cdc7e28a4e074fd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+    "sha512": "940af2a87ec8b5eced9825d05e4d1eb4a8f8c0143b1b1e52e8b8ca86c829f736fc2396ecbaf53fda5947d610d0723b057aa22ca2f315377dfdffca540c3057c4",
+    "dest-filename": "f2a87ec8b5eced9825d05e4d1eb4a8f8c0143b1b1e52e8b8ca86c829f736fc2396ecbaf53fda5947d610d0723b057aa22ca2f315377dfdffca540c3057c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+    "sha512": "7ec2bfb0d067c730652f83b524dad96a4550c4fb29aa9103e5d2ed36c652f6838a9ad4a974d233c47da49289791d84d624de3bb04db4ced3093f17d9f3da863a",
+    "dest-filename": "bfb0d067c730652f83b524dad96a4550c4fb29aa9103e5d2ed36c652f6838a9ad4a974d233c47da49289791d84d624de3bb04db4ced3093f17d9f3da863a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+    "sha512": "80b61be0121a7657d33984f980ee74de7f334235df960ce90f415cc8a874333c77aea0992a71e825657dc5ed4a5d4279971d897dc487aff9a1cd2d0f0bf31c00",
+    "dest-filename": "1be0121a7657d33984f980ee74de7f334235df960ce90f415cc8a874333c77aea0992a71e825657dc5ed4a5d4279971d897dc487aff9a1cd2d0f0bf31c00",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+    "sha512": "16372910a53227280782cd68e7455836f92de7eecb7bf544758b7402446990bdf7327c907f0afc979997c0c99f9936f230faf9bc92c2fbcfc677d8179f053541",
+    "dest-filename": "2910a53227280782cd68e7455836f92de7eecb7bf544758b7402446990bdf7327c907f0afc979997c0c99f9936f230faf9bc92c2fbcfc677d8179f053541",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+    "sha512": "31ef8f7cf2364cc78e424d206167cb419b5392dae6cdbafc7036e8a97f375ca73b52b8008b9e6017ed9d52459dc5dd7d9f9e44b2ca76c9e71af8ef4de6b0711e",
+    "dest-filename": "8f7cf2364cc78e424d206167cb419b5392dae6cdbafc7036e8a97f375ca73b52b8008b9e6017ed9d52459dc5dd7d9f9e44b2ca76c9e71af8ef4de6b0711e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+    "sha512": "c9ce56acbcd792ceb30907e7f4ec6bf293912b297fa45f908c7996fd0c77aaed28cabacd0becb624b4d4d44dab7166009b3967aa78165c7423cb9d55cd6ef457",
+    "dest-filename": "56acbcd792ceb30907e7f4ec6bf293912b297fa45f908c7996fd0c77aaed28cabacd0becb624b4d4d44dab7166009b3967aa78165c7423cb9d55cd6ef457",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/ce"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+    "sha512": "55b4063d7d9be2be3c4c0308336723825b883351d8bad9b8a5c4c426c95eee210feec075745aad3cb0556dd2c0642c72d6dc4270fc5fe1015fe2ff2ebe5b4fa8",
+    "dest-filename": "063d7d9be2be3c4c0308336723825b883351d8bad9b8a5c4c426c95eee210feec075745aad3cb0556dd2c0642c72d6dc4270fc5fe1015fe2ff2ebe5b4fa8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/b4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+    "sha512": "807bfcda4eb7cf8aa9579f90d72ff5d8aacad25b5606e9150c8f2765c6d3ed3b7f665388570a696b39deab417dde80f14e8dc88003040c8a108771369fa995b3",
+    "dest-filename": "fcda4eb7cf8aa9579f90d72ff5d8aacad25b5606e9150c8f2765c6d3ed3b7f665388570a696b39deab417dde80f14e8dc88003040c8a108771369fa995b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+    "sha512": "b5366e0c13f0f39b443793d08b5a67101cc3cb4678f47b5270b01b0f9b7a872794f7603de69456692330d466598bf470812814225d31ad2957213ffd433bd848",
+    "dest-filename": "6e0c13f0f39b443793d08b5a67101cc3cb4678f47b5270b01b0f9b7a872794f7603de69456692330d466598bf470812814225d31ad2957213ffd433bd848",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+    "sha512": "da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
+    "dest-filename": "5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+    "sha512": "044fd45afe85393a0075593412893392a4100ce5ad372758958ebe3ab9a26794823666f8d557a1b6d6e84deb543374ff7ebe840056155e3cf8332db0836df4ad",
+    "dest-filename": "d45afe85393a0075593412893392a4100ce5ad372758958ebe3ab9a26794823666f8d557a1b6d6e84deb543374ff7ebe840056155e3cf8332db0836df4ad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/4f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+    "sha512": "1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
+    "dest-filename": "e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+    "sha512": "9943192cadcdbf044b700013f6a99c2bef69eeda54d851dd0ec9ed477608e3e198f3c5eb806e17884eeed50d8b00ddbf1593b3fed74c0c2dc64024784fc9c5bb",
+    "dest-filename": "192cadcdbf044b700013f6a99c2bef69eeda54d851dd0ec9ed477608e3e198f3c5eb806e17884eeed50d8b00ddbf1593b3fed74c0c2dc64024784fc9c5bb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/99/43"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+    "sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+    "dest-filename": "c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+    "sha512": "3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+    "dest-filename": "b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+    "sha512": "bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
+    "dest-filename": "2aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/f1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+    "sha512": "5dc090cf44c1a418258e18f480cbae0e3e3d8ba62daa1e6ad68b13fc6a79b805495024d6c72b2493f9758f06188aedb170d1c78a974ccf8d0419f33555d6a656",
+    "dest-filename": "90cf44c1a418258e18f480cbae0e3e3d8ba62daa1e6ad68b13fc6a79b805495024d6c72b2493f9758f06188aedb170d1c78a974ccf8d0419f33555d6a656",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+    "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+    "dest-filename": "c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+    "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest-filename": "f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+    "sha512": "990c3ed9f9106c02f343b574318d08a9d9d734e793b4fe2bd2537dcfb0006b009782a79aedb0e28b6d0062b201ac577f1f1d0cd8e733e92d75d4268591471bd1",
+    "dest-filename": "3ed9f9106c02f343b574318d08a9d9d734e793b4fe2bd2537dcfb0006b009782a79aedb0e28b6d0062b201ac577f1f1d0cd8e733e92d75d4268591471bd1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/99/0c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+    "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest-filename": "037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+    "sha512": "37c69c1b356c432e8cfdf8c5731b72b0d738437efd4dc33974cfea2a436db071638bcf3200d9d74ebec12de3fbe623e717005f43333f8e0d8167df8766b1c264",
+    "dest-filename": "9c1b356c432e8cfdf8c5731b72b0d738437efd4dc33974cfea2a436db071638bcf3200d9d74ebec12de3fbe623e717005f43333f8e0d8167df8766b1c264",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+    "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+    "dest-filename": "547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+    "sha512": "804a514da94a768b29e016fca96b5cda23a013949e2079694b5ba9f5b16adb003262197551d4ce6d88877bdf3310cf5242f4a8a906752100f424da60dcc979a6",
+    "dest-filename": "514da94a768b29e016fca96b5cda23a013949e2079694b5ba9f5b16adb003262197551d4ce6d88877bdf3310cf5242f4a8a906752100f424da60dcc979a6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/4a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+    "sha512": "49c89acfc79e9cd4ca9fd6f7b7bfb1af48a94e9f58c4a418e27a704379ab46e2f404054704bc99c687e168a04056dce6b5167fcd3ca8d3fb68e01d6e586fc38e",
+    "dest-filename": "9acfc79e9cd4ca9fd6f7b7bfb1af48a94e9f58c4a418e27a704379ab46e2f404054704bc99c687e168a04056dce6b5167fcd3ca8d3fb68e01d6e586fc38e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+    "sha512": "67950f031ceb8e558d3721b2ea2eb9709cf3be02790f74fac0cbecfa05a963d77ba9184036bc6a029e8b871220661584c35f117c94c6711c63b8b201afe9bc5d",
+    "dest-filename": "0f031ceb8e558d3721b2ea2eb9709cf3be02790f74fac0cbecfa05a963d77ba9184036bc6a029e8b871220661584c35f117c94c6711c63b8b201afe9bc5d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/95"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+    "sha512": "41033f4e2fe141a8c9c0263e4625ae099f6c76d23f5d093b9c32b9bc2f2491dc22c5ecce94382f0f1efe453f908cae857054f8329b2ea019c7228fcedd2b5146",
+    "dest-filename": "3f4e2fe141a8c9c0263e4625ae099f6c76d23f5d093b9c32b9bc2f2491dc22c5ecce94382f0f1efe453f908cae857054f8329b2ea019c7228fcedd2b5146",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+    "sha512": "37b15505eea24b6e0c94ce91ff84414f11a14217991aceed890f54df652d17be4dccfe50ef158f46a2c108ac65450464deb6358c220f2f3c7b5b33a1b942112d",
+    "dest-filename": "5505eea24b6e0c94ce91ff84414f11a14217991aceed890f54df652d17be4dccfe50ef158f46a2c108ac65450464deb6358c220f2f3c7b5b33a1b942112d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/b1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+    "sha512": "8f6bff8ad9b2e0794dc6573abe829762006a362d0d8362d2860e33ec6b9fa4482cd393fedacb815728bd23a607ab9ba8545c7d1138a7dde08484b5725c64272a",
+    "dest-filename": "ff8ad9b2e0794dc6573abe829762006a362d0d8362d2860e33ec6b9fa4482cd393fedacb815728bd23a607ab9ba8545c7d1138a7dde08484b5725c64272a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/6b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+    "sha512": "ca23b944e32e6108176c2eb4ca3654e4261215918a5cbd071404d7b7d987267d7ecd6e79a02b4c23d35f7158582cc1432fb815ee804fa27fc498c3068363afb5",
+    "dest-filename": "b944e32e6108176c2eb4ca3654e4261215918a5cbd071404d7b7d987267d7ecd6e79a02b4c23d35f7158582cc1432fb815ee804fa27fc498c3068363afb5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+    "sha512": "6abf89bbb2e670dd09a381692f88691726f0346f7fdc0fc1af9296da7da3c8e0e0dcc1195da0d800375e9a8352f810cd7cc80abf29492e3e12e6dc9101cb6e02",
+    "dest-filename": "89bbb2e670dd09a381692f88691726f0346f7fdc0fc1af9296da7da3c8e0e0dcc1195da0d800375e9a8352f810cd7cc80abf29492e3e12e6dc9101cb6e02",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+    "sha512": "4588986e4a24c34b6b7caaaacdf179e658229f010fac3dce2437d3b89cc5b3530aea21670de9dacf57ea2cbb57e084c6dce92d2505ce7936b0d5ac2b0409593f",
+    "dest-filename": "986e4a24c34b6b7caaaacdf179e658229f010fac3dce2437d3b89cc5b3530aea21670de9dacf57ea2cbb57e084c6dce92d2505ce7936b0d5ac2b0409593f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+    "sha512": "d4af8c3df2d2155a69873a5d6df92195693ac01ad339b0734b64fa75bd743cd399811f46a15b005b3c0dcae8546186d3a76de3fb846b9dc7ee8d9e2e0335efc0",
+    "dest-filename": "8c3df2d2155a69873a5d6df92195693ac01ad339b0734b64fa75bd743cd399811f46a15b005b3c0dcae8546186d3a76de3fb846b9dc7ee8d9e2e0335efc0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+    "sha512": "3a5108083c7f5e5d05a92a786ebcbccc59c2bc6a628371a5e200aabaf6301eea892840b5fa7f4d8039e216fa871a632fd5992a0c9ac3a8a292ca44c35fe7a1b8",
+    "dest-filename": "08083c7f5e5d05a92a786ebcbccc59c2bc6a628371a5e200aabaf6301eea892840b5fa7f4d8039e216fa871a632fd5992a0c9ac3a8a292ca44c35fe7a1b8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+    "sha512": "5a4503ae88ee26cd3192019fdae756c5adf21814713edc54901efd8ba68264b46073b3ccf1f65ef53a2c7cf0dcbc4a5065bb850129c762644b04b51b98b38820",
+    "dest-filename": "03ae88ee26cd3192019fdae756c5adf21814713edc54901efd8ba68264b46073b3ccf1f65ef53a2c7cf0dcbc4a5065bb850129c762644b04b51b98b38820",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/45"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz",
+    "sha512": "4415213e457fb25d67ce5f25a245652b9b804cfc27d0096cb9d0816578acb30fe40e5f72cfc69ce29349e3788fa4c5681ce781607fc1677bd40b569da9aff315",
+    "dest-filename": "213e457fb25d67ce5f25a245652b9b804cfc27d0096cb9d0816578acb30fe40e5f72cfc69ce29349e3788fa4c5681ce781607fc1677bd40b569da9aff315",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+    "sha512": "1e03260aa2094802aaa3af25d2b4b601a9c459f931699e703621056f98209b4f250ecf579762b10655f73d371a0f672104cd605c061fe3dd7f33646ff09c1aca",
+    "dest-filename": "260aa2094802aaa3af25d2b4b601a9c459f931699e703621056f98209b4f250ecf579762b10655f73d371a0f672104cd605c061fe3dd7f33646ff09c1aca",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+    "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+    "dest-filename": "b13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+    "sha512": "6f394a4f2349efe2dd188230cbc8a316922a11022f69f6a157b798ca427c0af878d8474978e0e827a814257a5026f7a3d4175d1fc3aa4d764d13f29f6d602ef1",
+    "dest-filename": "4a4f2349efe2dd188230cbc8a316922a11022f69f6a157b798ca427c0af878d8474978e0e827a814257a5026f7a3d4175d1fc3aa4d764d13f29f6d602ef1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/39"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+    "sha512": "839d39f3acebe1b666c0589395f94cbbc1346c34dbe48e607abb60c002a6b1d5254d022166dba7cd4943d564b3c1c5563e8015a6cac0eaf95f083ee85ef47082",
+    "dest-filename": "39f3acebe1b666c0589395f94cbbc1346c34dbe48e607abb60c002a6b1d5254d022166dba7cd4943d564b3c1c5563e8015a6cac0eaf95f083ee85ef47082",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+    "sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+    "dest-filename": "2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/6e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+    "sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+    "dest-filename": "a1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/2f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+    "sha512": "b7dcf6f5c2635dffefc50f1dca1092a6de87e9a4b01d393c713e48de2cba48c5ee169939981e8f2fa5df0bc3c2c2b3d3c7ddee7702949bd1d1b5e0254c604b88",
+    "dest-filename": "f6f5c2635dffefc50f1dca1092a6de87e9a4b01d393c713e48de2cba48c5ee169939981e8f2fa5df0bc3c2c2b3d3c7ddee7702949bd1d1b5e0254c604b88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+    "sha512": "76129ff74dd4fcf41963a6e834db4019d59b1bce5601b8d3ff5c58a19202ec5018d3259aa4e05056c56b0e5e7c5bcebffded55a4c341b5157831a5df74cc9214",
+    "dest-filename": "9ff74dd4fcf41963a6e834db4019d59b1bce5601b8d3ff5c58a19202ec5018d3259aa4e05056c56b0e5e7c5bcebffded55a4c341b5157831a5df74cc9214",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+    "sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+    "dest-filename": "a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+    "sha512": "2ab387f3673f5be1984342c7aadaf771a469337213825ab796319421bf0b4e48bb07269c259f73fa98921a2c190ec4728506d804e04982bda4e97e016578b72b",
+    "dest-filename": "87f3673f5be1984342c7aadaf771a469337213825ab796319421bf0b4e48bb07269c259f73fa98921a2c190ec4728506d804e04982bda4e97e016578b72b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+    "sha512": "c59a1c5b07f2a788646cde212d6c4c8e6bf643c68d6bd32198e67b2fd68264f4fe759b2046beb0651ad2604dc74ddca4ff6a5928f4a0a88ee7b3b11e9f5c4c48",
+    "dest-filename": "1c5b07f2a788646cde212d6c4c8e6bf643c68d6bd32198e67b2fd68264f4fe759b2046beb0651ad2604dc74ddca4ff6a5928f4a0a88ee7b3b11e9f5c4c48",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+    "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest-filename": "8c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+    "sha512": "83f2b36d829b1f90b6bcf91a5c6bbc0c9947ac62872ec336e5983d5ae0bda4c19fbaf4fe5f6e6d6505a8e5f2b5063066f3e52b544f4b0c2bda63409093e7d70c",
+    "dest-filename": "b36d829b1f90b6bcf91a5c6bbc0c9947ac62872ec336e5983d5ae0bda4c19fbaf4fe5f6e6d6505a8e5f2b5063066f3e52b544f4b0c2bda63409093e7d70c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/f2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+    "sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+    "dest-filename": "6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+    "sha512": "ed42cbc2c09d631fe7472ae9884c2fa9be53147acc559c81b7eae0fce0174fbae08ffcfe0ed4c3c8a15e2c074392e6c3543283f233ac9dd9b2ee6e795dc7d4b3",
+    "dest-filename": "cbc2c09d631fe7472ae9884c2fa9be53147acc559c81b7eae0fce0174fbae08ffcfe0ed4c3c8a15e2c074392e6c3543283f233ac9dd9b2ee6e795dc7d4b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+    "sha512": "0876e5d9941bc71d7ae08816460cc99e8e215ad338b456d16a6d507c8dd8c61b37c3f0efaa5b95c5559e5ecde82f9fdf6c691234b2a8d13cb932051671e361a2",
+    "dest-filename": "e5d9941bc71d7ae08816460cc99e8e215ad338b456d16a6d507c8dd8c61b37c3f0efaa5b95c5559e5ecde82f9fdf6c691234b2a8d13cb932051671e361a2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/76"
+  },
+  {
+    "type": "inline",
+    "contents": "00eb23a1e4fb817f806b85707e4668789b1909dc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz\", \"integrity\": \"sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==\", \"time\": 0, \"size\": 7721669, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "50f5f8c88198105e590014a4b636ec67446a751a852f7fb224ecca081706",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "021bbf9b6bd29579f01c42405ed3e609f727f40f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz\", \"integrity\": \"sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==\", \"time\": 0, \"size\": 13198, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4ac5d88548eaabb0b15898256869af76c0c5ac5859127846f6bcdb273c55",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "0327dcda608a0fabe8a4796c9768c79aa5dad397\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"integrity\": \"sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\", \"time\": 0, \"size\": 1089001, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4244544732d3e784c8fd360e0ea256a943488c53a834da3d0ddf3e83af9b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "047f0ca5bb52dc40b60eae3caa4a5e157c55e8e6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz\", \"integrity\": \"sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==\", \"time\": 0, \"size\": 38848, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f539f027e367c9873071eb96c5d59a2e023ebe21150abb4c5225f90cb58e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/88"
+  },
+  {
+    "type": "inline",
+    "contents": "04e0113e71931b7a6c21978b4b6856956847987a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz\", \"integrity\": \"sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==\", \"time\": 0, \"size\": 7334033, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0d0df0356a35773c76f44079ee5ebd7e6dec8de775076770da80723db815",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "0e3f5290c0829a6be9e79347b8ceabf69d945a4d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz\", \"integrity\": \"sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==\", \"time\": 0, \"size\": 7047224, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "eacc3514f935c660beb91bdae73f0a9c34c025f5f6b953ea5172fe4da4fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/88"
+  },
+  {
+    "type": "inline",
+    "contents": "0e59844e5b609f7c714da16cd1eecb9b256d1782\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"integrity\": \"sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\", \"time\": 0, \"size\": 2842, \"metadata\": {\"url\": \"https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "452a94b385f28d524a6fd9178863fe32cc70bc3d94033a3dda9c91b2e128",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "0fd51aca4004ee18b0eb9468c9195b94075804ff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz\", \"integrity\": \"sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==\", \"time\": 0, \"size\": 189776, \"metadata\": {\"url\": \"https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "19c944bd43af6c9d00f31ef7a35302a822a1aa7a404d894c6ae78f95adde",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/de/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "11a081e97bad306aac6021978f02d7caec09a8b3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/events/-/events-3.3.0.tgz\", \"integrity\": \"sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==\", \"time\": 0, \"size\": 16574, \"metadata\": {\"url\": \"https://registry.npmjs.org/events/-/events-3.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "69ef82dceb3095bd8cae43cfb9a1267bf1e5a1aba1be4bc9c37a046fccfe",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/79"
+  },
+  {
+    "type": "inline",
+    "contents": "11b758212ff22c713fa53c29124ff87b79144d60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"integrity\": \"sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\", \"time\": 0, \"size\": 81751, \"metadata\": {\"url\": \"https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "434e6cce71a37629e1945f6d35d5e52c1e34aa88ef24d1915846c72775f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/e2"
+  },
+  {
+    "type": "inline",
+    "contents": "11d800321c2f66e70918f16490b95534ac190f37\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz\", \"integrity\": \"sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==\", \"time\": 0, \"size\": 3455710, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8a4692c5af27a6e5a8e598b50ec0cd59080f16605a7dbc8389090014b1c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/1c"
+  },
+  {
+    "type": "inline",
+    "contents": "126e80245284ce83881e5c5ba87ef3683779fdb0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz\", \"integrity\": \"sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==\", \"time\": 0, \"size\": 7457263, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f00427f3ff860b8d5c650e567cceaa29698a8aab1fad0691400d4f5157e3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/a0"
+  },
+  {
+    "type": "inline",
+    "contents": "13cb458141025f28d2a41ff6c2f42c8110baf96d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==\", \"time\": 0, \"size\": 7398543, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ef5c6352cccafe2cb1da29eda68764ea6da315df0e63f0b756a706794af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/70"
+  },
+  {
+    "type": "inline",
+    "contents": "161b2bbdb104c0d02ebd274f43f31dab3ed4cae3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz\", \"integrity\": \"sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==\", \"time\": 0, \"size\": 31561, \"metadata\": {\"url\": \"https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "020a631b7dbedd81909954cf4043e8fc50b58c634b38f28fa4c7b5c4f53f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/6d"
+  },
+  {
+    "type": "inline",
+    "contents": "1abd1b75319587330b67a5369f964160c676fa24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz\", \"integrity\": \"sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==\", \"time\": 0, \"size\": 3325762, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ccb297c37f1de2131ee8a7fbb7aa1793f532514cdbb3c4009595074ca740",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/f3"
+  },
+  {
+    "type": "inline",
+    "contents": "1bb1b2a66343938e1ff5462ea2a5e9cec111ca41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz\", \"integrity\": \"sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==\", \"time\": 0, \"size\": 179825, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4024a3c3a3f7616c15d375a49d98c9f4476b1edaa324a9a8b720eb59c25e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/fa"
+  },
+  {
+    "type": "inline",
+    "contents": "1d60404b3281c92034abd12e57aa0af0e64aa315\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"integrity\": \"sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\", \"time\": 0, \"size\": 22808, \"metadata\": {\"url\": \"https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c98f1cdf494d5afde6448966f8b5b9ae83d1b42c6702670e15e8a7f68552",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/61"
+  },
+  {
+    "type": "inline",
+    "contents": "1ea75376a6a62476972c6217d4bb12b40dcc818c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz\", \"integrity\": \"sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==\", \"time\": 0, \"size\": 3855795, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "39345cbd0b682d9268be5a690e5b52e727c71d6848e56a355a1afc57a333",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/15"
+  },
+  {
+    "type": "inline",
+    "contents": "1ed6a94f525d66067f426f6af58d2bdd921dde75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz\", \"integrity\": \"sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==\", \"time\": 0, \"size\": 5634, \"metadata\": {\"url\": \"https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c5f5ec553e5ff12677149a0ba446e32ebf6f632cecd83bf7b417176055d5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/cf"
+  },
+  {
+    "type": "inline",
+    "contents": "2273e39c0cee5b8b0f727cdc098a3af72febe49c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==\", \"time\": 0, \"size\": 7790863, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bae51e9e0643286a1ea952823d1f6a45199c4d41a82d7eaf21b01d1c27c0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/88"
+  },
+  {
+    "type": "inline",
+    "contents": "27dc0433cef8018acc4c5bfcd3abb99d003e29fb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz\", \"integrity\": \"sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==\", \"time\": 0, \"size\": 3632951, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c5b1556426611d1d97f1b14b99f9792c2f496970d48ef1fbeb0a09f05d53",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/83"
+  },
+  {
+    "type": "inline",
+    "contents": "28d7ebeb799af7c5bba4f90b93011f8d5892b69f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz\", \"integrity\": \"sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==\", \"time\": 0, \"size\": 22983, \"metadata\": {\"url\": \"https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "94ab231f0191530125f23d1df6cabdaf58f470d73809dc4ee5cf50c660bb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/13"
+  },
+  {
+    "type": "inline",
+    "contents": "29ad0fe5f9cf371af37a787ea515d06b5549a6f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz\", \"integrity\": \"sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==\", \"time\": 0, \"size\": 3875799, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d7b8fc39b4ad17384b51ae3b426fbec6e30f27e641d07e58861575f28ee1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "2ebdfa2d0df771bf0a53e52a05205e898e9dc39a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz\", \"integrity\": \"sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==\", \"time\": 0, \"size\": 3706526, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d1a3a59735e070059c4ee94963ff3a2b7c7fea15a3423a6031d501bf04f3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/44"
+  },
+  {
+    "type": "inline",
+    "contents": "2effc950335f542cb9e34be1f5613751faa274ab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz\", \"integrity\": \"sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==\", \"time\": 0, \"size\": 139395, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0289af91a3172fd5d07df274e145e62f9d3f83ecc69c58f6c3eeb84f0ec0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/c0"
+  },
+  {
+    "type": "inline",
+    "contents": "2fbe3418f7259652679d5163a30e4cd80365e855\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz\", \"integrity\": \"sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==\", \"time\": 0, \"size\": 67772, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87de74786d807a230a6db3ce121b6747b6619c10b96e0acf0a3b7c4f6433",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "30fb9cd26e8dce4f1b585464301bc7f0ebe1e6ae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz\", \"integrity\": \"sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==\", \"time\": 0, \"size\": 87820, \"metadata\": {\"url\": \"https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "be889abbeac29f0055dd8a331ca84d2bc053c397225f9e7b8efde96c80b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/38"
+  },
+  {
+    "type": "inline",
+    "contents": "31249b9eb2d4ccb5b348f1599db2a0eb514bd2f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jose/-/jose-6.2.4.tgz\", \"integrity\": \"sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==\", \"time\": 0, \"size\": 50059, \"metadata\": {\"url\": \"https://registry.npmjs.org/jose/-/jose-6.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d5dcd9d5ba8ccc2be24c895c344ca058c968fd2c04b5fab9a25da8d52965",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/32"
+  },
+  {
+    "type": "inline",
+    "contents": "35f5e967b70002d9f106f55ea57f9c621603d973\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz\", \"integrity\": \"sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==\", \"time\": 0, \"size\": 4377468, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cff74a8452b6159ec5df4cd310e05e05bfaa99de31da7de4b5a7a7a849d9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "3a68713712b8f4435780af1a04dd341b49899355\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz\", \"integrity\": \"sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==\", \"time\": 0, \"size\": 7349472, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3b03f7b2a0d360328571499e669340ddb46b3e8c9cd5ccddb77d4783e1f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "3ba2606c1b4f2a9d4d29689ed30c91064001a1f0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz\", \"integrity\": \"sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==\", \"time\": 0, \"size\": 7298733, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "418471ed42378e91e6e4b7b66a3e72f3156027bf4e1bc0926db33b55830f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/fe"
+  },
+  {
+    "type": "inline",
+    "contents": "3ea31c4c1491157af1c8cfa7bb49cc30e88200d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz\", \"integrity\": \"sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==\", \"time\": 0, \"size\": 685134, \"metadata\": {\"url\": \"https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e5817c0c6ffa986a2284bf337d36c17f0eb4f43bb77c59558212350addc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/40"
+  },
+  {
+    "type": "inline",
+    "contents": "3fe647054c80757fdb2c792206083dba305f467f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite/-/vite-8.1.5.tgz\", \"integrity\": \"sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==\", \"time\": 0, \"size\": 549330, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite/-/vite-8.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "488d3c452cdc65387a51e7d81ec721379e342d5d2913000a1c21a21a6c96",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/ce"
+  },
+  {
+    "type": "inline",
+    "contents": "44ce804d714e821318d379b24b898a8743cd4955\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz\", \"integrity\": \"sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==\", \"time\": 0, \"size\": 3592480, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c99bac59fccb5428ac1951c98fddfffbce58ac263784bd91bebdf634f7e9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/96"
+  },
+  {
+    "type": "inline",
+    "contents": "49874de63f3bdfd637c16453fe8977a9eadfcc64\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"integrity\": \"sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\", \"time\": 0, \"size\": 3009, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9ddc9f878c52039554fd9be6ee3852f10163225591207069618d4544e7b8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "49d9673b937c6320c46c9f732f46ad685579b35a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz\", \"integrity\": \"sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==\", \"time\": 0, \"size\": 51391, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5e37ff3d78b1e68f6a1ef9d9f062b68d3b3e2fd7b4eb1b406b77c0562061",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/a6"
+  },
+  {
+    "type": "inline",
+    "contents": "50514e76ac867cdeffcfd7e812bade86037f09cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz\", \"integrity\": \"sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==\", \"time\": 0, \"size\": 7358, \"metadata\": {\"url\": \"https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1233df81caed04fa586cf78cc7a0f8539c54202f1557b013338cab334bc8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "52ce8b517749313402e9c91c63b65fa0aa770586\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz\", \"integrity\": \"sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==\", \"time\": 0, \"size\": 2653951, \"metadata\": {\"url\": \"https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "80057a53541111d96f1f45684a7f12071be57ce9db1dab5143e18c1de272",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "5cd415b6dd1d11619964f707e6b4296ab507e2b0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz\", \"integrity\": \"sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==\", \"time\": 0, \"size\": 7815587, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6ee951b9ff53b231e7a595d5dedf045d9114c9ca6a0caacddc0e556b0aa3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "68227a5236f733df541f5f76d63cfcfd5bb23d2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz\", \"integrity\": \"sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==\", \"time\": 0, \"size\": 7776, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e58a240f7a1b156aa7b4c5145722ca5054ef8ba5b3d6d7fe41c4811b9b12",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/42"
+  },
+  {
+    "type": "inline",
+    "contents": "6fe327c6b56632ddbf3e19851fadbbf367aea089\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz\", \"integrity\": \"sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==\", \"time\": 0, \"size\": 7717, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cdce4f9e622ff2fcf32e02d90c84f3807c386967db2c5c8e7dba30432d72",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/7d"
+  },
+  {
+    "type": "inline",
+    "contents": "719ea523cc47269953393542ba84568bc220dac4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"integrity\": \"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\", \"time\": 0, \"size\": 35340, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1018bd2617c9bf8a0c2742b8d6db95d9995670b0e195cb06cfea9d61c009",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "823d5419d195e9c85890c7de0e9c05e270bc71c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz\", \"integrity\": \"sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==\", \"time\": 0, \"size\": 6681, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3dc9cfa8ed72b5329a97236a6f169606a8344ca21f60a8677b3ad62c5382",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/82"
+  },
+  {
+    "type": "inline",
+    "contents": "82997b838629a6e5cdbb8092d3b5bc124c18adb7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz\", \"integrity\": \"sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==\", \"time\": 0, \"size\": 3863824, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "987ec4a67bc5ab6833b96f6e548ab298672101f39195fff2e31b51bee5d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "838279ba68701d3c9c77a3d73d2f5d31e607dad5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz\", \"integrity\": \"sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==\", \"time\": 0, \"size\": 612953, \"metadata\": {\"url\": \"https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "69e920534f834d35a4076ffe7189ee9d1dfa439dc547f0cfd42d0a2953e0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/c1"
+  },
+  {
+    "type": "inline",
+    "contents": "8a0b4856a941a8475c6a90273fa2f933e04227d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz\", \"integrity\": \"sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==\", \"time\": 0, \"size\": 246183, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "86dfc11f0405dc0f65729a6574e67599a22a6640c389559f751171508c89",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/04"
+  },
+  {
+    "type": "inline",
+    "contents": "a26a153237ae1eb383877e6a8aeb8e1059b3f821\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz\", \"integrity\": \"sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==\", \"time\": 0, \"size\": 7067543, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99f60f7afa8a44a29bb2417e96818024ef3e9cbb3cdf58f339a338dbcf4c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/24"
+  },
+  {
+    "type": "inline",
+    "contents": "a63e42027424915e80b9121a7a07f21bfffce595\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz\", \"integrity\": \"sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==\", \"time\": 0, \"size\": 7392085, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99a8bb1ed13b9fa9ed32e2ce0af8ad73a868b0dde48f218506e7bbcc9acc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/18"
+  },
+  {
+    "type": "inline",
+    "contents": "af4d25a5dc4a087b7ef2d71f4faaaed2634b305b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz\", \"integrity\": \"sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==\", \"time\": 0, \"size\": 13647, \"metadata\": {\"url\": \"https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "83186b036aeb6b0b2f4d2d10f857e91653e66e70824c9059b1175f44b0c2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/70"
+  },
+  {
+    "type": "inline",
+    "contents": "b29fe8e4744862bd844e95e26157e0860f27ac8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz\", \"integrity\": \"sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==\", \"time\": 0, \"size\": 751525, \"metadata\": {\"url\": \"https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ef3ad5111001a610f814d854d1ce9853e9d6d710a41430d086d07a0986cb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "b41fa47b3b483a52676d969c4c78076be83dfada\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@capacitor/core/-/core-8.5.0.tgz\", \"integrity\": \"sha512-Ca4krtqH1hothjtBIwf2J2TW7IhYq1ujp8QeItTiJohNsqij8ja2DYYH3DU0l8RmxCWaBAFTGA2TgOgOMCSNsQ==\", \"time\": 0, \"size\": 70697, \"metadata\": {\"url\": \"https://registry.npmjs.org/@capacitor/core/-/core-8.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e1c326644840cf324cc5c4aa8ec365fcd1bf84d9d34a43a741b535736d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/e5"
+  },
+  {
+    "type": "inline",
+    "contents": "b67db885f212ce7ef813b99c26bfc88182ec034d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"integrity\": \"sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\", \"time\": 0, \"size\": 17726, \"metadata\": {\"url\": \"https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3aa5d94761ad382e1a1acc61203736494009e20422bce1dd1433666dd012",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/57"
+  },
+  {
+    "type": "inline",
+    "contents": "bf17bc9feca98e76e2167d1981a076e31663a7c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz\", \"integrity\": \"sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==\", \"time\": 0, \"size\": 9608, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4022921afad2e38857eb774774f73ce1bd92b1c21069b7125dc7c7578551",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/d4"
+  },
+  {
+    "type": "inline",
+    "contents": "c1b04811b6c23d3ae6da904389654a003226b23a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz\", \"integrity\": \"sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==\", \"time\": 0, \"size\": 3141, \"metadata\": {\"url\": \"https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2181a9e23ad0d2188aa3b1c2d4fa64e47e3d31dc967b0820871698df5d0e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/db"
+  },
+  {
+    "type": "inline",
+    "contents": "c3eb55febe46b954fd7176a98a6304adeab4c941\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz\", \"integrity\": \"sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==\", \"time\": 0, \"size\": 7753314, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b39812e0a410c1f81de850fecf5a26e6313b4b220545ef21b3d4160280a5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/b0"
+  },
+  {
+    "type": "inline",
+    "contents": "c5e48a44cf292d5eba68943305071331847ca28b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz\", \"integrity\": \"sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==\", \"time\": 0, \"size\": 22256, \"metadata\": {\"url\": \"https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "78d47303a034c408eff777d0ed2d38a70f674b6c98005767018866ec4e12",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/33"
+  },
+  {
+    "type": "inline",
+    "contents": "c601090cd6c8b1839c4124219198a5715b7d8250\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz\", \"integrity\": \"sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==\", \"time\": 0, \"size\": 80345, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9af1f2c5216d57925681562e3a425fcaed71f790c8207dcdef380ef352f5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "ca91f04817393710e55219c7ee56712b98a44923\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==\", \"time\": 0, \"size\": 8645234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "74d31121387f8a002ab45838d7cfe554a9419e5045ef4e8e221216e145dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/95"
+  },
+  {
+    "type": "inline",
+    "contents": "d31c9160378263d3bc01ee81e386c673303cf2d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"integrity\": \"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\", \"time\": 0, \"size\": 138324, \"metadata\": {\"url\": \"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "97d2c6e5c772f993e1a5b5fdeae5e52c835ac89d689ba43dbe025d54d880",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e8"
+  },
+  {
+    "type": "inline",
+    "contents": "e1f7efeca6a19551f083d8acb0244a690fd997cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz\", \"integrity\": \"sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==\", \"time\": 0, \"size\": 87655, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fcd7361fa1ce7c26e19f0e9ff2b14f5aa0cf05b5f663c00076aa4aa839db",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "e6b4f5680bc5ef3590e72095689a92be9b3eedf1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz\", \"integrity\": \"sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==\", \"time\": 0, \"size\": 3429085, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5e2207db941c165c99aa7bc563dd68df9045193dcc59577e109da05a48ca",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/60"
+  },
+  {
+    "type": "inline",
+    "contents": "e70361b7250bdae2cf593caced47a6657be76b7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz\", \"integrity\": \"sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==\", \"time\": 0, \"size\": 3593473, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b2723f771ce052a4fcaa9f2f87c50d40024564c32de4fac5fa09dc9cf2cc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/91"
+  },
+  {
+    "type": "inline",
+    "contents": "e79a958b9cb82b625f1b5b572044c246629ec6a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz\", \"integrity\": \"sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==\", \"time\": 0, \"size\": 2334, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d0fb13b3d966f9a8b2d3f98d2ec7a2373d4fac0038a825e1ac61e978b32b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/c0"
+  },
+  {
+    "type": "inline",
+    "contents": "eb2e7cc7c27b088084e6759b3be15c759f694a48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"integrity\": \"sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\", \"time\": 0, \"size\": 6542, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "df2b2137355548fc0e2edd8c75e03ade0d1036d9466886d3c4f7ea6248af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/48"
+  },
+  {
+    "type": "inline",
+    "contents": "ed59b59b7ff8bfc62a8b96b1b3cdcfb221414ab9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz\", \"integrity\": \"sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==\", \"time\": 0, \"size\": 3853971, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "defe489f61dce80f4249bc4f7f76c14aeec329e872903bca13ad930637c7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/fe"
+  },
+  {
+    "type": "inline",
+    "contents": "f8ea790763a604d695fa0e688f7be6b84f3703fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz\", \"integrity\": \"sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==\", \"time\": 0, \"size\": 7800844, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1eb5a9eef13baba7323ba4fca52015b4c83820822b6b5b80947c168e6f88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/5d"
+  },
+  {
+    "type": "inline",
+    "contents": "fba8681946ce59154571db6660d930bd7ff43e60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz\", \"integrity\": \"sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==\", \"time\": 0, \"size\": 3536007, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4bfc45edf23b391d38ade0404c82bcaff9c533e9439737ddd2ee71dec344",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/07"
+  }
+]

--- a/io.github.blindrun.OutpostChat.desktop
+++ b/io.github.blindrun.OutpostChat.desktop
@@ -1,0 +1,17 @@
+[Desktop Entry]
+Type=Application
+Name=Outpost
+GenericName=Chat
+Comment=Self-hosted chat with voice, for one community
+Exec=outpost %U
+Icon=io.github.blindrun.OutpostChat
+Terminal=false
+Categories=Network;InstantMessaging;Chat;
+# main.js calls setAsDefaultProtocolClient("outpost") and handles open-url /
+# second-instance, but that only registers the app with Electron. The desktop
+# environment will not route an outpost:// URL anywhere without this line, so
+# without it the desktop SSO flow opens the browser and the result never gets
+# back to the app. Exec already passes %U to carry the URL.
+MimeType=x-scheme-handler/outpost;
+Keywords=chat;voice;self-hosted;community;
+StartupWMClass=Outpost

--- a/io.github.blindrun.OutpostChat.metainfo.xml
+++ b/io.github.blindrun.OutpostChat.metainfo.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.blindrun.OutpostChat</id>
+
+  <name>Outpost</name>
+  <summary>Self-hosted chat with voice, for one community</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="io.github.blindrun">
+    <name>blindrun</name>
+  </developer>
+
+  <description>
+    <p>
+      Outpost is a self-hosted chat app: text channels, voice channels and
+      direct messages for a single community, running on a server that
+      community controls rather than on someone else's platform.
+    </p>
+    <p>
+      This is the desktop client. It connects to any Outpost server. Your
+      own, or one you have been invited to. You can be signed into several
+      at once.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Text channels with replies, threads, reactions, custom emoji, code blocks, image and video attachments, and link previews</li>
+      <li>Voice channels with push-to-talk, automatic voice sensitivity, and screen sharing</li>
+      <li>Direct messages, with optional end-to-end encryption</li>
+      <li>Roles and permissions, moderation tools, and per-channel permission overrides</li>
+      <li>Two-factor authentication with TOTP or a security key</li>
+      <li>Automatic updates</li>
+    </ul>
+    <p>
+      Running a server is a single Docker Compose file. Nothing in the app
+      reports to a central service. There is no central service.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">io.github.blindrun.OutpostChat.desktop</launchable>
+
+  <!-- Captured from the Flatpak build running on Bazzite, 2026-08-12, and
+       hosted alongside the wiki assets on sonofatech.com. Flathub needs these
+       reachable over HTTPS at build time. The email field in the user-settings
+       capture is covered: it held a real address, and these get scraped. -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://sonofatech.com/outpost/screenshots/channels.png</image>
+      <caption>A text channel, with the community switcher at the top of the channel list.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sonofatech.com/outpost/screenshots/voice.png</image>
+      <caption>A voice channel, joined. Cameras and screen shares tile together.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sonofatech.com/outpost/screenshots/dms.png</image>
+      <caption>A direct message. The header shows the encryption state, and markers show where it starts and stops.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sonofatech.com/outpost/screenshots/settings.png</image>
+      <caption>Instance settings. Name, theme, default channel, registration.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sonofatech.com/outpost/screenshots/usersettings.png</image>
+      <caption>User settings. Pick your own theme and density, overriding the server's default.</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://sonofatech.com/outpost/screenshots/channels-light.png</image>
+      <caption>The Daylight light theme.</caption>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://outpost-chat.com</url>
+  <url type="bugtracker">https://github.com/blindrun/outpost-chat/issues</url>
+  <url type="vcs-browser">https://github.com/blindrun/outpost-chat</url>
+
+  <!-- OARS, stated honestly: this is an app for talking to other people, and
+       the operator of whichever server you join sets the rules. Under-rating
+       a chat app is the fastest way to fail review, and it would be
+       dishonest — anything a member types or says can reach you.
+       social-info is "moderate" because an account carries an email address
+       and username, which go to the server you choose to join. -->
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-info">moderate</content_attribute>
+  </content_rating>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#e8703a</color>
+    <color type="primary" scheme_preference="dark">#2b2d31</color>
+  </branding>
+
+  <categories>
+    <category>Network</category>
+    <category>InstantMessaging</category>
+    <category>Chat</category>
+  </categories>
+
+  <keywords>
+    <keyword>chat</keyword>
+    <keyword>voice</keyword>
+    <keyword>self-hosted</keyword>
+    <keyword>community</keyword>
+  </keywords>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <!-- Keep this in sync with each release; Flathub shows it as the
+       what's-new text. The dates are release dates, not build dates. -->
+  <releases>
+    <release version="0.6.2" date="2026-08-14">
+      <description>
+        <p>Encrypted direct messages no longer sit on "Decrypting..." forever on a new device. A new device has never been given your key, so it says so and tells you to restore your recovery code.</p>
+      </description>
+    </release>
+    <release version="0.6.1" date="2026-08-12">
+      <description>
+        <p>Fixed the row of tabs in User Settings dropping onto a second line.</p>
+      </description>
+    </release>
+    <release version="0.6.0" date="2026-08-12">
+      <description>
+        <p>The server rail is gone. Your servers moved into the name at the top of the channel list, and the channel list gets that width back.</p>
+        <p>Daylight, the first light theme. The theme is yours now, not just the server owner's, along with a compact density option in User Settings, Appearance.</p>
+        <p>Pop out any camera or screen share into its own window on top of whatever else you are doing.</p>
+      </description>
+    </release>
+    <release version="0.5.1" date="2026-08-12">
+      <description>
+        <p>Turning encrypted direct messages on now applies straight away instead of needing a restart, and can be switched off again without losing your existing key or history.</p>
+      </description>
+    </release>
+    <release version="0.5.0" date="2026-08-11">
+      <description>
+        <p>Sign in with your own OpenID Connect provider. Camera video in voice channels. Noise suppression, echo cancellation and automatic gain can now be turned off individually.</p>
+      </description>
+    </release>
+    <release version="0.4.0" date="2026-08-11">
+      <description>
+        <p>End-to-end encrypted direct messages, with reporting and blocking to go with them. Screen sharing in the desktop app is fixed. It had never worked on any platform.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.github.blindrun.OutpostChat.yml
+++ b/io.github.blindrun.OutpostChat.yml
@@ -1,0 +1,172 @@
+# Flatpak manifest for the Outpost desktop client.
+#
+# Flathub builds with NO network access. Every npm dependency therefore has
+# to be declared up front, generated from electron/package-lock.json — see
+# generated-sources.json, and flatpak/README.md in the app repo. `npm install`
+# reaching the network is the single most common reason an Electron
+# submission fails to build on Flathub's infrastructure but works locally.
+#
+# VERSIONS: runtime-version / base-version / the node SDK extension all
+# rotate, and a stale runtime is an automatic review rejection. These were
+# verified against `flatpak remote-ls flathub` on 2026-08-12: Platform, Sdk,
+# Electron2.BaseApp and Sdk.Extension.node22 all publish a 25.08 branch.
+# Re-check before submitting if that date is no longer recent.
+app-id: io.github.blindrun.OutpostChat
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+command: outpost
+separate-locales: false
+
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node22
+
+finish-args:
+  # Display. Both, because Bazzite is Wayland-first but X11 sessions exist.
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+
+  # Talking to whichever Outpost server the user adds — there is no fixed
+  # host to narrow this to, since the whole point is that they choose it.
+  - --share=network
+
+  # Voice. --socket=pulseaudio covers playback and microphone capture on
+  # both PulseAudio and PipeWire's pulse shim.
+  - --socket=pulseaudio
+
+  # Screen sharing goes through the xdg-desktop-portal ScreenCast portal,
+  # which hands back a PipeWire stream — the app needs to reach the PipeWire
+  # socket to consume it. This is the part most likely to need adjusting
+  # after real testing on Wayland; see task notes.
+  - --filesystem=xdg-run/pipewire-0:ro
+
+  # Desktop notifications and a tray icon.
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+  # Saving an attachment, and picking one to upload. Downloads only —
+  # deliberately not --filesystem=home, since file *picking* goes through
+  # the portal and doesn't need blanket access.
+  - --filesystem=xdg-download
+
+modules:
+  - name: outpost
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/node22/bin
+      env:
+        # Belt and braces: fail loudly at build time if something still
+        # tries to fetch, rather than silently producing a broken bundle.
+        NPM_CONFIG_OFFLINE: 'true'
+        NPM_CONFIG_AUDIT: 'false'
+        NPM_CONFIG_FUND: 'false'
+        # Without this, offline mode is pointed at npm's DEFAULT cache, which
+        # is empty in the build sandbox, and every package fails ENOTCACHED
+        # even though generated-sources.json laid the real cache down here.
+        # Path is <module build dir>/flatpak-node/npm-cache, and the module
+        # is named `outpost`, hence /run/build/outpost.
+        NPM_CONFIG_CACHE: /run/build/outpost/flatpak-node/npm-cache
+        # node-gyp headers for any package with a native component; the
+        # generator's setup_sdk_node_headers.sh stages them to match.
+        NPM_CONFIG_NODEDIR: /usr/lib/sdk/node22
+        # NOTE: org.electronjs.Electron2.BaseApp does NOT ship an Electron
+        # runtime. It supplies zypak, which is the wrapper that makes
+        # Chromium's sandbox work inside Flatpak, plus a few helpers. The
+        # Electron binary itself still has to come from the npm `electron`
+        # devDependency, whose linux-x64 zip flatpak-node-generator cached
+        # under flatpak-node/cache/electron. So the download must NOT be
+        # skipped -- it just has to resolve offline, which is what pointing
+        # ELECTRON_CACHE at that directory does.
+        ELECTRON_CACHE: /run/build/outpost/flatpak-node/cache/electron
+    build-commands:
+      # The web client is built first and bundled into the Electron app —
+      # same as scripts/build-web.js does for the normal desktop build.
+      - npm ci --offline --prefix web
+      - npm run build --prefix web
+      - npm ci --offline --prefix electron
+      - npm run build-web --prefix electron
+
+      # electron-builder is not used here. Flathub wants the app tree laid
+      # out directly, with a launcher wrapper, rather than a self-contained
+      # installer.
+      - mkdir -p /app/lib/outpost
+
+      # The Electron runtime. npm does not run the electron package's
+      # postinstall in this sandbox -- after `npm ci` there is no dist/ and no
+      # path.txt -- so rather than depend on that hook firing, unzip the
+      # archive flatpak-node-generator already cached. Offline and
+      # deterministic by construction. The glob picks whichever arch's zip was
+      # fetched; the generator guards each one with only-arches, so exactly
+      # one is present per build.
+      - mkdir -p /app/lib/outpost/electron
+      - unzip -q flatpak-node/cache/electron/electron-v*-linux-*.zip -d /app/lib/outpost/electron
+      - chmod +x /app/lib/outpost/electron/electron
+      # chrome-sandbox must be REMOVED, not just stripped of its setuid bit.
+      # Flatpak will not export a setuid binary, but if the helper is merely
+      # present-and-not-setuid Electron finds it, decides it is misconfigured
+      # and aborts outright:
+      #   "The SUID sandbox helper binary was found, but is not configured
+      #    correctly ... I'm aborting now"
+      # zypak provides the sandbox inside Flatpak, so the helper is redundant.
+      - rm -f /app/lib/outpost/electron/chrome-sandbox
+
+      # main.js does `require("electron-updater")` at runtime, so production
+      # dependencies have to ship. Pruning dev dependencies first keeps
+      # electron-builder and the Electron package itself out of the image --
+      # the runtime was already copied out above.
+      - npm prune --omit=dev --prefix electron
+      - cp -r electron/node_modules /app/lib/outpost/node_modules
+
+      # package.json is what makes Electron resolve `main` and pick up the
+      # app name and version; preload.js and build/icon.png are both
+      # referenced by main.js via __dirname and were previously missing, so
+      # the preload IPC bridge (used by desktop SSO) had nothing to load.
+      - install -Dm644 -t /app/lib/outpost electron/main.js electron/preload.js electron/package.json
+      - install -Dm644 electron/build/icon.png /app/lib/outpost/build/icon.png
+      - cp -r electron/web-dist /app/lib/outpost/
+      - install -Dm755 outpost.sh /app/bin/outpost
+      - install -Dm644 io.github.blindrun.OutpostChat.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 io.github.blindrun.OutpostChat.desktop -t /app/share/applications/
+      # The repo ships a single 1024x1024 icon, and flatpak's icon validator
+      # rejects anything above 512x512 at export time. gdk-pixbuf-thumbnailer
+      # is part of the freedesktop SDK, so this needs no extra tooling and no
+      # pre-resized binary checked in beside the manifest.
+      - gdk-pixbuf-thumbnailer -s 512 electron/build/icon.png icon-512.png
+      - install -Dm644 icon-512.png /app/share/icons/hicolor/512x512/apps/io.github.blindrun.OutpostChat.png
+    sources:
+      - type: git
+        url: https://github.com/blindrun/outpost-chat.git
+        tag: v0.6.2
+        # Flathub requires a pinned commit alongside the tag, so a moved tag
+        # can't silently change what gets built.
+        commit: a33ffb3f4be520aa2209411675ea0dcf02ed2ecf
+
+      # Generated by flatpak-node-generator from electron/package-lock.json
+      # and web/package-lock.json. Regenerate on every release — a stale
+      # file means the build fetches nothing and fails offline.
+      - generated-sources.json
+
+      - type: script
+        dest-filename: outpost.sh
+        commands:
+          # zypak makes Chromium's own sandbox work inside Flatpak; without it
+          # Electron either refuses to start or runs unsandboxed. It has to be
+          # handed the Electron BINARY, not a .js file -- and Electron is then
+          # given the app DIRECTORY, so it reads package.json for `main`, the
+          # app name and the version, and resolves node_modules beside it.
+          - exec zypak-wrapper /app/lib/outpost/electron/electron /app/lib/outpost "$@"
+
+      # Both of these are copied in from alongside this manifest rather than
+      # taken from the git checkout. The checkout does contain a flatpak/
+      # directory, but it is whatever was committed at the tag, which goes
+      # stale the moment either file is edited here — and on Flathub these
+      # live in the manifest repo anyway, not in the app repo.
+      - type: file
+        path: io.github.blindrun.OutpostChat.desktop
+
+      - type: file
+        path: io.github.blindrun.OutpostChat.metainfo.xml


### PR DESCRIPTION
Outpost is a self-hosted chat app with text channels, voice channels and direct messages, for a single community. This submission is the desktop client, which connects to any Outpost server.

Homepage: https://outpost-chat.com
Source: https://github.com/blindrun/outpost-chat (MIT)

I am the author of the app. Built against the `v0.6.2` tag, pinned to commit `a33ffb3f4be520aa2209411675ea0dcf02ed2ecf`.

**Checks done before opening this**

- Builds clean with `flatpak-builder` on x86_64 against `org.freedesktop.Platform` 25.08, `org.electronjs.Electron2.BaseApp` 25.08 and `org.freedesktop.Sdk.Extension.node22` 25.08.
- Fully offline. All npm dependencies come from `generated-sources.json`, generated with `flatpak-node-generator` from the lockfiles at that tag. `NPM_CONFIG_OFFLINE` is set so a build that tries to fetch fails loudly rather than silently.
- Installed from a local repo and run through its own launcher. Reaches window creation on a headless box and stops only at `Missing X server or $DISPLAY`.
- `appstreamcli validate` passes on the metainfo. All six screenshots resolve over HTTPS.
- Installed and used on Bazzite, including a screen share capture through the ScreenCast portal.

**Notes on the finish-args**

- `--share=network` is unavoidable. The app has no fixed host to narrow to. The user types the address of whichever server they run or were invited to.
- `--socket=pulseaudio` is for voice channels, capture and playback.
- `--filesystem=xdg-run/pipewire-0:ro` is for consuming the PipeWire stream the ScreenCast portal hands back when sharing a screen.
- `--filesystem=xdg-download` is for saving an attachment. Picking a file to upload goes through the portal, so there is deliberately no `--filesystem=home`.

**Notes on the build commands**

Two things in there are not obvious and are commented in the manifest. The Electron BaseApp ships zypak rather than an Electron runtime, so the runtime is unzipped from the archive `flatpak-node-generator` cached. And `chrome-sandbox` is removed rather than chmod'd, because Electron aborts on startup if it finds the helper present and not setuid.
