### PR TITLE
Add io.github.comicdeed.jots

### DIFF
--- a/io.github.comicdeed.jots.yml
+++ b/io.github.comicdeed.jots.yml
@@ -1,0 +1,38 @@
+app-id: io.github.comicdeed.jots
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+base: io.elementary.BaseApp
+base-version: 'circe-25.08'
+command: io.github.comicdeed.jots
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --socket=session-bus
+  - --own-name=io.github.comicdeed.jots
+  - --filesystem=xdg-data/io.github.elly_code.jorts:ro
+  - --filesystem=~/.var/app/io.github.elly_code.jorts:ro
+  - --device=dri
+
+cleanup:
+  - /include
+  - /lib/girepository-1.0
+  - /lib/pkgconfig
+  - /share/gir-1.0
+  - /share/vala
+
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
+
+modules:
+  - name: jots
+    buildsystem: meson
+    config-opts:
+      - --buildtype=release
+      - -Dicon_variant=default
+    sources:
+      - type: archive
+        url: https://github.com/comicdeed/jots/archive/refs/tags/1.0.0-beta.1.tar.gz
+        sha256: 0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly.
Jots is a lightweight, elegant desktop sticky notes application with native Markdown storage, full-text search across open and saved notes, and standalone Model Context Protocol (MCP) server integration for local AI tools.

- [x] Please attach a video showcasing the application on Linux using the Flatpak.
https://raw.githubusercontent.com/comicdeed/jots/main/data/screenshots/demo.gif

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer/upstream contributor to the project. **Link:** https://github.com/comicdeed/jots

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->
Maintainers: @codemedic

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission

### Permissions Justification
- `--socket=wayland` & `--socket=fallback-x11`: Native GTK4 window presentation.
- `--socket=session-bus` & `--own-name=io.github.comicdeed.jots`: Desktop IPC and MCP daemon communication.
- `--filesystem=xdg-data/io.github.elly_code.jorts:ro` & `--filesystem=~/.var/app/io.github.elly_code.jorts:ro`: Read-only access for the non-destructive legacy Jorts notes migration wizard.
