### PR TITLE
Add net.krafting.PedantiK.Lang.French

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Build the App
+
+```shell
+flatpak run org.flatpak.Builder --force-clean --sandbox --user --install --install-deps-from=flathub --ccache --mirror-screenshots-url=https://dl.flathub.org/media/ --repo=repo build-dir net.krafting.PedantiK.Lang.French.yml  && flatpak run net.krafting.PedantiK
+```

--- a/net.krafting.PedantiK.Lang.French.metainfo.xml
+++ b/net.krafting.PedantiK.Lang.French.metainfo.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component type="addon">
+  <id>net.krafting.PedantiK.Lang.French</id>
+  <name>PedantiK French Language Pack</name>
+  <extends>net.krafting.PedantiK</extends>
+  <summary>French language pack for PedantiK</summary>
+  <summary xml:lang="fr">Pack de langue française pour PedantiK</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <developer id="net.krafting">
+    <name>Krafting</name>
+  </developer>
+  <description>
+    <p>French language pack for PedantiK</p>
+    <p xml:lang="fr">Pack de langue française pour PedantiK</p>
+  </description>
+  <url type="homepage">https://gitlab.com/Krafting/pedantik</url>
+  <url type="vcs-browser">https://gitlab.com/Krafting/pedantik</url>
+  <url type="bugtracker">https://gitlab.com/Krafting/pedantik/issues</url>
+  <url type="help">https://gitlab.com/Krafting/pedantik/issues</url>
+  <keywords>
+    <keyword>pedantik</keyword>
+    <keyword>french</keyword>
+    <keyword>wikipedia</keyword>
+  </keywords>
+  <releases>
+    <release type="stable" version="1.0.0" date="2026-08-22T00:00:00Z">
+      <description>
+        <p>This release adds the following features:</p>
+        <ul>
+          <li>+ Initial release</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/net.krafting.PedantiK.Lang.French.metainfo.xml
+++ b/net.krafting.PedantiK.Lang.French.metainfo.xml
@@ -24,7 +24,7 @@
     <keyword>wikipedia</keyword>
   </keywords>
   <releases>
-    <release type="stable" version="1.0.0" date="2026-08-22T00:00:00Z">
+    <release type="stable" version="1.0.0" date="2026-08-27T00:00:00Z">
       <description>
         <p>This release adds the following features:</p>
         <ul>

--- a/net.krafting.PedantiK.Lang.French.metainfo.xml
+++ b/net.krafting.PedantiK.Lang.French.metainfo.xml
@@ -16,8 +16,8 @@
   </description>
   <url type="homepage">https://gitlab.com/Krafting/pedantik</url>
   <url type="vcs-browser">https://gitlab.com/Krafting/pedantik</url>
-  <url type="bugtracker">https://gitlab.com/Krafting/pedantik/issues</url>
-  <url type="help">https://gitlab.com/Krafting/pedantik/issues</url>
+  <url type="bugtracker">https://gitlab.com/Krafting/pedantik/-/work_items</url>
+  <url type="help">https://gitlab.com/Krafting/pedantik/-/work_items</url>
   <keywords>
     <keyword>pedantik</keyword>
     <keyword>french</keyword>

--- a/net.krafting.PedantiK.Lang.French.yml
+++ b/net.krafting.PedantiK.Lang.French.yml
@@ -27,6 +27,6 @@ modules:
     sources:
       - type: git
         url: https://gitlab.com/Krafting/language-vectors-models
-        branch: french
+        tag: 1.0-french
         commit: c92c10a468fca52fb62a80f96e978b4567877323
 

--- a/net.krafting.PedantiK.Lang.French.yml
+++ b/net.krafting.PedantiK.Lang.French.yml
@@ -1,0 +1,32 @@
+app-id: net.krafting.PedantiK.Lang.French
+build-extension: true
+separate-locales: false
+runtime: net.krafting.PedantiK
+runtime-version: stable
+sdk: org.freedesktop.Sdk//25.08
+
+modules:
+  - name: French_Options_File
+    buildsystem: simple
+    build-commands:
+      - install -Dm 644 languages/Français/options.py /app/share/extra/Français/options.py
+      - install -Dm 644 net.krafting.PedantiK.Lang.French.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
+    sources:
+      - type: file
+        path: net.krafting.PedantiK.Lang.French.metainfo.xml
+      - type: git
+        url: https://gitlab.com/Krafting/pedantik
+        tag: '1.5.2'
+        commit: d20745604a911bf1ca07ab3170635e64a3441907
+
+  - name: French_Model_File
+    buildsystem: simple
+    build-commands:
+      - unzip frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.zip
+      - install -Dm 644 frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.bin /app/share/extra/Français/model.bin
+    sources:
+      - type: git
+        url: https://gitlab.com/Krafting/language-vectors-models
+        branch: french
+        commit: c92c10a468fca52fb62a80f96e978b4567877323
+

--- a/net.krafting.PedantiK.Lang.French.yml
+++ b/net.krafting.PedantiK.Lang.French.yml
@@ -9,7 +9,7 @@ modules:
   - name: French_Options_File
     buildsystem: simple
     build-commands:
-      - install -Dm 644 languages/Français/options.py /app/share/extra/Français/options.py
+      - install -Dm 644 languages/Français/options.py /app/share/extra/French/options.py
       - install -Dm 644 net.krafting.PedantiK.Lang.French.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
     sources:
       - type: file
@@ -23,7 +23,7 @@ modules:
     buildsystem: simple
     build-commands:
       - unzip frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.zip
-      - install -Dm 644 frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.bin /app/share/extra/Français/model.bin
+      - install -Dm 644 frWac_non_lem_no_postag_no_phrase_200_cbow_cut100.bin /app/share/extra/French/model.bin
     sources:
       - type: git
         url: https://gitlab.com/Krafting/language-vectors-models


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

<!-- 💡 Please replace each `[ ]` with `[X]` when the step is complete 💡 -->

<!-- 💡 Please tick and write 'N/A' with a reason if a checklist item below is not applicable 💡 -->

- [x] Please describe the application briefly. < Please insert the description here >

Same as #9858 

This adds the French language pack for Pedantik (Not locales, but actual content for the application). While the app shipped with this language built-in, I found that making it an addon would allow user to uninstall it if they don't need it and want only another language. Saving space for the user.

The work to remove the baked-in language file from the main app has been done, I just need this to be published to create a new release.

- [x] Please attach a video showcasing the application on Linux using the Flatpak. < Please insert the video here >

https://github.com/user-attachments/assets/f57f0e7b-d896-4929-a1ab-e501ad7f4d5e

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author to the project. 

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
