### PR TITLE
Add io.github.tduarte.Scribe

### DIFF
--- a/io.github.tduarte.Scribe.yaml
+++ b/io.github.tduarte.Scribe.yaml
@@ -1,0 +1,74 @@
+# Flathub submission manifest. This file and the module files beside it are
+# what goes to the flathub/flathub PR -- the filename has to match the app id
+# exactly or flatpak-builder-lint fails with appid-filename-mismatch, which is
+# why the development manifest is the oddly-named one (scribe-dev.yaml).
+#
+# It differs from scribe-dev.yaml ONLY below the shared modules: the source is
+# a pinned git commit rather than the working tree, and the portal spikes are
+# not shipped. finish-args and cleanup are identical in both.
+#
+# Test it the way Flathub builds it -- fetch first, then build with the network
+# off, so anything not declared as a source fails loudly:
+#
+#   flatpak-builder --download-only --state-dir=.fb-offline  x build-aux/io.github.tduarte.Scribe.yaml
+#   flatpak-builder --sandbox --disable-download --state-dir=.fb-offline --force-clean \
+#       build-dir build-aux/io.github.tduarte.Scribe.yaml
+app-id: io.github.tduarte.Scribe
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: scribe
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  # GPU: Vulkan compute for whisper.cpp, and GTK4 rendering.
+  - --device=dri
+  # Microphone. Flatpak has no capture-only audio permission and no microphone
+  # portal exists, so this is the only available mechanism.
+  - --socket=pulseaudio
+  - --filesystem=xdg-run/pipewire-0:ro
+  # Downloading speech models on first run.
+  - --share=network
+  #
+  # Deliberately absent:
+  #   --device=all      would be needed for ydotool/uinput; rejected by
+  #                     flatpak-builder-lint and unnecessary given the
+  #                     RemoteDesktop portal.
+  #   --filesystem=*    models live in the app's own data directory.
+  #   --talk-name=...   every portal is reachable from any sandbox by default.
+
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/man
+  - '*.a'
+  - '*.la'
+  # Console scripts from numpy, requests, tqdm and pywhispercpp's own demo
+  # entry points. Only /app/bin/scribe belongs on a user's PATH.
+  - /bin/f2py
+  - /bin/idna
+  - /bin/normalizer
+  - /bin/numpy-config
+  - /bin/tqdm
+  - /bin/pwcpp
+  - /bin/pwcpp-*
+
+modules:
+  - spirv-headers.yaml
+  # numpy, requests, tqdm, platformdirs -- pywhispercpp's install_requires.
+  - python3-deps.yaml
+  - pywhispercpp.yaml
+  - silero-vad-model.yaml
+
+  - name: scribe
+    buildsystem: meson
+    config-opts:
+      - -Dbuildtype=release
+    sources:
+      - type: git
+        url: https://github.com/tduarte/Scribe.git
+        tag: v0.1.2
+        commit: 48d64bf1bfd549240e00e6d2ee4f95d57815a6da

--- a/python3-deps.yaml
+++ b/python3-deps.yaml
@@ -1,0 +1,60 @@
+# Generated with flatpak-pip-generator --runtime=org.gnome.Sdk//50 --yaml --prefer-wheels numpy --output python3-deps numpy requests tqdm platformdirs
+name: python3-deps
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-numpy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "numpy" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+        sha256: 29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee
+        only-arches:
+          - x86_64
+      - type: file
+        url: https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl
+        sha256: 0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3
+        only-arches:
+          - aarch64
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+        sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+      - type: file
+        url: https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl
+        sha256: 6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6
+      - type: file
+        url: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
+        sha256: 815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
+      - type: file
+        url: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+        sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+      - type: file
+        url: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+        sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+  - name: python3-tqdm
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "tqdm" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+        sha256: 7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+  - name: python3-platformdirs
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "platformdirs" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl
+        sha256: 89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b

--- a/pywhispercpp.yaml
+++ b/pywhispercpp.yaml
@@ -1,0 +1,61 @@
+# pywhispercpp bundles the complete whisper.cpp and pybind11 trees, so this
+# builds with no network access.
+#
+# Its setup.py turns EVERY environment variable into a -D CMake define
+# (setup.py:159), which is the documented way GGML_VULKAN is passed, and it
+# also honours CMAKE_ARGS (setup.py:91). Hence:
+#   PYWHISPERCPP_VERSION      version.txt is absent from the sdist
+#   CMAKE_POLICY_VERSION_MINIMUM  its CMakeLists declares 3.4...3.18, which
+#                             the SDK's CMake 4.x refuses
+#   GGML_NATIVE=OFF           defaults ON and would bake in -march=native
+#   CMAKE_INSTALL_RPATH       libwhisper/libggml land beside the extension
+#                             module, and the RPATH is only set automatically
+#                             for editable installs
+name: pywhispercpp
+buildsystem: simple
+build-commands:
+  # The sdist declares [tool.setuptools_scm], so its version comes from git
+  # metadata that a release tarball does not carry -- it builds as 0.0.0 and
+  # pip then rejects it as inconsistent. setup() has no version= of its own,
+  # so drop the scm section and wire in the version function the package
+  # already ships.
+  - sed -i '/^\[tool\.setuptools_scm\]/,$d' pyproject.toml
+  - sed -i 's/^    name="pywhispercpp",/    name="pywhispercpp",\n    version=get_version(),/' setup.py
+  - |
+    set -eu
+    # setup.py turns every environment variable into a -D CMake define
+    # (setup.py:159); that is the documented route for GGML_VULKAN.
+    export PYWHISPERCPP_VERSION=1.5.1
+    export CMAKE_POLICY_VERSION_MINIMUM=3.5   # its CMakeLists declares 3.4...3.18
+    export CMAKE_GENERATOR=Ninja
+    export GGML_VULKAN=1
+    export GGML_NATIVE=OFF                    # defaults ON; would bake in -march=native
+    # AVX2/FMA/F16C are baked in deliberately. There is no runtime CPU dispatch
+    # in this build, so these emit vfmadd/ymm unconditionally and the CPU
+    # fallback SIGILLs on x86_64 without AVX2 -- pre-2013 hardware, which we
+    # have chosen not to support. Building without them is correct everywhere
+    # but far slower, and not only on the CPU path: whisper runs part of the
+    # graph on the CPU backend even when Vulkan is active, so on an 11.5 s clip
+    # dropping these cost 0.21 s -> 4.56 s on the GPU and 18.7 s -> 237 s on the
+    # CPU. They gate GPU performance too, which is not obvious.
+    # The clean fix is GGML_CPU_ALL_VARIANTS + GGML_BACKEND_DL, which builds one
+    # backend per instruction-set tier and picks at load time.
+    export GGML_AVX=ON
+    export GGML_AVX2=ON
+    export GGML_F16C=ON
+    export GGML_FMA=ON
+    # libwhisper/libggml land beside the extension module, and the RPATH is
+    # only set automatically for editable installs.
+    export CMAKE_ARGS="-DCMAKE_INSTALL_RPATH=\$ORIGIN -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+    pip3 install --no-index --no-build-isolation --no-deps \
+        --prefix="${FLATPAK_DEST}" --verbose .
+  # Belt and braces, in case the RPATH above did not take.
+  - |
+    set -eu
+    site="$(find "${FLATPAK_DEST}/lib" -maxdepth 2 -type d -name site-packages | head -n1)"
+    find "${site}" -maxdepth 2 \( -name 'libggml*.so*' -o -name 'libwhisper*.so*' \) \
+      -exec ln -sfn {} "${FLATPAK_DEST}/lib/" \;
+sources:
+  - type: archive
+    url: https://files.pythonhosted.org/packages/9f/35/610787a277e177e6b7983277a35a2969c0876b46c0d889bc6a0c4b4ac4a7/pywhispercpp-1.5.1.tar.gz
+    sha256: 5df897e5dd9d9f16804fc937bd85b9f5880a0b29a55f8843585e0e03d76195e5

--- a/silero-vad-model.yaml
+++ b/silero-vad-model.yaml
@@ -1,0 +1,13 @@
+# Silero VAD is only 885 KB, so it ships with the app: silence trimming works
+# before any speech model has been downloaded, and it is what stops large-v3
+# inventing words during pauses.
+name: silero-vad-model
+buildsystem: simple
+build-commands:
+  - install -Dm644 ggml-silero-v6.2.0.bin
+      /app/share/scribe/models/ggml-silero-v6.2.0.bin
+sources:
+  - type: file
+    url: https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v6.2.0.bin
+    sha256: 2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987
+    dest-filename: ggml-silero-v6.2.0.bin

--- a/spirv-headers.yaml
+++ b/spirv-headers.yaml
@@ -1,0 +1,13 @@
+# ggml-vulkan does find_package(SPIRV-Headers CONFIG REQUIRED) and the GNOME
+# SDK does not ship it. Headers only -- nothing is needed at runtime.
+name: spirv-headers
+buildsystem: cmake-ninja
+config-opts:
+  - -DCMAKE_BUILD_TYPE=Release
+  - -DSPIRV_HEADERS_SKIP_EXAMPLES=ON
+cleanup:
+  - '*'
+sources:
+  - type: archive
+    url: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-1.4.335.0.tar.gz
+    sha256: 1c47ca6342ebe86f57b46b8dbeb266fa655a1ca8e10d07e45370ff2d9c36312e


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. **Scribe is a dictation app for GNOME. You hold a global shortcut, speak, and release; the audio is transcribed locally with whisper.cpp and inserted into the focused application. It uses the GlobalShortcuts, RemoteDesktop and Clipboard portals, and works offline once a model has been downloaded.**
- [x] Please attach a video showcasing the application on Linux using the Flatpak.


https://github.com/user-attachments/assets/772ae694-661a-485f-9ade-7539f424123a


- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. **The app is hosted at https://github.com/tduarte/Scribe and I am the `tduarte` GitHub account.**
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer to the project.

Built and tested locally against `org.gnome.Platform//50`; `flatpak-builder-lint manifest` and `flatpak-builder-lint repo` are both clean. Upstream CI builds this same manifest on every push.

I have only been able to test on x86_64. If the aarch64 build fails I will add a `flathub.json` restricting arches.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
