### PR TITLE
Add tf.prn.Prntf

### DIFF
--- a/tf.prn.Prntf.yml
+++ b/tf.prn.Prntf.yml
@@ -1,0 +1,47 @@
+app-id: tf.prn.Prntf
+runtime: org.kde.Platform
+runtime-version: '6.8'
+sdk: org.kde.Sdk
+command: prntf
+
+finish-args:
+  - --share=ipc
+  - --share=network          # screenshot uploads to prn.tf, update checks
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --talk-name=org.kde.StatusNotifierWatcher   # system tray / AppIndicator
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.portal.Desktop  # screenshot portal (Wayland)
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - '*.a'
+
+modules:
+  - name: prntf
+    buildsystem: cmake-ninja
+    builddir: true
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+    sources:
+      - type: git
+        url: https://github.com/Tuntii/prntf.git
+        commit: f1984d07f33c4603712aa0a1bdcbdd2b49210129
+      # Dependencies are vendored into external/ so that the CMake build
+      # never needs network access (see the external/ guards in
+      # CMakeLists.txt).
+      - type: git
+        url: https://gitlab.com/mattbas/Qt-Color-Widgets.git
+        commit: 352bc8f99bf2174d5724ee70623427aa31ddc26a
+        dest: external/Qt-Color-Widgets
+      - type: git
+        url: https://github.com/KDAB/KDSingleApplication.git
+        tag: v1.2.0
+        dest: external/KDSingleApplication
+      - type: git
+        url: https://github.com/Skycoder42/QHotkey.git
+        tag: '1.5.0'
+        dest: external/QHotkey


### PR DESCRIPTION
## New submission: tf.prn.Prntf (Prntf)

Prntf is the official desktop screenshot client for **prn.tf** — a Flameshot-based (GPL-3.0) client that captures a region or fullscreen, annotates it, and uploads directly to prn.tf with the shareable link on the clipboard.

- **Homepage:** https://prn.tf
- **Source:** https://github.com/Tuntii/prntf (branch `linux-client`, pinned commit `f1984d07f33c4603712aa0a1bdcbdd2b49210129`)
- **License:** GPL-3.0-or-later (Flameshot fork; upstream flameshot-org is Cc'd by license)
- **App id rationale:** reverse-DNS of the service domain `prn.tf`

### Notes for reviewers
- All three CMake dependencies (QtColorWidgets, KDSingleApplication, QHotkey) are vendored as pinned git sources into `external/`, so the build needs no network access at configure time.
- Uses `org.kde.Platform 6.8`; Qt6 only.
- Wayland screen capture goes through xdg-desktop-portal (`--talk-name=org.freedesktop.portal.Desktop`); X11/XWayland uses X11 capture. Tray uses StatusNotifierWatcher.
- The Windows client already ships binaries from cdn.prn.tf; this PR brings the same client to Linux. I maintain the client code.

I have tested the app locally on GNOME (Wayland) with the same code state: capture via portal fallback chain, tray registration and upload flow all work.