### PR TITLE
Add io.github.LightZirconite.Kiln

### DIFF
--- a/io.github.LightZirconite.Kiln.yml
+++ b/io.github.LightZirconite.Kiln.yml
@@ -1,0 +1,120 @@
+# Flathub submission manifest. The manifest under packaging/flatpak builds the working
+# tree for local testing; this one builds a published tag and is the file that belongs in
+# the flathub/io.github.LightZirconite.Kiln repository.
+id: io.github.LightZirconite.Kiln
+runtime: org.kde.Platform
+runtime-version: '6.11'
+sdk: org.kde.Sdk
+base: io.qt.qtwebengine.BaseApp
+base-version: '6.11'
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.mingw-w64
+command: kiln
+
+finish-args:
+  - --require-version=1.16.0
+  - --allow=multiarch
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --device=input
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --filesystem=xdg-run/discord-ipc-0:ro
+
+build-options:
+  append-path: /usr/lib/sdk/mingw-w64/bin
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - name: utf8proc
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DUTF8PROC_ENABLE_TESTING=OFF
+    sources:
+      - type: archive
+        url: https://github.com/JuliaStrings/utf8proc/archive/refs/tags/v2.11.3.tar.gz
+        sha256: abfed50b6d4da51345713661370290f4f4747263ee73dc90356299dfc7990c78
+
+  - name: nlohmann-json
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DJSON_BuildTests=OFF
+      - -DJSON_MultipleHeaders=ON
+    sources:
+      - type: archive
+        url: https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+        sha256: 42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
+
+  - name: minizip-ng
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DMZ_COMPAT=OFF
+      - -DMZ_ZLIB_FLAVOR=zlib
+      - -DMZ_BZIP2=OFF
+      - -DMZ_LZMA=OFF
+      - -DMZ_PPMD=OFF
+      - -DMZ_ZSTD=OFF
+      - -DMZ_FETCH_LIBS=OFF
+      - -DMZ_PKCRYPT=OFF
+      - -DMZ_WZAES=OFF
+      - -DMZ_OPENSSL=OFF
+      - -DMZ_LIBBSD=OFF
+      - -DMZ_ICONV=OFF
+      - -DMZ_DECOMPRESS_ONLY=ON
+      - -DMZ_BUILD_TESTS=OFF
+      - -DMZ_BUILD_UNIT_TESTS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/zlib-ng/minizip-ng/archive/7b2387161c542fa9f427352dcdef76097d0d692b.tar.gz
+        sha256: 467a189e998c7754ada577758d29324d5b3c866a7fb5d43700b8c551d72ca998
+
+  - name: wine
+    buildsystem: autotools
+    builddir: true
+    config-opts:
+      - --enable-archs=i386,x86_64
+      - --disable-tests
+      - --without-capi
+      - --without-cups
+      - --without-gphoto
+      - --without-oss
+      - --without-pcap
+      - --without-sane
+    sources:
+      - type: archive
+        url: https://dl.winehq.org/wine/source/11.0/wine-11.0.tar.xz
+        sha256: c07a6857933c1fc60dff5448d79f39c92481c1e9db5aa628db9d0358446e0701
+
+  - name: kiln
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DKILN_BUILD_TESTS=OFF
+    sources:
+      # Flathub builds from a published, immutable revision, so the tag and the commit must both
+      # be present and must agree. Flathub's External Data Checker watches this repository for a
+      # new vX.Y.Z tag every two hours and opens the update pull request with both fields already
+      # rewritten, so neither is normally edited by hand.
+      - type: git
+        url: https://github.com/LightZirconite/Kiln.git
+        tag: v0.1.1
+        commit: 9fc190d0128e9ac98b887b96f1d500db9da3e6d6
+        x-checker-data:
+          type: git
+          tag-pattern: "^v([\\d.]+)$"
+          version-scheme: semantic


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly.

Kiln runs the official Roblox Android client and Roblox Studio on Linux from a single Qt
interface. Play mode loads the official client through an in-process Android ABI compatibility
runtime. Studio mode resolves the current official Windows release and prepares a dedicated
WoW64 Wine prefix with pinned DXVK and WebView2.

Kiln bundles no Roblox binary, asset or APK, and redistributes nothing proprietary. Client files
are downloaded by the user's own machine at runtime, and every download is verified against
Roblox's signing block, a pinned leaf certificate and the exact package name before it is used.
Verification is fail-closed and has no bypass in any build type.

The manifest builds Wine from source because Studio mode requires it. `--device=input` is needed
for controller support, and `--talk-name=org.freedesktop.secrets` keeps the Roblox session token
in the system keyring rather than on disk.

Kiln is an independent community project. It is not affiliated with, endorsed by, or supported by
Roblox Corporation, and says so in its AppStream description, its interface and its README.

- [X] Please attach a video showcasing the application on Linux using the Flatpak.
https://github.com/user-attachments/assets/282b7cb3-a330-43fa-b38f-7c9cdff37d22

- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

`io.github.LightZirconite.Kiln` matches the repository hosted at
https://github.com/LightZirconite/Kiln

- [X] I have read and followed all the [Submission requirements][reqs] and thed I agree to them.

- [X] I am an author/developer of the project.

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#applicatio
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission