### PR TITLE
Add org.justiceclient.launcher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "org.justiceclient.launcher"]
+	path = org.justiceclient.launcher
+	url = https://github.com/kapaisu/org.justiceclient.launcher.git


### PR DESCRIPTION
Adds the Justice Client Minecraft launcher.

- Prebuilt x86_64 payload (extra-data from upstream's GitHub Releases; the upstream project ships prebuilt binaries and does not publish source)
- Built against the GNOME 50 runtime (webkit2gtk-4.1, gtk3, libsoup3)
- x86_64 only (only-arches), matching the available prebuilt payload