### PR TITLE
Add io.github.soccervortex.MintHub

### DIFF
--- a/io.github.soccervortex.MintHub.yml
+++ b/io.github.soccervortex.MintHub.yml
@@ -1,0 +1,76 @@
+app-id: io.github.soccervortex.MintHub
+runtime: org.gnome.Platform
+runtime-version: '46'
+sdk: org.gnome.Sdk
+command: mint-hub
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --filesystem=home:ro
+  - --filesystem=/usr/share/themes:ro
+  - --filesystem=/usr/share/icons:ro
+  - --filesystem=/usr/share/fonts:ro
+  - --filesystem=/usr/share/wallpapers:ro
+  - --filesystem=/usr/share/cinnamon:ro
+  - --filesystem=xdg-data/themes:ro
+  - --filesystem=xdg-data/icons:ro
+  - --filesystem=xdg-data/fonts:ro
+  - --filesystem=xdg-data/cinnamon:create
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=ca.desrt.dconf
+
+modules:
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} requests
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3-py3-none-any.whl
+        sha256: 70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+      - type: file
+        url: https://files.pythonhosted.org/packages/ca/1c/89ffc63a9605b583d5df2be791a27bc1a42b7c32bab68d3c8f2f73a98cd4/urllib3-2.2.2-py3-none-any.whl
+        sha256: a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472
+      - type: file
+        url: https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.7.4-py3-none-any.whl
+        sha256: c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90
+      - type: file
+        url: https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz
+        sha256: f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5
+      - type: file
+        url: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.7-py3-none-any.whl
+        sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
+
+  - name: mint-hub
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 mint_hub.py ${FLATPAK_DEST}/share/mint-hub/mint_hub.py
+      - install -Dm644 application.py ${FLATPAK_DEST}/share/mint-hub/application.py
+      - install -Dm644 window.py ${FLATPAK_DEST}/share/mint-hub/window.py
+      - install -Dm644 tiles.py ${FLATPAK_DEST}/share/mint-hub/tiles.py
+      - install -Dm644 imaging.py ${FLATPAK_DEST}/share/mint-hub/imaging.py
+      - install -Dm644 scanner.py ${FLATPAK_DEST}/share/mint-hub/scanner.py
+      - install -Dm644 enhancement.py ${FLATPAK_DEST}/share/mint-hub/enhancement.py
+      - install -Dm644 constants.py ${FLATPAK_DEST}/share/mint-hub/constants.py
+      - install -Dm644 local_cache.py ${FLATPAK_DEST}/share/mint-hub/local_cache.py
+      - install -Dm644 installer.py ${FLATPAK_DEST}/share/mint-hub/installer.py
+      - install -Dm644 api_client.py ${FLATPAK_DEST}/share/mint-hub/api_client.py
+      - install -Dm644 spices_fetcher.py ${FLATPAK_DEST}/share/mint-hub/spices_fetcher.py
+      - install -Dm644 seeder.py ${FLATPAK_DEST}/share/mint-hub/seeder.py
+      - install -Dm644 seed_catalog.json ${FLATPAK_DEST}/share/mint-hub/seed_catalog.json
+      - install -Dm644 threading_utils.py ${FLATPAK_DEST}/share/mint-hub/threading_utils.py
+      - install -Dm644 safety_scanner.py ${FLATPAK_DEST}/share/mint-hub/safety_scanner.py
+      - install -Dm644 updater.py ${FLATPAK_DEST}/share/mint-hub/updater.py
+      - install -Dm644 applier.py ${FLATPAK_DEST}/share/mint-hub/applier.py
+      - install -Dm644 packager.py ${FLATPAK_DEST}/share/mint-hub/packager.py
+      - install -Dm755 mint-hub-wrapper.sh ${FLATPAK_DEST}/bin/mint-hub
+      - install -Dm644 data/io.github.soccervortex.MintHub.desktop ${FLATPAK_DEST}/share/applications/io.github.soccervortex.MintHub.desktop
+      - install -Dm644 data/mint-hub.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.soccervortex.MintHub.svg
+      - install -Dm644 data/io.github.soccervortex.MintHub.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.soccervortex.MintHub.metainfo.xml
+      - install -Dm644 COPYING ${FLATPAK_DEST}/share/licenses/io.github.soccervortex.MintHub/COPYING
+    sources:
+      - type: git
+        url: https://github.com/soccervortex/mint-hub.git
+        commit: fbe8d6b6176c8e01566e4573ac4e3109f1cdde5f


### PR DESCRIPTION
## New App: Linux Mint Hub

**App ID:** `io.github.soccervortex.MintHub`
**Homepage:** https://github.com/soccervortex/mint-hub
**License:** GPL-3.0-or-later

### Description

Linux Mint Hub is a native GTK3 desktop application for browsing, installing, and managing Linux Mint enhancements. It provides a unified interface for discovering and applying themes, icons, cursors, wallpapers, applets, extensions, desklets, fonts, and more.

### Features

- Browse 1500+ enhancements across 16 categories
- Install directly from Cinnamon Spices and the Mint Hub marketplace
- Scan and manage locally installed themes, icons, and fonts
- Built-in malware scanning for safe installations
- Apply themes, icons, and cursors with one click
- Search, filter, and sort enhancements
- Rate and review community contributions
- Works offline with local-only mode

### Technical Details

- **Runtime:** org.gnome.Platform 46
- **SDK:** org.gnome.Sdk
- **Dependencies:** python3-requests (bundled)
- **Display protocol:** X11/Wayland

### Checklist

- [x] App has a proper reverse-DNS app ID
- [x] AppStream metainfo file included
- [x] Desktop file included
- [x] SVG icon included
- [x] GPL-3.0 license file installed
- [x] Screenshots included in metainfo
- [x] Source code is publicly available
- [x] Content rating (OARS) included