### PR TITLE
Add io.github.juwan_hwang.Zephyr

### DIFF
--- a/io.github.juwan_hwang.Zephyr.metainfo.xml
+++ b/io.github.juwan_hwang.Zephyr.metainfo.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.juwan_hwang.Zephyr</id>
+  <name>Zephyr</name>
+  <summary>A modern, lightweight Mihomo GUI client</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>Juwan</developer_name>
+
+  <description>
+    <p>
+      Zephyr is a state-of-the-art cross-platform GUI client for Mihomo, combining modern desktop aesthetics, high performance with Rust and Tauri v2, and a 13-layer security defense architecture.
+    </p>
+    <ul>
+      <li>High performance and low memory footprint with Tauri v2 and native Rust IPC</li>
+      <li>Zero heavyweight frontend frameworks — pure native JavaScript UI</li>
+      <li>Full proxy protocol management, subscription parsing, and latency testing</li>
+      <li>Real-time traffic oscilloscope monitoring and system tray integration</li>
+    </ul>
+  </description>
+
+  <url type="homepage">https://github.com/Juwan-Hwang/Zephyr</url>
+  <url type="bugtracker">https://github.com/Juwan-Hwang/Zephyr/issues</url>
+  <url type="vcs-browser">https://github.com/Juwan-Hwang/Zephyr</url>
+
+  <launchable type="desktop-id">io.github.juwan_hwang.Zephyr.desktop</launchable>
+
+  <provides>
+    <binary>zephyr</binary>
+  </provides>
+
+  <content_rating type="oars-1.1" />
+
+  <releases>
+    <release version="2.4.3" date="2026-08-08">
+      <description>
+        <p>Zephyr v2.4.3 release with UI optimizations, multi-architecture Linux package improvements, and security enhancements.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/io.github.juwan_hwang.Zephyr.yml
+++ b/io.github.juwan_hwang.Zephyr.yml
@@ -1,0 +1,49 @@
+app-id: io.github.juwan_hwang.Zephyr
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: zephyr
+
+finish-args:
+  # Network & IPC
+  - --share=network
+  - --share=ipc
+  # Display (X11 & Wayland)
+  - --socket=fallback-x11
+  - --socket=wayland
+  # Audio (if needed)
+  - --socket=pulseaudio
+  # Tray notification support
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.Notifications
+  # App configuration & profile storage
+  - --filesystem=xdg-config/Zephyr:create
+  - --filesystem=xdg-data/Zephyr:create
+
+modules:
+  - name: zephyr
+    buildsystem: simple
+    build-commands:
+      - ar x package.deb
+      - tar xf data.tar.* -C /app/
+      # Install desktop file & icons into standard flatpak export paths
+      - install -Dm644 /app/usr/share/applications/zephyr.desktop /app/share/applications/io.github.juwan_hwang.Zephyr.desktop
+      - install -Dm644 io.github.juwan_hwang.Zephyr.metainfo.xml /app/share/metainfo/io.github.juwan_hwang.Zephyr.metainfo.xml
+      # Symlink binary to /app/bin/zephyr
+      - mkdir -p /app/bin
+      - ln -sf /app/usr/bin/zephyr /app/bin/zephyr
+    sources:
+      - type: file
+        url: https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_2.4.3_amd64-full.deb
+        sha256: 09cae645e0f1cffe40344b800e45e5808f2b7c0a4e9909bd241fb4a953615bdc
+        dest-filename: package.deb
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://github.com/Juwan-Hwang/Zephyr/releases/download/v2.4.3/Zephyr_2.4.3_arm64-full.deb
+        sha256: d0a5df971b3e945fe0cbbe78d4615a201b1e7f3c4c9528ad689dc330d4a75344
+        dest-filename: package.deb
+        only-arches:
+          - aarch64
+      - type: file
+        path: io.github.juwan_hwang.Zephyr.metainfo.xml


### PR DESCRIPTION
### Summary

Adds Zephyr (io.github.juwan_hwang.Zephyr), a modern, lightweight Mihomo GUI client.

- **Upstream**: https://github.com/Juwan-Hwang/Zephyr
- **License**: MIT
- **Category**: Network / Utility
