### PR TITLE
Add io.github.azazel21t.RobloxStretched

### DIFF
--- a/io.github.azazel21t.RobloxStretched.yml
+++ b/io.github.azazel21t.RobloxStretched.yml
@@ -1,0 +1,15 @@
+id: io.github.azazel21t.RobloxStretched
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: stretch_roblox.sh
+finish-args:
+  - --talk-name=org.freedesktop.Flatpak
+modules:
+  - name: roblox-stretched-script
+    buildsystem: simple
+    build-commands:
+      - install -D stretch_roblox.sh /app/bin/stretch_roblox.sh
+    sources:
+      - type: file
+        path: stretch_roblox.sh


### PR DESCRIPTION
- [x] I have read the Submission guide and I agree to them.
- [x] I am an author/developer/upstream contributor to the project. Link: https://github.com

Hello Flathub Review Team,

I am submitting a custom resolution scaling utility launcher tailored for Linux Roblox players using the Sober framework.

Permission Justification:
This utility requires the --talk-name=org.freedesktop.Flatpak permission argument to utilize flatpak-spawn --host. This is a strict operational dependency because the underlying startup logic must break out of the sandboxed app container to execute host-level xrandr operations. This scales the user's active display profile out to a stretched 4:3 canvas size upon game initialization, and safely handles resetting parameters cleanly back to the player's default resolution immediately upon game closure. Thank you for your review!