### PR TITLE
Add io.github.sigmasd.aiuse

### DIFF
--- a/deno-sources.json
+++ b/deno-sources.json
@@ -1,0 +1,336 @@
+[
+  {
+    "type": "inline",
+    "contents": "{\"scope\":\"std\",\"name\":\"assert\",\"latest\":\"1.0.19\",\"versions\":{}}",
+    "dest": "vendor/jsr.io/@std/assert",
+    "dest-filename": "meta.json"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19_meta.json",
+    "sha256": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+    "dest": "vendor/jsr.io/@std/assert",
+    "dest-filename": "1.0.19_meta.json"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/array_includes.ts",
+    "sha256": "2dad64d743ca20af30a869ee7cf08408017bba95f11d3d172c65afc7c4197f0a",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "array_includes.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/equals.ts",
+    "sha256": "3621d3bfbef47b6a11709de0544dcce0b2c6626123fa379a4c54301f44090a8e",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/string_includes.ts",
+    "sha256": "c6921a2799299235c662f28929ffe1e08f429892e8d28ee9307ada38d90d1f1f",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "string_includes.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/not_equals.ts",
+    "sha256": "9e376d5009eae6053d78522da3de7ceab90469861d868de655bf53f68f4b9964",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "not_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/rejects.ts",
+    "sha256": "44c36f9424baa7e81c305dcd930f33585ee9408a2fa94e900a30c18da3459149",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "rejects.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/exists.ts",
+    "sha256": "f94c2c43e8657413c4a0ff8f0c6d0f4eb90b83e7bf5f22bcaffc6ee504093948",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "exists.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/fail.ts",
+    "sha256": "b7c2756c2444c546ef23477f828c5c848a4de529a128eece1ebb080480676434",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "fail.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/not_strict_equals.ts",
+    "sha256": "8bb7f371a888cdb69016131611d467729e3e62a65b24f059ed186358b83c069c",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "not_strict_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/throws.ts",
+    "sha256": "0ef612c1624f0b0b4b6e07320bd24dcd5094077774c0fe608f897682b772822b",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "throws.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/not_instance_of.ts",
+    "sha256": "f2ee2c8d8a591c53aebdf6a6ff24450024f15cbf8f46edde790b5dc6280d4c9a",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "not_instance_of.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/match.ts",
+    "sha256": "b39df7aa77e4ed43e1823fd7ac6bb31229464ca7e853aa9ff1acfcf06ad54523",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "match.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/not_match.ts",
+    "sha256": "7e00371062defbb5ceaede29015d5de75bb832c3125727229f7d3b7f22bc15c6",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "not_match.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/unstable_never.ts",
+    "sha256": "8f96efec263b0f495bd6780a0190b9979d6c8d33aa45e9fda65e4b5400b21abf",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "unstable_never.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/instance_of.ts",
+    "sha256": "2c4e16ee181f424b91d27f26e7fd5bd493864ad1987c33ccb06f3eb6710c87e3",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "instance_of.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/strict_equals.ts",
+    "sha256": "92145ed74ffa8c96a2407754634c840f3ac2bc033236552a37f7b7d3d317917f",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "strict_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/greater_or_equal.ts",
+    "sha256": "b4eb8147e519b7c6a46daee132908921a8e1566cea4592945aa7800811cc259a",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "greater_or_equal.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/less_or_equal.ts",
+    "sha256": "9d9eb025efa49ded1459c58288b6b9399448216db842bc59146181dd77c091e1",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "less_or_equal.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/equal.ts",
+    "sha256": "084be4c5911482a2c38431a6341db9c816677e0a277a8ced2c4c5a4cda4d4394",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "equal.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/assert.ts",
+    "sha256": "577cd3382908011da36639d019d9be54340e7e388b6db599425de0e977894318",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "assert.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/unstable_equals.ts",
+    "sha256": "4e63d0fd3c5692bcc3b479aa531b1ba1de04ed8a58dd3aa07e47df162f01bc43",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "unstable_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/less.ts",
+    "sha256": "c578b053e2c554a37923885c829a9bcbaedefaf18fe812addc871f6f02d0fe1a",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "less.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/unreachable.ts",
+    "sha256": "bf47aa8b78e2eb19550a1ffe2fef74e2cca804b19fa64cffecef9a4ae4dd47d2",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "unreachable.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/object_match.ts",
+    "sha256": "4858f036c4977694488f6467e13d84414d2cfdd924efaa53a4ffe08a5e982468",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "object_match.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/assertion_error.ts",
+    "sha256": "7082ae41b34eb0bc9054d8f2867996d0593af80904f98bfc0ad4f27b98f00d91",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "assertion_error.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/false.ts",
+    "sha256": "7891e342f1c36244161cf21f554ab381fdb1df23acdd5df29e16a990129fc9b8",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "false.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/greater.ts",
+    "sha256": "18a798d5afafb0d47d8baa8a2f598df79e3bb7939937c866802a7d5f6908298a",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "greater.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/mod.ts",
+    "sha256": "c3fc0e0ff82dbeb6c2274dfc5ff3a90830834dcb0400e2d7f69380cfb8b9ec5d",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "mod.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/unimplemented.ts",
+    "sha256": "13341d1f065390d682450c185bd2cc3241f05d952fb45437b450f4b1f004ca1c",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "unimplemented.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/is_error.ts",
+    "sha256": "36323f0da5b789e9be40313059e5fb3224fb81d35fa636aecc0fcf534a1f345e",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "is_error.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/unstable_strict_equals.ts",
+    "sha256": "9010dd3c0720b4df1ffe3be15c2303a327830f933d4c626755c178aa9e5e61f1",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "unstable_strict_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/almost_equals.ts",
+    "sha256": "4c69f1e45a4e65bc8aa737baf336e48cf9f9b2697e4db56197895c3d0b9b1fce",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "almost_equals.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/assert/1.0.19/deno.json",
+    "sha256": "9d61ddfb03b6b5c110cc7ce3f66d419c1303cb59934cf2163fe67865065b59a7",
+    "dest": "vendor/jsr.io/@std/assert/1.0.19",
+    "dest-filename": "deno.json"
+  },
+  {
+    "type": "inline",
+    "contents": "{\"scope\":\"std\",\"name\":\"internal\",\"latest\":\"1.0.14\",\"versions\":{}}",
+    "dest": "vendor/jsr.io/@std/internal",
+    "dest-filename": "meta.json"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14_meta.json",
+    "sha256": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7",
+    "dest": "vendor/jsr.io/@std/internal",
+    "dest-filename": "1.0.14_meta.json"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/format.ts",
+    "sha256": "634db20a15f925d7848d2767c3c9d2632c679ce224e151a245a94a2e5ea8a02e",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "format.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/types.ts",
+    "sha256": "b1d4db1e60a077649bdc11179d3f42bb644a614cc0eb89650a23bcdb8765dd5b",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "types.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/_os.ts",
+    "sha256": "c1c731bb7453e21e6041b36b01519b945a561df245f2f3db336efe1ba6177e26",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "_os.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/diff.ts",
+    "sha256": "f61957fd895f095851b379f958e19aa63b5d54450a47e56d7f4464354e30655e",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "diff.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/mod.ts",
+    "sha256": "8351b6ad5fda8f596fabf0c778cd0e5b59e3882d69d675934edd7b3f88215745",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "mod.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/diff_str.ts",
+    "sha256": "f7f0f13449f36b311d4a433e60299b9be1982377498aa075ee708cca54764107",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "diff_str.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/build_message.ts",
+    "sha256": "2d61aeb69668466d8a4a15cb697a2bb2edf42d33d35f79e3a5388efbb854e9fa",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "build_message.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/os.ts",
+    "sha256": "69e3dd08eab87582e741f8acc8adc95dbcd1f12c6b23102e020ce3c7857c3abc",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "os.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/truncate_build_message.ts",
+    "sha256": "d98a5feef24abcc37fa421f91e6ba266c8d911ed0d619e1d11bbdb1a147d988e",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "truncate_build_message.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/styles.ts",
+    "sha256": "b3eedf496a0512b1fb02752aead108d5cd454384e380292d20dcc33ddeca6425",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "styles.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/assertion_state.ts",
+    "sha256": "712c16a93ec4e4ab8f7e2b62ab4ca0faba4fe5de71df4033cb20abc404383051",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "assertion_state.ts"
+  },
+  {
+    "type": "file",
+    "url": "https://jsr.io/@std/internal/1.0.14/deno.json",
+    "sha256": "62815c0f97f2d86d55891fea813f04c882009d0ac1694ffd5b2a8f475a8cf910",
+    "dest": "vendor/jsr.io/@std/internal/1.0.14",
+    "dest-filename": "deno.json"
+  }
+]

--- a/io.github.sigmasd.aiuse.json
+++ b/io.github.sigmasd.aiuse.json
@@ -1,0 +1,97 @@
+{
+  "app-id": "io.github.sigmasd.aiuse",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
+  "command": "aiuse",
+  "finish-args": [
+    "--share=network",
+    "--share=ipc",
+    "--socket=x11",
+    "--socket=wayland",
+    "--device=dri"
+  ],
+  "modules": [
+    {
+      "name": "aiuse",
+      "buildsystem": "simple",
+      "build-options": {
+        "env": {
+          "DENO_DIR": "deno_dir"
+        }
+      },
+      "build-commands": [
+        "mkdir -p deno_dir/laufey/0.5.0/webview/x86_64-unknown-linux-gnu && (tar -xzf laufey-webview-x86_64-unknown-linux-gnu.tar.gz -C deno_dir/laufey/0.5.0/webview/x86_64-unknown-linux-gnu 2>/dev/null || true) && printf 'v0.5.0\\n' > deno_dir/laufey/0.5.0/webview/x86_64-unknown-linux-gnu/.downloaded",
+        "mkdir -p deno_dir/laufey/0.5.0/webview/aarch64-unknown-linux-gnu && (tar -xzf laufey-webview-aarch64-unknown-linux-gnu.tar.gz -C deno_dir/laufey/0.5.0/webview/aarch64-unknown-linux-gnu 2>/dev/null || true) && printf 'v0.5.0\\n' > deno_dir/laufey/0.5.0/webview/aarch64-unknown-linux-gnu/.downloaded",
+        "./deno desktop --cached-only --vendor --allow-net --allow-env --output aiuse report.ts",
+        "install -Dm755 aiuse/aiuse /app/lib/aiuse/aiuse",
+        "install -Dm644 aiuse/aiuse.so /app/lib/aiuse/aiuse.so",
+        "mkdir -p /app/bin && ln -s ../lib/aiuse/aiuse /app/bin/aiuse",
+        "install -Dm644 flatpak/io.github.sigmasd.aiuse.desktop /app/share/applications/io.github.sigmasd.aiuse.desktop",
+        "install -Dm644 flatpak/io.github.sigmasd.aiuse.metainfo.xml /app/share/metainfo/io.github.sigmasd.aiuse.metainfo.xml",
+        "install -Dm644 assets/icon.png /app/share/icons/hicolor/512x512/apps/io.github.sigmasd.aiuse.png",
+        "install -Dm644 LICENSE /app/share/licenses/io.github.sigmasd.aiuse/LICENSE"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/denoland/deno/releases/download/v2.9.3/deno-x86_64-unknown-linux-gnu.zip",
+          "sha256": "8101865641cbede56f08ad19c0a67a87df84bce127fee0d3e3e1f7467717ffa6",
+          "only-arches": [
+            "x86_64"
+          ]
+        },
+        {
+          "type": "archive",
+          "url": "https://github.com/denoland/deno/releases/download/v2.9.3/deno-aarch64-unknown-linux-gnu.zip",
+          "sha256": "753937db98a4b56cbbbd26e8f00eb4b789191a229afec93f74bcfa4e79bc2c8b",
+          "only-arches": [
+            "aarch64"
+          ]
+        },
+        {
+          "type": "file",
+          "url": "https://dl.deno.land/release/v2.9.3/libdenort-x86_64-unknown-linux-gnu.zip",
+          "sha256": "e1e46329b344d1e67b87989af34a7de9837f5b7d2cebca33fbf174ce32345d3f",
+          "only-arches": [
+            "x86_64"
+          ],
+          "dest": "deno_dir/dl/release/v2.9.3",
+          "dest-filename": "libdenort-x86_64-unknown-linux-gnu.zip"
+        },
+        {
+          "type": "file",
+          "url": "https://dl.deno.land/release/v2.9.3/libdenort-aarch64-unknown-linux-gnu.zip",
+          "sha256": "75cbbac09f72fd61abe86adeedcded437cc98acfa38c7ff2be45d66e1bca04d4",
+          "only-arches": [
+            "aarch64"
+          ],
+          "dest": "deno_dir/dl/release/v2.9.3",
+          "dest-filename": "libdenort-aarch64-unknown-linux-gnu.zip"
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/littledivy/laufey/releases/download/v0.5.0/laufey-webview-x86_64-unknown-linux-gnu.tar.gz",
+          "sha256": "79ea97868f7c95aa11a2cb617dffe64a337cacdc9b32a54a4ffd038e9a2409a4",
+          "only-arches": [
+            "x86_64"
+          ]
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/littledivy/laufey/releases/download/v0.5.0/laufey-webview-aarch64-unknown-linux-gnu.tar.gz",
+          "sha256": "14ad8fabf71e991e0c7cb9c2980c86777847176ba184e789fb5d874c4e70150d",
+          "only-arches": [
+            "aarch64"
+          ]
+        },
+        "deno-sources.json",
+        {
+          "type": "git",
+          "url": "https://github.com/sigmaSd/aiuse.git",
+          "tag": "v0.2.0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Supersedes #9780 (auto-closed due to wrong layout; this PR has the manifest at toplevel).

### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. AI Usage is a desktop usage monitor for Claude.ai and OpenCode Go. It polls both providers independently and displays rate-limit and usage data side-by-side in a single desktop dashboard.
- [x] Please attach a video showcasing the application on Linux using the Flatpak.  https://github.com/user-attachments/assets/35d8b25a-4662-4d46-9ae4-4eaeb43d6aad

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].



- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am the author to the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
