### PR TITLE
Add io.github.mvinhas.Chronicle

### DIFF
--- a/io.github.mvinhas.Chronicle.json
+++ b/io.github.mvinhas.Chronicle.json
@@ -40,8 +40,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/MVinhas/chronicle.git",
-                    "tag": "v1.0.0",
-                    "commit": "81667c9aaaf5953e73c50b0286e1a4a3a30a9411",
+                    "tag": "v1.0.1",
+                    "commit": "a09c0efbfd267a089eb9d7392714886145d9da5e",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"

--- a/io.github.mvinhas.Chronicle.json
+++ b/io.github.mvinhas.Chronicle.json
@@ -1,0 +1,53 @@
+{
+    "id": "io.github.mvinhas.Chronicle",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "50",
+    "sdk": "org.gnome.Sdk",
+    "command": "chronicle",
+    "finish-args": [
+        "--share=network",
+        "--share=ipc",
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "*.pyc",
+        "__pycache__",
+        "*.dist-info",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    "modules": [
+        {
+            "name": "chronicle",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 build-aux/chronicle.launcher /app/bin/chronicle",
+                "install -Dm755 build-aux/chronicle-cli.launcher /app/bin/chronicle-cli",
+                "mkdir -p /app/share/chronicle",
+                "cp -r src/chronicle /app/share/chronicle/chronicle",
+                "cp -r vendor/bs4 vendor/soupsieve vendor/typing_extensions.py /app/share/chronicle/",
+                "cp -r data/fonts /app/share/chronicle/fonts",
+                "install -Dm644 data/fonts/OFL.txt /app/share/licenses/chronicle/SourceSerif4-OFL.txt",
+                "install -Dm644 build-aux/io.github.mvinhas.Chronicle.desktop /app/share/applications/io.github.mvinhas.Chronicle.desktop",
+                "install -Dm644 build-aux/io.github.mvinhas.Chronicle.metainfo.xml /app/share/metainfo/io.github.mvinhas.Chronicle.metainfo.xml",
+                "install -Dm644 data/icons/hicolor/scalable/apps/io.github.mvinhas.Chronicle.svg /app/share/icons/hicolor/scalable/apps/io.github.mvinhas.Chronicle.svg",
+                "install -Dm644 data/icons/hicolor/symbolic/apps/io.github.mvinhas.Chronicle-symbolic.svg /app/share/icons/hicolor/symbolic/apps/io.github.mvinhas.Chronicle-symbolic.svg"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/MVinhas/chronicle.git",
+                    "tag": "v1.0.0",
+                    "commit": "81667c9aaaf5953e73c50b0286e1a4a3a30a9411",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [X] Please describe the application briefly.

  **Chronicle** is a reader that builds a complete historical archive of the
  blogs you follow and merges every article into a single queue ordered by
  original publication date, oldest first, regardless of which blog it came
  from. It is meant for reading a body of writing in the order it was written
  rather than the order you happened to discover it.

  Unlike a feed reader, it is not limited to what an RSS feed exposes — usually
  only the newest handful of posts. When a blog is added, Chronicle probes it
  and picks whichever route recovers the most history: a WordPress REST API, a
  Ghost content API, a sitemap crawl, the blog's own archive index and its
  pagination, or a feed as a last resort.

  It also treats publication dates carefully, since they decide the reading
  order: it records the original publication date rather than the date of
  discovery or a later revision, keeps the real precision (a month-precision
  date is shown as a month, not as an invented day), stores where each date
  came from and how confident it is, and collects articles whose date cannot be
  determined into a separate list rather than placing them somewhere wrong in
  the queue.

  Articles are read inside the application on a typographic reading surface,
  with images cached locally so the library works offline. It ships with no
  blogs configured; the library starts empty.

- [X] Please attach a video showcasing the application on Linux using the Flatpak.

[chronicle-demo.webm](https://github.com/user-attachments/assets/58e7c307-b99c-4fd2-a8a6-77d8eb1462aa)


- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

  `io.github.mvinhas.Chronicle` — four components, `io.github.` prefix as
  required for a project hosted on GitHub, lowercase domain portion, no dashes,
  and it matches the source repository at
  <https://github.com/MVinhas/chronicle>.

- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

  Verified locally before submitting:

  - `flatpak-builder-lint manifest` — no errors, no warnings
  - `flatpak-builder-lint builddir` — clean apart from
    `appstream-external-screenshot-url`, which I understand is expected until
    the screenshots are mirrored by Flathub's own build
  - `appstreamcli validate` — passes
  - `desktop-file-validate` — passes
  - Built from the pinned `v1.0.0` tag and run on Fedora Silverblue (GNOME 50)
  - No local sources in the manifest; the only bundled third-party code is
    BeautifulSoup, soupsieve and typing_extensions, all pure Python and
    included in the tagged source tree
  - Licence: GPL-3.0-or-later. The bundled Source Serif 4 typeface is under the
    SIL Open Font License, shipped to `/app/share/licenses`
  - `x-checker-data` is set so flatpak-external-data-checker can propose updates
    when a new `vX.Y.Z` tag is published

- [X] I am an author to the project. If not, I contacted upstream developers about this submission. **Link:** N/A — I am the author and this is the upstream repository.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
