### PR TITLE
Add tools.lolly.Desktop

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -1,0 +1,8757 @@
+[
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/adler2/adler2-2.0.1.crate",
+        "sha256": "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
+        "dest": "cargo/vendor/adler2-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa\", \"files\": {}}",
+        "dest": "cargo/vendor/adler2-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aead/aead-0.5.2.crate",
+        "sha256": "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0",
+        "dest": "cargo/vendor/aead-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0\", \"files\": {}}",
+        "dest": "cargo/vendor/aead-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aes/aes-0.8.4.crate",
+        "sha256": "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0",
+        "dest": "cargo/vendor/aes-0.8.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0\", \"files\": {}}",
+        "dest": "cargo/vendor/aes-0.8.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aes-gcm/aes-gcm-0.10.3.crate",
+        "sha256": "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1",
+        "dest": "cargo/vendor/aes-gcm-0.10.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1\", \"files\": {}}",
+        "dest": "cargo/vendor/aes-gcm-0.10.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ahash/ahash-0.8.12.crate",
+        "sha256": "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75",
+        "dest": "cargo/vendor/ahash-0.8.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75\", \"files\": {}}",
+        "dest": "cargo/vendor/ahash-0.8.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-1.1.4.crate",
+        "sha256": "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301",
+        "dest": "cargo/vendor/aho-corasick-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301\", \"files\": {}}",
+        "dest": "cargo/vendor/aho-corasick-1.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-no-stdlib/alloc-no-stdlib-2.0.4.crate",
+        "sha256": "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-no-stdlib-2.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/alloc-stdlib/alloc-stdlib-0.2.2.crate",
+        "sha256": "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece\", \"files\": {}}",
+        "dest": "cargo/vendor/alloc-stdlib-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
+        "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
+        "dest": "cargo/vendor/android_system_properties-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311\", \"files\": {}}",
+        "dest": "cargo/vendor/android_system_properties-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/anyhow/anyhow-1.0.102.crate",
+        "sha256": "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c",
+        "dest": "cargo/vendor/anyhow-1.0.102"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c\", \"files\": {}}",
+        "dest": "cargo/vendor/anyhow-1.0.102",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/arboard/arboard-3.6.1.crate",
+        "sha256": "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf",
+        "dest": "cargo/vendor/arboard-3.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf\", \"files\": {}}",
+        "dest": "cargo/vendor/arboard-3.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ashpd/ashpd-0.13.13.crate",
+        "sha256": "fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111",
+        "dest": "cargo/vendor/ashpd-0.13.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb8421aaa9644a5faf26735f258b669b15f063313ef8f8e2bdb28912a1a6f111\", \"files\": {}}",
+        "dest": "cargo/vendor/ashpd-0.13.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-broadcast/async-broadcast-0.7.2.crate",
+        "sha256": "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532",
+        "dest": "cargo/vendor/async-broadcast-0.7.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532\", \"files\": {}}",
+        "dest": "cargo/vendor/async-broadcast-0.7.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-channel/async-channel-2.5.0.crate",
+        "sha256": "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2",
+        "dest": "cargo/vendor/async-channel-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2\", \"files\": {}}",
+        "dest": "cargo/vendor/async-channel-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-executor/async-executor-1.14.0.crate",
+        "sha256": "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a",
+        "dest": "cargo/vendor/async-executor-1.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a\", \"files\": {}}",
+        "dest": "cargo/vendor/async-executor-1.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-io/async-io-2.6.0.crate",
+        "sha256": "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc",
+        "dest": "cargo/vendor/async-io-2.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc\", \"files\": {}}",
+        "dest": "cargo/vendor/async-io-2.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-lock/async-lock-3.4.2.crate",
+        "sha256": "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311",
+        "dest": "cargo/vendor/async-lock-3.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311\", \"files\": {}}",
+        "dest": "cargo/vendor/async-lock-3.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-process/async-process-2.5.0.crate",
+        "sha256": "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75",
+        "dest": "cargo/vendor/async-process-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75\", \"files\": {}}",
+        "dest": "cargo/vendor/async-process-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-recursion/async-recursion-1.1.1.crate",
+        "sha256": "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11",
+        "dest": "cargo/vendor/async-recursion-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11\", \"files\": {}}",
+        "dest": "cargo/vendor/async-recursion-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-signal/async-signal-0.2.14.crate",
+        "sha256": "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485",
+        "dest": "cargo/vendor/async-signal-0.2.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485\", \"files\": {}}",
+        "dest": "cargo/vendor/async-signal-0.2.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-task/async-task-4.7.1.crate",
+        "sha256": "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de",
+        "dest": "cargo/vendor/async-task-4.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de\", \"files\": {}}",
+        "dest": "cargo/vendor/async-task-4.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.92.crate",
+        "sha256": "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667",
+        "dest": "cargo/vendor/async-trait-0.1.92"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667\", \"files\": {}}",
+        "dest": "cargo/vendor/async-trait-0.1.92",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atk/atk-0.18.2.crate",
+        "sha256": "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b",
+        "dest": "cargo/vendor/atk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b\", \"files\": {}}",
+        "dest": "cargo/vendor/atk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atk-sys/atk-sys-0.18.2.crate",
+        "sha256": "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086",
+        "dest": "cargo/vendor/atk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086\", \"files\": {}}",
+        "dest": "cargo/vendor/atk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/atomic-waker/atomic-waker-1.1.2.crate",
+        "sha256": "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0",
+        "dest": "cargo/vendor/atomic-waker-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0\", \"files\": {}}",
+        "dest": "cargo/vendor/atomic-waker-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/auto_generate_cdp/auto_generate_cdp-0.4.6.crate",
+        "sha256": "359220d0b9360b79d17d648d0a3ba1e792ec36bdbc227c8fd0351df3a0415704",
+        "dest": "cargo/vendor/auto_generate_cdp-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"359220d0b9360b79d17d648d0a3ba1e792ec36bdbc227c8fd0351df3a0415704\", \"files\": {}}",
+        "dest": "cargo/vendor/auto_generate_cdp-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.5.1.crate",
+        "sha256": "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53",
+        "dest": "cargo/vendor/autocfg-1.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.13.1.crate",
+        "sha256": "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8",
+        "dest": "cargo/vendor/base64-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.21.7.crate",
+        "sha256": "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567",
+        "dest": "cargo/vendor/base64-0.21.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.21.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.22.1.crate",
+        "sha256": "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6",
+        "dest": "cargo/vendor/base64-0.22.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64ct/base64ct-1.8.3.crate",
+        "sha256": "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06",
+        "dest": "cargo/vendor/base64ct-1.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06\", \"files\": {}}",
+        "dest": "cargo/vendor/base64ct-1.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-set/bit-set-0.8.0.crate",
+        "sha256": "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3",
+        "dest": "cargo/vendor/bit-set-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-set-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bit-vec/bit-vec-0.8.0.crate",
+        "sha256": "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7",
+        "dest": "cargo/vendor/bit-vec-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7\", \"files\": {}}",
+        "dest": "cargo/vendor/bit-vec-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+        "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "dest": "cargo/vendor/bitflags-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-2.13.0.crate",
+        "sha256": "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8",
+        "dest": "cargo/vendor/bitflags-2.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-2.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blake2/blake2-0.10.6.crate",
+        "sha256": "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe",
+        "dest": "cargo/vendor/blake2-0.10.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe\", \"files\": {}}",
+        "dest": "cargo/vendor/blake2-0.10.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.10.4.crate",
+        "sha256": "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71",
+        "dest": "cargo/vendor/block-buffer-0.10.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71\", \"files\": {}}",
+        "dest": "cargo/vendor/block-buffer-0.10.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/block2/block2-0.6.2.crate",
+        "sha256": "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5",
+        "dest": "cargo/vendor/block2-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5\", \"files\": {}}",
+        "dest": "cargo/vendor/block2-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/blocking/blocking-1.7.0.crate",
+        "sha256": "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa",
+        "dest": "cargo/vendor/blocking-1.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa\", \"files\": {}}",
+        "dest": "cargo/vendor/blocking-1.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/brotli/brotli-8.0.3.crate",
+        "sha256": "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610",
+        "dest": "cargo/vendor/brotli-8.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-8.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/brotli-decompressor/brotli-decompressor-5.0.1.crate",
+        "sha256": "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924\", \"files\": {}}",
+        "dest": "cargo/vendor/brotli-decompressor-5.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bs58/bs58-0.5.1.crate",
+        "sha256": "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4",
+        "dest": "cargo/vendor/bs58-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4\", \"files\": {}}",
+        "dest": "cargo/vendor/bs58-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.20.3.crate",
+        "sha256": "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649",
+        "dest": "cargo/vendor/bumpalo-3.20.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649\", \"files\": {}}",
+        "dest": "cargo/vendor/bumpalo-3.20.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.25.0.crate",
+        "sha256": "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec",
+        "dest": "cargo/vendor/bytemuck-1.25.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec\", \"files\": {}}",
+        "dest": "cargo/vendor/bytemuck-1.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder/byteorder-1.5.0.crate",
+        "sha256": "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b",
+        "dest": "cargo/vendor/byteorder-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/byteorder-lite/byteorder-lite-0.1.0.crate",
+        "sha256": "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495\", \"files\": {}}",
+        "dest": "cargo/vendor/byteorder-lite-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bytes/bytes-1.11.1.crate",
+        "sha256": "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33",
+        "dest": "cargo/vendor/bytes-1.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33\", \"files\": {}}",
+        "dest": "cargo/vendor/bytes-1.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.18.5.crate",
+        "sha256": "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2",
+        "dest": "cargo/vendor/cairo-rs-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-rs-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cairo-sys-rs/cairo-sys-rs-0.18.2.crate",
+        "sha256": "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51",
+        "dest": "cargo/vendor/cairo-sys-rs-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51\", \"files\": {}}",
+        "dest": "cargo/vendor/cairo-sys-rs-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/camino/camino-1.2.2.crate",
+        "sha256": "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48",
+        "dest": "cargo/vendor/camino-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48\", \"files\": {}}",
+        "dest": "cargo/vendor/camino-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo-platform/cargo-platform-0.1.9.crate",
+        "sha256": "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea",
+        "dest": "cargo/vendor/cargo-platform-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo-platform-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo_metadata/cargo_metadata-0.19.2.crate",
+        "sha256": "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba",
+        "dest": "cargo/vendor/cargo_metadata-0.19.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo_metadata-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cargo_toml/cargo_toml-0.22.3.crate",
+        "sha256": "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77",
+        "dest": "cargo/vendor/cargo_toml-0.22.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77\", \"files\": {}}",
+        "dest": "cargo/vendor/cargo_toml-0.22.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/castaway/castaway-0.2.4.crate",
+        "sha256": "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a",
+        "dest": "cargo/vendor/castaway-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a\", \"files\": {}}",
+        "dest": "cargo/vendor/castaway-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cc/cc-1.2.63.crate",
+        "sha256": "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f",
+        "dest": "cargo/vendor/cc-1.2.63"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f\", \"files\": {}}",
+        "dest": "cargo/vendor/cc-1.2.63",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cesu8/cesu8-1.1.0.crate",
+        "sha256": "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c",
+        "dest": "cargo/vendor/cesu8-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c\", \"files\": {}}",
+        "dest": "cargo/vendor/cesu8-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfb/cfb-0.7.3.crate",
+        "sha256": "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f",
+        "dest": "cargo/vendor/cfb-0.7.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f\", \"files\": {}}",
+        "dest": "cargo/vendor/cfb-0.7.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-expr/cfg-expr-0.15.8.crate",
+        "sha256": "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02",
+        "dest": "cargo/vendor/cfg-expr-0.15.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-expr-0.15.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.4.crate",
+        "sha256": "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801",
+        "dest": "cargo/vendor/cfg-if-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.2.1.crate",
+        "sha256": "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724",
+        "dest": "cargo/vendor/cfg_aliases-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg_aliases-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chacha20/chacha20-0.9.1.crate",
+        "sha256": "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818",
+        "dest": "cargo/vendor/chacha20-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818\", \"files\": {}}",
+        "dest": "cargo/vendor/chacha20-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chacha20/chacha20-0.10.0.crate",
+        "sha256": "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601",
+        "dest": "cargo/vendor/chacha20-0.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601\", \"files\": {}}",
+        "dest": "cargo/vendor/chacha20-0.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chacha20poly1305/chacha20poly1305-0.10.1.crate",
+        "sha256": "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35",
+        "dest": "cargo/vendor/chacha20poly1305-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35\", \"files\": {}}",
+        "dest": "cargo/vendor/chacha20poly1305-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.45.crate",
+        "sha256": "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327",
+        "dest": "cargo/vendor/chrono-0.4.45"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.45",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cipher/cipher-0.4.4.crate",
+        "sha256": "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad",
+        "dest": "cargo/vendor/cipher-0.4.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad\", \"files\": {}}",
+        "dest": "cargo/vendor/cipher-0.4.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/clipboard-win/clipboard-win-5.4.1.crate",
+        "sha256": "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4",
+        "dest": "cargo/vendor/clipboard-win-5.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4\", \"files\": {}}",
+        "dest": "cargo/vendor/clipboard-win-5.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/combine/combine-4.6.7.crate",
+        "sha256": "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd",
+        "dest": "cargo/vendor/combine-4.6.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd\", \"files\": {}}",
+        "dest": "cargo/vendor/combine-4.6.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/compact_str/compact_str-0.9.1.crate",
+        "sha256": "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab",
+        "dest": "cargo/vendor/compact_str-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab\", \"files\": {}}",
+        "dest": "cargo/vendor/compact_str-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/concurrent-queue/concurrent-queue-2.5.0.crate",
+        "sha256": "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973\", \"files\": {}}",
+        "dest": "cargo/vendor/concurrent-queue-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/convert_case/convert_case-0.8.0.crate",
+        "sha256": "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f",
+        "dest": "cargo/vendor/convert_case-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f\", \"files\": {}}",
+        "dest": "cargo/vendor/convert_case-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cookie/cookie-0.18.1.crate",
+        "sha256": "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747",
+        "dest": "cargo/vendor/cookie-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747\", \"files\": {}}",
+        "dest": "cargo/vendor/cookie-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cookie_store/cookie_store-0.22.1.crate",
+        "sha256": "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206",
+        "dest": "cargo/vendor/cookie_store-0.22.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206\", \"files\": {}}",
+        "dest": "cargo/vendor/cookie_store-0.22.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.4.crate",
+        "sha256": "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f",
+        "dest": "cargo/vendor/core-foundation-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.10.1.crate",
+        "sha256": "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6",
+        "dest": "cargo/vendor/core-foundation-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.7.crate",
+        "sha256": "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b\", \"files\": {}}",
+        "dest": "cargo/vendor/core-foundation-sys-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.25.0.crate",
+        "sha256": "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97",
+        "dest": "cargo/vendor/core-graphics-0.25.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-0.25.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.2.0.crate",
+        "sha256": "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb\", \"files\": {}}",
+        "dest": "cargo/vendor/core-graphics-types-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.17.crate",
+        "sha256": "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280",
+        "dest": "cargo/vendor/cpufeatures-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.3.0.crate",
+        "sha256": "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201",
+        "dest": "cargo/vendor/cpufeatures-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201\", \"files\": {}}",
+        "dest": "cargo/vendor/cpufeatures-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.5.0.crate",
+        "sha256": "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511",
+        "dest": "cargo/vendor/crc32fast-1.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511\", \"files\": {}}",
+        "dest": "cargo/vendor/crc32fast-1.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.15.crate",
+        "sha256": "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-channel-0.5.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.7.crate",
+        "sha256": "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-deque-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.20.crate",
+        "sha256": "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.21.crate",
+        "sha256": "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28\", \"files\": {}}",
+        "dest": "cargo/vendor/crossbeam-utils-0.8.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crunchy/crunchy-0.2.4.crate",
+        "sha256": "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5",
+        "dest": "cargo/vendor/crunchy-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5\", \"files\": {}}",
+        "dest": "cargo/vendor/crunchy-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.7.crate",
+        "sha256": "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a",
+        "dest": "cargo/vendor/crypto-common-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a\", \"files\": {}}",
+        "dest": "cargo/vendor/crypto-common-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cssparser/cssparser-0.36.0.crate",
+        "sha256": "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2",
+        "dest": "cargo/vendor/cssparser-0.36.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2\", \"files\": {}}",
+        "dest": "cargo/vendor/cssparser-0.36.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cssparser-macros/cssparser-macros-0.6.1.crate",
+        "sha256": "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331",
+        "dest": "cargo/vendor/cssparser-macros-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331\", \"files\": {}}",
+        "dest": "cargo/vendor/cssparser-macros-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctor/ctor-0.8.0.crate",
+        "sha256": "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98",
+        "dest": "cargo/vendor/ctor-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctor-proc-macro/ctor-proc-macro-0.0.7.crate",
+        "sha256": "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1",
+        "dest": "cargo/vendor/ctor-proc-macro-0.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1\", \"files\": {}}",
+        "dest": "cargo/vendor/ctor-proc-macro-0.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ctr/ctr-0.9.2.crate",
+        "sha256": "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835",
+        "dest": "cargo/vendor/ctr-0.9.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835\", \"files\": {}}",
+        "dest": "cargo/vendor/ctr-0.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/curve25519-dalek/curve25519-dalek-4.1.3.crate",
+        "sha256": "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be",
+        "dest": "cargo/vendor/curve25519-dalek-4.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be\", \"files\": {}}",
+        "dest": "cargo/vendor/curve25519-dalek-4.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/curve25519-dalek-derive/curve25519-dalek-derive-0.1.1.crate",
+        "sha256": "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3",
+        "dest": "cargo/vendor/curve25519-dalek-derive-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3\", \"files\": {}}",
+        "dest": "cargo/vendor/curve25519-dalek-derive-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling/darling-0.20.11.crate",
+        "sha256": "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee",
+        "dest": "cargo/vendor/darling-0.20.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee\", \"files\": {}}",
+        "dest": "cargo/vendor/darling-0.20.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling/darling-0.23.0.crate",
+        "sha256": "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d",
+        "dest": "cargo/vendor/darling-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d\", \"files\": {}}",
+        "dest": "cargo/vendor/darling-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_core/darling_core-0.20.11.crate",
+        "sha256": "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e",
+        "dest": "cargo/vendor/darling_core-0.20.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_core-0.20.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_core/darling_core-0.23.0.crate",
+        "sha256": "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0",
+        "dest": "cargo/vendor/darling_core-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_core-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.20.11.crate",
+        "sha256": "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead",
+        "dest": "cargo/vendor/darling_macro-0.20.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_macro-0.20.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.23.0.crate",
+        "sha256": "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d",
+        "dest": "cargo/vendor/darling_macro-0.23.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d\", \"files\": {}}",
+        "dest": "cargo/vendor/darling_macro-0.23.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dary_heap/dary_heap-0.3.9.crate",
+        "sha256": "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe",
+        "dest": "cargo/vendor/dary_heap-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe\", \"files\": {}}",
+        "dest": "cargo/vendor/dary_heap-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-encoding/data-encoding-2.11.0.crate",
+        "sha256": "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8",
+        "dest": "cargo/vendor/data-encoding-2.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8\", \"files\": {}}",
+        "dest": "cargo/vendor/data-encoding-2.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/data-url/data-url-0.3.2.crate",
+        "sha256": "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376",
+        "dest": "cargo/vendor/data-url-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376\", \"files\": {}}",
+        "dest": "cargo/vendor/data-url-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dbus/dbus-0.9.11.crate",
+        "sha256": "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73",
+        "dest": "cargo/vendor/dbus-0.9.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73\", \"files\": {}}",
+        "dest": "cargo/vendor/dbus-0.9.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/der/der-0.8.1.crate",
+        "sha256": "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d",
+        "dest": "cargo/vendor/der-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d\", \"files\": {}}",
+        "dest": "cargo/vendor/der-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/deranged/deranged-0.5.8.crate",
+        "sha256": "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c",
+        "dest": "cargo/vendor/deranged-0.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c\", \"files\": {}}",
+        "dest": "cargo/vendor/deranged-0.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_builder/derive_builder-0.20.2.crate",
+        "sha256": "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947",
+        "dest": "cargo/vendor/derive_builder-0.20.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder-0.20.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_builder_core/derive_builder_core-0.20.2.crate",
+        "sha256": "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8",
+        "dest": "cargo/vendor/derive_builder_core-0.20.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder_core-0.20.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_builder_macro/derive_builder_macro-0.20.2.crate",
+        "sha256": "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c",
+        "dest": "cargo/vendor/derive_builder_macro-0.20.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_builder_macro-0.20.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more/derive_more-2.1.1.crate",
+        "sha256": "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134",
+        "dest": "cargo/vendor/derive_more-2.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/derive_more-impl/derive_more-impl-2.1.1.crate",
+        "sha256": "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb",
+        "dest": "cargo/vendor/derive_more-impl-2.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb\", \"files\": {}}",
+        "dest": "cargo/vendor/derive_more-impl-2.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/digest/digest-0.10.7.crate",
+        "sha256": "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292",
+        "dest": "cargo/vendor/digest-0.10.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292\", \"files\": {}}",
+        "dest": "cargo/vendor/digest-0.10.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs/dirs-6.0.0.crate",
+        "sha256": "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e",
+        "dest": "cargo/vendor/dirs-6.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-6.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dirs-sys/dirs-sys-0.5.0.crate",
+        "sha256": "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab",
+        "dest": "cargo/vendor/dirs-sys-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab\", \"files\": {}}",
+        "dest": "cargo/vendor/dirs-sys-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dispatch2/dispatch2-0.3.1.crate",
+        "sha256": "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38",
+        "dest": "cargo/vendor/dispatch2-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38\", \"files\": {}}",
+        "dest": "cargo/vendor/dispatch2-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/displaydoc/displaydoc-0.2.6.crate",
+        "sha256": "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f",
+        "dest": "cargo/vendor/displaydoc-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f\", \"files\": {}}",
+        "dest": "cargo/vendor/displaydoc-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlopen2/dlopen2-0.8.2.crate",
+        "sha256": "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4",
+        "dest": "cargo/vendor/dlopen2-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dlopen2_derive/dlopen2_derive-0.4.3.crate",
+        "sha256": "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f\", \"files\": {}}",
+        "dest": "cargo/vendor/dlopen2_derive-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/document-features/document-features-0.2.12.crate",
+        "sha256": "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61",
+        "dest": "cargo/vendor/document-features-0.2.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61\", \"files\": {}}",
+        "dest": "cargo/vendor/document-features-0.2.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dom_query/dom_query-0.27.0.crate",
+        "sha256": "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89",
+        "dest": "cargo/vendor/dom_query-0.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89\", \"files\": {}}",
+        "dest": "cargo/vendor/dom_query-0.27.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dpi/dpi-0.1.2.crate",
+        "sha256": "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76",
+        "dest": "cargo/vendor/dpi-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76\", \"files\": {}}",
+        "dest": "cargo/vendor/dpi-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtoa/dtoa-1.0.11.crate",
+        "sha256": "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590",
+        "dest": "cargo/vendor/dtoa-1.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590\", \"files\": {}}",
+        "dest": "cargo/vendor/dtoa-1.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtoa-short/dtoa-short-0.3.5.crate",
+        "sha256": "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87",
+        "dest": "cargo/vendor/dtoa-short-0.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87\", \"files\": {}}",
+        "dest": "cargo/vendor/dtoa-short-0.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtor/dtor-0.3.0.crate",
+        "sha256": "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4",
+        "dest": "cargo/vendor/dtor-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4\", \"files\": {}}",
+        "dest": "cargo/vendor/dtor-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dtor-proc-macro/dtor-proc-macro-0.0.6.crate",
+        "sha256": "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5",
+        "dest": "cargo/vendor/dtor-proc-macro-0.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5\", \"files\": {}}",
+        "dest": "cargo/vendor/dtor-proc-macro-0.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dunce/dunce-1.0.5.crate",
+        "sha256": "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813",
+        "dest": "cargo/vendor/dunce-1.0.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813\", \"files\": {}}",
+        "dest": "cargo/vendor/dunce-1.0.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/dyn-clone/dyn-clone-1.0.20.crate",
+        "sha256": "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555",
+        "dest": "cargo/vendor/dyn-clone-1.0.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555\", \"files\": {}}",
+        "dest": "cargo/vendor/dyn-clone-1.0.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/either/either-1.17.0.crate",
+        "sha256": "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d",
+        "dest": "cargo/vendor/either-1.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d\", \"files\": {}}",
+        "dest": "cargo/vendor/either-1.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embed-resource/embed-resource-3.0.9.crate",
+        "sha256": "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb",
+        "dest": "cargo/vendor/embed-resource-3.0.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb\", \"files\": {}}",
+        "dest": "cargo/vendor/embed-resource-3.0.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/embed_plist/embed_plist-1.2.2.crate",
+        "sha256": "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7",
+        "dest": "cargo/vendor/embed_plist-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7\", \"files\": {}}",
+        "dest": "cargo/vendor/embed_plist-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.35.crate",
+        "sha256": "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3",
+        "dest": "cargo/vendor/encoding_rs-0.8.35"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3\", \"files\": {}}",
+        "dest": "cargo/vendor/encoding_rs-0.8.35",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/endi/endi-1.1.1.crate",
+        "sha256": "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099",
+        "dest": "cargo/vendor/endi-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099\", \"files\": {}}",
+        "dest": "cargo/vendor/endi-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumflags2/enumflags2-0.7.12.crate",
+        "sha256": "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef",
+        "dest": "cargo/vendor/enumflags2-0.7.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2-0.7.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/enumflags2_derive/enumflags2_derive-0.7.12.crate",
+        "sha256": "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827\", \"files\": {}}",
+        "dest": "cargo/vendor/enumflags2_derive-0.7.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/equivalent/equivalent-1.0.2.crate",
+        "sha256": "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f",
+        "dest": "cargo/vendor/equivalent-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f\", \"files\": {}}",
+        "dest": "cargo/vendor/equivalent-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/erased-serde/erased-serde-0.4.10.crate",
+        "sha256": "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec",
+        "dest": "cargo/vendor/erased-serde-0.4.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec\", \"files\": {}}",
+        "dest": "cargo/vendor/erased-serde-0.4.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/errno/errno-0.3.14.crate",
+        "sha256": "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb",
+        "dest": "cargo/vendor/errno-0.3.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb\", \"files\": {}}",
+        "dest": "cargo/vendor/errno-0.3.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/error-code/error-code-3.4.0.crate",
+        "sha256": "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7",
+        "dest": "cargo/vendor/error-code-3.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7\", \"files\": {}}",
+        "dest": "cargo/vendor/error-code-3.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/esaxx-rs/esaxx-rs-0.1.10.crate",
+        "sha256": "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6",
+        "dest": "cargo/vendor/esaxx-rs-0.1.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6\", \"files\": {}}",
+        "dest": "cargo/vendor/esaxx-rs-0.1.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener/event-listener-5.4.2.crate",
+        "sha256": "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2",
+        "dest": "cargo/vendor/event-listener-5.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-5.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/event-listener-strategy/event-listener-strategy-0.5.4.crate",
+        "sha256": "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93\", \"files\": {}}",
+        "dest": "cargo/vendor/event-listener-strategy-0.5.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fancy-regex/fancy-regex-0.14.0.crate",
+        "sha256": "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298",
+        "dest": "cargo/vendor/fancy-regex-0.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298\", \"files\": {}}",
+        "dest": "cargo/vendor/fancy-regex-0.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fastrand/fastrand-2.4.1.crate",
+        "sha256": "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6",
+        "dest": "cargo/vendor/fastrand-2.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6\", \"files\": {}}",
+        "dest": "cargo/vendor/fastrand-2.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fax/fax-0.2.7.crate",
+        "sha256": "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a",
+        "dest": "cargo/vendor/fax-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a\", \"files\": {}}",
+        "dest": "cargo/vendor/fax-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fdeflate/fdeflate-0.3.7.crate",
+        "sha256": "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c",
+        "dest": "cargo/vendor/fdeflate-0.3.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c\", \"files\": {}}",
+        "dest": "cargo/vendor/fdeflate-0.3.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fiat-crypto/fiat-crypto-0.2.9.crate",
+        "sha256": "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d",
+        "dest": "cargo/vendor/fiat-crypto-0.2.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d\", \"files\": {}}",
+        "dest": "cargo/vendor/fiat-crypto-0.2.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/field-offset/field-offset-0.3.6.crate",
+        "sha256": "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f",
+        "dest": "cargo/vendor/field-offset-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f\", \"files\": {}}",
+        "dest": "cargo/vendor/field-offset-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/filetime/filetime-0.2.29.crate",
+        "sha256": "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759",
+        "dest": "cargo/vendor/filetime-0.2.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759\", \"files\": {}}",
+        "dest": "cargo/vendor/filetime-0.2.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/find-msvc-tools/find-msvc-tools-0.1.9.crate",
+        "sha256": "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582",
+        "dest": "cargo/vendor/find-msvc-tools-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582\", \"files\": {}}",
+        "dest": "cargo/vendor/find-msvc-tools-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flate2/flate2-1.1.9.crate",
+        "sha256": "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c",
+        "dest": "cargo/vendor/flate2-1.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c\", \"files\": {}}",
+        "dest": "cargo/vendor/flate2-1.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/flume/flume-0.11.1.crate",
+        "sha256": "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095",
+        "dest": "cargo/vendor/flume-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095\", \"files\": {}}",
+        "dest": "cargo/vendor/flume-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
+        "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
+        "dest": "cargo/vendor/fnv-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
+        "dest": "cargo/vendor/fnv-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foldhash/foldhash-0.1.5.crate",
+        "sha256": "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2",
+        "dest": "cargo/vendor/foldhash-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2\", \"files\": {}}",
+        "dest": "cargo/vendor/foldhash-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foldhash/foldhash-0.2.0.crate",
+        "sha256": "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb",
+        "dest": "cargo/vendor/foldhash-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb\", \"files\": {}}",
+        "dest": "cargo/vendor/foldhash-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.3.2.crate",
+        "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
+        "dest": "cargo/vendor/foreign-types-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.5.0.crate",
+        "sha256": "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965",
+        "dest": "cargo/vendor/foreign-types-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-macros/foreign-types-macros-0.2.3.crate",
+        "sha256": "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-macros-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
+        "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.3.1.crate",
+        "sha256": "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b\", \"files\": {}}",
+        "dest": "cargo/vendor/foreign-types-shared-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.2.2.crate",
+        "sha256": "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf",
+        "dest": "cargo/vendor/form_urlencoded-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf\", \"files\": {}}",
+        "dest": "cargo/vendor/form_urlencoded-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/fsevent-sys/fsevent-sys-4.1.0.crate",
+        "sha256": "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2",
+        "dest": "cargo/vendor/fsevent-sys-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2\", \"files\": {}}",
+        "dest": "cargo/vendor/fsevent-sys-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.32.crate",
+        "sha256": "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d",
+        "dest": "cargo/vendor/futures-channel-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-channel-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.32.crate",
+        "sha256": "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d",
+        "dest": "cargo/vendor/futures-core-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-core-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.32.crate",
+        "sha256": "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d",
+        "dest": "cargo/vendor/futures-executor-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-executor-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.32.crate",
+        "sha256": "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718",
+        "dest": "cargo/vendor/futures-io-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-io-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-lite/futures-lite-2.6.1.crate",
+        "sha256": "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad",
+        "dest": "cargo/vendor/futures-lite-2.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-lite-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.32.crate",
+        "sha256": "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b",
+        "dest": "cargo/vendor/futures-macro-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-macro-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.32.crate",
+        "sha256": "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893",
+        "dest": "cargo/vendor/futures-sink-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-sink-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.32.crate",
+        "sha256": "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393",
+        "dest": "cargo/vendor/futures-task-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-task-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.32.crate",
+        "sha256": "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6",
+        "dest": "cargo/vendor/futures-util-0.3.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6\", \"files\": {}}",
+        "dest": "cargo/vendor/futures-util-0.3.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk/gdk-0.18.2.crate",
+        "sha256": "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691",
+        "dest": "cargo/vendor/gdk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-pixbuf/gdk-pixbuf-0.18.5.crate",
+        "sha256": "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec",
+        "dest": "cargo/vendor/gdk-pixbuf-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-pixbuf-sys/gdk-pixbuf-sys-0.18.0.crate",
+        "sha256": "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-pixbuf-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdk-sys/gdk-sys-0.18.2.crate",
+        "sha256": "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7",
+        "dest": "cargo/vendor/gdk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7\", \"files\": {}}",
+        "dest": "cargo/vendor/gdk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkwayland-sys/gdkwayland-sys-0.18.2.crate",
+        "sha256": "140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69",
+        "dest": "cargo/vendor/gdkwayland-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"140071d506d223f7572b9f09b5e155afbd77428cd5cc7af8f2694c41d98dfe69\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkwayland-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkx11/gdkx11-0.18.2.crate",
+        "sha256": "3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe",
+        "dest": "cargo/vendor/gdkx11-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3caa00e14351bebbc8183b3c36690327eb77c49abc2268dd4bd36b856db3fbfe\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkx11-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gdkx11-sys/gdkx11-sys-0.18.2.crate",
+        "sha256": "6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d",
+        "dest": "cargo/vendor/gdkx11-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e2e7445fe01ac26f11601db260dd8608fe172514eb63b3b5e261ea6b0f4428d\", \"files\": {}}",
+        "dest": "cargo/vendor/gdkx11-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/generic-array/generic-array-0.14.7.crate",
+        "sha256": "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a",
+        "dest": "cargo/vendor/generic-array-0.14.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a\", \"files\": {}}",
+        "dest": "cargo/vendor/generic-array-0.14.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gethostname/gethostname-1.1.0.crate",
+        "sha256": "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8",
+        "dest": "cargo/vendor/gethostname-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8\", \"files\": {}}",
+        "dest": "cargo/vendor/gethostname-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.17.crate",
+        "sha256": "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0",
+        "dest": "cargo/vendor/getrandom-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.3.4.crate",
+        "sha256": "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd",
+        "dest": "cargo/vendor/getrandom-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/getrandom/getrandom-0.4.2.crate",
+        "sha256": "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555",
+        "dest": "cargo/vendor/getrandom-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555\", \"files\": {}}",
+        "dest": "cargo/vendor/getrandom-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ghash/ghash-0.5.1.crate",
+        "sha256": "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1",
+        "dest": "cargo/vendor/ghash-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1\", \"files\": {}}",
+        "dest": "cargo/vendor/ghash-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gio/gio-0.18.4.crate",
+        "sha256": "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73",
+        "dest": "cargo/vendor/gio-0.18.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-0.18.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gio-sys/gio-sys-0.18.1.crate",
+        "sha256": "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2",
+        "dest": "cargo/vendor/gio-sys-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2\", \"files\": {}}",
+        "dest": "cargo/vendor/gio-sys-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib/glib-0.18.5.crate",
+        "sha256": "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5",
+        "dest": "cargo/vendor/glib-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-macros/glib-macros-0.18.5.crate",
+        "sha256": "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc",
+        "dest": "cargo/vendor/glib-macros-0.18.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-macros-0.18.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glib-sys/glib-sys-0.18.1.crate",
+        "sha256": "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898",
+        "dest": "cargo/vendor/glib-sys-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898\", \"files\": {}}",
+        "dest": "cargo/vendor/glib-sys-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/glob/glob-0.3.3.crate",
+        "sha256": "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280",
+        "dest": "cargo/vendor/glob-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280\", \"files\": {}}",
+        "dest": "cargo/vendor/glob-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gobject-sys/gobject-sys-0.18.0.crate",
+        "sha256": "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44",
+        "dest": "cargo/vendor/gobject-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44\", \"files\": {}}",
+        "dest": "cargo/vendor/gobject-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk/gtk-0.18.2.crate",
+        "sha256": "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a",
+        "dest": "cargo/vendor/gtk-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk-sys/gtk-sys-0.18.2.crate",
+        "sha256": "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414",
+        "dest": "cargo/vendor/gtk-sys-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk-sys-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/gtk3-macros/gtk3-macros-0.18.2.crate",
+        "sha256": "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d",
+        "dest": "cargo/vendor/gtk3-macros-0.18.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d\", \"files\": {}}",
+        "dest": "cargo/vendor/gtk3-macros-0.18.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/h2/h2-0.4.14.crate",
+        "sha256": "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733",
+        "dest": "cargo/vendor/h2-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733\", \"files\": {}}",
+        "dest": "cargo/vendor/h2-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/half/half-2.7.1.crate",
+        "sha256": "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b",
+        "dest": "cargo/vendor/half-2.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b\", \"files\": {}}",
+        "dest": "cargo/vendor/half-2.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate",
+        "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
+        "dest": "cargo/vendor/hashbrown-0.12.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.12.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.15.5.crate",
+        "sha256": "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1",
+        "dest": "cargo/vendor/hashbrown-0.15.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.15.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.17.1.crate",
+        "sha256": "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a",
+        "dest": "cargo/vendor/hashbrown-0.17.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a\", \"files\": {}}",
+        "dest": "cargo/vendor/hashbrown-0.17.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/headless_chrome/headless_chrome-1.0.22.crate",
+        "sha256": "5754ca220578ad74a5d5174c8ca2ff956fd3b94025f870844de1e910b47dfee5",
+        "dest": "cargo/vendor/headless_chrome-1.0.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5754ca220578ad74a5d5174c8ca2ff956fd3b94025f870844de1e910b47dfee5\", \"files\": {}}",
+        "dest": "cargo/vendor/headless_chrome-1.0.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.4.1.crate",
+        "sha256": "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8",
+        "dest": "cargo/vendor/heck-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/heck/heck-0.5.0.crate",
+        "sha256": "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea",
+        "dest": "cargo/vendor/heck-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea\", \"files\": {}}",
+        "dest": "cargo/vendor/heck-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.5.2.crate",
+        "sha256": "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c",
+        "dest": "cargo/vendor/hermit-abi-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c\", \"files\": {}}",
+        "dest": "cargo/vendor/hermit-abi-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
+        "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
+        "dest": "cargo/vendor/hex-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
+        "dest": "cargo/vendor/hex-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/html5ever/html5ever-0.38.0.crate",
+        "sha256": "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2",
+        "dest": "cargo/vendor/html5ever-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2\", \"files\": {}}",
+        "dest": "cargo/vendor/html5ever-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http/http-1.4.2.crate",
+        "sha256": "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425",
+        "dest": "cargo/vendor/http-1.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425\", \"files\": {}}",
+        "dest": "cargo/vendor/http-1.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http-body/http-body-1.0.1.crate",
+        "sha256": "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184",
+        "dest": "cargo/vendor/http-body-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184\", \"files\": {}}",
+        "dest": "cargo/vendor/http-body-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/http-body-util/http-body-util-0.1.3.crate",
+        "sha256": "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a",
+        "dest": "cargo/vendor/http-body-util-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a\", \"files\": {}}",
+        "dest": "cargo/vendor/http-body-util-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/httparse/httparse-1.10.1.crate",
+        "sha256": "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87",
+        "dest": "cargo/vendor/httparse-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87\", \"files\": {}}",
+        "dest": "cargo/vendor/httparse-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper/hyper-1.10.1.crate",
+        "sha256": "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498",
+        "dest": "cargo/vendor/hyper-1.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-1.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper-rustls/hyper-rustls-0.27.9.crate",
+        "sha256": "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f",
+        "dest": "cargo/vendor/hyper-rustls-0.27.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-rustls-0.27.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/hyper-util/hyper-util-0.1.20.crate",
+        "sha256": "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0",
+        "dest": "cargo/vendor/hyper-util-0.1.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0\", \"files\": {}}",
+        "dest": "cargo/vendor/hyper-util-0.1.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.65.crate",
+        "sha256": "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470",
+        "dest": "cargo/vendor/iana-time-zone-0.1.65"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-0.1.65",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/iana-time-zone-haiku/iana-time-zone-haiku-0.1.2.crate",
+        "sha256": "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
+        "dest": "cargo/vendor/iana-time-zone-haiku-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f\", \"files\": {}}",
+        "dest": "cargo/vendor/iana-time-zone-haiku-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ico/ico-0.5.0.crate",
+        "sha256": "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371",
+        "dest": "cargo/vendor/ico-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371\", \"files\": {}}",
+        "dest": "cargo/vendor/ico-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_collections/icu_collections-2.2.0.crate",
+        "sha256": "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c",
+        "dest": "cargo/vendor/icu_collections-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_collections-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_locale_core/icu_locale_core-2.2.0.crate",
+        "sha256": "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29",
+        "dest": "cargo/vendor/icu_locale_core-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_locale_core-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer/icu_normalizer-2.2.0.crate",
+        "sha256": "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4",
+        "dest": "cargo/vendor/icu_normalizer-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_normalizer-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_normalizer_data/icu_normalizer_data-2.2.0.crate",
+        "sha256": "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38",
+        "dest": "cargo/vendor/icu_normalizer_data-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_normalizer_data-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties/icu_properties-2.2.0.crate",
+        "sha256": "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de",
+        "dest": "cargo/vendor/icu_properties-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_properties_data/icu_properties_data-2.2.0.crate",
+        "sha256": "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14",
+        "dest": "cargo/vendor/icu_properties_data-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_properties_data-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/icu_provider/icu_provider-2.2.0.crate",
+        "sha256": "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421",
+        "dest": "cargo/vendor/icu_provider-2.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421\", \"files\": {}}",
+        "dest": "cargo/vendor/icu_provider-2.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/id-arena/id-arena-2.3.0.crate",
+        "sha256": "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954",
+        "dest": "cargo/vendor/id-arena-2.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954\", \"files\": {}}",
+        "dest": "cargo/vendor/id-arena-2.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
+        "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
+        "dest": "cargo/vendor/ident_case-1.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39\", \"files\": {}}",
+        "dest": "cargo/vendor/ident_case-1.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna/idna-1.1.0.crate",
+        "sha256": "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de",
+        "dest": "cargo/vendor/idna-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de\", \"files\": {}}",
+        "dest": "cargo/vendor/idna-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/idna_adapter/idna_adapter-1.2.2.crate",
+        "sha256": "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714",
+        "dest": "cargo/vendor/idna_adapter-1.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714\", \"files\": {}}",
+        "dest": "cargo/vendor/idna_adapter-1.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/if-addrs/if-addrs-0.13.4.crate",
+        "sha256": "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24",
+        "dest": "cargo/vendor/if-addrs-0.13.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24\", \"files\": {}}",
+        "dest": "cargo/vendor/if-addrs-0.13.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/image/image-0.25.10.crate",
+        "sha256": "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104",
+        "dest": "cargo/vendor/image-0.25.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104\", \"files\": {}}",
+        "dest": "cargo/vendor/image-0.25.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-1.9.3.crate",
+        "sha256": "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99",
+        "dest": "cargo/vendor/indexmap-1.9.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-1.9.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indexmap/indexmap-2.14.0.crate",
+        "sha256": "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9",
+        "dest": "cargo/vendor/indexmap-2.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9\", \"files\": {}}",
+        "dest": "cargo/vendor/indexmap-2.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/infer/infer-0.19.0.crate",
+        "sha256": "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7",
+        "dest": "cargo/vendor/infer-0.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7\", \"files\": {}}",
+        "dest": "cargo/vendor/infer-0.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inotify/inotify-0.11.5.crate",
+        "sha256": "4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592",
+        "dest": "cargo/vendor/inotify-0.11.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cc00ea907cab49550b7da656f80ebb97be1b997d931fbcd28d39734e17ce592\", \"files\": {}}",
+        "dest": "cargo/vendor/inotify-0.11.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inotify-sys/inotify-sys-0.1.8.crate",
+        "sha256": "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d",
+        "dest": "cargo/vendor/inotify-sys-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d\", \"files\": {}}",
+        "dest": "cargo/vendor/inotify-sys-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/inout/inout-0.1.4.crate",
+        "sha256": "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01",
+        "dest": "cargo/vendor/inout-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01\", \"files\": {}}",
+        "dest": "cargo/vendor/inout-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ipnet/ipnet-2.12.0.crate",
+        "sha256": "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2",
+        "dest": "cargo/vendor/ipnet-2.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2\", \"files\": {}}",
+        "dest": "cargo/vendor/ipnet-2.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-docker/is-docker-0.2.0.crate",
+        "sha256": "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3",
+        "dest": "cargo/vendor/is-docker-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3\", \"files\": {}}",
+        "dest": "cargo/vendor/is-docker-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/is-wsl/is-wsl-0.4.0.crate",
+        "sha256": "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5",
+        "dest": "cargo/vendor/is-wsl-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5\", \"files\": {}}",
+        "dest": "cargo/vendor/is-wsl-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itertools/itertools-0.14.0.crate",
+        "sha256": "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285",
+        "dest": "cargo/vendor/itertools-0.14.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285\", \"files\": {}}",
+        "dest": "cargo/vendor/itertools-0.14.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/itoa/itoa-1.0.18.crate",
+        "sha256": "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682",
+        "dest": "cargo/vendor/itoa-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682\", \"files\": {}}",
+        "dest": "cargo/vendor/itoa-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/javascriptcore-rs/javascriptcore-rs-1.1.2.crate",
+        "sha256": "ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc",
+        "dest": "cargo/vendor/javascriptcore-rs-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca5671e9ffce8ffba57afc24070e906da7fc4b1ba66f2cabebf61bf2ea257fcc\", \"files\": {}}",
+        "dest": "cargo/vendor/javascriptcore-rs-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/javascriptcore-rs-sys/javascriptcore-rs-sys-1.1.1.crate",
+        "sha256": "af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124",
+        "dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"af1be78d14ffa4b75b66df31840478fef72b51f8c2465d4ca7c194da9f7a5124\", \"files\": {}}",
+        "dest": "cargo/vendor/javascriptcore-rs-sys-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni/jni-0.21.1.crate",
+        "sha256": "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97",
+        "dest": "cargo/vendor/jni-0.21.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-0.21.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.1.crate",
+        "sha256": "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258",
+        "dest": "cargo/vendor/jni-sys-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.4.1.crate",
+        "sha256": "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2",
+        "dest": "cargo/vendor/jni-sys-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jni-sys-macros/jni-sys-macros-0.4.1.crate",
+        "sha256": "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264",
+        "dest": "cargo/vendor/jni-sys-macros-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264\", \"files\": {}}",
+        "dest": "cargo/vendor/jni-sys-macros-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.100.crate",
+        "sha256": "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162",
+        "dest": "cargo/vendor/js-sys-0.3.100"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162\", \"files\": {}}",
+        "dest": "cargo/vendor/js-sys-0.3.100",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/json-patch/json-patch-3.0.1.crate",
+        "sha256": "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08",
+        "dest": "cargo/vendor/json-patch-3.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08\", \"files\": {}}",
+        "dest": "cargo/vendor/json-patch-3.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/jsonptr/jsonptr-0.6.3.crate",
+        "sha256": "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70",
+        "dest": "cargo/vendor/jsonptr-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70\", \"files\": {}}",
+        "dest": "cargo/vendor/jsonptr-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/keyboard-types/keyboard-types-0.7.0.crate",
+        "sha256": "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a",
+        "dest": "cargo/vendor/keyboard-types-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a\", \"files\": {}}",
+        "dest": "cargo/vendor/keyboard-types-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kqueue/kqueue-1.2.1.crate",
+        "sha256": "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea",
+        "dest": "cargo/vendor/kqueue-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea\", \"files\": {}}",
+        "dest": "cargo/vendor/kqueue-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/kqueue-sys/kqueue-sys-1.1.2.crate",
+        "sha256": "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087",
+        "dest": "cargo/vendor/kqueue-sys-1.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087\", \"files\": {}}",
+        "dest": "cargo/vendor/kqueue-sys-1.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/leb128fmt/leb128fmt-0.1.0.crate",
+        "sha256": "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2",
+        "dest": "cargo/vendor/leb128fmt-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2\", \"files\": {}}",
+        "dest": "cargo/vendor/leb128fmt-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libappindicator/libappindicator-0.9.0.crate",
+        "sha256": "03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a",
+        "dest": "cargo/vendor/libappindicator-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03589b9607c868cc7ae54c0b2a22c8dc03dd41692d48f2d7df73615c6a95dc0a\", \"files\": {}}",
+        "dest": "cargo/vendor/libappindicator-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libappindicator-sys/libappindicator-sys-0.9.0.crate",
+        "sha256": "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf",
+        "dest": "cargo/vendor/libappindicator-sys-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf\", \"files\": {}}",
+        "dest": "cargo/vendor/libappindicator-sys-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.186.crate",
+        "sha256": "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66",
+        "dest": "cargo/vendor/libc-0.2.186"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.186",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libdbus-sys/libdbus-sys-0.2.7.crate",
+        "sha256": "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043",
+        "dest": "cargo/vendor/libdbus-sys-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043\", \"files\": {}}",
+        "dest": "cargo/vendor/libdbus-sys-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libloading/libloading-0.7.4.crate",
+        "sha256": "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f",
+        "dest": "cargo/vendor/libloading-0.7.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f\", \"files\": {}}",
+        "dest": "cargo/vendor/libloading-0.7.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libredox/libredox-0.1.17.crate",
+        "sha256": "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3",
+        "dest": "cargo/vendor/libredox-0.1.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3\", \"files\": {}}",
+        "dest": "cargo/vendor/libredox-0.1.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/linux-raw-sys/linux-raw-sys-0.12.1.crate",
+        "sha256": "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53",
+        "dest": "cargo/vendor/linux-raw-sys-0.12.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53\", \"files\": {}}",
+        "dest": "cargo/vendor/linux-raw-sys-0.12.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/litemap/litemap-0.8.2.crate",
+        "sha256": "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0",
+        "dest": "cargo/vendor/litemap-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0\", \"files\": {}}",
+        "dest": "cargo/vendor/litemap-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/litrs/litrs-1.0.0.crate",
+        "sha256": "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092",
+        "dest": "cargo/vendor/litrs-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092\", \"files\": {}}",
+        "dest": "cargo/vendor/litrs-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.14.crate",
+        "sha256": "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965",
+        "dest": "cargo/vendor/lock_api-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/log/log-0.4.32.crate",
+        "sha256": "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a",
+        "dest": "cargo/vendor/log-0.4.32"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a\", \"files\": {}}",
+        "dest": "cargo/vendor/log-0.4.32",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lru-slab/lru-slab-0.1.2.crate",
+        "sha256": "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154",
+        "dest": "cargo/vendor/lru-slab-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154\", \"files\": {}}",
+        "dest": "cargo/vendor/lru-slab-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/macro_rules_attribute/macro_rules_attribute-0.2.3.crate",
+        "sha256": "b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c",
+        "dest": "cargo/vendor/macro_rules_attribute-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b3ae8f6d608c795738406608304d30a2dfbdc8e58e44f7ba43236da5208ded3c\", \"files\": {}}",
+        "dest": "cargo/vendor/macro_rules_attribute-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/macro_rules_attribute-proc_macro/macro_rules_attribute-proc_macro-0.2.3.crate",
+        "sha256": "fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c",
+        "dest": "cargo/vendor/macro_rules_attribute-proc_macro-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc04a4c58212d57930a24bf47d3fa87485264a3a054e9c10e042eb373573ad3c\", \"files\": {}}",
+        "dest": "cargo/vendor/macro_rules_attribute-proc_macro-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/markup5ever/markup5ever-0.38.0.crate",
+        "sha256": "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862",
+        "dest": "cargo/vendor/markup5ever-0.38.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862\", \"files\": {}}",
+        "dest": "cargo/vendor/markup5ever-0.38.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/matrixmultiply/matrixmultiply-0.3.11.crate",
+        "sha256": "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7",
+        "dest": "cargo/vendor/matrixmultiply-0.3.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7\", \"files\": {}}",
+        "dest": "cargo/vendor/matrixmultiply-0.3.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mdns-sd/mdns-sd-0.11.5.crate",
+        "sha256": "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e",
+        "dest": "cargo/vendor/mdns-sd-0.11.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e\", \"files\": {}}",
+        "dest": "cargo/vendor/mdns-sd-0.11.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memchr/memchr-2.8.1.crate",
+        "sha256": "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8",
+        "dest": "cargo/vendor/memchr-2.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8\", \"files\": {}}",
+        "dest": "cargo/vendor/memchr-2.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/memoffset/memoffset-0.9.1.crate",
+        "sha256": "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a",
+        "dest": "cargo/vendor/memoffset-0.9.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
+        "dest": "cargo/vendor/memoffset-0.9.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mime/mime-0.3.17.crate",
+        "sha256": "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a",
+        "dest": "cargo/vendor/mime-0.3.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a\", \"files\": {}}",
+        "dest": "cargo/vendor/mime-0.3.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
+        "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
+        "dest": "cargo/vendor/minimal-lexical-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.8.9.crate",
+        "sha256": "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316",
+        "dest": "cargo/vendor/miniz_oxide-0.8.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316\", \"files\": {}}",
+        "dest": "cargo/vendor/miniz_oxide-0.8.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/mio/mio-1.2.1.crate",
+        "sha256": "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda",
+        "dest": "cargo/vendor/mio-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda\", \"files\": {}}",
+        "dest": "cargo/vendor/mio-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/monostate/monostate-0.1.18.crate",
+        "sha256": "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67",
+        "dest": "cargo/vendor/monostate-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67\", \"files\": {}}",
+        "dest": "cargo/vendor/monostate-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/monostate-impl/monostate-impl-0.1.18.crate",
+        "sha256": "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9",
+        "dest": "cargo/vendor/monostate-impl-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9\", \"files\": {}}",
+        "dest": "cargo/vendor/monostate-impl-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/moxcms/moxcms-0.8.1.crate",
+        "sha256": "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b",
+        "dest": "cargo/vendor/moxcms-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b\", \"files\": {}}",
+        "dest": "cargo/vendor/moxcms-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/muda/muda-0.19.2.crate",
+        "sha256": "47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c",
+        "dest": "cargo/vendor/muda-0.19.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"47a2e3dff89cd322c66647942668faee0a2b1f88ea6cbb4d374b4a8d7e92528c\", \"files\": {}}",
+        "dest": "cargo/vendor/muda-0.19.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/native-tls/native-tls-0.2.18.crate",
+        "sha256": "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2",
+        "dest": "cargo/vendor/native-tls-0.2.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2\", \"files\": {}}",
+        "dest": "cargo/vendor/native-tls-0.2.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndarray/ndarray-0.16.1.crate",
+        "sha256": "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841",
+        "dest": "cargo/vendor/ndarray-0.16.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841\", \"files\": {}}",
+        "dest": "cargo/vendor/ndarray-0.16.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk/ndk-0.9.0.crate",
+        "sha256": "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4",
+        "dest": "cargo/vendor/ndk-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.6.0+11769913.crate",
+        "sha256": "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873\", \"files\": {}}",
+        "dest": "cargo/vendor/ndk-sys-0.6.0+11769913",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/new_debug_unreachable/new_debug_unreachable-1.0.6.crate",
+        "sha256": "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086\", \"files\": {}}",
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/nom/nom-7.1.3.crate",
+        "sha256": "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a",
+        "dest": "cargo/vendor/nom-7.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a\", \"files\": {}}",
+        "dest": "cargo/vendor/nom-7.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/notify/notify-8.2.0.crate",
+        "sha256": "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3",
+        "dest": "cargo/vendor/notify-8.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3\", \"files\": {}}",
+        "dest": "cargo/vendor/notify-8.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/notify-types/notify-types-2.1.0.crate",
+        "sha256": "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a",
+        "dest": "cargo/vendor/notify-types-2.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a\", \"files\": {}}",
+        "dest": "cargo/vendor/notify-types-2.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-complex/num-complex-0.4.6.crate",
+        "sha256": "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495",
+        "dest": "cargo/vendor/num-complex-0.4.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495\", \"files\": {}}",
+        "dest": "cargo/vendor/num-complex-0.4.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-conv/num-conv-0.2.2.crate",
+        "sha256": "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441",
+        "dest": "cargo/vendor/num-conv-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441\", \"files\": {}}",
+        "dest": "cargo/vendor/num-conv-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.47.crate",
+        "sha256": "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b",
+        "dest": "cargo/vendor/num-integer-0.1.47"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.47",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.19.crate",
+        "sha256": "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841",
+        "dest": "cargo/vendor/num-traits-0.2.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum/num_enum-0.7.6.crate",
+        "sha256": "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26",
+        "dest": "cargo/vendor/num_enum-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.7.6.crate",
+        "sha256": "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8",
+        "dest": "cargo/vendor/num_enum_derive-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8\", \"files\": {}}",
+        "dest": "cargo/vendor/num_enum_derive-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2/objc2-0.6.4.crate",
+        "sha256": "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f",
+        "dest": "cargo/vendor/objc2-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-app-kit/objc2-app-kit-0.3.2.crate",
+        "sha256": "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c",
+        "dest": "cargo/vendor/objc2-app-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-app-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-cloud-kit/objc2-cloud-kit-0.3.2.crate",
+        "sha256": "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-cloud-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-data/objc2-core-data-0.3.2.crate",
+        "sha256": "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa",
+        "dest": "cargo/vendor/objc2-core-data-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-data-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-foundation/objc2-core-foundation-0.3.2.crate",
+        "sha256": "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536",
+        "dest": "cargo/vendor/objc2-core-foundation-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-foundation-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-graphics/objc2-core-graphics-0.3.2.crate",
+        "sha256": "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807",
+        "dest": "cargo/vendor/objc2-core-graphics-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-graphics-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-image/objc2-core-image-0.3.2.crate",
+        "sha256": "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006",
+        "dest": "cargo/vendor/objc2-core-image-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-image-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-location/objc2-core-location-0.3.2.crate",
+        "sha256": "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009",
+        "dest": "cargo/vendor/objc2-core-location-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-location-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-core-text/objc2-core-text-0.3.2.crate",
+        "sha256": "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d",
+        "dest": "cargo/vendor/objc2-core-text-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-core-text-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-encode/objc2-encode-4.1.0.crate",
+        "sha256": "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33",
+        "dest": "cargo/vendor/objc2-encode-4.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-encode-4.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-exception-helper/objc2-exception-helper-0.1.1.crate",
+        "sha256": "c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a",
+        "dest": "cargo/vendor/objc2-exception-helper-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c7a1c5fbb72d7735b076bb47b578523aedc40f3c439bea6dfd595c089d79d98a\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-exception-helper-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-foundation/objc2-foundation-0.3.2.crate",
+        "sha256": "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272",
+        "dest": "cargo/vendor/objc2-foundation-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-foundation-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-io-surface/objc2-io-surface-0.3.2.crate",
+        "sha256": "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d",
+        "dest": "cargo/vendor/objc2-io-surface-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-io-surface-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-quartz-core/objc2-quartz-core-0.3.2.crate",
+        "sha256": "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f",
+        "dest": "cargo/vendor/objc2-quartz-core-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-quartz-core-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-ui-kit/objc2-ui-kit-0.3.2.crate",
+        "sha256": "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22",
+        "dest": "cargo/vendor/objc2-ui-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-ui-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-user-notifications/objc2-user-notifications-0.3.2.crate",
+        "sha256": "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e",
+        "dest": "cargo/vendor/objc2-user-notifications-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-user-notifications-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/objc2-web-kit/objc2-web-kit-0.3.2.crate",
+        "sha256": "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f",
+        "dest": "cargo/vendor/objc2-web-kit-0.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f\", \"files\": {}}",
+        "dest": "cargo/vendor/objc2-web-kit-0.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.21.4.crate",
+        "sha256": "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50",
+        "dest": "cargo/vendor/once_cell-1.21.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.21.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/opaque-debug/opaque-debug-0.3.1.crate",
+        "sha256": "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381",
+        "dest": "cargo/vendor/opaque-debug-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381\", \"files\": {}}",
+        "dest": "cargo/vendor/opaque-debug-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/open/open-5.3.5.crate",
+        "sha256": "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c",
+        "dest": "cargo/vendor/open-5.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c\", \"files\": {}}",
+        "dest": "cargo/vendor/open-5.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl/openssl-0.10.81.crate",
+        "sha256": "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45",
+        "dest": "cargo/vendor/openssl-0.10.81"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-0.10.81",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-macros/openssl-macros-0.1.1.crate",
+        "sha256": "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c",
+        "dest": "cargo/vendor/openssl-macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.2.1.crate",
+        "sha256": "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe",
+        "dest": "cargo/vendor/openssl-probe-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-probe-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.117.crate",
+        "sha256": "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695",
+        "dest": "cargo/vendor/openssl-sys-0.9.117"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695\", \"files\": {}}",
+        "dest": "cargo/vendor/openssl-sys-0.9.117",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/option-ext/option-ext-0.2.0.crate",
+        "sha256": "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d",
+        "dest": "cargo/vendor/option-ext-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d\", \"files\": {}}",
+        "dest": "cargo/vendor/option-ext-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ordered-stream/ordered-stream-0.2.0.crate",
+        "sha256": "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50",
+        "dest": "cargo/vendor/ordered-stream-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50\", \"files\": {}}",
+        "dest": "cargo/vendor/ordered-stream-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ort/ort-2.0.0-rc.10.crate",
+        "sha256": "1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721",
+        "dest": "cargo/vendor/ort-2.0.0-rc.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1fa7e49bd669d32d7bc2a15ec540a527e7764aec722a45467814005725bcd721\", \"files\": {}}",
+        "dest": "cargo/vendor/ort-2.0.0-rc.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ort-sys/ort-sys-2.0.0-rc.10.crate",
+        "sha256": "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890",
+        "dest": "cargo/vendor/ort-sys-2.0.0-rc.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890\", \"files\": {}}",
+        "dest": "cargo/vendor/ort-sys-2.0.0-rc.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/os_pipe/os_pipe-1.2.3.crate",
+        "sha256": "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967",
+        "dest": "cargo/vendor/os_pipe-1.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967\", \"files\": {}}",
+        "dest": "cargo/vendor/os_pipe-1.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pango/pango-0.18.3.crate",
+        "sha256": "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4",
+        "dest": "cargo/vendor/pango-0.18.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-0.18.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pango-sys/pango-sys-0.18.0.crate",
+        "sha256": "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5",
+        "dest": "cargo/vendor/pango-sys-0.18.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5\", \"files\": {}}",
+        "dest": "cargo/vendor/pango-sys-0.18.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking/parking-2.2.1.crate",
+        "sha256": "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba",
+        "dest": "cargo/vendor/parking-2.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba\", \"files\": {}}",
+        "dest": "cargo/vendor/parking-2.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.5.crate",
+        "sha256": "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a",
+        "dest": "cargo/vendor/parking_lot-0.12.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.12.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.12.crate",
+        "sha256": "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.9.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste/paste-1.0.15.crate",
+        "sha256": "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a",
+        "dest": "cargo/vendor/paste-1.0.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-1.0.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pastey/pastey-0.2.3.crate",
+        "sha256": "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4",
+        "dest": "cargo/vendor/pastey-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4\", \"files\": {}}",
+        "dest": "cargo/vendor/pastey-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pathdiff/pathdiff-0.2.3.crate",
+        "sha256": "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3",
+        "dest": "cargo/vendor/pathdiff-0.2.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3\", \"files\": {}}",
+        "dest": "cargo/vendor/pathdiff-0.2.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem-rfc7468/pem-rfc7468-1.0.0.crate",
+        "sha256": "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-rfc7468-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.3.2.crate",
+        "sha256": "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220",
+        "dest": "cargo/vendor/percent-encoding-2.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220\", \"files\": {}}",
+        "dest": "cargo/vendor/percent-encoding-2.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf/phf-0.13.1.crate",
+        "sha256": "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf",
+        "dest": "cargo/vendor/phf-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf\", \"files\": {}}",
+        "dest": "cargo/vendor/phf-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.13.1.crate",
+        "sha256": "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1",
+        "dest": "cargo/vendor/phf_codegen-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_codegen-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.13.1.crate",
+        "sha256": "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737",
+        "dest": "cargo/vendor/phf_generator-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_generator-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_macros/phf_macros-0.13.1.crate",
+        "sha256": "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef",
+        "dest": "cargo/vendor/phf_macros-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_macros-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.13.1.crate",
+        "sha256": "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266",
+        "dest": "cargo/vendor/phf_shared-0.13.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266\", \"files\": {}}",
+        "dest": "cargo/vendor/phf_shared-0.13.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.17.crate",
+        "sha256": "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd\", \"files\": {}}",
+        "dest": "cargo/vendor/pin-project-lite-0.2.17",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/piper/piper-0.2.5.crate",
+        "sha256": "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1",
+        "dest": "cargo/vendor/piper-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1\", \"files\": {}}",
+        "dest": "cargo/vendor/piper-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.33.crate",
+        "sha256": "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e",
+        "dest": "cargo/vendor/pkg-config-0.3.33"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e\", \"files\": {}}",
+        "dest": "cargo/vendor/pkg-config-0.3.33",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/plist/plist-1.9.0.crate",
+        "sha256": "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1",
+        "dest": "cargo/vendor/plist-1.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1\", \"files\": {}}",
+        "dest": "cargo/vendor/plist-1.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.17.16.crate",
+        "sha256": "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526",
+        "dest": "cargo/vendor/png-0.17.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.17.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/png/png-0.18.1.crate",
+        "sha256": "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61",
+        "dest": "cargo/vendor/png-0.18.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61\", \"files\": {}}",
+        "dest": "cargo/vendor/png-0.18.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polling/polling-2.8.0.crate",
+        "sha256": "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce",
+        "dest": "cargo/vendor/polling-2.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-2.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polling/polling-3.11.0.crate",
+        "sha256": "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218",
+        "dest": "cargo/vendor/polling-3.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218\", \"files\": {}}",
+        "dest": "cargo/vendor/polling-3.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/poly1305/poly1305-0.8.0.crate",
+        "sha256": "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf",
+        "dest": "cargo/vendor/poly1305-0.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf\", \"files\": {}}",
+        "dest": "cargo/vendor/poly1305-0.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/polyval/polyval-0.6.2.crate",
+        "sha256": "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25",
+        "dest": "cargo/vendor/polyval-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25\", \"files\": {}}",
+        "dest": "cargo/vendor/polyval-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/portable-atomic/portable-atomic-1.15.0.crate",
+        "sha256": "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85",
+        "dest": "cargo/vendor/portable-atomic-1.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-1.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/portable-atomic-util/portable-atomic-util-0.2.7.crate",
+        "sha256": "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618",
+        "dest": "cargo/vendor/portable-atomic-util-0.2.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618\", \"files\": {}}",
+        "dest": "cargo/vendor/portable-atomic-util-0.2.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/potential_utf/potential_utf-0.1.5.crate",
+        "sha256": "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564",
+        "dest": "cargo/vendor/potential_utf-0.1.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564\", \"files\": {}}",
+        "dest": "cargo/vendor/potential_utf-0.1.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/powerfmt/powerfmt-0.2.0.crate",
+        "sha256": "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391",
+        "dest": "cargo/vendor/powerfmt-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391\", \"files\": {}}",
+        "dest": "cargo/vendor/powerfmt-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.21.crate",
+        "sha256": "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9",
+        "dest": "cargo/vendor/ppv-lite86-0.2.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9\", \"files\": {}}",
+        "dest": "cargo/vendor/ppv-lite86-0.2.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/precomputed-hash/precomputed-hash-0.1.1.crate",
+        "sha256": "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
+        "dest": "cargo/vendor/precomputed-hash-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c\", \"files\": {}}",
+        "dest": "cargo/vendor/precomputed-hash-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/prettyplease/prettyplease-0.2.37.crate",
+        "sha256": "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b",
+        "dest": "cargo/vendor/prettyplease-0.2.37"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b\", \"files\": {}}",
+        "dest": "cargo/vendor/prettyplease-0.2.37",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.3.1.crate",
+        "sha256": "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919",
+        "dest": "cargo/vendor/proc-macro-crate-1.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-1.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-2.0.2.crate",
+        "sha256": "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24",
+        "dest": "cargo/vendor/proc-macro-crate-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-3.5.0.crate",
+        "sha256": "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-crate-3.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
+        "sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate",
+        "sha256": "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.106.crate",
+        "sha256": "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934",
+        "dest": "cargo/vendor/proc-macro2-1.0.106"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.106",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/psl-types/psl-types-2.0.11.crate",
+        "sha256": "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac",
+        "dest": "cargo/vendor/psl-types-2.0.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac\", \"files\": {}}",
+        "dest": "cargo/vendor/psl-types-2.0.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/publicsuffix/publicsuffix-2.3.0.crate",
+        "sha256": "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf",
+        "dest": "cargo/vendor/publicsuffix-2.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf\", \"files\": {}}",
+        "dest": "cargo/vendor/publicsuffix-2.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pxfm/pxfm-0.1.30.crate",
+        "sha256": "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea",
+        "dest": "cargo/vendor/pxfm-0.1.30"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea\", \"files\": {}}",
+        "dest": "cargo/vendor/pxfm-0.1.30",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-error/quick-error-2.0.1.crate",
+        "sha256": "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3",
+        "dest": "cargo/vendor/quick-error-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-error-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.39.4.crate",
+        "sha256": "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e",
+        "dest": "cargo/vendor/quick-xml-0.39.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e\", \"files\": {}}",
+        "dest": "cargo/vendor/quick-xml-0.39.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn/quinn-0.11.9.crate",
+        "sha256": "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20",
+        "dest": "cargo/vendor/quinn-0.11.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-0.11.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn-proto/quinn-proto-0.11.14.crate",
+        "sha256": "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098",
+        "dest": "cargo/vendor/quinn-proto-0.11.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-proto-0.11.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quinn-udp/quinn-udp-0.5.14.crate",
+        "sha256": "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd",
+        "dest": "cargo/vendor/quinn-udp-0.5.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd\", \"files\": {}}",
+        "dest": "cargo/vendor/quinn-udp-0.5.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.45.crate",
+        "sha256": "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924",
+        "dest": "cargo/vendor/quote-1.0.45"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.45",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/r-efi/r-efi-5.3.0.crate",
+        "sha256": "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f",
+        "dest": "cargo/vendor/r-efi-5.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f\", \"files\": {}}",
+        "dest": "cargo/vendor/r-efi-5.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/r-efi/r-efi-6.0.0.crate",
+        "sha256": "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf",
+        "dest": "cargo/vendor/r-efi-6.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf\", \"files\": {}}",
+        "dest": "cargo/vendor/r-efi-6.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.8.7.crate",
+        "sha256": "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a",
+        "dest": "cargo/vendor/rand-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.9.4.crate",
+        "sha256": "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea",
+        "dest": "cargo/vendor/rand-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand/rand-0.10.1.crate",
+        "sha256": "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207",
+        "dest": "cargo/vendor/rand-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207\", \"files\": {}}",
+        "dest": "cargo/vendor/rand-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate",
+        "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
+        "dest": "cargo/vendor/rand_chacha-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.9.0.crate",
+        "sha256": "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb",
+        "dest": "cargo/vendor/rand_chacha-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_chacha-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.6.4.crate",
+        "sha256": "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c",
+        "dest": "cargo/vendor/rand_core-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.9.5.crate",
+        "sha256": "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c",
+        "dest": "cargo/vendor/rand_core-0.9.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.9.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rand_core/rand_core-0.10.1.crate",
+        "sha256": "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69",
+        "dest": "cargo/vendor/rand_core-0.10.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69\", \"files\": {}}",
+        "dest": "cargo/vendor/rand_core-0.10.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.6.2.crate",
+        "sha256": "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539\", \"files\": {}}",
+        "dest": "cargo/vendor/raw-window-handle-0.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rawpointer/rawpointer-0.2.1.crate",
+        "sha256": "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3",
+        "dest": "cargo/vendor/rawpointer-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3\", \"files\": {}}",
+        "dest": "cargo/vendor/rawpointer-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon/rayon-1.12.0.crate",
+        "sha256": "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d",
+        "dest": "cargo/vendor/rayon-1.12.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-1.12.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon-cond/rayon-cond-0.4.0.crate",
+        "sha256": "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f",
+        "dest": "cargo/vendor/rayon-cond-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-cond-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.13.0.crate",
+        "sha256": "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91",
+        "dest": "cargo/vendor/rayon-core-1.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91\", \"files\": {}}",
+        "dest": "cargo/vendor/rayon-core-1.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.5.18.crate",
+        "sha256": "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d",
+        "dest": "cargo/vendor/redox_syscall-0.5.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.5.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_users/redox_users-0.5.2.crate",
+        "sha256": "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac",
+        "dest": "cargo/vendor/redox_users-0.5.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_users-0.5.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ref-cast/ref-cast-1.0.25.crate",
+        "sha256": "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d",
+        "dest": "cargo/vendor/ref-cast-1.0.25"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d\", \"files\": {}}",
+        "dest": "cargo/vendor/ref-cast-1.0.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ref-cast-impl/ref-cast-impl-1.0.25.crate",
+        "sha256": "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da",
+        "dest": "cargo/vendor/ref-cast-impl-1.0.25"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da\", \"files\": {}}",
+        "dest": "cargo/vendor/ref-cast-impl-1.0.25",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex/regex-1.12.4.crate",
+        "sha256": "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba",
+        "dest": "cargo/vendor/regex-1.12.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-1.12.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.4.14.crate",
+        "sha256": "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f",
+        "dest": "cargo/vendor/regex-automata-0.4.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-automata-0.4.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.8.11.crate",
+        "sha256": "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4",
+        "dest": "cargo/vendor/regex-syntax-0.8.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4\", \"files\": {}}",
+        "dest": "cargo/vendor/regex-syntax-0.8.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.12.28.crate",
+        "sha256": "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147",
+        "dest": "cargo/vendor/reqwest-0.12.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.12.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/reqwest/reqwest-0.13.4.crate",
+        "sha256": "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3",
+        "dest": "cargo/vendor/reqwest-0.13.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3\", \"files\": {}}",
+        "dest": "cargo/vendor/reqwest-0.13.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ring/ring-0.17.14.crate",
+        "sha256": "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7",
+        "dest": "cargo/vendor/ring-0.17.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7\", \"files\": {}}",
+        "dest": "cargo/vendor/ring-0.17.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-2.1.2.crate",
+        "sha256": "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe",
+        "dest": "cargo/vendor/rustc-hash-2.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc-hash-2.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.1.crate",
+        "sha256": "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92",
+        "dest": "cargo/vendor/rustc_version-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92\", \"files\": {}}",
+        "dest": "cargo/vendor/rustc_version-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustix/rustix-1.1.4.crate",
+        "sha256": "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190",
+        "dest": "cargo/vendor/rustix-1.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190\", \"files\": {}}",
+        "dest": "cargo/vendor/rustix-1.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls/rustls-0.23.40.crate",
+        "sha256": "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b",
+        "dest": "cargo/vendor/rustls-0.23.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-0.23.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-pki-types/rustls-pki-types-1.14.1.crate",
+        "sha256": "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9",
+        "dest": "cargo/vendor/rustls-pki-types-1.14.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-pki-types-1.14.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustls-webpki/rustls-webpki-0.103.13.crate",
+        "sha256": "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e\", \"files\": {}}",
+        "dest": "cargo/vendor/rustls-webpki-0.103.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.22.crate",
+        "sha256": "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d",
+        "dest": "cargo/vendor/rustversion-1.0.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d\", \"files\": {}}",
+        "dest": "cargo/vendor/rustversion-1.0.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ryu/ryu-1.0.23.crate",
+        "sha256": "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f",
+        "dest": "cargo/vendor/ryu-1.0.23"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f\", \"files\": {}}",
+        "dest": "cargo/vendor/ryu-1.0.23",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/same-file/same-file-1.0.6.crate",
+        "sha256": "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502",
+        "dest": "cargo/vendor/same-file-1.0.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502\", \"files\": {}}",
+        "dest": "cargo/vendor/same-file-1.0.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schannel/schannel-0.1.29.crate",
+        "sha256": "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939",
+        "dest": "cargo/vendor/schannel-0.1.29"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939\", \"files\": {}}",
+        "dest": "cargo/vendor/schannel-0.1.29",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-0.8.22.crate",
+        "sha256": "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615",
+        "dest": "cargo/vendor/schemars-0.8.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-0.8.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-0.9.0.crate",
+        "sha256": "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f",
+        "dest": "cargo/vendor/schemars-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars/schemars-1.2.1.crate",
+        "sha256": "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc",
+        "dest": "cargo/vendor/schemars-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/schemars_derive/schemars_derive-0.8.22.crate",
+        "sha256": "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d",
+        "dest": "cargo/vendor/schemars_derive-0.8.22"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d\", \"files\": {}}",
+        "dest": "cargo/vendor/schemars_derive-0.8.22",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.2.0.crate",
+        "sha256": "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49",
+        "dest": "cargo/vendor/scopeguard-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49\", \"files\": {}}",
+        "dest": "cargo/vendor/scopeguard-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework/security-framework-3.7.0.crate",
+        "sha256": "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d",
+        "dest": "cargo/vendor/security-framework-3.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-3.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.17.0.crate",
+        "sha256": "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3\", \"files\": {}}",
+        "dest": "cargo/vendor/security-framework-sys-2.17.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/selectors/selectors-0.36.1.crate",
+        "sha256": "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c",
+        "dest": "cargo/vendor/selectors-0.36.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c\", \"files\": {}}",
+        "dest": "cargo/vendor/selectors-0.36.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/semver/semver-1.0.28.crate",
+        "sha256": "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd",
+        "dest": "cargo/vendor/semver-1.0.28"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd\", \"files\": {}}",
+        "dest": "cargo/vendor/semver-1.0.28",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde/serde-1.0.228.crate",
+        "sha256": "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e",
+        "dest": "cargo/vendor/serde-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde-untagged/serde-untagged-0.1.9.crate",
+        "sha256": "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058",
+        "dest": "cargo/vendor/serde-untagged-0.1.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-untagged-0.1.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_core/serde_core-1.0.228.crate",
+        "sha256": "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad",
+        "dest": "cargo/vendor/serde_core-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_core-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.228.crate",
+        "sha256": "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79",
+        "dest": "cargo/vendor/serde_derive-1.0.228"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.228",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_derive_internals/serde_derive_internals-0.29.1.crate",
+        "sha256": "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711",
+        "dest": "cargo/vendor/serde_derive_internals-0.29.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive_internals-0.29.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.150.crate",
+        "sha256": "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9",
+        "dest": "cargo/vendor/serde_json-1.0.150"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.150",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_repr/serde_repr-0.1.20.crate",
+        "sha256": "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c",
+        "dest": "cargo/vendor/serde_repr-0.1.20"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_repr-0.1.20",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-0.6.9.crate",
+        "sha256": "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3",
+        "dest": "cargo/vendor/serde_spanned-0.6.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-0.6.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_spanned/serde_spanned-1.1.1.crate",
+        "sha256": "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26",
+        "dest": "cargo/vendor/serde_spanned-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_spanned-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_urlencoded/serde_urlencoded-0.7.1.crate",
+        "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd",
+        "dest": "cargo/vendor/serde_urlencoded-0.7.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_urlencoded-0.7.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_with/serde_with-3.21.0.crate",
+        "sha256": "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c",
+        "dest": "cargo/vendor/serde_with-3.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_with-3.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serde_with_macros/serde_with_macros-3.21.0.crate",
+        "sha256": "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660",
+        "dest": "cargo/vendor/serde_with_macros-3.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_with_macros-3.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serialize-to-javascript/serialize-to-javascript-0.1.2.crate",
+        "sha256": "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5",
+        "dest": "cargo/vendor/serialize-to-javascript-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5\", \"files\": {}}",
+        "dest": "cargo/vendor/serialize-to-javascript-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/serialize-to-javascript-impl/serialize-to-javascript-impl-0.1.2.crate",
+        "sha256": "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d",
+        "dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d\", \"files\": {}}",
+        "dest": "cargo/vendor/serialize-to-javascript-impl-0.1.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/servo_arc/servo_arc-0.4.3.crate",
+        "sha256": "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930",
+        "dest": "cargo/vendor/servo_arc-0.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930\", \"files\": {}}",
+        "dest": "cargo/vendor/servo_arc-0.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sha1/sha1-0.10.6.crate",
+        "sha256": "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba",
+        "dest": "cargo/vendor/sha1-0.10.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba\", \"files\": {}}",
+        "dest": "cargo/vendor/sha1-0.10.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sha2/sha2-0.10.9.crate",
+        "sha256": "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283",
+        "dest": "cargo/vendor/sha2-0.10.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283\", \"files\": {}}",
+        "dest": "cargo/vendor/sha2-0.10.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/shared_child/shared_child-1.1.1.crate",
+        "sha256": "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7",
+        "dest": "cargo/vendor/shared_child-1.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7\", \"files\": {}}",
+        "dest": "cargo/vendor/shared_child-1.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/shlex/shlex-2.0.1.crate",
+        "sha256": "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba",
+        "dest": "cargo/vendor/shlex-2.0.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba\", \"files\": {}}",
+        "dest": "cargo/vendor/shlex-2.0.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sigchld/sigchld-0.2.4.crate",
+        "sha256": "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1",
+        "dest": "cargo/vendor/sigchld-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1\", \"files\": {}}",
+        "dest": "cargo/vendor/sigchld-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook/signal-hook-0.3.18.crate",
+        "sha256": "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2",
+        "dest": "cargo/vendor/signal-hook-0.3.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-0.3.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.8.crate",
+        "sha256": "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b\", \"files\": {}}",
+        "dest": "cargo/vendor/signal-hook-registry-1.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/simd-adler32/simd-adler32-0.3.9.crate",
+        "sha256": "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214",
+        "dest": "cargo/vendor/simd-adler32-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214\", \"files\": {}}",
+        "dest": "cargo/vendor/simd-adler32-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/siphasher/siphasher-1.0.3.crate",
+        "sha256": "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649",
+        "dest": "cargo/vendor/siphasher-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649\", \"files\": {}}",
+        "dest": "cargo/vendor/siphasher-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/slab/slab-0.4.12.crate",
+        "sha256": "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5",
+        "dest": "cargo/vendor/slab-0.4.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5\", \"files\": {}}",
+        "dest": "cargo/vendor/slab-0.4.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.15.1.crate",
+        "sha256": "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03",
+        "dest": "cargo/vendor/smallvec-1.15.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.15.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-2.0.0-alpha.10.crate",
+        "sha256": "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b",
+        "dest": "cargo/vendor/smallvec-2.0.0-alpha.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-2.0.0-alpha.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/snow/snow-0.9.6.crate",
+        "sha256": "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85",
+        "dest": "cargo/vendor/snow-0.9.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85\", \"files\": {}}",
+        "dest": "cargo/vendor/snow-0.9.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/socket2/socket2-0.5.10.crate",
+        "sha256": "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678",
+        "dest": "cargo/vendor/socket2-0.5.10"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.5.10",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/socket2/socket2-0.6.4.crate",
+        "sha256": "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51",
+        "dest": "cargo/vendor/socket2-0.6.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51\", \"files\": {}}",
+        "dest": "cargo/vendor/socket2-0.6.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/socks/socks-0.3.4.crate",
+        "sha256": "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b",
+        "dest": "cargo/vendor/socks-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b\", \"files\": {}}",
+        "dest": "cargo/vendor/socks-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/softbuffer/softbuffer-0.4.8.crate",
+        "sha256": "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3",
+        "dest": "cargo/vendor/softbuffer-0.4.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3\", \"files\": {}}",
+        "dest": "cargo/vendor/softbuffer-0.4.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/soup3/soup3-0.5.0.crate",
+        "sha256": "471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f",
+        "dest": "cargo/vendor/soup3-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"471f924a40f31251afc77450e781cb26d55c0b650842efafc9c6cbd2f7cc4f9f\", \"files\": {}}",
+        "dest": "cargo/vendor/soup3-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/soup3-sys/soup3-sys-0.5.0.crate",
+        "sha256": "7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27",
+        "dest": "cargo/vendor/soup3-sys-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7ebe8950a680a12f24f15ebe1bf70db7af98ad242d9db43596ad3108aab86c27\", \"files\": {}}",
+        "dest": "cargo/vendor/soup3-sys-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spin/spin-0.9.9.crate",
+        "sha256": "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e",
+        "dest": "cargo/vendor/spin-0.9.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e\", \"files\": {}}",
+        "dest": "cargo/vendor/spin-0.9.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/spm_precompiled/spm_precompiled-0.1.4.crate",
+        "sha256": "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326",
+        "dest": "cargo/vendor/spm_precompiled-0.1.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326\", \"files\": {}}",
+        "dest": "cargo/vendor/spm_precompiled-0.1.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.1.crate",
+        "sha256": "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596\", \"files\": {}}",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
+        "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
+        "dest": "cargo/vendor/static_assertions-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
+        "dest": "cargo/vendor/static_assertions-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache/string_cache-0.9.0.crate",
+        "sha256": "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901",
+        "dest": "cargo/vendor/string_cache-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.6.1.crate",
+        "sha256": "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69",
+        "dest": "cargo/vendor/string_cache_codegen-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69\", \"files\": {}}",
+        "dest": "cargo/vendor/string_cache_codegen-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/strsim/strsim-0.11.1.crate",
+        "sha256": "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f",
+        "dest": "cargo/vendor/strsim-0.11.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f\", \"files\": {}}",
+        "dest": "cargo/vendor/strsim-0.11.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/subtle/subtle-2.6.1.crate",
+        "sha256": "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292",
+        "dest": "cargo/vendor/subtle-2.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292\", \"files\": {}}",
+        "dest": "cargo/vendor/subtle-2.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/swift-rs/swift-rs-1.0.7.crate",
+        "sha256": "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7",
+        "dest": "cargo/vendor/swift-rs-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7\", \"files\": {}}",
+        "dest": "cargo/vendor/swift-rs-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-1.0.109.crate",
+        "sha256": "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237",
+        "dest": "cargo/vendor/syn-1.0.109"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-1.0.109",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-2.0.117.crate",
+        "sha256": "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99",
+        "dest": "cargo/vendor/syn-2.0.117"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-2.0.117",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-3.0.4.crate",
+        "sha256": "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f",
+        "dest": "cargo/vendor/syn-3.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-3.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/sync_wrapper/sync_wrapper-1.0.2.crate",
+        "sha256": "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263",
+        "dest": "cargo/vendor/sync_wrapper-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263\", \"files\": {}}",
+        "dest": "cargo/vendor/sync_wrapper-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/synstructure/synstructure-0.13.2.crate",
+        "sha256": "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2",
+        "dest": "cargo/vendor/synstructure-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2\", \"files\": {}}",
+        "dest": "cargo/vendor/synstructure-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-configuration/system-configuration-0.7.0.crate",
+        "sha256": "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b",
+        "dest": "cargo/vendor/system-configuration-0.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b\", \"files\": {}}",
+        "dest": "cargo/vendor/system-configuration-0.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-configuration-sys/system-configuration-sys-0.6.0.crate",
+        "sha256": "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4",
+        "dest": "cargo/vendor/system-configuration-sys-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4\", \"files\": {}}",
+        "dest": "cargo/vendor/system-configuration-sys-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/system-deps/system-deps-6.2.2.crate",
+        "sha256": "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349",
+        "dest": "cargo/vendor/system-deps-6.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349\", \"files\": {}}",
+        "dest": "cargo/vendor/system-deps-6.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tao/tao-0.35.3.crate",
+        "sha256": "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9",
+        "dest": "cargo/vendor/tao-0.35.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9\", \"files\": {}}",
+        "dest": "cargo/vendor/tao-0.35.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tao-macros/tao-macros-0.1.3.crate",
+        "sha256": "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd",
+        "dest": "cargo/vendor/tao-macros-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd\", \"files\": {}}",
+        "dest": "cargo/vendor/tao-macros-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tar/tar-0.4.46.crate",
+        "sha256": "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840",
+        "dest": "cargo/vendor/tar-0.4.46"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840\", \"files\": {}}",
+        "dest": "cargo/vendor/tar-0.4.46",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/target-lexicon/target-lexicon-0.12.16.crate",
+        "sha256": "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1",
+        "dest": "cargo/vendor/target-lexicon-0.12.16"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1\", \"files\": {}}",
+        "dest": "cargo/vendor/target-lexicon-0.12.16",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri/tauri-2.11.2.crate",
+        "sha256": "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28",
+        "dest": "cargo/vendor/tauri-2.11.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-2.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-build/tauri-build-2.6.2.crate",
+        "sha256": "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7",
+        "dest": "cargo/vendor/tauri-build-2.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-build-2.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-codegen/tauri-codegen-2.6.2.crate",
+        "sha256": "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9",
+        "dest": "cargo/vendor/tauri-codegen-2.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-codegen-2.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-macros/tauri-macros-2.6.2.crate",
+        "sha256": "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924",
+        "dest": "cargo/vendor/tauri-macros-2.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-macros-2.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin/tauri-plugin-2.6.2.crate",
+        "sha256": "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e",
+        "dest": "cargo/vendor/tauri-plugin-2.6.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-2.6.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-fs/tauri-plugin-fs-2.5.1.crate",
+        "sha256": "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371",
+        "dest": "cargo/vendor/tauri-plugin-fs-2.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-fs-2.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-http/tauri-plugin-http-2.5.9.crate",
+        "sha256": "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067",
+        "dest": "cargo/vendor/tauri-plugin-http-2.5.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-http-2.5.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-shell/tauri-plugin-shell-2.3.5.crate",
+        "sha256": "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b",
+        "dest": "cargo/vendor/tauri-plugin-shell-2.3.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-shell-2.3.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-plugin-single-instance/tauri-plugin-single-instance-2.4.3.crate",
+        "sha256": "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c",
+        "dest": "cargo/vendor/tauri-plugin-single-instance-2.4.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-plugin-single-instance-2.4.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-runtime/tauri-runtime-2.11.2.crate",
+        "sha256": "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef",
+        "dest": "cargo/vendor/tauri-runtime-2.11.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-runtime-2.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-runtime-wry/tauri-runtime-wry-2.11.2.crate",
+        "sha256": "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.11.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-runtime-wry-2.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-utils/tauri-utils-2.9.2.crate",
+        "sha256": "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95",
+        "dest": "cargo/vendor/tauri-utils-2.9.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-utils-2.9.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tauri-winres/tauri-winres-0.3.6.crate",
+        "sha256": "cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6",
+        "dest": "cargo/vendor/tauri-winres-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cc65d45c68858bfe420dd29e834b5d15dbecf8a07a8a16cf4d532c7b1f69d4b6\", \"files\": {}}",
+        "dest": "cargo/vendor/tauri-winres-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tempfile/tempfile-3.27.0.crate",
+        "sha256": "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd",
+        "dest": "cargo/vendor/tempfile-3.27.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd\", \"files\": {}}",
+        "dest": "cargo/vendor/tempfile-3.27.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tendril/tendril-0.5.0.crate",
+        "sha256": "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24",
+        "dest": "cargo/vendor/tendril-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24\", \"files\": {}}",
+        "dest": "cargo/vendor/tendril-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.69.crate",
+        "sha256": "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52",
+        "dest": "cargo/vendor/thiserror-1.0.69"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.69",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror/thiserror-2.0.18.crate",
+        "sha256": "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4",
+        "dest": "cargo/vendor/thiserror-2.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-2.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.69.crate",
+        "sha256": "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1",
+        "dest": "cargo/vendor/thiserror-impl-1.0.69"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.69",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-2.0.18.crate",
+        "sha256": "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5",
+        "dest": "cargo/vendor/thiserror-impl-2.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-2.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tiff/tiff-0.11.3.crate",
+        "sha256": "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52",
+        "dest": "cargo/vendor/tiff-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52\", \"files\": {}}",
+        "dest": "cargo/vendor/tiff-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time/time-0.3.47.crate",
+        "sha256": "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c",
+        "dest": "cargo/vendor/time-0.3.47"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c\", \"files\": {}}",
+        "dest": "cargo/vendor/time-0.3.47",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time-core/time-core-0.1.8.crate",
+        "sha256": "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca",
+        "dest": "cargo/vendor/time-core-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca\", \"files\": {}}",
+        "dest": "cargo/vendor/time-core-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.27.crate",
+        "sha256": "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215",
+        "dest": "cargo/vendor/time-macros-0.2.27"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215\", \"files\": {}}",
+        "dest": "cargo/vendor/time-macros-0.2.27",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinystr/tinystr-0.8.3.crate",
+        "sha256": "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d",
+        "dest": "cargo/vendor/tinystr-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d\", \"files\": {}}",
+        "dest": "cargo/vendor/tinystr-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.11.0.crate",
+        "sha256": "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3",
+        "dest": "cargo/vendor/tinyvec-1.11.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec-1.11.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.1.crate",
+        "sha256": "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20\", \"files\": {}}",
+        "dest": "cargo/vendor/tinyvec_macros-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokenizers/tokenizers-0.21.4.crate",
+        "sha256": "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476",
+        "dest": "cargo/vendor/tokenizers-0.21.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476\", \"files\": {}}",
+        "dest": "cargo/vendor/tokenizers-0.21.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio/tokio-1.52.3.crate",
+        "sha256": "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe",
+        "dest": "cargo/vendor/tokio-1.52.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-1.52.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-2.7.0.crate",
+        "sha256": "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496",
+        "dest": "cargo/vendor/tokio-macros-2.7.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-macros-2.7.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.26.4.crate",
+        "sha256": "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61",
+        "dest": "cargo/vendor/tokio-rustls-0.26.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-rustls-0.26.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.7.18.crate",
+        "sha256": "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098",
+        "dest": "cargo/vendor/tokio-util-0.7.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098\", \"files\": {}}",
+        "dest": "cargo/vendor/tokio-util-0.7.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.8.2.crate",
+        "sha256": "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d",
+        "dest": "cargo/vendor/toml-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-0.9.12+spec-1.1.0.crate",
+        "sha256": "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863",
+        "dest": "cargo/vendor/toml-0.9.12+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-0.9.12+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml/toml-1.1.2+spec-1.1.0.crate",
+        "sha256": "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee",
+        "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee\", \"files\": {}}",
+        "dest": "cargo/vendor/toml-1.1.2+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.6.3.crate",
+        "sha256": "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b",
+        "dest": "cargo/vendor/toml_datetime-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-0.7.5+spec-1.1.0.crate",
+        "sha256": "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-0.7.5+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_datetime/toml_datetime-1.1.1+spec-1.1.0.crate",
+        "sha256": "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7",
+        "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_datetime-1.1.1+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.19.15.crate",
+        "sha256": "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421",
+        "dest": "cargo/vendor/toml_edit-0.19.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.19.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.20.2.crate",
+        "sha256": "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338",
+        "dest": "cargo/vendor/toml_edit-0.20.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.20.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_edit/toml_edit-0.25.12+spec-1.1.0.crate",
+        "sha256": "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_edit-0.25.12+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_parser/toml_parser-1.1.2+spec-1.1.0.crate",
+        "sha256": "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526",
+        "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_parser-1.1.2+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/toml_writer/toml_writer-1.1.1+spec-1.1.0.crate",
+        "sha256": "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db",
+        "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db\", \"files\": {}}",
+        "dest": "cargo/vendor/toml_writer-1.1.1+spec-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower/tower-0.5.3.crate",
+        "sha256": "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4",
+        "dest": "cargo/vendor/tower-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-http/tower-http-0.6.11.crate",
+        "sha256": "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840",
+        "dest": "cargo/vendor/tower-http-0.6.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-http-0.6.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-layer/tower-layer-0.3.3.crate",
+        "sha256": "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e",
+        "dest": "cargo/vendor/tower-layer-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-layer-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tower-service/tower-service-0.3.3.crate",
+        "sha256": "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3",
+        "dest": "cargo/vendor/tower-service-0.3.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3\", \"files\": {}}",
+        "dest": "cargo/vendor/tower-service-0.3.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing/tracing-0.1.44.crate",
+        "sha256": "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100",
+        "dest": "cargo/vendor/tracing-0.1.44"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-0.1.44",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.31.crate",
+        "sha256": "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da",
+        "dest": "cargo/vendor/tracing-attributes-0.1.31"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-attributes-0.1.31",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.36.crate",
+        "sha256": "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a",
+        "dest": "cargo/vendor/tracing-core-0.1.36"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a\", \"files\": {}}",
+        "dest": "cargo/vendor/tracing-core-0.1.36",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tray-icon/tray-icon-0.23.1.crate",
+        "sha256": "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773",
+        "dest": "cargo/vendor/tray-icon-0.23.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773\", \"files\": {}}",
+        "dest": "cargo/vendor/tray-icon-0.23.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/try-lock/try-lock-0.2.5.crate",
+        "sha256": "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b",
+        "dest": "cargo/vendor/try-lock-0.2.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b\", \"files\": {}}",
+        "dest": "cargo/vendor/try-lock-0.2.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/tungstenite/tungstenite-0.29.0.crate",
+        "sha256": "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8",
+        "dest": "cargo/vendor/tungstenite-0.29.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8\", \"files\": {}}",
+        "dest": "cargo/vendor/tungstenite-0.29.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/typeid/typeid-1.0.3.crate",
+        "sha256": "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c",
+        "dest": "cargo/vendor/typeid-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c\", \"files\": {}}",
+        "dest": "cargo/vendor/typeid-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/typenum/typenum-1.20.1.crate",
+        "sha256": "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20",
+        "dest": "cargo/vendor/typenum-1.20.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20\", \"files\": {}}",
+        "dest": "cargo/vendor/typenum-1.20.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/uds_windows/uds_windows-1.2.1.crate",
+        "sha256": "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e",
+        "dest": "cargo/vendor/uds_windows-1.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e\", \"files\": {}}",
+        "dest": "cargo/vendor/uds_windows-1.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-char-property/unic-char-property-0.9.0.crate",
+        "sha256": "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221",
+        "dest": "cargo/vendor/unic-char-property-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-char-property-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-char-range/unic-char-range-0.9.0.crate",
+        "sha256": "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc",
+        "dest": "cargo/vendor/unic-char-range-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-char-range-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-common/unic-common-0.9.0.crate",
+        "sha256": "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc",
+        "dest": "cargo/vendor/unic-common-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-common-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-ucd-ident/unic-ucd-ident-0.9.0.crate",
+        "sha256": "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987",
+        "dest": "cargo/vendor/unic-ucd-ident-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-ucd-ident-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unic-ucd-version/unic-ucd-version-0.9.0.crate",
+        "sha256": "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4",
+        "dest": "cargo/vendor/unic-ucd-version-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4\", \"files\": {}}",
+        "dest": "cargo/vendor/unic-ucd-version-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.24.crate",
+        "sha256": "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75",
+        "dest": "cargo/vendor/unicode-ident-1.0.24"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-ident-1.0.24",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-normalization-alignments/unicode-normalization-alignments-0.1.12.crate",
+        "sha256": "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de",
+        "dest": "cargo/vendor/unicode-normalization-alignments-0.1.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-normalization-alignments-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.13.3.crate",
+        "sha256": "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8",
+        "dest": "cargo/vendor/unicode-segmentation-1.13.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-segmentation-1.13.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.6.crate",
+        "sha256": "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853",
+        "dest": "cargo/vendor/unicode-xid-0.2.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-xid-0.2.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode_categories/unicode_categories-0.1.1.crate",
+        "sha256": "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e",
+        "dest": "cargo/vendor/unicode_categories-0.1.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode_categories-0.1.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/universal-hash/universal-hash-0.5.1.crate",
+        "sha256": "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea",
+        "dest": "cargo/vendor/universal-hash-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea\", \"files\": {}}",
+        "dest": "cargo/vendor/universal-hash-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/untrusted/untrusted-0.9.0.crate",
+        "sha256": "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1",
+        "dest": "cargo/vendor/untrusted-0.9.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1\", \"files\": {}}",
+        "dest": "cargo/vendor/untrusted-0.9.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ureq/ureq-3.3.0.crate",
+        "sha256": "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0",
+        "dest": "cargo/vendor/ureq-3.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0\", \"files\": {}}",
+        "dest": "cargo/vendor/ureq-3.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ureq-proto/ureq-proto-0.6.0.crate",
+        "sha256": "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c",
+        "dest": "cargo/vendor/ureq-proto-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c\", \"files\": {}}",
+        "dest": "cargo/vendor/ureq-proto-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/url/url-2.5.8.crate",
+        "sha256": "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed",
+        "dest": "cargo/vendor/url-2.5.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed\", \"files\": {}}",
+        "dest": "cargo/vendor/url-2.5.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/urlpattern/urlpattern-0.3.0.crate",
+        "sha256": "70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d",
+        "dest": "cargo/vendor/urlpattern-0.3.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"70acd30e3aa1450bc2eece896ce2ad0d178e9c079493819301573dae3c37ba6d\", \"files\": {}}",
+        "dest": "cargo/vendor/urlpattern-0.3.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf-8/utf-8-0.7.6.crate",
+        "sha256": "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9",
+        "dest": "cargo/vendor/utf-8-0.7.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9\", \"files\": {}}",
+        "dest": "cargo/vendor/utf-8-0.7.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8-zero/utf8-zero-0.8.1.crate",
+        "sha256": "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e",
+        "dest": "cargo/vendor/utf8-zero-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8-zero-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/utf8_iter/utf8_iter-1.0.4.crate",
+        "sha256": "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be",
+        "dest": "cargo/vendor/utf8_iter-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be\", \"files\": {}}",
+        "dest": "cargo/vendor/utf8_iter-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/uuid/uuid-1.23.3.crate",
+        "sha256": "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7",
+        "dest": "cargo/vendor/uuid-1.23.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7\", \"files\": {}}",
+        "dest": "cargo/vendor/uuid-1.23.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vcpkg/vcpkg-0.2.15.crate",
+        "sha256": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426",
+        "dest": "cargo/vendor/vcpkg-0.2.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426\", \"files\": {}}",
+        "dest": "cargo/vendor/vcpkg-0.2.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version-compare/version-compare-0.2.1.crate",
+        "sha256": "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e",
+        "dest": "cargo/vendor/version-compare-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e\", \"files\": {}}",
+        "dest": "cargo/vendor/version-compare-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.5.crate",
+        "sha256": "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a",
+        "dest": "cargo/vendor/version_check-0.9.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a\", \"files\": {}}",
+        "dest": "cargo/vendor/version_check-0.9.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vswhom/vswhom-0.1.0.crate",
+        "sha256": "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b",
+        "dest": "cargo/vendor/vswhom-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b\", \"files\": {}}",
+        "dest": "cargo/vendor/vswhom-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/vswhom-sys/vswhom-sys-0.1.3.crate",
+        "sha256": "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150",
+        "dest": "cargo/vendor/vswhom-sys-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150\", \"files\": {}}",
+        "dest": "cargo/vendor/vswhom-sys-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/walkdir/walkdir-2.5.0.crate",
+        "sha256": "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b",
+        "dest": "cargo/vendor/walkdir-2.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b\", \"files\": {}}",
+        "dest": "cargo/vendor/walkdir-2.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/want/want-0.3.1.crate",
+        "sha256": "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e",
+        "dest": "cargo/vendor/want-0.3.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e\", \"files\": {}}",
+        "dest": "cargo/vendor/want-0.3.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasi/wasi-0.11.1+wasi-snapshot-preview1.crate",
+        "sha256": "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasi-0.11.1+wasi-snapshot-preview1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasip2/wasip2-1.0.3+wasi-0.2.9.crate",
+        "sha256": "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6",
+        "dest": "cargo/vendor/wasip2-1.0.3+wasi-0.2.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6\", \"files\": {}}",
+        "dest": "cargo/vendor/wasip2-1.0.3+wasi-0.2.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasip3/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06.crate",
+        "sha256": "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5",
+        "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5\", \"files\": {}}",
+        "dest": "cargo/vendor/wasip3-0.4.0+wasi-0.3.0-rc-2026-01-06",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.123.crate",
+        "sha256": "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.123"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-0.2.123",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.73.crate",
+        "sha256": "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.73"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.73",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.123.crate",
+        "sha256": "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.123"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.123",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.123.crate",
+        "sha256": "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.123"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.123",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.123.crate",
+        "sha256": "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.123"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.123",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-encoder/wasm-encoder-0.244.0.crate",
+        "sha256": "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319",
+        "dest": "cargo/vendor/wasm-encoder-0.244.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-encoder-0.244.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-metadata/wasm-metadata-0.244.0.crate",
+        "sha256": "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909",
+        "dest": "cargo/vendor/wasm-metadata-0.244.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-metadata-0.244.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasm-streams/wasm-streams-0.5.0.crate",
+        "sha256": "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb",
+        "dest": "cargo/vendor/wasm-streams-0.5.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb\", \"files\": {}}",
+        "dest": "cargo/vendor/wasm-streams-0.5.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wasmparser/wasmparser-0.244.0.crate",
+        "sha256": "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe",
+        "dest": "cargo/vendor/wasmparser-0.244.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe\", \"files\": {}}",
+        "dest": "cargo/vendor/wasmparser-0.244.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.100.crate",
+        "sha256": "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69",
+        "dest": "cargo/vendor/web-sys-0.3.100"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69\", \"files\": {}}",
+        "dest": "cargo/vendor/web-sys-0.3.100",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web-time/web-time-1.1.0.crate",
+        "sha256": "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb",
+        "dest": "cargo/vendor/web-time-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb\", \"files\": {}}",
+        "dest": "cargo/vendor/web-time-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/web_atoms/web_atoms-0.2.4.crate",
+        "sha256": "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538",
+        "dest": "cargo/vendor/web_atoms-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538\", \"files\": {}}",
+        "dest": "cargo/vendor/web_atoms-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webkit2gtk/webkit2gtk-2.0.2.crate",
+        "sha256": "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793",
+        "dest": "cargo/vendor/webkit2gtk-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793\", \"files\": {}}",
+        "dest": "cargo/vendor/webkit2gtk-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webkit2gtk-sys/webkit2gtk-sys-2.0.2.crate",
+        "sha256": "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5",
+        "dest": "cargo/vendor/webkit2gtk-sys-2.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5\", \"files\": {}}",
+        "dest": "cargo/vendor/webkit2gtk-sys-2.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-root-certs/webpki-root-certs-1.0.9.crate",
+        "sha256": "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-root-certs-1.0.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-1.0.7.crate",
+        "sha256": "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d",
+        "dest": "cargo/vendor/webpki-roots-1.0.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d\", \"files\": {}}",
+        "dest": "cargo/vendor/webpki-roots-1.0.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com/webview2-com-0.38.2.crate",
+        "sha256": "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a",
+        "dest": "cargo/vendor/webview2-com-0.38.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-0.38.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com-macros/webview2-com-macros-0.8.1.crate",
+        "sha256": "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54",
+        "dest": "cargo/vendor/webview2-com-macros-0.8.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-macros-0.8.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/webview2-com-sys/webview2-com-sys-0.38.2.crate",
+        "sha256": "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c",
+        "dest": "cargo/vendor/webview2-com-sys-0.38.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c\", \"files\": {}}",
+        "dest": "cargo/vendor/webview2-com-sys-0.38.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/weezl/weezl-0.1.12.crate",
+        "sha256": "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88",
+        "dest": "cargo/vendor/weezl-0.1.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88\", \"files\": {}}",
+        "dest": "cargo/vendor/weezl-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/which/which-8.0.4.crate",
+        "sha256": "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248",
+        "dest": "cargo/vendor/which-8.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248\", \"files\": {}}",
+        "dest": "cargo/vendor/which-8.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "dest": "cargo/vendor/winapi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.11.crate",
+        "sha256": "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22",
+        "dest": "cargo/vendor/winapi-util-0.1.11"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-util-0.1.11",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/window-vibrancy/window-vibrancy-0.6.0.crate",
+        "sha256": "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c",
+        "dest": "cargo/vendor/window-vibrancy-0.6.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c\", \"files\": {}}",
+        "dest": "cargo/vendor/window-vibrancy-0.6.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows/windows-0.61.3.crate",
+        "sha256": "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893",
+        "dest": "cargo/vendor/windows-0.61.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-0.61.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-collections/windows-collections-0.2.0.crate",
+        "sha256": "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8",
+        "dest": "cargo/vendor/windows-collections-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-collections-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.61.2.crate",
+        "sha256": "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3",
+        "dest": "cargo/vendor/windows-core-0.61.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.61.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-core/windows-core-0.62.2.crate",
+        "sha256": "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb",
+        "dest": "cargo/vendor/windows-core-0.62.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-core-0.62.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-future/windows-future-0.2.1.crate",
+        "sha256": "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e",
+        "dest": "cargo/vendor/windows-future-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-future-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-implement/windows-implement-0.60.2.crate",
+        "sha256": "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf",
+        "dest": "cargo/vendor/windows-implement-0.60.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-implement-0.60.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-interface/windows-interface-0.59.3.crate",
+        "sha256": "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358",
+        "dest": "cargo/vendor/windows-interface-0.59.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-interface-0.59.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-link/windows-link-0.1.3.crate",
+        "sha256": "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a",
+        "dest": "cargo/vendor/windows-link-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-link-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-link/windows-link-0.2.1.crate",
+        "sha256": "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5",
+        "dest": "cargo/vendor/windows-link-0.2.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-link-0.2.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-numerics/windows-numerics-0.2.0.crate",
+        "sha256": "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1",
+        "dest": "cargo/vendor/windows-numerics-0.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-numerics-0.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-registry/windows-registry-0.6.1.crate",
+        "sha256": "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720",
+        "dest": "cargo/vendor/windows-registry-0.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-registry-0.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.3.4.crate",
+        "sha256": "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6",
+        "dest": "cargo/vendor/windows-result-0.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-result/windows-result-0.4.1.crate",
+        "sha256": "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5",
+        "dest": "cargo/vendor/windows-result-0.4.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-result-0.4.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.4.2.crate",
+        "sha256": "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57",
+        "dest": "cargo/vendor/windows-strings-0.4.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.4.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-strings/windows-strings-0.5.1.crate",
+        "sha256": "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091",
+        "dest": "cargo/vendor/windows-strings-0.5.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-strings-0.5.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.45.0.crate",
+        "sha256": "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0",
+        "dest": "cargo/vendor/windows-sys-0.45.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.45.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.48.0.crate",
+        "sha256": "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9",
+        "dest": "cargo/vendor/windows-sys-0.48.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.48.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.52.0.crate",
+        "sha256": "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+        "dest": "cargo/vendor/windows-sys-0.52.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.52.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.59.0.crate",
+        "sha256": "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b",
+        "dest": "cargo/vendor/windows-sys-0.59.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.59.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.60.2.crate",
+        "sha256": "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb",
+        "dest": "cargo/vendor/windows-sys-0.60.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.60.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.61.2.crate",
+        "sha256": "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc",
+        "dest": "cargo/vendor/windows-sys-0.61.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-sys-0.61.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.42.2.crate",
+        "sha256": "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071",
+        "dest": "cargo/vendor/windows-targets-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.48.5.crate",
+        "sha256": "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c",
+        "dest": "cargo/vendor/windows-targets-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.52.6.crate",
+        "sha256": "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973",
+        "dest": "cargo/vendor/windows-targets-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-targets/windows-targets-0.53.5.crate",
+        "sha256": "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3",
+        "dest": "cargo/vendor/windows-targets-0.53.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-targets-0.53.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-threading/windows-threading-0.1.0.crate",
+        "sha256": "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6",
+        "dest": "cargo/vendor/windows-threading-0.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-threading-0.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows-version/windows-version-0.1.7.crate",
+        "sha256": "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631",
+        "dest": "cargo/vendor/windows-version-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631\", \"files\": {}}",
+        "dest": "cargo/vendor/windows-version-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.42.2.crate",
+        "sha256": "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.48.5.crate",
+        "sha256": "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.52.6.crate",
+        "sha256": "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_gnullvm/windows_aarch64_gnullvm-0.53.1.crate",
+        "sha256": "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.42.2.crate",
+        "sha256": "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.48.5.crate",
+        "sha256": "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.52.6.crate",
+        "sha256": "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.53.1.crate",
+        "sha256": "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.42.2.crate",
+        "sha256": "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.48.5.crate",
+        "sha256": "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.52.6.crate",
+        "sha256": "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.53.1.crate",
+        "sha256": "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3",
+        "dest": "cargo/vendor/windows_i686_gnu-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnu-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.52.6.crate",
+        "sha256": "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_gnullvm/windows_i686_gnullvm-0.53.1.crate",
+        "sha256": "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.42.2.crate",
+        "sha256": "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.48.5.crate",
+        "sha256": "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.52.6.crate",
+        "sha256": "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.53.1.crate",
+        "sha256": "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2",
+        "dest": "cargo/vendor/windows_i686_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_i686_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.42.2.crate",
+        "sha256": "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.48.5.crate",
+        "sha256": "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.52.6.crate",
+        "sha256": "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.53.1.crate",
+        "sha256": "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.42.2.crate",
+        "sha256": "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.48.5.crate",
+        "sha256": "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.52.6.crate",
+        "sha256": "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_gnullvm/windows_x86_64_gnullvm-0.53.1.crate",
+        "sha256": "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_gnullvm-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.42.2.crate",
+        "sha256": "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.42.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.48.5.crate",
+        "sha256": "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.48.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.52.6.crate",
+        "sha256": "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.52.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.53.1.crate",
+        "sha256": "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.53.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650\", \"files\": {}}",
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.53.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.5.40.crate",
+        "sha256": "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876",
+        "dest": "cargo/vendor/winnow-0.5.40"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.5.40",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-0.7.15.crate",
+        "sha256": "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945",
+        "dest": "cargo/vendor/winnow-0.7.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-0.7.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winnow/winnow-1.0.3.crate",
+        "sha256": "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1",
+        "dest": "cargo/vendor/winnow-1.0.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1\", \"files\": {}}",
+        "dest": "cargo/vendor/winnow-1.0.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winreg/winreg-0.55.0.crate",
+        "sha256": "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97",
+        "dest": "cargo/vendor/winreg-0.55.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97\", \"files\": {}}",
+        "dest": "cargo/vendor/winreg-0.55.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winreg/winreg-0.56.0.crate",
+        "sha256": "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10",
+        "dest": "cargo/vendor/winreg-0.56.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10\", \"files\": {}}",
+        "dest": "cargo/vendor/winreg-0.56.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.51.0.crate",
+        "sha256": "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5",
+        "dest": "cargo/vendor/wit-bindgen-0.51.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-0.51.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen/wit-bindgen-0.57.1.crate",
+        "sha256": "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e",
+        "dest": "cargo/vendor/wit-bindgen-0.57.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-0.57.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen-core/wit-bindgen-core-0.51.0.crate",
+        "sha256": "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc",
+        "dest": "cargo/vendor/wit-bindgen-core-0.51.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-core-0.51.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen-rust/wit-bindgen-rust-0.51.0.crate",
+        "sha256": "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21",
+        "dest": "cargo/vendor/wit-bindgen-rust-0.51.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-rust-0.51.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-bindgen-rust-macro/wit-bindgen-rust-macro-0.51.0.crate",
+        "sha256": "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a",
+        "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-bindgen-rust-macro-0.51.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-component/wit-component-0.244.0.crate",
+        "sha256": "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2",
+        "dest": "cargo/vendor/wit-component-0.244.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-component-0.244.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wit-parser/wit-parser-0.244.0.crate",
+        "sha256": "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736",
+        "dest": "cargo/vendor/wit-parser-0.244.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736\", \"files\": {}}",
+        "dest": "cargo/vendor/wit-parser-0.244.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/writeable/writeable-0.6.3.crate",
+        "sha256": "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4",
+        "dest": "cargo/vendor/writeable-0.6.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4\", \"files\": {}}",
+        "dest": "cargo/vendor/writeable-0.6.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/wry/wry-0.55.1.crate",
+        "sha256": "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514",
+        "dest": "cargo/vendor/wry-0.55.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514\", \"files\": {}}",
+        "dest": "cargo/vendor/wry-0.55.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11/x11-2.21.0.crate",
+        "sha256": "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e",
+        "dest": "cargo/vendor/x11-2.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-2.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.21.0.crate",
+        "sha256": "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f",
+        "dest": "cargo/vendor/x11-dl-2.21.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f\", \"files\": {}}",
+        "dest": "cargo/vendor/x11-dl-2.21.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb/x11rb-0.13.2.crate",
+        "sha256": "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414",
+        "dest": "cargo/vendor/x11rb-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/x11rb-protocol/x11rb-protocol-0.13.2.crate",
+        "sha256": "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd\", \"files\": {}}",
+        "dest": "cargo/vendor/x11rb-protocol-0.13.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/xattr/xattr-1.6.1.crate",
+        "sha256": "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156",
+        "dest": "cargo/vendor/xattr-1.6.1"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156\", \"files\": {}}",
+        "dest": "cargo/vendor/xattr-1.6.1",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yoke/yoke-0.8.3.crate",
+        "sha256": "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5",
+        "dest": "cargo/vendor/yoke-0.8.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5\", \"files\": {}}",
+        "dest": "cargo/vendor/yoke-0.8.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/yoke-derive/yoke-derive-0.8.2.crate",
+        "sha256": "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e",
+        "dest": "cargo/vendor/yoke-derive-0.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e\", \"files\": {}}",
+        "dest": "cargo/vendor/yoke-derive-0.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus/zbus-5.19.0.crate",
+        "sha256": "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907",
+        "dest": "cargo/vendor/zbus-5.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus-5.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_macros/zbus_macros-5.19.0.crate",
+        "sha256": "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40",
+        "dest": "cargo/vendor/zbus_macros-5.19.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_macros-5.19.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zbus_names/zbus_names-4.3.4.crate",
+        "sha256": "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e",
+        "dest": "cargo/vendor/zbus_names-4.3.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e\", \"files\": {}}",
+        "dest": "cargo/vendor/zbus_names-4.3.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zcheapstr/zcheapstr-1.1.0.crate",
+        "sha256": "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473",
+        "dest": "cargo/vendor/zcheapstr-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473\", \"files\": {}}",
+        "dest": "cargo/vendor/zcheapstr-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy/zerocopy-0.8.52.crate",
+        "sha256": "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f",
+        "dest": "cargo/vendor/zerocopy-0.8.52"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-0.8.52",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerocopy-derive/zerocopy-derive-0.8.52.crate",
+        "sha256": "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.52"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930\", \"files\": {}}",
+        "dest": "cargo/vendor/zerocopy-derive-0.8.52",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerofrom/zerofrom-0.1.8.crate",
+        "sha256": "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272",
+        "dest": "cargo/vendor/zerofrom-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272\", \"files\": {}}",
+        "dest": "cargo/vendor/zerofrom-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerofrom-derive/zerofrom-derive-0.1.7.crate",
+        "sha256": "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1",
+        "dest": "cargo/vendor/zerofrom-derive-0.1.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1\", \"files\": {}}",
+        "dest": "cargo/vendor/zerofrom-derive-0.1.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zeroize/zeroize-1.8.2.crate",
+        "sha256": "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0",
+        "dest": "cargo/vendor/zeroize-1.8.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0\", \"files\": {}}",
+        "dest": "cargo/vendor/zeroize-1.8.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerotrie/zerotrie-0.2.4.crate",
+        "sha256": "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf",
+        "dest": "cargo/vendor/zerotrie-0.2.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf\", \"files\": {}}",
+        "dest": "cargo/vendor/zerotrie-0.2.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerovec/zerovec-0.11.6.crate",
+        "sha256": "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239",
+        "dest": "cargo/vendor/zerovec-0.11.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239\", \"files\": {}}",
+        "dest": "cargo/vendor/zerovec-0.11.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zerovec-derive/zerovec-derive-0.11.3.crate",
+        "sha256": "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555",
+        "dest": "cargo/vendor/zerovec-derive-0.11.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555\", \"files\": {}}",
+        "dest": "cargo/vendor/zerovec-derive-0.11.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zmij/zmij-1.0.21.crate",
+        "sha256": "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa",
+        "dest": "cargo/vendor/zmij-1.0.21"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa\", \"files\": {}}",
+        "dest": "cargo/vendor/zmij-1.0.21",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-core/zune-core-0.5.3.crate",
+        "sha256": "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b",
+        "dest": "cargo/vendor/zune-core-0.5.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-core-0.5.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zune-jpeg/zune-jpeg-0.5.15.crate",
+        "sha256": "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296",
+        "dest": "cargo/vendor/zune-jpeg-0.5.15"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296\", \"files\": {}}",
+        "dest": "cargo/vendor/zune-jpeg-0.5.15",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant/zvariant-5.15.0.crate",
+        "sha256": "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147",
+        "dest": "cargo/vendor/zvariant-5.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant-5.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_derive/zvariant_derive-5.15.0.crate",
+        "sha256": "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497",
+        "dest": "cargo/vendor/zvariant_derive-5.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_derive-5.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/zvariant_utils/zvariant_utils-4.2.0.crate",
+        "sha256": "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3",
+        "dest": "cargo/vendor/zvariant_utils-4.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3\", \"files\": {}}",
+        "dest": "cargo/vendor/zvariant_utils-4.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
+]

--- a/node-sources.json
+++ b/node-sources.json
@@ -1,0 +1,9413 @@
+[
+  {
+    "type": "archive",
+    "url": "https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-headless-shell-linux64.zip",
+    "strip-components": 0,
+    "sha256": "3cfc2bd00d1bafcf8a68dc74c9c92bb7150ddc8d26ade948a776316e1cec4f14",
+    "dest": "flatpak-node/cache/ms-playwright/chromium-headless-shell-1234"
+  },
+  {
+    "type": "archive",
+    "url": "https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-linux64.zip",
+    "strip-components": 0,
+    "sha256": "ae8736ac28bc69278551500f219fc749575648263c43ec5990749eff43b9fcf8",
+    "dest": "flatpak-node/cache/ms-playwright/chromium-1234"
+  },
+  {
+    "type": "archive",
+    "url": "https://cdn.playwright.dev/builds/ffmpeg/1011/ffmpeg-linux.zip",
+    "strip-components": 0,
+    "sha256": "ebc74fc5b94830176a3c2914ae96bd8bc7f6a91f4f33890230f84a172ee61ccc",
+    "dest": "flatpak-node/cache/ms-playwright/ffmpeg-1011"
+  },
+  {
+    "type": "archive",
+    "url": "https://cdn.playwright.dev/builds/firefox/1538/firefox-ubuntu-22.04.zip",
+    "strip-components": 0,
+    "sha256": "f97de5eb169b41cbbc64fd976e27486ed794a589392d0d12a2f64d127caba07e",
+    "dest": "flatpak-node/cache/ms-playwright/firefox-1538"
+  },
+  {
+    "type": "archive",
+    "url": "https://cdn.playwright.dev/builds/webkit/2336/webkit-ubuntu-24.04.zip",
+    "strip-components": 0,
+    "sha256": "357cd5d52f0770f01a86c1e0e2e193b5cfdb760452fc766e26eb5c8ee3951345",
+    "dest": "flatpak-node/cache/ms-playwright/webkit-2336"
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+    "strip-components": 1,
+    "sha512": "5e50e7bb6ab9ca8a9e9acfb16b2eb0480720f430c3ecaf512ca64404e3199b7724369241bce5f6d2d49f6f2f0a7ebae120d0f2bfd57661564a63f4a9a06248f3",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.28.2",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+    "strip-components": 1,
+    "sha512": "a56e000b43f78adf1cedda3d315338a79d45cc7cdd33f4d9adeaeeae045c1c9d964dad55435088ab5f319dc7e9049c38a23922659aca5b6c8805604ff768fa52",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.28.2",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+    "strip-components": 1,
+    "sha512": "0986e78fbf07b08780f8386050a80509fbcdb131c584c32b8a752b319a435c95ca37c4f75d589367ffb0b47795c44598f1ec12cd314dfa74664b03b6b5968b51",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.28.2",
+    "only-arches": [
+      "i386"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+    "strip-components": 1,
+    "sha512": "e314d9af5154992a105b85c85a68addedcd0ad44d933e3773f45d5f3144e298179d177c8ef178ef74fb56d9bcdc3122e7d0f610d0551247e588603d517c03f1d",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.28.2",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
+    "sha512": "df25b13d3ab7510fc563da7512b3f12327d3eb87a559a32f33d9481e76aaa727edeb7b64c68745e5a5049581eb762b16bdee5c113921d7e281c35c89b96d1a47",
+    "dest-filename": "b13d3ab7510fc563da7512b3f12327d3eb87a559a32f33d9481e76aaa727edeb7b64c68745e5a5049581eb762b16bdee5c113921d7e281c35c89b96d1a47",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz",
+    "sha512": "665be63454ff88817a243d77af16db3160fc9ef191d11694a7ac8c427a1cfb801fd188d555efdb21d5b55d2410b28c5702d83535a4fa55a9342ca165278777ed",
+    "dest-filename": "e63454ff88817a243d77af16db3160fc9ef191d11694a7ac8c427a1cfb801fd188d555efdb21d5b55d2410b28c5702d83535a4fa55a9342ca165278777ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/66/5b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+    "sha512": "2b503acfcb52dd7b2608c33ceb1a16767ec591d9fd9ba45256da1c52b25823066715592783f3ef904a16b4e5a63fe49c73ab1a6161d66586e7744117c65db88f",
+    "dest-filename": "3acfcb52dd7b2608c33ceb1a16767ec591d9fd9ba45256da1c52b25823066715592783f3ef904a16b4e5a63fe49c73ab1a6161d66586e7744117c65db88f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2b/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+    "sha512": "36af0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87",
+    "dest-filename": "0e8465a264864657a84b1e8c8028b2dc26284fff115e04c189a14af14d7da9b08f1d0a27f32e16484856fe5564b7c053110e6086c3947e74ec920aa3cb87",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz",
+    "sha512": "2a4802bdd1c1e0886da47a45e7ae29940f63a3a7c33b058643fde3beb78bce03ad44b103a0faabed03bda9e8cd03c8cac03b129002abefb86a0479f251b230e2",
+    "dest-filename": "02bdd1c1e0886da47a45e7ae29940f63a3a7c33b058643fde3beb78bce03ad44b103a0faabed03bda9e8cd03c8cac03b129002abefb86a0479f251b230e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz",
+    "sha512": "6a6db6a57d9a06ace7aaad5e332223fdb67efab885dcb93a72dedc6effa040ad1cb0586bf9df0ed1190e8b6145daa4a016000d6ea364219d3f3f19675b6a4b16",
+    "dest-filename": "b6a57d9a06ace7aaad5e332223fdb67efab885dcb93a72dedc6effa040ad1cb0586bf9df0ed1190e8b6145daa4a016000d6ea364219d3f3f19675b6a4b16",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz",
+    "sha512": "978e0a5831cb0ef1270f437f5dcad5b3b5576f7035f312fb412dd607478bf77c1b9a4e76f5f7c81b9e6f95e182a9aba7a515232eb7678cad394248b576c8f296",
+    "dest-filename": "0a5831cb0ef1270f437f5dcad5b3b5576f7035f312fb412dd607478bf77c1b9a4e76f5f7c81b9e6f95e182a9aba7a515232eb7678cad394248b576c8f296",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz",
+    "sha512": "ec89953f004b0ad926a51e5eb1df111e14ea5bde1fd092c942e9ba027798732f788d19b5f1368f3e6eec95a8a01b31617e0b774220f5563e762ca9810272a2cc",
+    "dest-filename": "953f004b0ad926a51e5eb1df111e14ea5bde1fd092c942e9ba027798732f788d19b5f1368f3e6eec95a8a01b31617e0b774220f5563e762ca9810272a2cc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/89"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz",
+    "sha512": "20268af8861a559bca6c1c57dabc2b3d3d037540cc9c4f559b79d019efa696d40f994835f6938dce43d619d638142b28ade0c44d60f29ef76de32b026c5e6035",
+    "dest-filename": "8af8861a559bca6c1c57dabc2b3d3d037540cc9c4f559b79d019efa696d40f994835f6938dce43d619d638142b28ade0c44d60f29ef76de32b026c5e6035",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz",
+    "sha512": "45719a0f4a35fe94d382e630d5a783261f5a77a2dfaee8b47c8ee605d7ab4f21abed6b94264048b6d80b911dd7272a313a49207c10eca5a513f305c0ad3a8b67",
+    "dest-filename": "9a0f4a35fe94d382e630d5a783261f5a77a2dfaee8b47c8ee605d7ab4f21abed6b94264048b6d80b911dd7272a313a49207c10eca5a513f305c0ad3a8b67",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz",
+    "sha512": "cf6d90ff31584af6c825f5b509b7d93eee17f0f75d4ba41dd8e45b73a87e693e84730031505de6e9f0381e336f0374d4e17d1d4c947034f075eb9112dcf257ce",
+    "dest-filename": "90ff31584af6c825f5b509b7d93eee17f0f75d4ba41dd8e45b73a87e693e84730031505de6e9f0381e336f0374d4e17d1d4c947034f075eb9112dcf257ce",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz",
+    "sha512": "9c72befc71c2f83d288001d4c689a0a124dd8c899be9f98d3554ca99fd2dcaee1e0cbd43a8f2881dcfa2f942fcf9bd119c0bbcdb6e2aa3c176b42567693d00df",
+    "dest-filename": "befc71c2f83d288001d4c689a0a124dd8c899be9f98d3554ca99fd2dcaee1e0cbd43a8f2881dcfa2f942fcf9bd119c0bbcdb6e2aa3c176b42567693d00df",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/72"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz",
+    "sha512": "622ab41f9e8b8d7492c3f85df589178122d07f3c832736f35364dece8cf1c8dc3eb8a580a8eb6a195bc17f329144389a145e5abc60211dd58ac7b2ed0ce4a153",
+    "dest-filename": "b41f9e8b8d7492c3f85df589178122d07f3c832736f35364dece8cf1c8dc3eb8a580a8eb6a195bc17f329144389a145e5abc60211dd58ac7b2ed0ce4a153",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz",
+    "sha512": "eb073b724eb972d03be47abb1581d3b53bc69d8b3a9ac81dc6249420243e034d6754e5a0eabaa8b9907c21dcad79195fa58622168be47faedd21e3a05885334c",
+    "dest-filename": "3b724eb972d03be47abb1581d3b53bc69d8b3a9ac81dc6249420243e034d6754e5a0eabaa8b9907c21dcad79195fa58622168be47faedd21e3a05885334c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+    "sha512": "21c84d7fa74de2d1e8305227ffb384f0b599d7d63aabfebb0667fabe719112ff1149b0556fd2cf27111c9f0adcc17ea2c52bda886a2898052fbb8612c57ad583",
+    "dest-filename": "4d7fa74de2d1e8305227ffb384f0b599d7d63aabfebb0667fabe719112ff1149b0556fd2cf27111c9f0adcc17ea2c52bda886a2898052fbb8612c57ad583",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+    "sha512": "4b5d445d6272cb4333e5262f46663c9c96131457752c2355fbb717c80810b4e3aecdbe04b207ea0ee7cbfbd7acc7bdbf78b86c45d199c1a95dbbf87e138b7804",
+    "dest-filename": "445d6272cb4333e5262f46663c9c96131457752c2355fbb717c80810b4e3aecdbe04b207ea0ee7cbfbd7acc7bdbf78b86c45d199c1a95dbbf87e138b7804",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+    "sha512": "dcdf286a3fb48ee530ff51f76309830c95c281307580a53a1dcfdb079d36bbdcd1d2adaf77bf3a5c91fd41faca2048059599a1662aba7a95e5e2b1ea873b0881",
+    "dest-filename": "286a3fb48ee530ff51f76309830c95c281307580a53a1dcfdb079d36bbdcd1d2adaf77bf3a5c91fd41faca2048059599a1662aba7a95e5e2b1ea873b0881",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/df"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+    "sha512": "9dbb4ac21ddaeb1355229fd546e5d5eb8c932a76f52234c01048778abcd2f8790a8c03982d318d6fda6654d9ed67c8950477160c0d83a1fd10b4f80523505a4c",
+    "dest-filename": "4ac21ddaeb1355229fd546e5d5eb8c932a76f52234c01048778abcd2f8790a8c03982d318d6fda6654d9ed67c8950477160c0d83a1fd10b4f80523505a4c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+    "sha512": "0da0de5245d92a374686061a1cd25357da55ed8f41ddbeb8e2308bb3d52973755e34683a2d6011013e8ef90fbf08ea3eda083f6cce6b869300b5fef45aa7c175",
+    "dest-filename": "de5245d92a374686061a1cd25357da55ed8f41ddbeb8e2308bb3d52973755e34683a2d6011013e8ef90fbf08ea3eda083f6cce6b869300b5fef45aa7c175",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+    "sha512": "55dffd1150e2bba3cf26df72021eaba193fa125d711eb76f2151a3c81b07474458c0d1e02fb1493f22085b87c0349346e85b7265fbe544fa4523864cfe5b9bbf",
+    "dest-filename": "fd1150e2bba3cf26df72021eaba193fa125d711eb76f2151a3c81b07474458c0d1e02fb1493f22085b87c0349346e85b7265fbe544fa4523864cfe5b9bbf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/df"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+    "sha512": "452bdb4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
+    "dest-filename": "db4261f374accdb0b61aff01eb6dcdca378b182ca01d3d9c6a88cd87013aaffd2064dbf10d487a6f5c668b38c72c032cf4a68106aa49a62981b739688911",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+    "sha512": "be08fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
+    "dest-filename": "fb477cb75a0c76e0841a18f03f47a6055cb1d530e674b951322103da5acfab7750337c43179400b6d856303b55e4291e8d3ecabb9946a7747f2821175917",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+    "sha512": "9323a5dd7d03b93893d61d9fb7caf67d83bc258b54f5af578acff305288602b35a6a008e5b1f74375936c31a75f1ccc50c7f8e81c5866f964ffd732dddd7323c",
+    "dest-filename": "a5dd7d03b93893d61d9fb7caf67d83bc258b54f5af578acff305288602b35a6a008e5b1f74375936c31a75f1ccc50c7f8e81c5866f964ffd732dddd7323c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+    "sha512": "73de6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
+    "dest-filename": "6a39790777274d2a1b1c05379ba840b5095019a72a8e7d57c1cd0d6a833ca5de07de95d5232208036c86600cab072e09ec33e8a01fb4c9fde01ab1a56e30",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+    "sha512": "5c4c5c3be76f2cabd5b4d4e26d24c17a3d4d0806da1a15a7f56c3564fc7cd2ab1a8613c57bff238163f421c84d7b41771f0914ee7f1e8e11fc6e3a27aa1b7c99",
+    "dest-filename": "5c3be76f2cabd5b4d4e26d24c17a3d4d0806da1a15a7f56c3564fc7cd2ab1a8613c57bff238163f421c84d7b41771f0914ee7f1e8e11fc6e3a27aa1b7c99",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5c/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+    "sha512": "9175e888f55519072721818e79aa2fc0e511a678830694aae00d37aa443e04c42ab461ba1d86a9df19def42d4ed72a384d1deac65097e48aaa997e9f168d8baa",
+    "dest-filename": "e888f55519072721818e79aa2fc0e511a678830694aae00d37aa443e04c42ab461ba1d86a9df19def42d4ed72a384d1deac65097e48aaa997e9f168d8baa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+    "sha512": "e587ca79e23ca967c16485febb6c590b76656f73acfe02d2dac6c428cf88e1939cb169874b658bcac09c4190c0151b250d45393a2ab8e207fa3d8375bc6c06e4",
+    "dest-filename": "ca79e23ca967c16485febb6c590b76656f73acfe02d2dac6c428cf88e1939cb169874b658bcac09c4190c0151b250d45393a2ab8e207fa3d8375bc6c06e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/87"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+    "sha512": "3b7f3b8ad7bb4b353209ccb72505f83f86cbb4403b6cb2e4c7e7acbdee491e7c987cd4f1715a57668f6385d07495328de38833b442d3754ee74bc36bd7a16cd5",
+    "dest-filename": "3b8ad7bb4b353209ccb72505f83f86cbb4403b6cb2e4c7e7acbdee491e7c987cd4f1715a57668f6385d07495328de38833b442d3754ee74bc36bd7a16cd5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+    "sha512": "9f82aa90e42badac4725c82333546fc1b8a07d028828956933bc69f8ab318b2512ad17485e7b7bdd586b3c0c747d5e388607e62152a3c4c37d275b798f249593",
+    "dest-filename": "aa90e42badac4725c82333546fc1b8a07d028828956933bc69f8ab318b2512ad17485e7b7bdd586b3c0c747d5e388607e62152a3c4c37d275b798f249593",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/82"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+    "sha512": "baaeacb885983f7eeacc675d04a3f0e501103e2e8788b1ac3bb5269297f2698350dc3fab37ac3a59fc07fa7baa7065d6bdac06c31384ae83b86069c587de5acf",
+    "dest-filename": "acb885983f7eeacc675d04a3f0e501103e2e8788b1ac3bb5269297f2698350dc3fab37ac3a59fc07fa7baa7065d6bdac06c31384ae83b86069c587de5acf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+    "sha512": "9fe234053491228cbe77a44f2a7115c2a979530049a25cadbd8e2600e204268aca96a80f208f22c7ab25555adf6794e78fb825219be5a3295b07f1093cc5845f",
+    "dest-filename": "34053491228cbe77a44f2a7115c2a979530049a25cadbd8e2600e204268aca96a80f208f22c7ab25555adf6794e78fb825219be5a3295b07f1093cc5845f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+    "sha512": "efc5c94c992f3ecd24cf6c3ad77d353c98d797883bab726a898319fccff2548ef710706b0914e0921bbda2a1bbbcfaaaf9aff269d116f1a0fe6a02a5939c6b9a",
+    "dest-filename": "c94c992f3ecd24cf6c3ad77d353c98d797883bab726a898319fccff2548ef710706b0914e0921bbda2a1bbbcfaaaf9aff269d116f1a0fe6a02a5939c6b9a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/c5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+    "sha512": "5e50e7bb6ab9ca8a9e9acfb16b2eb0480720f430c3ecaf512ca64404e3199b7724369241bce5f6d2d49f6f2f0a7ebae120d0f2bfd57661564a63f4a9a06248f3",
+    "dest-filename": "e7bb6ab9ca8a9e9acfb16b2eb0480720f430c3ecaf512ca64404e3199b7724369241bce5f6d2d49f6f2f0a7ebae120d0f2bfd57661564a63f4a9a06248f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+    "sha512": "a56e000b43f78adf1cedda3d315338a79d45cc7cdd33f4d9adeaeeae045c1c9d964dad55435088ab5f319dc7e9049c38a23922659aca5b6c8805604ff768fa52",
+    "dest-filename": "000b43f78adf1cedda3d315338a79d45cc7cdd33f4d9adeaeeae045c1c9d964dad55435088ab5f319dc7e9049c38a23922659aca5b6c8805604ff768fa52",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/6e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+    "sha512": "0986e78fbf07b08780f8386050a80509fbcdb131c584c32b8a752b319a435c95ca37c4f75d589367ffb0b47795c44598f1ec12cd314dfa74664b03b6b5968b51",
+    "dest-filename": "e78fbf07b08780f8386050a80509fbcdb131c584c32b8a752b319a435c95ca37c4f75d589367ffb0b47795c44598f1ec12cd314dfa74664b03b6b5968b51",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+    "sha512": "6eec2477c9eca61e11f9a8d1bf0d2a3391e36bf4d7428c37a6dcd63b611b1bf72a70890796846b76506d425b21c98193345bdf91f279b693cb5646380edb0f7d",
+    "dest-filename": "2477c9eca61e11f9a8d1bf0d2a3391e36bf4d7428c37a6dcd63b611b1bf72a70890796846b76506d425b21c98193345bdf91f279b693cb5646380edb0f7d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+    "sha512": "655ca46c3ca4ef9d7d57088d6fd2dc8fd9bc5cceafe55f6e28fbeb10c92411e7557b07fed22b6485a869e070e98044578702d1a56172a6c19b1bf27cb3442324",
+    "dest-filename": "a46c3ca4ef9d7d57088d6fd2dc8fd9bc5cceafe55f6e28fbeb10c92411e7557b07fed22b6485a869e070e98044578702d1a56172a6c19b1bf27cb3442324",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/5c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+    "sha512": "0805e5f83b5df5452e25df2928a77087a30b9b7314322a8c3e6859ded4d25cfa9fc90def0e5e91e6165d67f918a232b8a1f5ed75f4afd6d16af17cd6c7785e35",
+    "dest-filename": "e5f83b5df5452e25df2928a77087a30b9b7314322a8c3e6859ded4d25cfa9fc90def0e5e91e6165d67f918a232b8a1f5ed75f4afd6d16af17cd6c7785e35",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/05"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+    "sha512": "19e5c27a3e0842d53507e4250d5f16fd146f6f32373bf4adb2cfbf6c25efe25665b3958646dbb66bedc9900de2e2a21494c5e970779b5a917c024261013a30b8",
+    "dest-filename": "c27a3e0842d53507e4250d5f16fd146f6f32373bf4adb2cfbf6c25efe25665b3958646dbb66bedc9900de2e2a21494c5e970779b5a917c024261013a30b8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/e5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+    "sha512": "dc7d707936193f1b7f58e841caccd06726d2f70e652b3527d450ccb2010285b1d64301d841045f071802719bcf8631df2b22632227afbcc98451ac09add63d0e",
+    "dest-filename": "707936193f1b7f58e841caccd06726d2f70e652b3527d450ccb2010285b1d64301d841045f071802719bcf8631df2b22632227afbcc98451ac09add63d0e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+    "sha512": "e314d9af5154992a105b85c85a68addedcd0ad44d933e3773f45d5f3144e298179d177c8ef178ef74fb56d9bcdc3122e7d0f610d0551247e588603d517c03f1d",
+    "dest-filename": "d9af5154992a105b85c85a68addedcd0ad44d933e3773f45d5f3144e298179d177c8ef178ef74fb56d9bcdc3122e7d0f610d0551247e588603d517c03f1d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/14"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+    "sha512": "b120134633de0c1837a5d807a107e8601a1bd752a4d4519af65ba2e51207642a029096bd40a96f977fef2b3daeb02998623b3bca6251ff6367b2a7be1e3b799f",
+    "dest-filename": "134633de0c1837a5d807a107e8601a1bd752a4d4519af65ba2e51207642a029096bd40a96f977fef2b3daeb02998623b3bca6251ff6367b2a7be1e3b799f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+    "sha512": "96a9f3095fa633480800368a8a188283a89f81f5362f7879137deb35004dd58e0c6951a7cebcb39afbdfed41f1a6ba50744f21a6a2e8949f5197e4a42110e9cb",
+    "dest-filename": "f3095fa633480800368a8a188283a89f81f5362f7879137deb35004dd58e0c6951a7cebcb39afbdfed41f1a6ba50744f21a6a2e8949f5197e4a42110e9cb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/a9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+    "sha512": "00bdaa2482c7ee5363ac3982403bddc4c7c0508bfc28c3593afaf0010f22f3ffe7b4bf457e584ec8c27c39948c05bf3f0165dedffe6fe52db4cb7cc2a1958aa1",
+    "dest-filename": "aa2482c7ee5363ac3982403bddc4c7c0508bfc28c3593afaf0010f22f3ffe7b4bf457e584ec8c27c39948c05bf3f0165dedffe6fe52db4cb7cc2a1958aa1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/bd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+    "sha512": "42d8ae3f2b5c851c82e2bc142a17b125d40abc3b99ea15a5a22de282a3d03542424b5feff4488edd44ce5d1e80dc5a0ca387e700a6d625da9a23084ece1f2a13",
+    "dest-filename": "ae3f2b5c851c82e2bc142a17b125d40abc3b99ea15a5a22de282a3d03542424b5feff4488edd44ce5d1e80dc5a0ca387e700a6d625da9a23084ece1f2a13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+    "sha512": "5a48580e6a538cbbc6952700d6bc234549a197893ca174777086eda969842e053f7457871e51259710ef75670d255f6b6f309ec41e6fcfc82d35ec162e0093ed",
+    "dest-filename": "580e6a538cbbc6952700d6bc234549a197893ca174777086eda969842e053f7457871e51259710ef75670d255f6b6f309ec41e6fcfc82d35ec162e0093ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+    "sha512": "18f3129133ad327bf653617c8317b8228eaa995b3e60aca9f37d84b6aab1af48459e0997437af3c32b5e966dc6227ed3e15be245495fdec3a004e89376f69fee",
+    "dest-filename": "129133ad327bf653617c8317b8228eaa995b3e60aca9f37d84b6aab1af48459e0997437af3c32b5e966dc6227ed3e15be245495fdec3a004e89376f69fee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/f3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+    "sha512": "3c886112413db8f06579106b404269527ecc06789b6736c6cd858f998df1f98a1583ff79cdb8c1e02c4f3ce43c979b5860ce2631a0ad845f3fd4321f05043259",
+    "dest-filename": "6112413db8f06579106b404269527ecc06789b6736c6cd858f998df1f98a1583ff79cdb8c1e02c4f3ce43c979b5860ce2631a0ad845f3fd4321f05043259",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3c/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+    "sha512": "62625b7d396f53b49d9fd041fb83d1112e2807aa71812dfb30038d8fe841aff7295d2d5a04f297c4d9c36eef900963e3d28f5d832c5eabbf60e9ce4ff0a7ae60",
+    "dest-filename": "5b7d396f53b49d9fd041fb83d1112e2807aa71812dfb30038d8fe841aff7295d2d5a04f297c4d9c36eef900963e3d28f5d832c5eabbf60e9ce4ff0a7ae60",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/62"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+    "sha512": "e5e6e9c6bde758cceb2ffae7508ef9e4992e79ed1b1cbfc6ab459317d96f729bfbdf0029e5ebbc31f0548162bd6e15af6638fbc97f1eb5fffcb48f0d7b2ebde6",
+    "dest-filename": "e9c6bde758cceb2ffae7508ef9e4992e79ed1b1cbfc6ab459317d96f729bfbdf0029e5ebbc31f0548162bd6e15af6638fbc97f1eb5fffcb48f0d7b2ebde6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/e6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+    "sha512": "d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
+    "dest-filename": "785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+    "sha512": "f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
+    "dest-filename": "52008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/06"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+    "sha512": "702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
+    "dest-filename": "766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+    "sha512": "46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
+    "dest-filename": "7fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+    "sha512": "796a5062bebbb6a24b79a49497443e4eabae61f51d4e26e9389954315d857d43fbf8aa820b94ee7e7c279572fa9a86d90496c601845ded9bc404309b2c89e386",
+    "dest-filename": "5062bebbb6a24b79a49497443e4eabae61f51d4e26e9389954315d857d43fbf8aa820b94ee7e7c279572fa9a86d90496c601845ded9bc404309b2c89e386",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+    "sha512": "b964c6fa5dd5251b25ec45f1622cee2f73fe7023e8737711a9b59645c40dd0585e8d17db76ad113610a66d8fd80ed9d3733f6271d2d8b8b0e3b27cf877c24cbb",
+    "dest-filename": "c6fa5dd5251b25ec45f1622cee2f73fe7023e8737711a9b59645c40dd0585e8d17db76ad113610a66d8fd80ed9d3733f6271d2d8b8b0e3b27cf877c24cbb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/64"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+    "sha512": "b6c4e4e33563226a9daa34bcfc0399836c8d2ddd73f52e6ffbba143e95da6ac0d1c040e107ec678252b593971a776ea52f9fd921a791120596cb46ecf72f693c",
+    "dest-filename": "e4e33563226a9daa34bcfc0399836c8d2ddd73f52e6ffbba143e95da6ac0d1c040e107ec678252b593971a776ea52f9fd921a791120596cb46ecf72f693c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+    "sha512": "4ddefaabb8f9ee8fed2d57604bbe3a7180117d2cb193c8847d1c5ec0bf61e0e3336216d6e1301ca69974993e1ecaa5dd761e8bfe3c2833be66a3b8b16bfa4279",
+    "dest-filename": "faabb8f9ee8fed2d57604bbe3a7180117d2cb193c8847d1c5ec0bf61e0e3336216d6e1301ca69974993e1ecaa5dd761e8bfe3c2833be66a3b8b16bfa4279",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+    "sha512": "44c9c55fb610b0ca21ee559f70ce0d1071f29815ffacbb8a34f54cf385c4f4e34f71a4820e013b087207a5280f70edb1711b61801cb51df34edf5f66c2120092",
+    "dest-filename": "c55fb610b0ca21ee559f70ce0d1071f29815ffacbb8a34f54cf385c4f4e34f71a4820e013b087207a5280f70edb1711b61801cb51df34edf5f66c2120092",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/c9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+    "sha512": "5e8fb9b8506d2cdd012aa89e4f1885cc53d00149416db1f98812b2457ff3d49adb9d8b074df2899d47cbf3ea764cf5ebd695ea6a8e1e78be11975e38b83a4af7",
+    "dest-filename": "b9b8506d2cdd012aa89e4f1885cc53d00149416db1f98812b2457ff3d49adb9d8b074df2899d47cbf3ea764cf5ebd695ea6a8e1e78be11975e38b83a4af7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+    "sha512": "954c5ca96223db0310f41af03639e072bd60594af9c606864e1051a8f3da9480b69faec2aa3d6e3e1f0d9c0fd984083c8546ca97e9151cac20508c1ee9960fae",
+    "dest-filename": "5ca96223db0310f41af03639e072bd60594af9c606864e1051a8f3da9480b69faec2aa3d6e3e1f0d9c0fd984083c8546ca97e9151cac20508c1ee9960fae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/95/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+    "sha512": "f49eb2a591694018f862778f1a8abf4b7f30ea7cfebea8395992eb2c663862e49e99d32ae3b18c2c13cee36333c1d1b0a60fda819ef1cd97051dae3cc65cb07e",
+    "dest-filename": "b2a591694018f862778f1a8abf4b7f30ea7cfebea8395992eb2c663862e49e99d32ae3b18c2c13cee36333c1d1b0a60fda819ef1cd97051dae3cc65cb07e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/9e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+    "sha512": "9b6a56d67e9c9ecf556ae6cdc2c67e737091623c4d416809e603e59cbd676c1729901bc59ba48214de68d29b051c8f30f67d7534a84591e1039ecf7cb62a9b13",
+    "dest-filename": "56d67e9c9ecf556ae6cdc2c67e737091623c4d416809e603e59cbd676c1729901bc59ba48214de68d29b051c8f30f67d7534a84591e1039ecf7cb62a9b13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+    "sha512": "d5e30bcf2f7623827aae68b89804fcc82dc7c4eb678b21842e5cc66cd30b2dea9ed39d9a84543487a2c5abe961e43b0321d6158880ecb74f1a6ef49b70474b5d",
+    "dest-filename": "0bcf2f7623827aae68b89804fcc82dc7c4eb678b21842e5cc66cd30b2dea9ed39d9a84543487a2c5abe961e43b0321d6158880ecb74f1a6ef49b70474b5d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/e3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+    "sha512": "76a5521729c2a31e02fc9f244f5e95ed2205027b3422380bc24bd84fba7c2d0566279392e5bead23d2067e5c537ae052fffcd77852146f0b79770c72675edc9c",
+    "dest-filename": "521729c2a31e02fc9f244f5e95ed2205027b3422380bc24bd84fba7c2d0566279392e5bead23d2067e5c537ae052fffcd77852146f0b79770c72675edc9c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/a5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+    "sha512": "df3d0d1c3c43ea7e48f60734e54d5e5b5032466f86ce7ceade768caed84f36a13aa18ca4728816d25fe37e925d8d89ee365f11ef223da4d6c4d578947b2ab403",
+    "dest-filename": "0d1c3c43ea7e48f60734e54d5e5b5032466f86ce7ceade768caed84f36a13aa18ca4728816d25fe37e925d8d89ee365f11ef223da4d6c4d578947b2ab403",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/df/3d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+    "sha512": "6ec6f8ac8f8d95d18eb17b9e8f6afc39d492f3ecd70d56825b1c96adcbfa9277933a58001ed640051cc1042c1db0f883f742789b2349b87a60ea4036d08996ff",
+    "dest-filename": "f8ac8f8d95d18eb17b9e8f6afc39d492f3ecd70d56825b1c96adcbfa9277933a58001ed640051cc1042c1db0f883f742789b2349b87a60ea4036d08996ff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+    "sha512": "fc006c8728fc802a7222b3579c79f82e8ac32741c79b55615cf065c59f3302d7d53c069269f5cf1a7fac5122118b0692072d269858d28e25c8e6691cc1d0a129",
+    "dest-filename": "6c8728fc802a7222b3579c79f82e8ac32741c79b55615cf065c59f3302d7d53c069269f5cf1a7fac5122118b0692072d269858d28e25c8e6691cc1d0a129",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+    "sha512": "2133c4b607df189d12e86f5d472c3fdfaead250a8545c1d63c7842f92b6983767c00432b0eb4ebda585dcf87ff63f1cc6d187fffb679981cc4a55762eb639cdf",
+    "dest-filename": "c4b607df189d12e86f5d472c3fdfaead250a8545c1d63c7842f92b6983767c00432b0eb4ebda585dcf87ff63f1cc6d187fffb679981cc4a55762eb639cdf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+    "sha512": "cc4f447625335268399834f96b5ae4e5f609e8658f9684f05816034b5e276aa1ec2fe11a3290e3d405a7a4b821deed1808e46fd93b79d30adcae962a90ff7b2b",
+    "dest-filename": "447625335268399834f96b5ae4e5f609e8658f9684f05816034b5e276aa1ec2fe11a3290e3d405a7a4b821deed1808e46fd93b79d30adcae962a90ff7b2b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/4f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+    "sha512": "9b496b2e252dfa50589c216bf2a57feb9c8c47813f73bff07fbf08e5e29376411a90502567d425cc433740886103055e5212c01cb702abb6bb56cceafe814d65",
+    "dest-filename": "6b2e252dfa50589c216bf2a57feb9c8c47813f73bff07fbf08e5e29376411a90502567d425cc433740886103055e5212c01cb702abb6bb56cceafe814d65",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+    "sha512": "69f7d55824cba28cbc4d2c5b0f1daa933b8379a58b355040f8ffff14d062ac7b17a4fd9fb81864e40b9ba18527ac39f3a177acf06163a53c7448114e09183e14",
+    "dest-filename": "d55824cba28cbc4d2c5b0f1daa933b8379a58b355040f8ffff14d062ac7b17a4fd9fb81864e40b9ba18527ac39f3a177acf06163a53c7448114e09183e14",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/f7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+    "sha512": "420283b291cf9eb53e190e795cf846c32842f1a70b54e392c80be8d6855f166ac85cb903366196cc07c3678c4af28480d6a050ac02dc1d7d06e546678bf4ae15",
+    "dest-filename": "83b291cf9eb53e190e795cf846c32842f1a70b54e392c80be8d6855f166ac85cb903366196cc07c3678c4af28480d6a050ac02dc1d7d06e546678bf4ae15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/02"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+    "sha512": "b0c77cac3c66a4b3b0bffecde38925163383e4350eec52dd8e25c3234868c5869fec0af6eb6750204928b04f7c6e9b3ee473cbb69fc4bcda9ea90b4ec9c3ff20",
+    "dest-filename": "7cac3c66a4b3b0bffecde38925163383e4350eec52dd8e25c3234868c5869fec0af6eb6750204928b04f7c6e9b3ee473cbb69fc4bcda9ea90b4ec9c3ff20",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+    "sha512": "d04a1befcca39583df2f9bcc356016e7997747d63a0504bf80e7ded1970ff66133f68861292b788a6d616b28a49d781ff005ab16a32f25c2887662e611eef279",
+    "dest-filename": "1befcca39583df2f9bcc356016e7997747d63a0504bf80e7ded1970ff66133f68861292b788a6d616b28a49d781ff005ab16a32f25c2887662e611eef279",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/4a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+    "sha512": "2a00314340f1a4d3aad6b1b6b797204e04a1245192b94ed73b8e5ca82fb53553ae6673fab6581946e49839f36ea46907203d28ddc24eb30e0355e269328bdc1b",
+    "dest-filename": "314340f1a4d3aad6b1b6b797204e04a1245192b94ed73b8e5ca82fb53553ae6673fab6581946e49839f36ea46907203d28ddc24eb30e0355e269328bdc1b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+    "sha512": "f29aafc6e6cbd8f19d8653f2e862eacc360c523c9198a03028760a8b1a5d2580542bb3c9d02d36f5776c9e91487604591baf1f66219d1d559c28fbed88f07870",
+    "dest-filename": "afc6e6cbd8f19d8653f2e862eacc360c523c9198a03028760a8b1a5d2580542bb3c9d02d36f5776c9e91487604591baf1f66219d1d559c28fbed88f07870",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+    "sha512": "573d22423cf37125f71c26dfc057c2486ffd48222ac8ed261f6b17ca21da0187c1934711b025974724185f4a2f08afcf01005b4f343476c3d01e1e4c0052f9f7",
+    "dest-filename": "22423cf37125f71c26dfc057c2486ffd48222ac8ed261f6b17ca21da0187c1934711b025974724185f4a2f08afcf01005b4f343476c3d01e1e4c0052f9f7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/3d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+    "sha512": "e8ed4d3ca703563f5011d83b1f1e78f445fc534ae9eb25d0111aabbbac9137b7c6067df652f2112549569e4fbcc430a21bbea15d505b5fcd8d67f64aaf47ae22",
+    "dest-filename": "4d3ca703563f5011d83b1f1e78f445fc534ae9eb25d0111aabbbac9137b7c6067df652f2112549569e4fbcc430a21bbea15d505b5fcd8d67f64aaf47ae22",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+    "sha512": "719d1791c606a47664a96ea20a4a93726502d020fd0e10f977fa9e6656647d1067e869c79e26572d4a39fbdc70f08bfbe9813a2d014df5834194a4447021bbeb",
+    "dest-filename": "1791c606a47664a96ea20a4a93726502d020fd0e10f977fa9e6656647d1067e869c79e26572d4a39fbdc70f08bfbe9813a2d014df5834194a4447021bbeb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+    "sha512": "dab9eaedb5f7373791d93e185a0cfcaa21b88774d274c7bebcdd62417a4995e489dd2339cd0f05cb64b2c9701695bc69119d98f99e2ed4178f8091186d2cbcd1",
+    "dest-filename": "eaedb5f7373791d93e185a0cfcaa21b88774d274c7bebcdd62417a4995e489dd2339cd0f05cb64b2c9701695bc69119d98f99e2ed4178f8091186d2cbcd1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+    "sha512": "e1b3f015d31b782e0943c2fc2cec96a7a9ec1dc6e83f97f1929ea23ce5f3d95838f51e364ee32cdb08642793803f8fd4974df9a8ecf2d0079c385f553ac727e3",
+    "dest-filename": "f015d31b782e0943c2fc2cec96a7a9ec1dc6e83f97f1929ea23ce5f3d95838f51e364ee32cdb08642793803f8fd4974df9a8ecf2d0079c385f553ac727e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+    "sha512": "af9de65ec04dea51540e2493efae12be0c1474702a338acf0220f30267f87cba01e97feb91fc93acb0a0ebe835ef0249882981dc96201ee5257425942111525f",
+    "dest-filename": "e65ec04dea51540e2493efae12be0c1474702a338acf0220f30267f87cba01e97feb91fc93acb0a0ebe835ef0249882981dc96201ee5257425942111525f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/af/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+    "sha512": "0f8cb5bcd799ac820908dfae1da595b47f3a07e682add31862389ccbda571ef6c665e1982cb49ddf0755b82dfb171557954d4046c93ce1e2967d631719812abc",
+    "dest-filename": "b5bcd799ac820908dfae1da595b47f3a07e682add31862389ccbda571ef6c665e1982cb49ddf0755b82dfb171557954d4046c93ce1e2967d631719812abc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/8c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+    "sha512": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+    "dest-filename": "128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+    "sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+    "dest-filename": "3ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+    "sha512": "dc17a5b7ab5d73c6cf800b5b72676d349962ad5a139846f97b6802f783e7930116f6323a0801d47a81bce6d8d63f95aabaa7dabe832d330886e0ff76e9928ab9",
+    "dest-filename": "a5b7ab5d73c6cf800b5b72676d349962ad5a139846f97b6802f783e7930116f6323a0801d47a81bce6d8d63f95aabaa7dabe832d330886e0ff76e9928ab9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@mcp-ui/client/-/client-6.1.1.tgz",
+    "sha512": "90de62a3ba2e12955f3939681041ab9ee5a2a3767360e5604e4e28f142e578009d284c3b560393a333e5f5a8fda9597f50187bad796f287d096c19ba4f0e762d",
+    "dest-filename": "62a3ba2e12955f3939681041ab9ee5a2a3767360e5604e4e28f142e578009d284c3b560393a333e5f5a8fda9597f50187bad796f287d096c19ba4f0e762d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.55.3.tgz",
+    "sha512": "338c54d7e8494eab4bb1c69395a4aac8aa017def9495239f6d2d74ed34f8eafad49165315bbe3b7832545fc58149f5f933f572cb595fee358bf8ddb776d7a8be",
+    "dest-filename": "54d7e8494eab4bb1c69395a4aac8aa017def9495239f6d2d74ed34f8eafad49165315bbe3b7832545fc58149f5f933f572cb595fee358bf8ddb776d7a8be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/33/8c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz",
+    "sha512": "410ab2b04e78f5c7ff63455a6c19800025e18fdd84841dedf3255cb760476e45a23d3140d52f7512a4d58d85d771911e7d7534a661dc74e6e1b0d31ca2624839",
+    "dest-filename": "b2b04e78f5c7ff63455a6c19800025e18fdd84841dedf3255cb760476e45a23d3140d52f7512a4d58d85d771911e7d7534a661dc74e6e1b0d31ca2624839",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.22.0.tgz",
+    "sha512": "677347a9ad734e36727dc777a89729230aa2486ed0951dd89183c5008a0cb0fc378487740281ed946e1246e789cf2982b05f51a9e8a7dcdcd49f7a93f9aa9407",
+    "dest-filename": "47a9ad734e36727dc777a89729230aa2486ed0951dd89183c5008a0cb0fc378487740281ed946e1246e789cf2982b05f51a9e8a7dcdcd49f7a93f9aa9407",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/73"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.22.0.tgz",
+    "sha512": "2c01628ddb762f8c718ea035e9d92a54f8c1f3955ec8701adf633e9c067231ee2da3cb37e5c5bdb1954f9c11058d71853780365ac674ed58a21bec0ce92292e3",
+    "dest-filename": "628ddb762f8c718ea035e9d92a54f8c1f3955ec8701adf633e9c067231ee2da3cb37e5c5bdb1954f9c11058d71853780365ac674ed58a21bec0ce92292e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.22.0.tgz",
+    "sha512": "84eac4c67a7cc0e952116554fadf540ff3ce1c5672d3d5f1f0b66a5fb3fd47b9b370376bc13541f7ab5b3c3f1c222f6655858540328635552c17a23bbbb7cf18",
+    "dest-filename": "c4c67a7cc0e952116554fadf540ff3ce1c5672d3d5f1f0b66a5fb3fd47b9b370376bc13541f7ab5b3c3f1c222f6655858540328635552c17a23bbbb7cf18",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.22.0.tgz",
+    "sha512": "1d4caf17ee82ddefec2f7c1949cef52e2d5292e5b2b22c5b945a55766f1cb092813a54f690d1b99163f400081d5d1891591676ed96a336d6a0620c2827e401a5",
+    "dest-filename": "af17ee82ddefec2f7c1949cef52e2d5292e5b2b22c5b945a55766f1cb092813a54f690d1b99163f400081d5d1891591676ed96a336d6a0620c2827e401a5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+    "sha512": "c4a77c388ce5a8dcdca9c36e98601aea0f8f5b69230f9beba5c28e9df95d0143cfde3ee59ea30fc254d7426f2017e5301fbdb3d25a9a45b8ebf61a86cf47884c",
+    "dest-filename": "7c388ce5a8dcdca9c36e98601aea0f8f5b69230f9beba5c28e9df95d0143cfde3ee59ea30fc254d7426f2017e5301fbdb3d25a9a45b8ebf61a86cf47884c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/a7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+    "sha512": "64bbff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
+    "dest-filename": "ff25d51f92f3b2f5e0a79c16867e23be5e299b8de6c078ef8c450a83fc1f85475b6744dd2da4a4891d16c4f2c15f4ba6aab1767aed34237f07ecc542d56e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+    "sha512": "afd807a61b42b3ed4cec9d29c3a4a7fe187f5a96bf890ace3a4acd02554b17f807abefc22661c858a2945217568dc0fa0886bc89d6abb290ac012897097bc553",
+    "dest-filename": "07a61b42b3ed4cec9d29c3a4a7fe187f5a96bf890ace3a4acd02554b17f807abefc22661c858a2945217568dc0fa0886bc89d6abb290ac012897097bc553",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/af/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+    "sha512": "854df404af4850dfecbb4327f5576554ab16052e86ca155faa3c25d458d93784f13fa702c348cfdb0ed5dc77f9b97eccd00649d7abdecbdc84d27cbb49ae7d64",
+    "dest-filename": "f404af4850dfecbb4327f5576554ab16052e86ca155faa3c25d458d93784f13fa702c348cfdb0ed5dc77f9b97eccd00649d7abdecbdc84d27cbb49ae7d64",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/4d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+    "sha512": "7502b6154310b68c153f4d26b4892cae56617455d064f0beb5a8a1d6ae02bcf679bea77147f2ca05a160d2801fcddd469476575d23dd41fcd09edf95886bc421",
+    "dest-filename": "b6154310b68c153f4d26b4892cae56617455d064f0beb5a8a1d6ae02bcf679bea77147f2ca05a160d2801fcddd469476575d23dd41fcd09edf95886bc421",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/02"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+    "sha512": "8fe80a13112e2e62b0bf3dce811397b6b276506db1f028766195316a187eb351761d9fb001c79434b92fcbacca08f551914fbe65642b771b147905e6720e2ea1",
+    "dest-filename": "0a13112e2e62b0bf3dce811397b6b276506db1f028766195316a187eb351761d9fb001c79434b92fcbacca08f551914fbe65642b771b147905e6720e2ea1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+    "sha512": "01991c000e6f9cdfefe0f0ea2b2311e65c7b859b6d3c380296ff3713ffc530d851d9331c2d485f4540470a64a5d288bdccc8030ea4542644b13b7c26f39f972e",
+    "dest-filename": "1c000e6f9cdfefe0f0ea2b2311e65c7b859b6d3c380296ff3713ffc530d851d9331c2d485f4540470a64a5d288bdccc8030ea4542644b13b7c26f39f972e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/99"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+    "sha512": "ce05c52f35b7029df77ba7745a58f8306226e827bc3bcf67fdaa54686341fe3c7e870fabb96129ec4c0652c85d2ca5510b1656d767e9f6be34135990adfff7e2",
+    "dest-filename": "c52f35b7029df77ba7745a58f8306226e827bc3bcf67fdaa54686341fe3c7e870fabb96129ec4c0652c85d2ca5510b1656d767e9f6be34135990adfff7e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/05"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+    "sha512": "bd6d469b03193672fe80c45aa2f961f72657ef891cf934d4dc539b924baba4c691b417cb3f795d8d2f4a416970660ada444d3e76178412803177370943c79766",
+    "dest-filename": "469b03193672fe80c45aa2f961f72657ef891cf934d4dc539b924baba4c691b417cb3f795d8d2f4a416970660ada444d3e76178412803177370943c79766",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+    "sha512": "1a9a6d2ebb39eda74c4ae1e2dd5363d26005f1dc21dfa2cc69817a5f227a24c5a556c73eb78dad9b51d210398eb3703c7c2f72c9e8ac80b86c4d542890e674cf",
+    "dest-filename": "6d2ebb39eda74c4ae1e2dd5363d26005f1dc21dfa2cc69817a5f227a24c5a556c73eb78dad9b51d210398eb3703c7c2f72c9e8ac80b86c4d542890e674cf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+    "sha512": "0dd6fe9155e55ecb7d77e47d3df4c8c61d4474d920a117b9b4e5fab74d5fd656163af26748f0c1946db8d502f37323dda0d4ec6e52d476e8c6484e11ceb4d919",
+    "dest-filename": "fe9155e55ecb7d77e47d3df4c8c61d4474d920a117b9b4e5fab74d5fd656163af26748f0c1946db8d502f37323dda0d4ec6e52d476e8c6484e11ceb4d919",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+    "sha512": "e8939c2794e6d3c74e1c06dd4771abbcffb25147e48c6e5e3ec1d87333052eadd998c9000fdf1c0e0713da2035949f4d57015de2d1ff8924a87b8e185a496d10",
+    "dest-filename": "9c2794e6d3c74e1c06dd4771abbcffb25147e48c6e5e3ec1d87333052eadd998c9000fdf1c0e0713da2035949f4d57015de2d1ff8924a87b8e185a496d10",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+    "sha512": "d2410b6864880c12af7204b8ce48f3d4f79d75ab6b8d87263163a502e00fc0079c714acf1dd52aa3f27a2e2ca61c7122253e4dac5d54570c58d787fe7f2e1643",
+    "dest-filename": "0b6864880c12af7204b8ce48f3d4f79d75ab6b8d87263163a502e00fc0079c714acf1dd52aa3f27a2e2ca61c7122253e4dac5d54570c58d787fe7f2e1643",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+    "sha512": "6f5510c1c119e320a73020fc0c02f55656ef04913dfc85f8153229ec11b5c58a5fdbd48b6b32d2aea5248f8c3b639cbb70254fe84e6d72aa9c234c5e98f907ba",
+    "dest-filename": "10c1c119e320a73020fc0c02f55656ef04913dfc85f8153229ec11b5c58a5fdbd48b6b32d2aea5248f8c3b639cbb70254fe84e6d72aa9c234c5e98f907ba",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz",
+    "sha512": "71e4f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a",
+    "dest-filename": "f06b173823920e8bdec3802a2d977a6a8b2446bdf7dc734a0eb04d9d418689385203b03b785561bac446e0d5078fbfd4166aeb02108a69b9dfed275c0d8a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+    "sha512": "ec07422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171",
+    "dest-filename": "422bd3d0ca29632a80436cdf0eb9cb426ddfdeb1dc193d0f11b4e1374acc90b54a623dbf8d0fbe6ad231210b59b579c048d0c14d78b26fc0887d88a1d171",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz",
+    "sha512": "29d8a5f41075ac8142fe48667f8842df96e7f3bd35009722cd353b1bb7146c46e4e57aaa6e30ee1d6eb4b947caa8ee56a238d971b016e7543b3f485198c2f0f0",
+    "dest-filename": "a5f41075ac8142fe48667f8842df96e7f3bd35009722cd353b1bb7146c46e4e57aaa6e30ee1d6eb4b947caa8ee56a238d971b016e7543b3f485198c2f0f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.6.tgz",
+    "sha512": "794114a06303a5f9201d6484f7b65969426dcd1d4cec42a7348a43d50d7afbc251f4d5a085c6aa32e971f4fb8243bdb4c3451c95f627e8511b09d7791f1d3cee",
+    "dest-filename": "14a06303a5f9201d6484f7b65969426dcd1d4cec42a7348a43d50d7afbc251f4d5a085c6aa32e971f4fb8243bdb4c3451c95f627e8511b09d7791f1d3cee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz",
+    "sha512": "7635bdfb37a0d77eca41d94fb6613cc67683f8adab7175cc585ad283486c99867a1d16dd4c0eed0c7160a5a5bdfa1b96544bb444269b2fef7ce53e13034044ee",
+    "dest-filename": "bdfb37a0d77eca41d94fb6613cc67683f8adab7175cc585ad283486c99867a1d16dd4c0eed0c7160a5a5bdfa1b96544bb444269b2fef7ce53e13034044ee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/35"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+    "sha512": "ad838ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584",
+    "dest-filename": "8ff0e327bae3cc405d6e84f56518d7020e592890aa86144dc97311558889005cfec4bc5594962240b2dadaa72a5a04b24d1db64bea31a16d50c64f099584",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+    "sha512": "4301f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa",
+    "dest-filename": "f83cee6eaeb6cef85686779020960f98260593cb2b99de0ffa98abecaab68b92094375c930f4969f80be4c70be55109e843cd76e3da4f7644f41b6d0c0aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz",
+    "sha512": "6a96b6f2695d8cc80e46613a83fc37b02700d18f5401579e0d5a28ccde22ee43b0d7698b97d4417217f32b7367eaac4e5a3ad984ad4b7f2edfd3b932cf1b6707",
+    "dest-filename": "b6f2695d8cc80e46613a83fc37b02700d18f5401579e0d5a28ccde22ee43b0d7698b97d4417217f32b7367eaac4e5a3ad984ad4b7f2edfd3b932cf1b6707",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/96"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+    "sha512": "0b7bc585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234",
+    "dest-filename": "c585bca2e125b73e66c08ba030a6ee0ecc9b5dd0cc46babbd2b18b6bee9ee733c44d0775401770949a7a768f9d249e992b45c07bfb27155f380b805eb234",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0b/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz",
+    "sha512": "e255215935808db0c8a85ac03d62775aa04ea4ee58721559f3c5f79e1e87f4bbb90058b99c251e4cf8f70fc1520e669b9857917bd304d010c0e0cc0a4e16b919",
+    "dest-filename": "215935808db0c8a85ac03d62775aa04ea4ee58721559f3c5f79e1e87f4bbb90058b99c251e4cf8f70fc1520e669b9857917bd304d010c0e0cc0a4e16b919",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+    "sha512": "728b7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5",
+    "dest-filename": "7f681fe63a6d086156134e641c1042b5338f256568bc16561ee670cf410f0d6195255c41609dc27da762b37abdd1292ad8edc4d3a4430b64a368f50a0fe5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz",
+    "sha512": "327f3c560db085a46870624d387f83285a989bac9214f41a8b01cdc593f28e7f7d079d8a004256598f4d3fcdfe9d6764d87337adda2ff924eef401b8ef546df7",
+    "dest-filename": "3c560db085a46870624d387f83285a989bac9214f41a8b01cdc593f28e7f7d079d8a004256598f4d3fcdfe9d6764d87337adda2ff924eef401b8ef546df7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+    "sha512": "7f24088460e1cdf73da4ada41fa3e5f5ce010c919f3243ea932220603b61c8d628360df0561a0930c875f564b8529ff528c3c556936c4f6ab75a65e7d8dd66ea",
+    "dest-filename": "088460e1cdf73da4ada41fa3e5f5ce010c919f3243ea932220603b61c8d628360df0561a0930c875f564b8529ff528c3c556936c4f6ab75a65e7d8dd66ea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+    "sha512": "a2b042f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0",
+    "dest-filename": "42f3c7eeb55a6a0a6857d69e1cbeab8d1ec10b43ec3ebc1267ba3ddfb444c8e5b25bd1b667dd3aaedd258dd8839c3f27139cc1a7870a1eae6bc84adef6b0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz",
+    "sha512": "dcf2af0c3c4e9fada4d285759f842d36d0f6be9bbecd88d747ba232c13da3ba48fbe1cb9df2834bc09a035e0507895b9ad5ddd7dfa111be1d87cb059bb3c3409",
+    "dest-filename": "af0c3c4e9fada4d285759f842d36d0f6be9bbecd88d747ba232c13da3ba48fbe1cb9df2834bc09a035e0507895b9ad5ddd7dfa111be1d87cb059bb3c3409",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/f2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.18.tgz",
+    "sha512": "a9d5c37acf9e1e59cc50694100001ee441bba0e42faac5eeab89aae7ce5d88cb9d83cd2207e8c76ec49e1b7f90e1e58db2880dca1a94da9ff78be6348847a9aa",
+    "dest-filename": "c37acf9e1e59cc50694100001ee441bba0e42faac5eeab89aae7ce5d88cb9d83cd2207e8c76ec49e1b7f90e1e58db2880dca1a94da9ff78be6348847a9aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/d5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.2.tgz",
+    "sha512": "dd05cd78c91db2179dd4c4772cda220a2ac1cb04453e40fc11325afc794fb8bc126a36908b17f6ae8fa2b280cd265180060f6e838d57b99a4835924895ee175a",
+    "dest-filename": "cd78c91db2179dd4c4772cda220a2ac1cb04453e40fc11325afc794fb8bc126a36908b17f6ae8fa2b280cd265180060f6e838d57b99a4835924895ee175a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dd/05"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+    "sha512": "cf7a177e66872c94c5d7092d6e3803e9c9fd8e211bab7592a27741d742c8b88b769b6626e22265ad6d38fdeb8cc043437560dd13bcfe3ae63b432a75629452c0",
+    "dest-filename": "177e66872c94c5d7092d6e3803e9c9fd8e211bab7592a27741d742c8b88b769b6626e22265ad6d38fdeb8cc043437560dd13bcfe3ae63b432a75629452c0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+    "sha512": "cdd4e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d",
+    "dest-filename": "e4e0f9543b4135f079d9df061b5b42a4249c5609d88d629ea0e97d4fb4e345871564834d6f9624c9026c08b3353a9878b204ea16f4fd2b02e825e7f8542d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/d4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+    "sha512": "6c2dcd8b0b29adbc4a8eea27f65ed7e81513c3b14f57311868bf7630f118e5209dffd8544cf5d516d570462c7befbf30b51b156a8fb3134eb680befd15995e79",
+    "dest-filename": "cd8b0b29adbc4a8eea27f65ed7e81513c3b14f57311868bf7630f118e5209dffd8544cf5d516d570462c7befbf30b51b156a8fb3134eb680befd15995e79",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/2d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz",
+    "sha512": "f10727c7de38eedc7f682060c3a25e9dfaa0e1292afafa9a6fd982066b86362a484b9617bcbdbbe706ca12eefe20260722500f80276e50c247d573987b0285e9",
+    "dest-filename": "27c7de38eedc7f682060c3a25e9dfaa0e1292afafa9a6fd982066b86362a484b9617bcbdbbe706ca12eefe20260722500f80276e50c247d573987b0285e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.2.tgz",
+    "sha512": "6eb5c3e82fd5d1f54ad030dbb1c2d5c3a2ec5eb8d0f9acbc8dd38168dfad2dbe2fb07b00326e86b7a793efbc075f512af063ed0f9ac9f91c45b5f0e8cec6f8f9",
+    "dest-filename": "c3e82fd5d1f54ad030dbb1c2d5c3a2ec5eb8d0f9acbc8dd38168dfad2dbe2fb07b00326e86b7a793efbc075f512af063ed0f9ac9f91c45b5f0e8cec6f8f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+    "sha512": "3288ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58",
+    "dest-filename": "ca92ee14fe688ef00bf80e46fe72d300431ec9998f7a2e6b4342501aac246d77bacde764024b3045f9702faf94ba7284958fd1c43c180700728425593f58",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.2.tgz",
+    "sha512": "b604412370dd370009604e01059c99733fc74510af02c3e446f1b5c2f29cfb8d6d0463313e7fdaf3b4ffc2291702fc83ca9350f64699c076de65efaf787086a4",
+    "dest-filename": "412370dd370009604e01059c99733fc74510af02c3e446f1b5c2f29cfb8d6d0463313e7fdaf3b4ffc2291702fc83ca9350f64699c076de65efaf787086a4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/04"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz",
+    "sha512": "bf701bda5ef3e94eed441e3103423229dab43aca9a3b5a3d663b0812828a9d267f97dea6673f1a0935f43425f0f98547257afc2a6e1df8c9fafd0f188d76be83",
+    "dest-filename": "1bda5ef3e94eed441e3103423229dab43aca9a3b5a3d663b0812828a9d267f97dea6673f1a0935f43425f0f98547257afc2a6e1df8c9fafd0f188d76be83",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.18.tgz",
+    "sha512": "60d1274c7578ee13dea7e53442f54cd363893646bdbb281111cfa4e0d87955264183832613e9b2238e36c7784219f4695fb3765924984892b0b38804f99f2582",
+    "dest-filename": "274c7578ee13dea7e53442f54cd363893646bdbb281111cfa4e0d87955264183832613e9b2238e36c7784219f4695fb3765924984892b0b38804f99f2582",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.11.tgz",
+    "sha512": "f1767a3f2df2dd6da713301418237971f54a6948be095029733d5dea5acd5557f686f6048b131192af24f6080f2a7414a5146e395e5abedf2ebf15621f68cbc0",
+    "dest-filename": "7a3f2df2dd6da713301418237971f54a6948be095029733d5dea5acd5557f686f6048b131192af24f6080f2a7414a5146e395e5abedf2ebf15621f68cbc0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+    "sha512": "c42b28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23",
+    "dest-filename": "28f63d7fbbcb0480fd513478c5ad724b0292fc2e2a8e908d51e32c2e374d2bc56758838a105eec0a2d2de2d23e4d58bae89940f6effe279718f650556f23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+    "sha512": "3cbcc2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac",
+    "dest-filename": "c2f74312f917a8a2d9a30b9f7b76fa29a1e96967c43ad472640d76521318ad22aecf2f9e6f1cd9deb001f082e1cad1a3df067a5d37342dbf5ba589aa90ac",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3c/bc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+    "sha512": "e9cf19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424",
+    "dest-filename": "19aaf3d35882c42a7c9590fe771064427299c988a4c2db5b12ffa475185e712b21c92564043df92a95c81491d4508af77ab5bdb769b5307b89e05a663424",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+    "sha512": "8eb0563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c",
+    "dest-filename": "563b16484ee19c9e3442336b7653964f9022f10fe626e838dfb2c4b985a4e3da289a93f0ce6fae0978de8e74b7cb829b5bebf7b690a47e66e4eb1a86533c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
+    "sha512": "2060503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b",
+    "dest-filename": "503ed44576137a310f1d6de815981ab52d5665bb26b71758d663ea6e21c402dcc1dcb51c130d20560a42ffdd97273092d3309fbe67e92d9af83417cf620b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/60"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+    "sha512": "77c6be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b",
+    "dest-filename": "be6c163f1718a434f960249a1a047657fb32956d61d82464cb9cbbef7908054939ed9067442afdc90ed1eb312d03358a65973da746c4cb18b298b6d6e99b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+    "sha512": "822590a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb",
+    "dest-filename": "90a7ee26c6304fb78299d0c9b2bb29053567db0f12ade31f9f3e44589a04452526c2645cd4825bcc6ff2a39f7f2d9b5d183f8b9f890643c77ce76b82d4eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz",
+    "sha512": "d703590608130cadc646eb90ea73f8936ca2edaea5ec8e6a6cc3db65c46cac6b0655e69dfdffdde45844cd4bea16cd1b72b0cbc7b9f5cca43726f2d1eb085a6b",
+    "dest-filename": "590608130cadc646eb90ea73f8936ca2edaea5ec8e6a6cc3db65c46cac6b0655e69dfdffdde45844cd4bea16cd1b72b0cbc7b9f5cca43726f2d1eb085a6b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d7/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+    "sha512": "c675c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64",
+    "dest-filename": "c4ef01b5dcf23e73189e56cb185e5409b98551847f4d068c6ddca370ce0843200ebd18c9bb778c17468b872188c4f8abd2e94fccb0c3bbdcd752d8c1fd64",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+    "sha512": "16b2626eb024eafdbd79a6c83e071350c3d7884cfcb2cac093b4d7c6c899cf0c3d5134356792806c526cf99d04cfe5594d882713921026a05ca1288c79bb4f1c",
+    "dest-filename": "626eb024eafdbd79a6c83e071350c3d7884cfcb2cac093b4d7c6c899cf0c3d5134356792806c526cf99d04cfe5594d882713921026a05ca1288c79bb4f1c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+    "sha512": "55c38a7b31219b656acd7a5c209a084eebd44bf7dc8c8c39340ff0ded8f35b2ce6be809d77e41722acb71411ae95674296fa7883e21f51e9a282b90b4e14a301",
+    "dest-filename": "8a7b31219b656acd7a5c209a084eebd44bf7dc8c8c39340ff0ded8f35b2ce6be809d77e41722acb71411ae95674296fa7883e21f51e9a282b90b4e14a301",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/c3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+    "sha512": "9e6a24d8b9c077a9cb50a235e9a101f7274c0ba2e27628aada6d671010d1d4b69a3fb146b38009f74a83adac57f825a556e465bcd8f26094cdbfca858ed2fdf8",
+    "dest-filename": "24d8b9c077a9cb50a235e9a101f7274c0ba2e27628aada6d671010d1d4b69a3fb146b38009f74a83adac57f825a556e465bcd8f26094cdbfca858ed2fdf8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9e/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+    "sha512": "1889f264b8e05837ec553ebe487c50551c0dcd5d00b80d6ea86b0e016fb4b61e7a27b361e9b1c72971c15b352b8a1c4c7ad7050e640c017d6d6757d90d8491b3",
+    "dest-filename": "f264b8e05837ec553ebe487c50551c0dcd5d00b80d6ea86b0e016fb4b61e7a27b361e9b1c72971c15b352b8a1c4c7ad7050e640c017d6d6757d90d8491b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/89"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+    "sha512": "608577bbf47dcc96e9a934cdc1364ce7fa1c59eb43286b2ba34496a7bd1e18433d795d8c7ab5b20516674088335376019d2050d51731459bd8fd4c701127d923",
+    "dest-filename": "77bbf47dcc96e9a934cdc1364ce7fa1c59eb43286b2ba34496a7bd1e18433d795d8c7ab5b20516674088335376019d2050d51731459bd8fd4c701127d923",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+    "sha512": "cdcd819494a29bb611e0564343c394a09839868958cdd89831ea1b6fda49b860e27462fd29952fed26e20f813ca19a20b58638d946446a9eddaa4918b80f75a6",
+    "dest-filename": "819494a29bb611e0564343c394a09839868958cdd89831ea1b6fda49b860e27462fd29952fed26e20f813ca19a20b58638d946446a9eddaa4918b80f75a6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+    "sha512": "de1ddd2cf58d812b03e2540124f6f87fe92f74e4891dae4f8d3615b161f12d4cc7e081532540279ae5a9c382aac90dcd039402ca1c384d68319378d1910c442a",
+    "dest-filename": "dd2cf58d812b03e2540124f6f87fe92f74e4891dae4f8d3615b161f12d4cc7e081532540279ae5a9c382aac90dcd039402ca1c384d68319378d1910c442a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+    "sha512": "21551ef9c9087ab03bc4c679d1db80673c1fd54ee48507b6134429531bb930124d6a8e51a82d33c15fd99bdeb9bf0e83de0185525ee3e26fa8263b9b055a1fb7",
+    "dest-filename": "1ef9c9087ab03bc4c679d1db80673c1fd54ee48507b6134429531bb930124d6a8e51a82d33c15fd99bdeb9bf0e83de0185525ee3e26fa8263b9b055a1fb7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+    "sha512": "50e7fcdefa93ce86103bd499d1f3e5d99205b4d233fd1affcbeed7f17457d599c162c43fb536fe723f5313e28739d9a54c5071858cd590fda5441c82cea8b88d",
+    "dest-filename": "fcdefa93ce86103bd499d1f3e5d99205b4d233fd1affcbeed7f17457d599c162c43fb536fe723f5313e28739d9a54c5071858cd590fda5441c82cea8b88d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+    "sha512": "ec2fd14a009afbbbea67ba806c8b5f89a016872452a03e25e014006d50ea451b11818f92fa1812de29f4471afb228aca529184ebd5f8f2aebf9ce02e4c943179",
+    "dest-filename": "d14a009afbbbea67ba806c8b5f89a016872452a03e25e014006d50ea451b11818f92fa1812de29f4471afb228aca529184ebd5f8f2aebf9ce02e4c943179",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/2f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+    "sha512": "85aaf868f025be39cb722978d000bbed80c893a96831ac2e27014834433b9f4a59be2c0c90cbe36f65b9662aec34e658e1a0dba39b4bc74c0d311129e41ae4fb",
+    "dest-filename": "f868f025be39cb722978d000bbed80c893a96831ac2e27014834433b9f4a59be2c0c90cbe36f65b9662aec34e658e1a0dba39b4bc74c0d311129e41ae4fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+    "sha512": "657b5886d52be5249a06b503abb0e2ca338526a0552ff74e04decdfea9a2fe93b42208965bf7ffb9ede76efbbd8e8584e5a00a0e8233cbf0b1b18d2cbb01a8b1",
+    "dest-filename": "5886d52be5249a06b503abb0e2ca338526a0552ff74e04decdfea9a2fe93b42208965bf7ffb9ede76efbbd8e8584e5a00a0e8233cbf0b1b18d2cbb01a8b1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+    "sha512": "c416898ac87939e1a69e20e3f5c5b93d16bf3ed9ae554df38aaadbaf9c498fdd356433784e8b2b55a359a4488b640c5d7e78407bbb90ed01567e33def5df4ad9",
+    "dest-filename": "898ac87939e1a69e20e3f5c5b93d16bf3ed9ae554df38aaadbaf9c498fdd356433784e8b2b55a359a4488b640c5d7e78407bbb90ed01567e33def5df4ad9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+    "sha512": "95983c7ea22fdafec5176dfb6f0320cc664426f18befdfece649c9fe2e859ac185e175e5cdc719e236fe4eb148c6d492c45b48a5db20acf65e324d48f4015cc9",
+    "dest-filename": "3c7ea22fdafec5176dfb6f0320cc664426f18befdfece649c9fe2e859ac185e175e5cdc719e236fe4eb148c6d492c45b48a5db20acf65e324d48f4015cc9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/95/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+    "sha512": "e75067c7da4d88c44a49436d05fc9290d27dbcc53d1e1dc8d68cc377a8323cf63369709f9e9b547046715c66059feba5d9db5c3148aa191d586a2d8ad74ba84f",
+    "dest-filename": "67c7da4d88c44a49436d05fc9290d27dbcc53d1e1dc8d68cc377a8323cf63369709f9e9b547046715c66059feba5d9db5c3148aa191d586a2d8ad74ba84f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+    "sha512": "4e6fa06df0b4687bb5b4103f26f290877d92d0ae988021e4880178fd6eb15f42b446636e73de1578ae35f5d26813ae51e5a4719a8fa7a194125ab00c17ac9bea",
+    "dest-filename": "a06df0b4687bb5b4103f26f290877d92d0ae988021e4880178fd6eb15f42b446636e73de1578ae35f5d26813ae51e5a4719a8fa7a194125ab00c17ac9bea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/6f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+    "sha512": "24ccc3282097abddd871c1b9833de1bceb35a1744a01fd176297ce4bcf1efb066b0bc22e823ea3ebcf3aeefad8664be90c3a4a9ff2a828e45386672132917a4c",
+    "dest-filename": "c3282097abddd871c1b9833de1bceb35a1744a01fd176297ce4bcf1efb066b0bc22e823ea3ebcf3aeefad8664be90c3a4a9ff2a828e45386672132917a4c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/cc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+    "sha512": "b8c2f6d63d8ae537cf1aeb4ac6e6fe33e9cb8d922b5a35d0e46af1e2509efe78a64e3f41e0beb7cc7a635cb978cb42f799c9b686d11021bd3aa021bfb337ab37",
+    "dest-filename": "f6d63d8ae537cf1aeb4ac6e6fe33e9cb8d922b5a35d0e46af1e2509efe78a64e3f41e0beb7cc7a635cb978cb42f799c9b686d11021bd3aa021bfb337ab37",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+    "sha512": "9dabd28ae4cca20be742866833fbfe977656a39d3f353c121d2ce1780071fd10a79943da2b0abda92a3806bd8e611b36d7e173f2e16a21364cdc7e28a4e074fd",
+    "dest-filename": "d28ae4cca20be742866833fbfe977656a39d3f353c121d2ce1780071fd10a79943da2b0abda92a3806bd8e611b36d7e173f2e16a21364cdc7e28a4e074fd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+    "sha512": "940af2a87ec8b5eced9825d05e4d1eb4a8f8c0143b1b1e52e8b8ca86c829f736fc2396ecbaf53fda5947d610d0723b057aa22ca2f315377dfdffca540c3057c4",
+    "dest-filename": "f2a87ec8b5eced9825d05e4d1eb4a8f8c0143b1b1e52e8b8ca86c829f736fc2396ecbaf53fda5947d610d0723b057aa22ca2f315377dfdffca540c3057c4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+    "sha512": "7ec2bfb0d067c730652f83b524dad96a4550c4fb29aa9103e5d2ed36c652f6838a9ad4a974d233c47da49289791d84d624de3bb04db4ced3093f17d9f3da863a",
+    "dest-filename": "bfb0d067c730652f83b524dad96a4550c4fb29aa9103e5d2ed36c652f6838a9ad4a974d233c47da49289791d84d624de3bb04db4ced3093f17d9f3da863a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+    "sha512": "80b61be0121a7657d33984f980ee74de7f334235df960ce90f415cc8a874333c77aea0992a71e825657dc5ed4a5d4279971d897dc487aff9a1cd2d0f0bf31c00",
+    "dest-filename": "1be0121a7657d33984f980ee74de7f334235df960ce90f415cc8a874333c77aea0992a71e825657dc5ed4a5d4279971d897dc487aff9a1cd2d0f0bf31c00",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+    "sha512": "16372910a53227280782cd68e7455836f92de7eecb7bf544758b7402446990bdf7327c907f0afc979997c0c99f9936f230faf9bc92c2fbcfc677d8179f053541",
+    "dest-filename": "2910a53227280782cd68e7455836f92de7eecb7bf544758b7402446990bdf7327c907f0afc979997c0c99f9936f230faf9bc92c2fbcfc677d8179f053541",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+    "sha512": "31ef8f7cf2364cc78e424d206167cb419b5392dae6cdbafc7036e8a97f375ca73b52b8008b9e6017ed9d52459dc5dd7d9f9e44b2ca76c9e71af8ef4de6b0711e",
+    "dest-filename": "8f7cf2364cc78e424d206167cb419b5392dae6cdbafc7036e8a97f375ca73b52b8008b9e6017ed9d52459dc5dd7d9f9e44b2ca76c9e71af8ef4de6b0711e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+    "sha512": "c9ce56acbcd792ceb30907e7f4ec6bf293912b297fa45f908c7996fd0c77aaed28cabacd0becb624b4d4d44dab7166009b3967aa78165c7423cb9d55cd6ef457",
+    "dest-filename": "56acbcd792ceb30907e7f4ec6bf293912b297fa45f908c7996fd0c77aaed28cabacd0becb624b4d4d44dab7166009b3967aa78165c7423cb9d55cd6ef457",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/ce"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+    "sha512": "55b4063d7d9be2be3c4c0308336723825b883351d8bad9b8a5c4c426c95eee210feec075745aad3cb0556dd2c0642c72d6dc4270fc5fe1015fe2ff2ebe5b4fa8",
+    "dest-filename": "063d7d9be2be3c4c0308336723825b883351d8bad9b8a5c4c426c95eee210feec075745aad3cb0556dd2c0642c72d6dc4270fc5fe1015fe2ff2ebe5b4fa8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/b4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+    "sha512": "807bfcda4eb7cf8aa9579f90d72ff5d8aacad25b5606e9150c8f2765c6d3ed3b7f665388570a696b39deab417dde80f14e8dc88003040c8a108771369fa995b3",
+    "dest-filename": "fcda4eb7cf8aa9579f90d72ff5d8aacad25b5606e9150c8f2765c6d3ed3b7f665388570a696b39deab417dde80f14e8dc88003040c8a108771369fa995b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+    "sha512": "b5366e0c13f0f39b443793d08b5a67101cc3cb4678f47b5270b01b0f9b7a872794f7603de69456692330d466598bf470812814225d31ad2957213ffd433bd848",
+    "dest-filename": "6e0c13f0f39b443793d08b5a67101cc3cb4678f47b5270b01b0f9b7a872794f7603de69456692330d466598bf470812814225d31ad2957213ffd433bd848",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+    "sha512": "da3f5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
+    "dest-filename": "5b1ade4987c863faf3ed8333ed97bda3d324711c0cae9a8a3a4cd7c08ec2c1d3852da52bcf6cf703701331cfb9fef42601d1cd46c501716118368e29aa1b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+    "sha512": "d5b9cf42a4b14ae737222e8c841caca160a0e7c8fdeda523b82499ac64a60f136ab72b488b493cbad51e9c0c1364de15e665d7606b15508f73781ab2fa304e49",
+    "dest-filename": "cf42a4b14ae737222e8c841caca160a0e7c8fdeda523b82499ac64a60f136ab72b488b493cbad51e9c0c1364de15e665d7606b15508f73781ab2fa304e49",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+    "sha512": "976685cb98c02e19e21b91e0aab0fa8d72e2feb516acabea37fa89c7aca826c80a85b95577e8aaa94e110976af9bf8cf8adc83a394c2bca327a632a73ab8b2d3",
+    "dest-filename": "85cb98c02e19e21b91e0aab0fa8d72e2feb516acabea37fa89c7aca826c80a85b95577e8aaa94e110976af9bf8cf8adc83a394c2bca327a632a73ab8b2d3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/66"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz",
+    "sha512": "ad5e909f8c260ba0717c5fb89aee9ba865a3f6f038a175e1b2ba576892f6ba18f1787006a1f8f0707a1fd97f38558cdec9781d96c1a6a8a89ee13029a555d951",
+    "dest-filename": "909f8c260ba0717c5fb89aee9ba865a3f6f038a175e1b2ba576892f6ba18f1787006a1f8f0707a1fd97f38558cdec9781d96c1a6a8a89ee13029a555d951",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/5e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.1.tgz",
+    "sha512": "54c17bc49c7aa841a25fa0d328d88bdf534bab2a4e71dff8b0d8c549ef2b6f8d4fc1e8c1261fe73aa5486c1bd69224fa34c1852f13218fbcc9f3fccfa358577a",
+    "dest-filename": "7bc49c7aa841a25fa0d328d88bdf534bab2a4e71dff8b0d8c549ef2b6f8d4fc1e8c1261fe73aa5486c1bd69224fa34c1852f13218fbcc9f3fccfa358577a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/c1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.1.tgz",
+    "sha512": "4e50b96ec4bea6a1134eb973e02673f513bf70a058b442c6231c2d29e8af527dde35f9cec506dbbb8583b22c087f3445c9dd0e3272a5e813ccd8a9d811e86811",
+    "dest-filename": "b96ec4bea6a1134eb973e02673f513bf70a058b442c6231c2d29e8af527dde35f9cec506dbbb8583b22c087f3445c9dd0e3272a5e813ccd8a9d811e86811",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.1.tgz",
+    "sha512": "7da0941e744fe3ba3d661f556595fa117ff9ebdb9dc3d568a66d8f80428f5ae28b136a9a4b9581b94554d2222d74998a52a69688e664a685b88ef9c39a3d1d7e",
+    "dest-filename": "941e744fe3ba3d661f556595fa117ff9ebdb9dc3d568a66d8f80428f5ae28b136a9a4b9581b94554d2222d74998a52a69688e664a685b88ef9c39a3d1d7e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz",
+    "sha512": "a47973999c763a51dfc90d324654f950be261a8933f78ec3b6166e61e7cdd4e95e56a3a41e95811bed89430aa836ae9b9b33277bddb36c7df6ae17095046128c",
+    "dest-filename": "73999c763a51dfc90d324654f950be261a8933f78ec3b6166e61e7cdd4e95e56a3a41e95811bed89430aa836ae9b9b33277bddb36c7df6ae17095046128c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.1.tgz",
+    "sha512": "7a9394a457c4981ce3be7aaf8efdaa1d7ecd02e2e8e5d94e195ebdd255aefac01832389bb8905e56f02228fc8509f44209353175b0c1de36da380d7211c109ef",
+    "dest-filename": "94a457c4981ce3be7aaf8efdaa1d7ecd02e2e8e5d94e195ebdd255aefac01832389bb8905e56f02228fc8509f44209353175b0c1de36da380d7211c109ef",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.1.tgz",
+    "sha512": "f056c14e47e744fe2255aa23fb68778966be1f47860c3df24f2542c2b9ae7bfb104e4a94354a12b8065adc60c6e12778d7174fc1327197d9d458680cd6a0c29f",
+    "dest-filename": "c14e47e744fe2255aa23fb68778966be1f47860c3df24f2542c2b9ae7bfb104e4a94354a12b8065adc60c6e12778d7174fc1327197d9d458680cd6a0c29f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.1.tgz",
+    "sha512": "6e515ff71f511b442becfdc5a001ffd37ddf7dafa630b667df8b6b56cf158b43e993a1662408391e96053ad998a1e44474d0c9e6b1c9295ed2a0009b38782c91",
+    "dest-filename": "5ff71f511b442becfdc5a001ffd37ddf7dafa630b667df8b6b56cf158b43e993a1662408391e96053ad998a1e44474d0c9e6b1c9295ed2a0009b38782c91",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.1.tgz",
+    "sha512": "4287b3374c1dbd72302d0e1e7b671c583697dd11b4973810a48329333e79a0f0e1a5455ac75fb5f40a6c4b9dcb91c92da52e046e73cbe313b80da264d15a7b3d",
+    "dest-filename": "b3374c1dbd72302d0e1e7b671c583697dd11b4973810a48329333e79a0f0e1a5455ac75fb5f40a6c4b9dcb91c92da52e046e73cbe313b80da264d15a7b3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/87"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.1.tgz",
+    "sha512": "8affe6f61ce5ea37d28fd43c5048c0c4e36f0a850368feccf524423f1dcf68b371036df44d30fa444d187b8cc527ccdeed9568249300aa0f50a6ad62620d8939",
+    "dest-filename": "e6f61ce5ea37d28fd43c5048c0c4e36f0a850368feccf524423f1dcf68b371036df44d30fa444d187b8cc527ccdeed9568249300aa0f50a6ad62620d8939",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8a/ff"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.1.tgz",
+    "sha512": "4ab0b8975904232bfd65715a23ff0b42a5363323268dccf0ed75ec59440e4cde185efd09c9580c351ddc23fc33d1ddb1b137c1759d4df394dd9e0f866b5b744a",
+    "dest-filename": "b8975904232bfd65715a23ff0b42a5363323268dccf0ed75ec59440e4cde185efd09c9580c351ddc23fc33d1ddb1b137c1759d4df394dd9e0f866b5b744a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.1.tgz",
+    "sha512": "425284eea9f9a8c9c81951a15d096f61e76f2ed349f73d1d9a2b79c3cbcf6fcb4acd6e12a64e8cecdda4aeea6bac303c181c077de479c2617e9e37d49b7e2ac6",
+    "dest-filename": "84eea9f9a8c9c81951a15d096f61e76f2ed349f73d1d9a2b79c3cbcf6fcb4acd6e12a64e8cecdda4aeea6bac303c181c077de479c2617e9e37d49b7e2ac6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/52"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.27.1.tgz",
+    "sha512": "f894da860413f8dc621a376e681dea255ca153fc21e26de956486dd446ab8a892ed9b9bf6a98f92dbf2b4a8c1afcd2583f707ea10815fd5e182f0e5db43801a0",
+    "dest-filename": "da860413f8dc621a376e681dea255ca153fc21e26de956486dd446ab8a892ed9b9bf6a98f92dbf2b4a8c1afcd2583f707ea10815fd5e182f0e5db43801a0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/94"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.1.tgz",
+    "sha512": "8c619eca7f6e4549cd8d24c7a5baa1886b29e8a6984d26d5d3d8c35cf248f5c0f07d5f61a6e80bbe968265dd013016e15350755ba90e7d7d01135e6a5ff1d07c",
+    "dest-filename": "9eca7f6e4549cd8d24c7a5baa1886b29e8a6984d26d5d3d8c35cf248f5c0f07d5f61a6e80bbe968265dd013016e15350755ba90e7d7d01135e6a5ff1d07c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/61"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.1.tgz",
+    "sha512": "ff68c17ecc416540c6266a5989fa9140fcfb7f5139aa94b505c913677f53003cd4257f9f78acbb449dc3b50d36fbccba492333bcff65a06563ae4eb310c4e4e2",
+    "dest-filename": "c17ecc416540c6266a5989fa9140fcfb7f5139aa94b505c913677f53003cd4257f9f78acbb449dc3b50d36fbccba492333bcff65a06563ae4eb310c4e4e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/68"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.1.tgz",
+    "sha512": "cf0465d351137c291652fb6f2b97f0f5b5ed01a8cc3e4be5904dc2aba26f1f72c5ed75c9c03b4d8f94e3edec5a70ca4269266694d738def15bdab0189eb9f030",
+    "dest-filename": "65d351137c291652fb6f2b97f0f5b5ed01a8cc3e4be5904dc2aba26f1f72c5ed75c9c03b4d8f94e3edec5a70ca4269266694d738def15bdab0189eb9f030",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/04"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.1.tgz",
+    "sha512": "388319365ccf48ef1645de2273bdc5c5c933978375b5eb238cb2f65c0a5a340fee3293b42e817a59244f016bfe676e16a7dd804512409d13fb899a08e7e2718a",
+    "dest-filename": "19365ccf48ef1645de2273bdc5c5c933978375b5eb238cb2f65c0a5a340fee3293b42e817a59244f016bfe676e16a7dd804512409d13fb899a08e7e2718a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz",
+    "sha512": "736529aeeee58f4fd957f21bc30e9c373eac512f26e83a7ff6eca016161c64e7775fc334c41204938d9cea6e9241e8643f389503c40e80d273eec32ab1bcf539",
+    "dest-filename": "29aeeee58f4fd957f21bc30e9c373eac512f26e83a7ff6eca016161c64e7775fc334c41204938d9cea6e9241e8643f389503c40e80d273eec32ab1bcf539",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.1.tgz",
+    "sha512": "198acaa83ffff671c9dabf34b97a9b0cccd19c5a46cdb6844114d219a3bf487ec3bd7585328c3c7af90e76343b3c240ed3b8cd8c9a3be7e03ce49c2edcebf700",
+    "dest-filename": "caa83ffff671c9dabf34b97a9b0cccd19c5a46cdb6844114d219a3bf487ec3bd7585328c3c7af90e76343b3c240ed3b8cd8c9a3be7e03ce49c2edcebf700",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/8a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.1.tgz",
+    "sha512": "ecaedea3582bb8e800b276caf86095db701455423470bd5b4e283c1da3e77a814c55b8a0eef75d93c8cd2ca0563bc4d755b1bb4ee1dd9c337817df2f76dc21e5",
+    "dest-filename": "dea3582bb8e800b276caf86095db701455423470bd5b4e283c1da3e77a814c55b8a0eef75d93c8cd2ca0563bc4d755b1bb4ee1dd9c337817df2f76dc21e5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.27.1.tgz",
+    "sha512": "96170d0dc73343be7224e4b2c021dbe7c1e6b60d5a3cbff64dd62678b3f156b3f4e3c0fbad1b35df7b1f38d720cb2c3402f8677e63ce9072d3bf742d292a3087",
+    "dest-filename": "0d0dc73343be7224e4b2c021dbe7c1e6b60d5a3cbff64dd62678b3f156b3f4e3c0fbad1b35df7b1f38d720cb2c3402f8677e63ce9072d3bf742d292a3087",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.1.tgz",
+    "sha512": "6370d6d63952942342c8c1873f7fb7a8134d3d2f37c2e173e114d81a366dbd145309187b6a96667bd5d158cab5acde662760abedf2a8700dbfe41b35dca80de9",
+    "dest-filename": "d6d63952942342c8c1873f7fb7a8134d3d2f37c2e173e114d81a366dbd145309187b6a96667bd5d158cab5acde662760abedf2a8700dbfe41b35dca80de9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.27.1.tgz",
+    "sha512": "6a8a707a81ee80ff9947959381bee671c5d75a68e836fecf063b500e5f2bbd2e085ac244d70db707eae48fb56ea2770ef162b96d4dd24bd3b797968e6ea97af3",
+    "dest-filename": "707a81ee80ff9947959381bee671c5d75a68e836fecf063b500e5f2bbd2e085ac244d70db707eae48fb56ea2770ef162b96d4dd24bd3b797968e6ea97af3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/8a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.27.1.tgz",
+    "sha512": "f89f44c8a3fa44c2277cc25b22835e9aa5b31f165ef5766fffb3a3a6cbed5593b57313137795b5c4883436dafb60c746f5e2810bc570c798e315b466dad6ccdc",
+    "dest-filename": "44c8a3fa44c2277cc25b22835e9aa5b31f165ef5766fffb3a3a6cbed5593b57313137795b5c4883436dafb60c746f5e2810bc570c798e315b466dad6ccdc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/9f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.27.1.tgz",
+    "sha512": "a5e11c6cd46b249f5073f58d2903456e4c01ac9bc1beadb60e9e5636a132827fd925ecf5a83f5cb5dd74f83e9fddbf46b52cb1d76b1f0e09fcc81b9f59af88ba",
+    "dest-filename": "1c6cd46b249f5073f58d2903456e4c01ac9bc1beadb60e9e5636a132827fd925ecf5a83f5cb5dd74f83e9fddbf46b52cb1d76b1f0e09fcc81b9f59af88ba",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/e1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.27.1.tgz",
+    "sha512": "b4d07c923c68d3e5cfade9a75a477a3548a4a5e27e250aecb3b1e7b4bf06808c57e2dd2091d9cb9fdc9459bd09cdc6983fb63c8936591dd90fb343f5e780c6f1",
+    "dest-filename": "7c923c68d3e5cfade9a75a477a3548a4a5e27e250aecb3b1e7b4bf06808c57e2dd2091d9cb9fdc9459bd09cdc6983fb63c8936591dd90fb343f5e780c6f1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.27.1.tgz",
+    "sha512": "1176b0b8904ee79c1df167136c74cca0f86fd02190c736b8c8208f0791eacf864f4306a122bdde8fef32a7f922988974c6891a6f0674fc5bbc49343802466fe6",
+    "dest-filename": "b0b8904ee79c1df167136c74cca0f86fd02190c736b8c8208f0791eacf864f4306a122bdde8fef32a7f922988974c6891a6f0674fc5bbc49343802466fe6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz",
+    "sha512": "278f16225fba60361314f8565d405093ebbbf8029552a4ddbeb64e4323d8086b903201eb633816ac8e7e1de1227d4817279acc21658fdeacada7b2a1555aa90d",
+    "dest-filename": "16225fba60361314f8565d405093ebbbf8029552a4ddbeb64e4323d8086b903201eb633816ac8e7e1de1227d4817279acc21658fdeacada7b2a1555aa90d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/8f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.1.tgz",
+    "sha512": "e99c1a6704ab0e1f8a145bfa57527bf683b7ef23ecef2d5b171be4d7ff48876ae7dd7af9016cfe78c4be9fc4691f776305554042974801e61081c9fe5424ac4e",
+    "dest-filename": "1a6704ab0e1f8a145bfa57527bf683b7ef23ecef2d5b171be4d7ff48876ae7dd7af9016cfe78c4be9fc4691f776305554042974801e61081c9fe5424ac4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.1.tgz",
+    "sha512": "37cf3d2789d737f4cf7d5b7cb85f4dd40d1263cd84f74cf0735cb6ea5a8e730e8a58d2e642b961321ffd383e2290b0db7a4985a4e06afd489ca477ffe92f216d",
+    "dest-filename": "3d2789d737f4cf7d5b7cb85f4dd40d1263cd84f74cf0735cb6ea5a8e730e8a58d2e642b961321ffd383e2290b0db7a4985a4e06afd489ca477ffe92f216d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz",
+    "sha512": "d53771f5f6b0f24d3ff3757a5fec420d5855f321251adf79271796dd8324290248e7a41d94fcf4c4e7493e532248624a8a73f25627abfb1f4b243fd86546486b",
+    "dest-filename": "71f5f6b0f24d3ff3757a5fec420d5855f321251adf79271796dd8324290248e7a41d94fcf4c4e7493e532248624a8a73f25627abfb1f4b243fd86546486b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz",
+    "sha512": "15f8f1faf8a698153bcc7fcaae95f3262777fa9ce209efd52f669ec524cfeb7732430290eb92e416408a688b12a4575042e6a45590465a3080e51a0157ce76a7",
+    "dest-filename": "f1faf8a698153bcc7fcaae95f3262777fa9ce209efd52f669ec524cfeb7732430290eb92e416408a688b12a4575042e6a45590465a3080e51a0157ce76a7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.1.tgz",
+    "sha512": "bdfc51b2a5bcac2734938a73a348a5537c286d58b6c2a563f3c5592364a581994d9d4024ac3183200a61ec24daf64f5fb2157e3b58afa4480f0b9c82d38ea3a3",
+    "dest-filename": "51b2a5bcac2734938a73a348a5537c286d58b6c2a563f3c5592364a581994d9d4024ac3183200a61ec24daf64f5fb2157e3b58afa4480f0b9c82d38ea3a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/fc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+    "sha512": "50260169e16f335d5a536cb760f67ffcee51863fb12b2cf2ee6bdc2280230126e2832f261ccaf23f970aedd823973da15b1875839a4bc34f381346bfc2551215",
+    "dest-filename": "0169e16f335d5a536cb760f67ffcee51863fb12b2cf2ee6bdc2280230126e2832f261ccaf23f970aedd823973da15b1875839a4bc34f381346bfc2551215",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+    "sha512": "72a79fb91b21d76a56c86b08a0128903d96e16ede6471080f8e459bc0e24b4b4b322e094b56571188b978a01303b9ff2c1614c67640418a5af9191b5cc33136a",
+    "dest-filename": "9fb91b21d76a56c86b08a0128903d96e16ede6471080f8e459bc0e24b4b4b322e094b56571188b978a01303b9ff2c1614c67640418a5af9191b5cc33136a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/a7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+    "sha512": "cac4fc9a1762c562ba1f0de2d55d80791a99e567d78351b8de6aa86253369dceb7f3c16ae63717cabe6646ca9588bc7f18961da0bd1b7d70fc9e617e667fc8a3",
+    "dest-filename": "fc9a1762c562ba1f0de2d55d80791a99e567d78351b8de6aa86253369dceb7f3c16ae63717cabe6646ca9588bc7f18961da0bd1b7d70fc9e617e667fc8a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+    "sha512": "bf1854cb827c9727b28a71fb033975a5d778dc6261647fed3f6c1e37c4e7b506e5398f80d176d3f03264d7fa023ee38eca0fc96bbe7bac6d028077160bc39f30",
+    "dest-filename": "54cb827c9727b28a71fb033975a5d778dc6261647fed3f6c1e37c4e7b506e5398f80d176d3f03264d7fa023ee38eca0fc96bbe7bac6d028077160bc39f30",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+    "sha512": "1777e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
+    "dest-filename": "e8d4c62b44960bdf3111d0e50e9a4bad8ebd55a76de6eceb12829ee7ab848fe8ea97e82ff9e971483c09796eddf3681463996ed21b3deeffa2f016961c3a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+    "sha512": "77bfd0b0b47017ceb80399a020cfd8adf8a0947a189fbce009c0282605b8d38afed83c2736bec405b2e7096a6638c807f32d2d7bbdcbd4057a1f56e66ae69617",
+    "dest-filename": "d0b0b47017ceb80399a020cfd8adf8a0947a189fbce009c0282605b8d38afed83c2736bec405b2e7096a6638c807f32d2d7bbdcbd4057a1f56e66ae69617",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+    "sha512": "3b986488521c8e3b333c8632512caf49ccafac1a15dcd384119c7fa4c96cbb8e132b358d90b5410719f1273e368a7e67dd022895839c0581423d967487c4a4c1",
+    "dest-filename": "6488521c8e3b333c8632512caf49ccafac1a15dcd384119c7fa4c96cbb8e132b358d90b5410719f1273e368a7e67dd022895839c0581423d967487c4a4c1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+    "sha512": "70c426ee9c6ee81c6d1f2a89ee6419da45d657948b9ae8326c57470816c9e5e1f33a8e95841724120013dfffeb3f91703c734f7848aae12990e6e701c2c3a8e1",
+    "dest-filename": "26ee9c6ee81c6d1f2a89ee6419da45d657948b9ae8326c57470816c9e5e1f33a8e95841724120013dfffeb3f91703c734f7848aae12990e6e701c2c3a8e1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+    "sha512": "e48be2ba54d9791369daf009e75e1c73f1d4958e6767d7c26eaf433320b9d81ae1159002a379c8d11eea0718509a8fdddbb3457bdeaeaff6fb5b0c6495d6be92",
+    "dest-filename": "e2ba54d9791369daf009e75e1c73f1d4958e6767d7c26eaf433320b9d81ae1159002a379c8d11eea0718509a8fdddbb3457bdeaeaff6fb5b0c6495d6be92",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+    "sha512": "5560c26eb2de55724cf5f8a162875c2e222fd24bbe02539afd34354af60e681bb2ad22a011cae8f792c9c88b09e2f4a8e815c8c4e2b188901ab74e029924fd17",
+    "dest-filename": "c26eb2de55724cf5f8a162875c2e222fd24bbe02539afd34354af60e681bb2ad22a011cae8f792c9c88b09e2f4a8e815c8c4e2b188901ab74e029924fd17",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/60"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+    "sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+    "dest-filename": "c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+    "sha512": "738600bcc79d6cf679b44cb1cd074ca0e861278443deb9e06487700b6fea0cddddec9a44841e9f88144a558d6583907b5a4fae3c18e7e5fdfd8f5ff6318d683b",
+    "dest-filename": "00bcc79d6cf679b44cb1cd074ca0e861278443deb9e06487700b6fea0cddddec9a44841e9f88144a558d6583907b5a4fae3c18e7e5fdfd8f5ff6318d683b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+    "sha512": "bdf12aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
+    "dest-filename": "2aa574efc13f75ca19b075fa2e4ad3768522b04efc91b3caa92df003cababf9310f0d2164ced693d520d4510b8fc8486f2f92ffe910092445177da7bf643",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/f1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+    "sha512": "49c68f767d5d41cce06e5d101537933a65471542eddfde17260390368c95859eabdaf2e730b25f04f779dd2079d93ff71b7e95235fe0d8c65a5f47300ee5ec7f",
+    "dest-filename": "8f767d5d41cce06e5d101537933a65471542eddfde17260390368c95859eabdaf2e730b25f04f779dd2079d93ff71b7e95235fe0d8c65a5f47300ee5ec7f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+    "sha512": "e5cbe0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e",
+    "dest-filename": "e0e82b4ac1f81d995a98d562225ca7374356e446a18b8bed96ffa6a8fba63b82efd10b046e021184ce1e41e0a96ccd2b932e0658baa16aa396c89a334a9e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/cb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+    "sha512": "1c41cd7db6abb3dbf8a60a56e923b52923e47e84b4c5538cffd53390996d8e5b0766625ab3183c69792e65aed231ff2f28620186952c3e5b904aa849142a9e6f",
+    "dest-filename": "cd7db6abb3dbf8a60a56e923b52923e47e84b4c5538cffd53390996d8e5b0766625ab3183c69792e65aed231ff2f28620186952c3e5b904aa849142a9e6f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+    "sha512": "c5141b0dbf419f00da7d8367e95c25f37f436158ea5d86f55d51ad58067591c0dcea2c002f8860dc1d5d665462b8434578ed87e778051b78a7eb6d4074445502",
+    "dest-filename": "1b0dbf419f00da7d8367e95c25f37f436158ea5d86f55d51ad58067591c0dcea2c002f8860dc1d5d665462b8434578ed87e778051b78a7eb6d4074445502",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/14"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+    "sha512": "5e57abc8c85bba4b1d2ada1f9d667d4a4fb80944db9ace0c6ff114df6499c13a00c99e51815a2cfe48bc9fecabd0b5873862ae6a46d74eeb983472d08e175d82",
+    "dest-filename": "abc8c85bba4b1d2ada1f9d667d4a4fb80944db9ace0c6ff114df6499c13a00c99e51815a2cfe48bc9fecabd0b5873862ae6a46d74eeb983472d08e175d82",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/57"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+    "sha512": "32703e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest-filename": "3e613f1fc1f24f801c779bad0c36a6a49b7d173a4c88a07d72ea1b9342f0b43f0646ee48bc35a70b05cacf6cda28f2f119cbb269ba4efe8cc3be094a2f4d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+    "sha512": "f2252a979d04511fae51c7514371c3a9ae84572a3776870bf20e5627714d7169aeeb621b90652e7bfa44c8b056f1518a2ae7133e0a9e92ce1f214d43038ca8c1",
+    "dest-filename": "2a979d04511fae51c7514371c3a9ae84572a3776870bf20e5627714d7169aeeb621b90652e7bfa44c8b056f1518a2ae7133e0a9e92ce1f214d43038ca8c1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/25"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+    "sha512": "7e0171ec77e8abad32b4ad9cec386717c8c8bf362038cc5fba08cb3923078cb20f81e9ea6bb4bba1a6a001352af7d995e8862f376b51982d309d3617ea23db33",
+    "dest-filename": "71ec77e8abad32b4ad9cec386717c8c8bf362038cc5fba08cb3923078cb20f81e9ea6bb4bba1a6a001352af7d995e8862f376b51982d309d3617ea23db33",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+    "sha512": "4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+    "dest-filename": "e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+    "sha512": "06f53c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336",
+    "dest-filename": "3c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+    "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest-filename": "505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/e2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+    "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+    "dest-filename": "d2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+    "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+    "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+    "dest-filename": "fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+    "sha512": "e7c4bd403a86d17c76ed8c0f4adf5f2718af8d8978df6602c1f0cc7d9fbbd5102a52b65e7fb2eb2906772c72cec024b814b341a653f9df7671f3de5278e087bc",
+    "dest-filename": "bd403a86d17c76ed8c0f4adf5f2718af8d8978df6602c1f0cc7d9fbbd5102a52b65e7fb2eb2906772c72cec024b814b341a653f9df7671f3de5278e087bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+    "sha512": "8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
+    "dest-filename": "d9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8a/4d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+    "sha512": "39e8bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest-filename": "bd387e2d461d18a94dc6c615fbf5d33f9b0560bdb64969235a464f9bb21923d12e5c7c772061a92b7818eb1f06ad5ca6f3f88a087582f1aca8a6d8c8d6d1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
+    "sha512": "a28be2a9dc3081f21f3660f0a3de3096c85c7737ceeb85d5d0283aa03b0360125f2130f3d449e00f6cfb0e46ef0969fe5c832c22a5b6eec11517aa9ca49ad172",
+    "dest-filename": "e2a9dc3081f21f3660f0a3de3096c85c7737ceeb85d5d0283aa03b0360125f2130f3d449e00f6cfb0e46ef0969fe5c832c22a5b6eec11517aa9ca49ad172",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+    "sha512": "21328dbaadb02a55b57c983db125b9d9e7a9a1881906082f3801c2d2efc262efeac50f445734e10a047af419d25cb1e3cb67fb498e73690e32b7b1fd655c58da",
+    "dest-filename": "8dbaadb02a55b57c983db125b9d9e7a9a1881906082f3801c2d2efc262efeac50f445734e10a047af419d25cb1e3cb67fb498e73690e32b7b1fd655c58da",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/32"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+    "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest-filename": "9e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+    "sha512": "237ca5e2bf500796516375ee25510f7dcd978593ba6307853c8f94a2f0339fef3f85bde827a967cac6857235699023df5561540efa19f249950cfed6c91b58b5",
+    "dest-filename": "a5e2bf500796516375ee25510f7dcd978593ba6307853c8f94a2f0339fef3f85bde827a967cac6857235699023df5561540efa19f249950cfed6c91b58b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+    "sha512": "d9c1a626ea5a36083e414c152c0b9c0ee5aea0c67a117f621c346cc19e65b0d6049b03da4649cc3c22d9cf4ef24f356affcde9e28ff0cdb0d96c1ad3bc619323",
+    "dest-filename": "a626ea5a36083e414c152c0b9c0ee5aea0c67a117f621c346cc19e65b0d6049b03da4649cc3c22d9cf4ef24f356affcde9e28ff0cdb0d96c1ad3bc619323",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/c1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+    "sha512": "25939203b328f6c34607cf948d283374bb68916024cb5cdbced3375912c26d9ef4ff771300d99098e751ef2da0f89d1ed965f2c32d724b8ebcb58f88aeea84c3",
+    "dest-filename": "9203b328f6c34607cf948d283374bb68916024cb5cdbced3375912c26d9ef4ff771300d99098e751ef2da0f89d1ed965f2c32d724b8ebcb58f88aeea84c3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/93"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+    "sha512": "11d7a9fd7f5f1aa54d9b328156c0d820eb43fb3d6db9ecd5ef42c18dd0acb7d4eabbbea5b27bd1899ea84e27359fefc12305fa4031803bde0f3783764800efb7",
+    "dest-filename": "a9fd7f5f1aa54d9b328156c0d820eb43fb3d6db9ecd5ef42c18dd0acb7d4eabbbea5b27bd1899ea84e27359fefc12305fa4031803bde0f3783764800efb7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/11/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+    "sha512": "b63c0ce5ec4c83a046448fa43664e7b4db2f7594b55fc045612ead9c9da1747d2457133afde559db1cbe16a4ad496bd89ad7c53032c8c6eae8ac7c0329f0f3e5",
+    "dest-filename": "0ce5ec4c83a046448fa43664e7b4db2f7594b55fc045612ead9c9da1747d2457133afde559db1cbe16a4ad496bd89ad7c53032c8c6eae8ac7c0329f0f3e5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/butterchurn-presets/-/butterchurn-presets-2.4.7.tgz",
+    "sha512": "e0c74cf2b8a9cff55f1f504295dac829d01cff5af2245043bea972a30e88be8d5faf08f41f776ecef48c142effc088c08f16f5429c151d5a86a92f6e0052a1a6",
+    "dest-filename": "4cf2b8a9cff55f1f504295dac829d01cff5af2245043bea972a30e88be8d5faf08f41f776ecef48c142effc088c08f16f5429c151d5a86a92f6e0052a1a6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/butterchurn/-/butterchurn-2.6.7.tgz",
+    "sha512": "04989103c2f42f6fbce2ea06d9249f929d2472506e37ebd029fdb5ee92bba4c97010ed99120dccb4edbfa3e97c429afc35b7a383cb662f56470f58e686269aaa",
+    "dest-filename": "9103c2f42f6fbce2ea06d9249f929d2472506e37ebd029fdb5ee92bba4c97010ed99120dccb4edbfa3e97c429afc35b7a383cb662f56470f58e686269aaa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+    "sha512": "a4c84e7c50cf8aff6de638c85e41e8b169a44b241bbec80454d933d044476ee2e1d93ffb8f832aaa9cf9db715ef0c558f3d282e9287f41f4b6b0cf928e014373",
+    "dest-filename": "4e7c50cf8aff6de638c85e41e8b169a44b241bbec80454d933d044476ee2e1d93ffb8f832aaa9cf9db715ef0c558f3d282e9287f41f4b6b0cf928e014373",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+    "sha512": "fcd7fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12",
+    "dest-filename": "fb4f2cd3c7a4b7c9124e6ce015efde7aafc72bdbe3a3f000b976df3048fdc1400a1e5f9f0da07c8253c3fccc690d5d2b634d28ba7f33ba174a4175c61b12",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+    "sha512": "4a9d5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest-filename": "5a6e52748af0e44b38dc68977112e9cde7f5ef92c149dac30115fabac74af285057fd9bfcac057b6d5c329987b4f3928a3f0af7dff049fa04b9339b9ae31",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+    "sha512": "fb2b3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
+    "dest-filename": "3df7b53dea9a382b1fc0069042aa103d12ec49690583420ef6f791f8841a61bf72198346e804abb0629b78617a7a319e4099942753fb72313951a5a49e8e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+    "sha512": "e4e37eabb8c24e0329f5c8e9bb8268e976ef7d8c120763b0de4cc729f23225f68200e1cb6dd28f42a18a81f103fd1e41fb74c515f7bca5e81803e6f8db7491c8",
+    "dest-filename": "7eabb8c24e0329f5c8e9bb8268e976ef7d8c120763b0de4cc729f23225f68200e1cb6dd28f42a18a81f103fd1e41fb74c515f7bca5e81803e6f8db7491c8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/e3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+    "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest-filename": "db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/a9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+    "sha512": "ecdcc12f4acde9f3145be7fb03a228e21e34a90946fb11a6b4cc5f6e71ff2bb4c0b6df094165502beea0d145ca31e549a3257912490db04ad0f29543ddb2c76c",
+    "dest-filename": "c12f4acde9f3145be7fb03a228e21e34a90946fb11a6b4cc5f6e71ff2bb4c0b6df094165502beea0d145ca31e549a3257912490db04ad0f29543ddb2c76c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+    "sha512": "29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
+    "dest-filename": "bd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+    "sha512": "fe5cc6a4458bffc3df23406604e3d1c29d1cff014d5f545d50c2f78cafd1712040f53f26643750a6a6012ad0854ce7d06f03ea5843a98ea5be1676b2734f7af6",
+    "dest-filename": "c6a4458bffc3df23406604e3d1c29d1cff014d5f545d50c2f78cafd1712040f53f26643750a6a6012ad0854ce7d06f03ea5843a98ea5be1676b2734f7af6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/5c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+    "sha512": "546b6532edf1ff80ceb4853012445ecf1519da505a70d2421dab21d0dd167990c14beed4c75766dd75808166312c914c31d39e5cc1d7a2bb2110585b31219e96",
+    "dest-filename": "6532edf1ff80ceb4853012445ecf1519da505a70d2421dab21d0dd167990c14beed4c75766dd75808166312c914c31d39e5cc1d7a2bb2110585b31219e96",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/6b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+    "sha512": "9cf75a15d43487f1848a06cf0a5cf5d43d2ffd9244c3199e55919e328dd9e52b4fb544e403da35943e90c288ab622483cdb7309f65dc8f0982a7af16d484b84c",
+    "dest-filename": "5a15d43487f1848a06cf0a5cf5d43d2ffd9244c3199e55919e328dd9e52b4fb544e403da35943e90c288ab622483cdb7309f65dc8f0982a7af16d484b84c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/f7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+    "sha512": "05278d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest-filename": "8d9f2bacef90b8fff350f6042dd7f72c4d7ca8ffc49bf9a7cb024cc0a6d16e32ca1df4716890636e759a62fe8415ef786754afac47ee4f55131df83afb61",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/27"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+    "sha512": "7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
+    "dest-filename": "b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/89"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+    "sha512": "56cbfb9056979bea6d1c3319ee2cda46c3fbd0682b5bd341346b30b7d39969504b944d123690eaf1ebbf5465f217dafb3346b32b75b2ece9585ecbb260b1731e",
+    "dest-filename": "fb9056979bea6d1c3319ee2cda46c3fbd0682b5bd341346b30b7d39969504b944d123690eaf1ebbf5465f217dafb3346b32b75b2ece9585ecbb260b1731e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/cb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
+    "sha512": "c71a1d0a605e9f78b2da2d16b402bc16514dad1ce352a8d1b0c7e1a39f314ffc2f654d584ccddf0a7463732d6024f31ea5a465826ff47bac3c4a9587a67dff70",
+    "dest-filename": "1d0a605e9f78b2da2d16b402bc16514dad1ce352a8d1b0c7e1a39f314ffc2f654d584ccddf0a7463732d6024f31ea5a465826ff47bac3c4a9587a67dff70",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+    "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+    "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+    "sha512": "1503783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest-filename": "783117ee25e1dfedc05b04c2455e12920eafb690002b06599106f72f144e410751d9297b5214048385d973f73398c3187c943767be630e7bffb971da0476",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+    "sha512": "c8f55abdfc82711866a2b0bbad69641e7d796f8c03560566040ee457841506c17b92fffd4ca2406c05d54f1bd39f03fc1c72a34422430a529b7228984bba740d",
+    "dest-filename": "5abdfc82711866a2b0bbad69641e7d796f8c03560566040ee457841506c17b92fffd4ca2406c05d54f1bd39f03fc1c72a34422430a529b7228984bba740d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+    "sha512": "feb15e0a934941b852663195c0ef51155df13ea6e71114bc326210cc2b43ff397a82926e57f6cc2ee37dda81b717b77ca031071d1aee8d25cd52bf1fa639ed2b",
+    "dest-filename": "5e0a934941b852663195c0ef51155df13ea6e71114bc326210cc2b43ff397a82926e57f6cc2ee37dda81b717b77ca031071d1aee8d25cd52bf1fa639ed2b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/b1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+    "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+    "sha512": "4d9d02121cb3bc58e0b40bc74eeb033208fbc0d76284287b2cb2ebcdd50e5c885d9672f624104603d789c51db8aedaa099d8e1dce03786b375ac21e3e8733ca8",
+    "dest-filename": "02121cb3bc58e0b40bc74eeb033208fbc0d76284287b2cb2ebcdd50e5c885d9672f624104603d789c51db8aedaa099d8e1dce03786b375ac21e3e8733ca8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/9d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+    "sha512": "911191670ddb2e5148483060c13480d5330114de89e865837ae6e60c4dc017edfec972fc8535aff2be6b90b6ea6176384633e4fc4cc79c2948df341fd5c1661c",
+    "dest-filename": "91670ddb2e5148483060c13480d5330114de89e865837ae6e60c4dc017edfec972fc8535aff2be6b90b6ea6176384633e4fc4cc79c2948df341fd5c1661c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+    "sha512": "e634421fd67ff8344feeb92f63cdc1fb2188197f7a3987499b39e0aa7c364814b1a8214f774c36926dece626b0a465fc92b9f0486985d055b9361af41df6a2de",
+    "dest-filename": "421fd67ff8344feeb92f63cdc1fb2188197f7a3987499b39e0aa7c364814b1a8214f774c36926dece626b0a465fc92b9f0486985d055b9361af41df6a2de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/34"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+    "sha512": "9d38ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038",
+    "dest-filename": "ea7dc045122a4a7570afe180d05827e670b64a9bcd65745d29028a53bf2ac51956dc47a3ff54001de46ecdfb4b53afc42a894d2d15a743e852b836d27038",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9d/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+    "sha512": "8ff3bf77b19c642c8d97bfe1c1901beb4eabcea932bda0dcb4b99c91bc4bcc7bc50734c91ee1847687404dc3f7c884680eb2c790801326ebf36c5969fe48b671",
+    "dest-filename": "bf77b19c642c8d97bfe1c1901beb4eabcea932bda0dcb4b99c91bc4bcc7bc50734c91ee1847687404dc3f7c884680eb2c790801326ebf36c5969fe48b671",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/f3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
+    "sha512": "adc4356ec40ef7bf7dc2adb8b84e40336b4020bcb88171882bf9e315671542418d67de9e765a58f80edb8f0bf38d8bcb0f2ce61b532630b661a5cb1bfa494d31",
+    "dest-filename": "356ec40ef7bf7dc2adb8b84e40336b4020bcb88171882bf9e315671542418d67de9e765a58f80edb8f0bf38d8bcb0f2ce61b532630b661a5cb1bfa494d31",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+    "sha512": "0fbeae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86",
+    "dest-filename": "ae53bdee9525eb0f5517178284d93331555c21b270a07c0c9383d93c3fa2866639572ab38b7b874940a2370718b9c237ac6681572561253560633d931b86",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/be"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+    "sha512": "ca48b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff",
+    "dest-filename": "b95e72ae7fbe74979d2e193965b7a90a20b6389d0d5e34841ab685c40726797568272aa6e7aa64eb044e41e0dee5acc24a436cad58c8933b6a34bfa130ff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+    "sha512": "29bdb00b47efb167d0ae093c1d4e655ba53f2dcb3cfbd69a61ccb864573a0c3968e2767b9fbd1d120139aed474a06eae7ca0d49ebc1f58bd665d1e658c36adad",
+    "dest-filename": "b00b47efb167d0ae093c1d4e655ba53f2dcb3cfbd69a61ccb864573a0c3968e2767b9fbd1d120139aed474a06eae7ca0d49ebc1f58bd665d1e658c36adad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/bd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+    "sha512": "0515a038b2a415e0a046e751eb3aecf29f57259704d7882bcca30cb2ca18ae4ea4aedb8467b31328f218e51cce9eab0428847d92cb7bc0dce986db6b693f98ab",
+    "dest-filename": "a038b2a415e0a046e751eb3aecf29f57259704d7882bcca30cb2ca18ae4ea4aedb8467b31328f218e51cce9eab0428847d92cb7bc0dce986db6b693f98ab",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+    "sha512": "b49b590411c0eaf8c801a17a12721aaba95a0413fd6aafd8de8b9526311fa076d105c1c100761c321ff0f0b0eb9363ef20c32af209a8a5ae43e15f1199baf11b",
+    "dest-filename": "590411c0eaf8c801a17a12721aaba95a0413fd6aafd8de8b9526311fa076d105c1c100761c321ff0f0b0eb9363ef20c32af209a8a5ae43e15f1199baf11b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+    "sha512": "75c2855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829",
+    "dest-filename": "855f78e7d0ca486978e2b2846f7b12095442b36aaef3dab64ac5ff8c4abf5391d9879ac5389b695c2e88eb8ff14797c9a4e55c4c99803e7ed4643ffde829",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+    "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest-filename": "903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+    "sha512": "14770a14265c0216b72f07d50610906d6da708d6e46579fb29550972c4f9fcff1899fb158dad0530f26bd01f74de3fc4ebd1d4a612a257d89002b5fc483600e3",
+    "dest-filename": "0a14265c0216b72f07d50610906d6da708d6e46579fb29550972c4f9fcff1899fb158dad0530f26bd01f74de3fc4ebd1d4a612a257d89002b5fc483600e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+    "sha512": "4e2cd3cd475d1bfc582c0dcd5e87453347d26cd8b35e338a86a890430be196ca5a759a249f5283cb4359152d30b84b9b218015e7f735fe502bd1369a157117cf",
+    "dest-filename": "d3cd475d1bfc582c0dcd5e87453347d26cd8b35e338a86a890430be196ca5a759a249f5283cb4359152d30b84b9b218015e7f735fe502bd1369a157117cf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+    "sha512": "380d2620bcc67359023824897ab39ea83c434381ce87e1bc35b38914e4e0382ce9c3b7c206e6e4d1f132c69f0080e2ff8ef2e0600fee57470c6dee3712517524",
+    "dest-filename": "2620bcc67359023824897ab39ea83c434381ce87e1bc35b38914e4e0382ce9c3b7c206e6e4d1f132c69f0080e2ff8ef2e0600fee57470c6dee3712517524",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+    "sha512": "5fbb2343371e521bb5bbb63fca5ad1645536152e8b462155a7aaca2cf836df2df1ddcdc338a030b97183a7e3c01a387a0929c28d8780ba5f29713f1b025fa548",
+    "dest-filename": "2343371e521bb5bbb63fca5ad1645536152e8b462155a7aaca2cf836df2df1ddcdc338a030b97183a7e3c01a387a0929c28d8780ba5f29713f1b025fa548",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+    "sha512": "bbf3b7bf06e9b7384cb372f57d013cd9948b1d041fb68e60c99cf0b5e54813279a63915ced1e1d6a917f06f46849815ea9f064e26d15d5569fab93e3bf6e70bc",
+    "dest-filename": "b7bf06e9b7384cb372f57d013cd9948b1d041fb68e60c99cf0b5e54813279a63915ced1e1d6a917f06f46849815ea9f064e26d15d5569fab93e3bf6e70bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/f3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+    "sha512": "d0baeb4ad3ce7498fe48f082ac6873af2c9c2e3c1c81448706dc4d03c6880f17f418bb1187570a621074d06775943392e32187ebdf92367d77f9359b54711315",
+    "dest-filename": "eb4ad3ce7498fe48f082ac6873af2c9c2e3c1c81448706dc4d03c6880f17f418bb1187570a621074d06775943392e32187ebdf92367d77f9359b54711315",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+    "sha512": "db3fab59dcdb6d266febfae1b6fcefa9e6501eb05aaa0a20aadf39b2a14d6da6d93ae15b09515bf243de12d66388a91bae6dfde62ae934a89878578b8909c53e",
+    "dest-filename": "ab59dcdb6d266febfae1b6fcefa9e6501eb05aaa0a20aadf39b2a14d6da6d93ae15b09515bf243de12d66388a91bae6dfde62ae934a89878578b8909c53e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/3f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+    "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+    "dest-filename": "c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+    "sha512": "d11f629116faebc1c1ed00f14f5be4a6e501b6a739dd8c80c0cc0679414a4688d8fcd58abdd67ef5462d45f1a686a35b4644d256931b9b28578a9145bf671bfc",
+    "dest-filename": "629116faebc1c1ed00f14f5be4a6e501b6a739dd8c80c0cc0679414a4688d8fcd58abdd67ef5462d45f1a686a35b4644d256931b9b28578a9145bf671bfc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/1f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+    "sha512": "6583f95411ec85a0c08956718db45570526973ee311a04f46cadefcf2d472cdf234cef7be4711bb98cd925c1e84046392b56b4cfc61ac899325444dad3c78d4e",
+    "dest-filename": "f95411ec85a0c08956718db45570526973ee311a04f46cadefcf2d472cdf234cef7be4711bb98cd925c1e84046392b56b4cfc61ac899325444dad3c78d4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+    "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest-filename": "305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+    "sha512": "6298108884d6dc95c69edcdd526c9447557cd761e7f13d58557842bbec0edcea52e1e53d97861d0f7aa3ca229d57a9af576f736a990c783dfdd145447f696452",
+    "dest-filename": "108884d6dc95c69edcdd526c9447557cd761e7f13d58557842bbec0edcea52e1e53d97861d0f7aa3ca229d57a9af576f736a990c783dfdd145447f696452",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+    "sha512": "c75542c5d5f8b7ef3055f775b28ffdc3ebd0e2fc7b94a776429e6d0d1bad12bc2647ce4e8267d7ed194b44c59a7d1318ee16c489721bb9d36b8ce00f6bf84bf1",
+    "dest-filename": "42c5d5f8b7ef3055f775b28ffdc3ebd0e2fc7b94a776429e6d0d1bad12bc2647ce4e8267d7ed194b44c59a7d1318ee16c489721bb9d36b8ce00f6bf84bf1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+    "sha512": "1fd2cc2ebe73c086d2c6b9af8a41ae23fe4a1a167c136cc7decb643203392e93960eeb463362596a3e3ad147677f56bef78eb373b60182ba845b06e4ef31ef1b",
+    "dest-filename": "cc2ebe73c086d2c6b9af8a41ae23fe4a1a167c136cc7decb643203392e93960eeb463362596a3e3ad147677f56bef78eb373b60182ba845b06e4ef31ef1b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+    "sha512": "ac132f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest-filename": "2f23396903cbfa13e489668a3ef87018aac2eb920ecc49f2229cc3c5866928af0ed7f9d39754942cf904faf731a4cccc9f0e720c3765a2775f8d6cbdd3f8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/13"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+    "sha512": "37e31e5d8a2aaf7a4e827f317f244f44437b8076a42d88e1b07856193ddf58088be08900b74883c35e108a2126d9b137d1ce575f9ab416d000dc22b97fdfc152",
+    "dest-filename": "1e5d8a2aaf7a4e827f317f244f44437b8076a42d88e1b07856193ddf58088be08900b74883c35e108a2126d9b137d1ce575f9ab416d000dc22b97fdfc152",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/e3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+    "sha512": "f109902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest-filename": "902aa10048b7799f1d14d41d6890b1256d4baeb6d27f0276264576db6c60d687ab92db4f048c3e17aaafc8f702bbbb4bfa3b4f178535a7b795ed11b47a0e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+    "sha512": "672483ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest-filename": "83ecd7fdd5a2c1d11c4be0a1ab28705797b11db350c098475ca156b05e72c3ed20e1a4d82db88236680920edaed04b8d63c4f499d7ba7855d1a730793731",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+    "sha512": "83b9c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
+    "dest-filename": "c7e8fe9dc838a8268800006a6b1a90ad5489898693e4feba02cdd6f77c887ad7fb3f9cfb1f47aa27c8cc2408047f3a50b7c810b49444af52840402cb08af",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/b9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+    "sha512": "06d8f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest-filename": "f604e38ef37a375b21f9f5ef0c817b3111055c6ab9143a9118aee6c1d2eaf09cdd74c90dfae2bb22072535d67665a966199b4e62fe87fb8a8e26ce2841b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+    "sha512": "ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
+    "dest-filename": "66254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+    "sha512": "5f4ee7b6d25093091f29fbd33c6fca4a713638c75c5026a8ebe797177c269c84119f668f0071f75710db0ce75e82477a25b3ec5ea4a1a6f10e1df013fa708dc1",
+    "dest-filename": "e7b6d25093091f29fbd33c6fca4a713638c75c5026a8ebe797177c269c84119f668f0071f75710db0ce75e82477a25b3ec5ea4a1a6f10e1df013fa708dc1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/4e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+    "sha512": "c08900af28aab7f9d5e4440aa90a68dd24e848e57d2740e76c9ab02bb5affd3adcf76cc801867816532ef893c55b50df185b7cd594c21a00c469b7df5de2f226",
+    "dest-filename": "00af28aab7f9d5e4440aa90a68dd24e848e57d2740e76c9ab02bb5affd3adcf76cc801867816532ef893c55b50df185b7cd594c21a00c469b7df5de2f226",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/89"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-3.7.2.tgz",
+    "sha512": "b907fea47bfa7908607c8f2dd9b16e8a75742ac3f24fc4d98022f071253cb8156037dbfa95e6f498ca6fa7a1d002501ca653f73427068f16dda9e7faa53cef9b",
+    "dest-filename": "fea47bfa7908607c8f2dd9b16e8a75742ac3f24fc4d98022f071253cb8156037dbfa95e6f498ca6fa7a1d002501ca653f73427068f16dda9e7faa53cef9b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+    "sha512": "38b113063eb0d0eb1a801c1d5e73dd37472731f17da2937af5ca3eed9adb7cf1ab7693d5341523d36b298ba07537bc0284b4223e7e02487ff326f5f0e7a8261f",
+    "dest-filename": "13063eb0d0eb1a801c1d5e73dd37472731f17da2937af5ca3eed9adb7cf1ab7693d5341523d36b298ba07537bc0284b4223e7e02487ff326f5f0e7a8261f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/b1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+    "sha512": "720c25bffd621508859d4f7a5d78113a1f314de7adb272620ec4dced36022c577dfbf58d908a8f4f188cffca5277c548ae15c64dfd4dcb5ab586ab95a83241e7",
+    "dest-filename": "25bffd621508859d4f7a5d78113a1f314de7adb272620ec4dced36022c577dfbf58d908a8f4f188cffca5277c548ae15c64dfd4dcb5ab586ab95a83241e7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/0c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+    "sha512": "daf998228aa3cded9dfa46a43fc4bf9d2e6c85fb25e7cee4cf012370695376292c5158051e7142b0b603563fc936a2553906464980539aec9cbf43e87709a731",
+    "dest-filename": "98228aa3cded9dfa46a43fc4bf9d2e6c85fb25e7cee4cf012370695376292c5158051e7142b0b603563fc936a2553906464980539aec9cbf43e87709a731",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+    "sha512": "ea464ac946a3943baa9472955f5c3b832b258fd30f217cc8162cffac6bb7e6e0b5c0c8be90c850c06865e25b7dba70bd55bf4836763d677fd9037f8584048b6b",
+    "dest-filename": "4ac946a3943baa9472955f5c3b832b258fd30f217cc8162cffac6bb7e6e0b5c0c8be90c850c06865e25b7dba70bd55bf4836763d677fd9037f8584048b6b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/46"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+    "sha512": "28837f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest-filename": "7f9c3241411717c3430b561644f62407986ebca80548060f42aa65188e64088608a3f54e4c16faea9142f915bb72cb366e39e3add3375e45ee1463b72df8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ecma-proposal-math-extensions/-/ecma-proposal-math-extensions-0.0.2.tgz",
+    "sha512": "f340670e9d859fb4715e512be471d96e59e2638690f7b30e02271d596a52a34be4422212484f702d1e12ab12acbb8802b5714120f3f3cbc24c85acb8356460fd",
+    "dest-filename": "670e9d859fb4715e512be471d96e59e2638690f7b30e02271d596a52a34be4422212484f702d1e12ab12acbb8802b5714120f3f3cbc24c85acb8356460fd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+    "sha512": "58cc26f4b851528f9651a44dfaf46e113a86f3d22066985548d91d16079beac4bf1383ab0c837bb78f0201ec121d773a0bc95e7c3f0a29faf9bd8eb56eb425a3",
+    "dest-filename": "26f4b851528f9651a44dfaf46e113a86f3d22066985548d91d16079beac4bf1383ab0c837bb78f0201ec121d773a0bc95e7c3f0a29faf9bd8eb56eb425a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/cc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+    "sha512": "b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+    "dest-filename": "08f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+    "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest-filename": "d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+    "sha512": "4349fd1d18b89ba26e188575785966bc907b644571bbddc8accca232c182d25acc24c5b3460c7a586aaec9f4206556f7d6f8468179df98f34d5e6c673a4441ae",
+    "dest-filename": "fd1d18b89ba26e188575785966bc907b644571bbddc8accca232c182d25acc24c5b3460c7a586aaec9f4206556f7d6f8468179df98f34d5e6c673a4441ae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+    "sha512": "5748631f87463e1f40a39a74328458e8156ab700a3873eaf2392d3f00279e47fb883dff8bdb1f1d48e787d2d17b9c94b8431c0acf40288c8c3c6368bf1f3f187",
+    "dest-filename": "631f87463e1f40a39a74328458e8156ab700a3873eaf2392d3f00279e47fb883dff8bdb1f1d48e787d2d17b9c94b8431c0acf40288c8c3c6368bf1f3f187",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+    "sha512": "68df7b357585e805814da85f54e22b07f352864ce2e47ec5f6bd6cf660f77038f82a8e5fdaa86156860c89b5c5ec694bbde6ff0f68a859acbc97123ded57a7de",
+    "dest-filename": "7b357585e805814da85f54e22b07f352864ce2e47ec5f6bd6cf660f77038f82a8e5fdaa86156860c89b5c5ec694bbde6ff0f68a859acbc97123ded57a7de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/df"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+    "sha512": "c54b683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1",
+    "dest-filename": "683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+    "sha512": "7b79d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest-filename": "d17e07d4678acd18bdb7da05205f4e90372c9ecf4e0a76316b17e2d34683979ab3a014a0e0e0109db235bc1274faf5ea9d606991a49c223d560dac2696de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+    "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest-filename": "47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+    "sha512": "146807da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c",
+    "dest-filename": "07da1f3328d8a6f658e3edd6a79053dc20220af42a796e6f9cda041261e3e1a5a1b9f9eb2b2ce0e2848a2b9fe3dee85189cd6857428b4fbfbde34da95d5c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/68"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+    "sha512": "8fabd6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest-filename": "d6cdfac655fc97c607be3b4c79b21e9cbf10288346bfe1175dd8adfacc2315e5e27effeb4e0278113bc70e0cc3566d545d5659866502f6612df247c6c850",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/ab"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+    "sha512": "1b9899e8f73f14d458feca0a6470be4f11830fcdeb1d40d7c73696846097e38bc0bffb4cb39e9632eb279bf28c34afa5b943ec800f54dbc706af8443952ccbda",
+    "dest-filename": "99e8f73f14d458feca0a6470be4f11830fcdeb1d40d7c73696846097e38bc0bffb4cb39e9632eb279bf28c34afa5b943ec800f54dbc706af8443952ccbda",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1b/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+    "sha512": "1ca54b4bc76f208fb1a0a5bd926ab16d12ab9d61177c926bfc56618499a2a880747b4e7740d605a8e068b9330efe4e6c203e0cbc28940afbfc6fd338877db020",
+    "dest-filename": "4b4bc76f208fb1a0a5bd926ab16d12ab9d61177c926bfc56618499a2a880747b4e7740d605a8e068b9330efe4e6c203e0cbc28940afbfc6fd338877db020",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/a5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+    "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+    "sha512": "3624aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3",
+    "dest-filename": "aea59e0e7ae1b0afaf251887b29bf92c219309a1d506392099fc54a74f172b7a46efaab81d53194938ca628da299563009ad6ac6b3fe89cbc38cbb28fda3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+    "sha512": "529cdc2c25e895459c36ee47b5530761d5c98c0ae3b05f42d1a367aae658638b96fd5bb49a2cb96285af6d5df8e476ae56f700527a51ba130c72a4dc18e636fb",
+    "dest-filename": "dc2c25e895459c36ee47b5530761d5c98c0ae3b05f42d1a367aae658638b96fd5bb49a2cb96285af6d5df8e476ae56f700527a51ba130c72a4dc18e636fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+    "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest-filename": "5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/da"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+    "sha512": "6882f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e",
+    "dest-filename": "f9171ee66b055adf4d1a976067104e2236fa35a844f12eb3c8fe8d392fbcfa828edf0b0d49e844266cae05989d804bb920545fca1195ae7c17dd0a531c3e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/82"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+    "sha512": "9097b3163f5814030b78e4728bb6822f12db0f9fea58c427a0c56554fc8722597b96044909cdc95659fd56097d9f0422d1890c9e17464cc367ec2911440a6d32",
+    "dest-filename": "b3163f5814030b78e4728bb6822f12db0f9fea58c427a0c56554fc8722597b96044909cdc95659fd56097d9f0422d1890c9e17464cc367ec2911440a6d32",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+    "sha512": "0914f5593cae4280fbef5196e7a5c464543f66849f5a27756a52860d832692ddb297c517ad5478a6ca6a58d11ca8abd523383a3c096d5a3c5c4923eb6e803888",
+    "dest-filename": "f5593cae4280fbef5196e7a5c464543f66849f5a27756a52860d832692ddb297c517ad5478a6ca6a58d11ca8abd523383a3c096d5a3c5c4923eb6e803888",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/14"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+    "sha512": "e4a6f7e22a4d5faf780c7e3cbcdf62ada935431df49dbd0f2d81d77c9830e18123882dd91266498703a9f957e2098c05cef153741f50900ad84b99176b6731d8",
+    "dest-filename": "f7e22a4d5faf780c7e3cbcdf62ada935431df49dbd0f2d81d77c9830e18123882dd91266498703a9f957e2098c05cef153741f50900ad84b99176b6731d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+    "sha512": "8484b889d5966a2ebd35ecc8751b76c455687da1788fee8834ea4995538b0cef335c6a54544573218935d94522d89ce313358bdc8380c5c4ee6e0cfd3e8d325f",
+    "dest-filename": "b889d5966a2ebd35ecc8751b76c455687da1788fee8834ea4995538b0cef335c6a54544573218935d94522d89ce313358bdc8380c5c4ee6e0cfd3e8d325f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+    "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest-filename": "90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/7a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+    "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+    "dest-filename": "7fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+    "sha512": "900a99ab54e58018d970baf999c37a34fe51bf85767f6db3d3473783cbd1af091caa37abc7b04484f6ce9d608fa9a1d49765d6401250bce4ff15085d313ed7fd",
+    "dest-filename": "99ab54e58018d970baf999c37a34fe51bf85767f6db3d3473783cbd1af091caa37abc7b04484f6ce9d608fa9a1d49765d6401250bce4ff15085d313ed7fd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+    "sha512": "9f5d5118ffe5ad610523f6d677280bc6123ea557a8d59608570bef3e45bb6b397facecbe1771d8459d8ae73784f669a4850a69caff6c405c7424cf5469b9e93d",
+    "dest-filename": "5118ffe5ad610523f6d677280bc6123ea557a8d59608570bef3e45bb6b397facecbe1771d8459d8ae73784f669a4850a69caff6c405c7424cf5469b9e93d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+    "sha512": "807c00d4ef4b0c870aba730a84e6d2fc78a6c2d7a13b59cf50408a02ee53a4a81a3b5f5f716125e1b96259ed635b1545bc85f3b498e34382fc5d0d4453d7fb27",
+    "dest-filename": "00d4ef4b0c870aba730a84e6d2fc78a6c2d7a13b59cf50408a02ee53a4a81a3b5f5f716125e1b96259ed635b1545bc85f3b498e34382fc5d0d4453d7fb27",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+    "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest-filename": "d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+    "sha512": "ef2010a43d94309ccb8b50eabfba856273db68fc7b65f14ae8f888c50e0f7e418fc8dca5d94831f9afee994a2798aaa384ce039df6ccbdd5faa2d5eaf37b2841",
+    "dest-filename": "10a43d94309ccb8b50eabfba856273db68fc7b65f14ae8f888c50e0f7e418fc8dca5d94831f9afee994a2798aaa384ce039df6ccbdd5faa2d5eaf37b2841",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+    "sha512": "b5b64db89acbc06529df3b2106d772e16f8e47166e221f1ae629722044030b9ad8d5fdd4db424caf2d0b977581cd4e7c1192ac12e2455e16f9830bfc0ac3ef80",
+    "dest-filename": "4db89acbc06529df3b2106d772e16f8e47166e221f1ae629722044030b9ad8d5fdd4db424caf2d0b977581cd4e7c1192ac12e2455e16f9830bfc0ac3ef80",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+    "sha512": "4bc2a866045937e6b9acdc2a4f195965e3e34ffe1c9e6d11395ef42de7511d9d29f2ef5f4480f484951942990a2f3ae8f0b7e60bcb31db76d8ead54dc6ff2940",
+    "dest-filename": "a866045937e6b9acdc2a4f195965e3e34ffe1c9e6d11395ef42de7511d9d29f2ef5f4480f484951942990a2f3ae8f0b7e60bcb31db76d8ead54dc6ff2940",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+    "sha512": "308d6ab3b2e8e12cb0d043b3525d318ecda5b287aa164bb8e0aa6781f21db87058bf39bc876fbb2bc60c421d49b55555ad4be12e9370a958b80c445e8142613d",
+    "dest-filename": "6ab3b2e8e12cb0d043b3525d318ecda5b287aa164bb8e0aa6781f21db87058bf39bc876fbb2bc60c421d49b55555ad4be12e9370a958b80c445e8142613d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/8d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+    "sha512": "f7b3cc1bf6b2c2862907822f6ef5098b44508bcbde6abbd4d28a2fd565b79345993c132b4d056a7a4497e428d21bf3384378ba03fd052970bb4720280145123f",
+    "dest-filename": "cc1bf6b2c2862907822f6ef5098b44508bcbde6abbd4d28a2fd565b79345993c132b4d056a7a4497e428d21bf3384378ba03fd052970bb4720280145123f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+    "sha512": "bca6ad021e129557e06eff98b66862463844309b18a6c1b5636acc42d47e49549bcadb120f5606cc321cac026674579cf3cbbff95a069b19e5fbcd202f5b5109",
+    "dest-filename": "ad021e129557e06eff98b66862463844309b18a6c1b5636acc42d47e49549bcadb120f5606cc321cac026674579cf3cbbff95a069b19e5fbcd202f5b5109",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+    "sha512": "6ee7b01f332f60bdbd8dd7904d520b79c49a64a9edfd12568e8642179396eb467aeff1a648b06438533baa1d4f237cc536d25b6992f9790bb5bcb7daccec23e2",
+    "dest-filename": "b01f332f60bdbd8dd7904d520b79c49a64a9edfd12568e8642179396eb467aeff1a648b06438533baa1d4f237cc536d25b6992f9790bb5bcb7daccec23e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+    "sha512": "6ee446d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
+    "dest-filename": "46d1fa41b511d24c238049eea10f6e7cb44b9b16844b6f864d03a3713151cdc3680e7301e8f70c9a6e5ccccce039cfdc40f4bd4a36393f36de8c4fd698a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+    "sha512": "471fd6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8",
+    "dest-filename": "d6c9c67ad0739aa8b2808ba70744a288ef3c566c9df53219ed9adc0ca1a4de17b5c51fd861069f2f21368c89d7e58d143a7985822a46932beca45491cfd8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/1f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+    "sha512": "38ed291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest-filename": "291f694ae9ad2166701d6aee48b731cf23aa5496f23b8cc567c54411b70e28c05db093c94e49a6ed1830933f81a0ae0d8c6c69d63bd5fc2b5b78f9f18c0f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/ed"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+    "sha512": "c62a8c411e3101e1d3b81f6e5a6f9f1517083a02813223813fe7978b24fb8ec8150aad5b915ca0b74d28012a3007b11db6938769a3e02adf35d8ff5a6fe0c328",
+    "dest-filename": "8c411e3101e1d3b81f6e5a6f9f1517083a02813223813fe7978b24fb8ec8150aad5b915ca0b74d28012a3007b11db6938769a3e02adf35d8ff5a6fe0c328",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/2a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+    "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest-filename": "037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/1a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+    "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest-filename": "cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+    "sha512": "764b9548e28ac21dde6ace55909cb5016d6f1697adf1303f7c699503992b4e197c61c39513ff19228100d7e535bc49f9724c7184b8ab49d63cdfb6b399b68d1c",
+    "dest-filename": "9548e28ac21dde6ace55909cb5016d6f1697adf1303f7c699503992b4e197c61c39513ff19228100d7e535bc49f9724c7184b8ab49d63cdfb6b399b68d1c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+    "sha512": "0f214fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest-filename": "4fdc133fdd81d340e0942ffc343991d1d25a4a786af1a2d70759ca8d11d9e5b6a1705d57e110143de1e228df801f429a34ac6922e1cc8889fb58d3a87616",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/21"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+    "sha512": "4116ef0c86f1e9892551ee91c5e4de95e311d32bf77181fa3ec3d91dc9d59fbc6fef33b504737caf45c44eef27e987b743e6a1b526ab7375a0b4d5a67a12017c",
+    "dest-filename": "ef0c86f1e9892551ee91c5e4de95e311d32bf77181fa3ec3d91dc9d59fbc6fef33b504737caf45c44eef27e987b743e6a1b526ab7375a0b4d5a67a12017c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+    "sha512": "f5f4a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest-filename": "a349aa2cfdf448548a7ec5226513a95fc21112ecb36d29a08121a987b23af69dad418800493e8d263a38f3f062435116ab9823c6a9a89583999f8dbf7c09",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+    "sha512": "1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
+    "dest-filename": "584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+    "sha512": "b1349f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest-filename": "9f063a17069f3d26f20a21e7eac3b53608279bb1cef892263a6b0886a202ada1219b823604fc6ffe97db05dcc5853cd73d21ca0e0b83837ca1dfc459a9d2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/34"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+    "sha512": "c5dafa01dadf18171fce770e3543a55cc06e739c090ed3ae784ddce6b746d28360b4834b0fe7f6885665b6b051658cc00916caafe992554ff1f7ccefdaede39b",
+    "dest-filename": "fa01dadf18171fce770e3543a55cc06e739c090ed3ae784ddce6b746d28360b4834b0fe7f6885665b6b051658cc00916caafe992554ff1f7ccefdaede39b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/da"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+    "sha512": "9c5474ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest-filename": "74ccba54d9809a471c28089bcbe94bc21f6245c85548bf04cbb087f6d40b8794cb240358614dd93e2e5609b4e958b7dbfa76fb330f604646a04bfa240af5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/54"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz",
+    "sha512": "2942445628ae153dc8f7bb7e19832290b3c94b62dfa3f4b617e0d0b815b3bb368c3e7bede72c9978fcc0af1dfa7c1ce9193c598c8a436d72dec922e087e93bea",
+    "dest-filename": "445628ae153dc8f7bb7e19832290b3c94b62dfa3f4b617e0d0b815b3bb368c3e7bede72c9978fcc0af1dfa7c1ce9193c598c8a436d72dec922e087e93bea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+    "sha512": "0e92ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest-filename": "ca6cd5385b2969c49ca442e8df09cc185a257f2619b9d06a28d30ad520b02fe633abf5df87f944773e14820f6ac2084220d2e73e1be9ae053c03e782610d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+    "sha512": "65429187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest-filename": "9187afe4505a0089302d4d83d9277870f70371c7e04804e8a39e51bd3e7ac9b027128ecd70cb20fabc9a5a62d827cc3aca6114aa7f738ee917daf77c6c46",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+    "sha512": "63c4f8bd88447f024e4dba2e444bc6fb75c3b23afc137908afbb9ff8967405896816cb6d88753459fbc0355b11ed3c4d5096bf5a90a7c3f227a3fa7e0de06105",
+    "dest-filename": "f8bd88447f024e4dba2e444bc6fb75c3b23afc137908afbb9ff8967405896816cb6d88753459fbc0355b11ed3c4d5096bf5a90a7c3f227a3fa7e0de06105",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/c4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+    "sha512": "e04ef5134ae939a42e251d80df10d9f863351f2598bf5725479f2d0bc7a640d7907b7447ecc03349b6adf95d301bbf0b401a3a9ba6f3486fcbe2906e0ac82751",
+    "dest-filename": "f5134ae939a42e251d80df10d9f863351f2598bf5725479f2d0bc7a640d7907b7447ecc03349b6adf95d301bbf0b401a3a9ba6f3486fcbe2906e0ac82751",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/4e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-1.4.0.tgz",
+    "sha512": "dcaaf28272dbe044ac9edc6fc5903b461272d828b8ec6757582f1f97d1f03c73443940d750dbf933ec7f4e20645ca8d4cfa8f3fc244938bd8ab20abc57751d2b",
+    "dest-filename": "f28272dbe044ac9edc6fc5903b461272d828b8ec6757582f1f97d1f03c73443940d750dbf933ec7f4e20645ca8d4cfa8f3fc244938bd8ab20abc57751d2b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+    "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+    "sha512": "e7924d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest-filename": "4d2ae216fafab829ed418ce4e333661cb5022f093ec61731f099f64f1a8e709eb82489dd1842d9c095e152aae9999b86b3de7d814be7ab6f2e62a49760ae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+    "sha512": "d5c0cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest-filename": "cd77027625aa2199bdec8383a629a301c2e0b8f2c6278b91d4c360efb02f0b8c64cb2bd87e79bd57e91cae3877b8853d142c25baf22a26863528294aa53d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+    "sha512": "36a00307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest-filename": "0307c5633c52ccd95d15bc751ec30c2cc3465605a21d828fa2787b4ade16ac2f3e2a78246361ca9f07a010ac182044aa69285f0be76fd5a9d56c3b8ec397",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+    "sha512": "4f651b7db044177db089ea5722c3254d6f7e743602eb0321fedfef600e2db8e30aa96cff9f7bebd4d152c508b23fece4da65eca0c03f8bfeea57a2cabadd6dd4",
+    "dest-filename": "1b7db044177db089ea5722c3254d6f7e743602eb0321fedfef600e2db8e30aa96cff9f7bebd4d152c508b23fece4da65eca0c03f8bfeea57a2cabadd6dd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+    "sha512": "f059ecfa56470169b3e54e485310de5cac087f77e806828d3cbc71158e01d0c90b8cdba89842070a80db0c4fb1fe59452b734210ed5cbb8fa7de250a63e4af9b",
+    "dest-filename": "ecfa56470169b3e54e485310de5cac087f77e806828d3cbc71158e01d0c90b8cdba89842070a80db0c4fb1fe59452b734210ed5cbb8fa7de250a63e4af9b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+    "sha512": "91d268155bf6c666b2c3a718d3d1fb01b30932df099f98dd944757b0fec0181745d83229b5594a94e2ca5cfe35c8f8a9e3f6b7c903eff6055c25823c618d3877",
+    "dest-filename": "68155bf6c666b2c3a718d3d1fb01b30932df099f98dd944757b0fec0181745d83229b5594a94e2ca5cfe35c8f8a9e3f6b7c903eff6055c25823c618d3877",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+    "sha512": "636da84ea214e2eb8f8047a67f3ecd0c9cfa39e29fd762ecbbe402facdc156975aeb895388c602c86c20e648b8bc5c6433041d7990e5d9a759a2a520745b9381",
+    "dest-filename": "a84ea214e2eb8f8047a67f3ecd0c9cfa39e29fd762ecbbe402facdc156975aeb895388c602c86c20e648b8bc5c6433041d7990e5d9a759a2a520745b9381",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/6d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+    "sha512": "7cf53a047369b32221afccb23294cb2f101b91a2bc02b20172664846204b8838637aabd7a256849831a610b16e5fd238c4371a28a70997e4ca64baabb816e658",
+    "dest-filename": "3a047369b32221afccb23294cb2f101b91a2bc02b20172664846204b8838637aabd7a256849831a610b16e5fd238c4371a28a70997e4ca64baabb816e658",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+    "sha512": "e056d17405fe6d2766a3801416e4b458d88fcfc36016dfabf138603569a5ae3423b7543b651f7ecd395c7b6f39f71e0a497af022c69e4ea0e82909ad3fca4b99",
+    "dest-filename": "d17405fe6d2766a3801416e4b458d88fcfc36016dfabf138603569a5ae3423b7543b651f7ecd395c7b6f39f71e0a497af022c69e4ea0e82909ad3fca4b99",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+    "sha512": "4f58240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest-filename": "240226180d6631dd5e419b2bbb1dc7dcbcbee652b4d688ceb239f6b73c8a6156227f8053dbbe2750faf7aa48e1dc8bf3f105c0da6de50d0b3a4e3832598a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/58"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+    "sha512": "bcaf4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest-filename": "4fe7f8947dd97de4023e255c94b88715b5de287efb6b3abdc736d336cb10bd6e731b11da77c74d4e8503678dbf082588b7f159531379815f071fbf2c2e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/af"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+    "sha512": "e1f0a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+    "dest-filename": "a4efdc2c84c773329dab1f4eaa5ab244e22a25a8b842507f8e8ae22053ef91074fbde0d9432fcd5ab4eec65f9e6e50ab9ea34b711cdb6f13223a0fb59d33",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+    "sha512": "20a5e9bc8ce39c2f574c051b54170c7c64b410f6885ed5babfecebf91469fa1a942c4a68d28c196b1eb0c91c0f3896d66f38d8b29430bac4ec7d5af489f878b9",
+    "dest-filename": "e9bc8ce39c2f574c051b54170c7c64b410f6885ed5babfecebf91469fa1a942c4a68d28c196b1eb0c91c0f3896d66f38d8b29430bac4ec7d5af489f878b9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/a5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+    "sha512": "2edc2d5725583b906a46f72c2ae0768943271f03d50723c25c55cea6e53de8864f3e83cdeb18ce1b1650ef8a6049554b416b5439883278be0613df016390f7c2",
+    "dest-filename": "2d5725583b906a46f72c2ae0768943271f03d50723c25c55cea6e53de8864f3e83cdeb18ce1b1650ef8a6049554b416b5439883278be0613df016390f7c2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2e/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+    "sha512": "9ba140a3fb299ac5b601bd9f537e494d8c2d38a6b6c80c174b08234afd53273878321ee60b797300e54b069adbef65ec4eb824108b25ed8ac53408838918481a",
+    "dest-filename": "40a3fb299ac5b601bd9f537e494d8c2d38a6b6c80c174b08234afd53273878321ee60b797300e54b069adbef65ec4eb824108b25ed8ac53408838918481a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/a1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+    "sha512": "93dd88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest-filename": "88fdbd3cab8c2f16c71708bbea7ec1c2ae3ac5ef2897b10b8856f544ecdf365b7f9aaa9cee51d05b7e159ccbf159477ff82207e532028b3acbcf0eb18224",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+    "sha512": "93fbc6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest-filename": "c6697e3f6256b75b3c8c0af4d039761e207bea38ab67a8176ecd31e9ce9419cc0b2428c859d8af849c189233dcc64a820578ca572b16b8758799210a9ec1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/93/fb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+    "sha512": "c85f76923de9981be4ee829b4aae6f1002cefffa3b67d0a4fce68b3659335cd7987707e9c4c4244a8c064c55024b9312bbd6d67d264c7b01a9a7b6c573ae83ed",
+    "dest-filename": "76923de9981be4ee829b4aae6f1002cefffa3b67d0a4fce68b3659335cd7987707e9c4c4244a8c064c55024b9312bbd6d67d264c7b01a9a7b6c573ae83ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/5f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
+    "sha512": "170eb89fb6216b975e6f5ac7635dfbcc74c06d24cd7a550ab81e4a924d870025c4b702070427fd387dad3ff2d0f5f4584e5d45d1d6606d6d333e7664e8503d2f",
+    "dest-filename": "b89fb6216b975e6f5ac7635dfbcc74c06d24cd7a550ab81e4a924d870025c4b702070427fd387dad3ff2d0f5f4584e5d45d1d6606d6d333e7664e8503d2f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/0e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+    "sha512": "06a714c96ac6f73ab91c8c16e8971f147b0861e6c991659be1f73335a87582850ed2fbf9be778895fc2e4bce6dc3227985847fcb5f05940614c6b3bd0a121656",
+    "dest-filename": "14c96ac6f73ab91c8c16e8971f147b0861e6c991659be1f73335a87582850ed2fbf9be778895fc2e4bce6dc3227985847fcb5f05940614c6b3bd0a121656",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/a7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+    "sha512": "6a013841f0762e4a7db880a7ec102aa2c730e1264ff644c4da1c62148de304f99725f76a89a8536d4b8a1ac3283761ada8bf40c61622a00715be0b1bd47bd16c",
+    "dest-filename": "3841f0762e4a7db880a7ec102aa2c730e1264ff644c4da1c62148de304f99725f76a89a8536d4b8a1ac3283761ada8bf40c61622a00715be0b1bd47bd16c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/01"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+    "sha512": "0d179b396baa0efc6e9df90d24095cdc8cd620f0f9c55c7050d6c7afbc4a07c13a68b27120f7cd5f70a83098217058e9bfa45642cadc25b821b44c123e826a30",
+    "dest-filename": "9b396baa0efc6e9df90d24095cdc8cd620f0f9c55c7050d6c7afbc4a07c13a68b27120f7cd5f70a83098217058e9bfa45642cadc25b821b44c123e826a30",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+    "sha512": "a122bde86ae6dda3fa3ab4b6eb7c55c5b3431952fbaf306d61da46aa50c6f2241da1e9c3a13b3f9e4922f837e561b00413c5e5ea8e58c61c65acabc8de7a8a5d",
+    "dest-filename": "bde86ae6dda3fa3ab4b6eb7c55c5b3431952fbaf306d61da46aa50c6f2241da1e9c3a13b3f9e4922f837e561b00413c5e5ea8e58c61c65acabc8de7a8a5d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/22"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+    "sha512": "d0a23feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede",
+    "dest-filename": "3feb4ef1a31493a07ec68cdd457d26cba14d3e6ed4e2723b1049642587f859ca437c2a998c7fbb98c0f5b747e6a467a47fc35f199574870585e26143cede",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/a2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+    "sha512": "7af3abf317d72b113aa924748525cbdabdec77b00b8fcfbb8d0114bcf61c9b9b20645749f806334fac8d9897a7bc8610060206c1fc33d3cb0bf33a0bef2ab604",
+    "dest-filename": "abf317d72b113aa924748525cbdabdec77b00b8fcfbb8d0114bcf61c9b9b20645749f806334fac8d9897a7bc8610060206c1fc33d3cb0bf33a0bef2ab604",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/f3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+    "sha512": "7a58dc8040e5127b3fec05c5a2c0792bfda708ce0fec540f90673f0d62f2e6b985116bd96b21ab8a4d5df7f4086399c9e1ff58b15bc1900ea42691e7f6b21275",
+    "dest-filename": "dc8040e5127b3fec05c5a2c0792bfda708ce0fec540f90673f0d62f2e6b985116bd96b21ab8a4d5df7f4086399c9e1ff58b15bc1900ea42691e7f6b21275",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/58"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+    "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest-filename": "a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+    "sha512": "3b82f4f78376fdd67bc6a55dad7861f6bd4a3833c9a459acf01e6c19d24b3f2ebae0082f5ecade654c82410348b59443958ba0e314ad2e3369feccf71ef068c1",
+    "dest-filename": "f4f78376fdd67bc6a55dad7861f6bd4a3833c9a459acf01e6c19d24b3f2ebae0082f5ecade654c82410348b59443958ba0e314ad2e3369feccf71ef068c1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/82"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+    "sha512": "e571d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931",
+    "dest-filename": "d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+    "sha512": "794b808f26d54c73185a6fd4faf04ed6c63f24e0a0a0f097471cdd8eed0af8ad018865b44828442f530b0b43e80884753a53e8e58029f07b90a1496c584202c2",
+    "dest-filename": "808f26d54c73185a6fd4faf04ed6c63f24e0a0a0f097471cdd8eed0af8ad018865b44828442f530b0b43e80884753a53e8e58029f07b90a1496c584202c2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+    "sha512": "28860b08226085f1d9c6a8d8044eeb132d0e06e4dde710874bbb47560bc22e4c7b4ad2286b1c0d5b784200b80452315f79193e306fd0c66a7fbed113105ded44",
+    "dest-filename": "0b08226085f1d9c6a8d8044eeb132d0e06e4dde710874bbb47560bc22e4c7b4ad2286b1c0d5b784200b80452315f79193e306fd0c66a7fbed113105ded44",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/86"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+    "sha512": "6c261e440dab5626ca65dfacdbadb98069c617fb7b0d2a83b3874fec2acb0359bb8ca5b3ea9a6cd0ba582c937c43ae07b663ca27586b3779f33cd28510a39489",
+    "dest-filename": "1e440dab5626ca65dfacdbadb98069c617fb7b0d2a83b3874fec2acb0359bb8ca5b3ea9a6cd0ba582c937c43ae07b663ca27586b3779f33cd28510a39489",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+    "sha512": "86fa6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701",
+    "dest-filename": "6823a928ae124c9de8f6f3975283a9eed7e7babb1b3bcc6dc16009b96f2a83b2024d5b0c7333acfa8998808104784c9df42660533b0a99530dd69721f701",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/fa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+    "sha512": "7baaef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b",
+    "dest-filename": "ef7540a240202eba666c971449591fc3a2ae15a4f47cda4a9c96f712d1e7e0b78df44a5188934e6f742379f3e56bce0b4871f34e0e3a335627a5c9c0f84b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+    "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest-filename": "4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+    "sha512": "61854322740a1497d1ff16b7a2351397c7362a84f088bd51e5683d602c9dc07d31d01f60adbce58391c2ee63230ad5098db43f627184648848e6d0a07d36f81f",
+    "dest-filename": "4322740a1497d1ff16b7a2351397c7362a84f088bd51e5683d602c9dc07d31d01f60adbce58391c2ee63230ad5098db43f627184648848e6d0a07d36f81f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+    "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+    "dest-filename": "547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/d2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+    "sha512": "f22ecbcd98fb045f2ea655fe6723a5233f3a57a4c0b12b3e9e9ea6d64a56f6ed095a2e33ff5b7e17370ad5a7a4fb26d39c00b82a104be2e5c2353d3071421e0b",
+    "dest-filename": "cbcd98fb045f2ea655fe6723a5233f3a57a4c0b12b3e9e9ea6d64a56f6ed095a2e33ff5b7e17370ad5a7a4fb26d39c00b82a104be2e5c2353d3071421e0b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+    "sha512": "f835a0f230891b64c49e9cbb90e9bfeff031698a1a45b8d50782c564bc926655a7f1ec46b3703838b251f7ae9c56f536e8ded7f535b197e26cc3b77302a293ea",
+    "dest-filename": "a0f230891b64c49e9cbb90e9bfeff031698a1a45b8d50782c564bc926655a7f1ec46b3703838b251f7ae9c56f536e8ded7f535b197e26cc3b77302a293ea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/35"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+    "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+    "dest-filename": "c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+    "sha512": "34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+    "dest-filename": "3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+    "sha512": "7d08685dd72f737576f31ec2ec132ce0fe7e90d96051445eda39944f54fffe8051303aeacb540f7a52629b0646a3b1e0f553d5dc4415e419eae216c5cb6bdeb4",
+    "dest-filename": "685dd72f737576f31ec2ec132ce0fe7e90d96051445eda39944f54fffe8051303aeacb540f7a52629b0646a3b1e0f553d5dc4415e419eae216c5cb6bdeb4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz",
+    "sha512": "632017caf9e68d36d1e1b1d044bcdec770ae20d0839509c1aa8498ca32704cfdb1f630cbb8a0f3cbb68a525d21831dee85c97bc73837d9a827e6f9627ba1c895",
+    "dest-filename": "17caf9e68d36d1e1b1d044bcdec770ae20d0839509c1aa8498ca32704cfdb1f630cbb8a0f3cbb68a525d21831dee85c97bc73837d9a827e6f9627ba1c895",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/kiwi-schema/-/kiwi-schema-0.5.0.tgz",
+    "sha512": "5fe1697d4d324c4b5ce9a4c74bb5706cea6f43046def4fa95d75912397dde82bd685eee94950bce784d5a38668d31e7fc307168feffd294957a5d70fd1d63d00",
+    "dest-filename": "697d4d324c4b5ce9a4c74bb5706cea6f43046def4fa95d75912397dde82bd685eee94950bce784d5a38668d31e7fc307168feffd294957a5d70fd1d63d00",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/e1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+    "sha512": "60aeff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
+    "dest-filename": "ff0a54ede2400ad2fa3ac375fe3e79b40f671fdaf3c76e139776836d8b519ad1a9753f84c1661c23013be33702c40429cabe325cda34201d71f4344c2502",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+    "sha512": "473786f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
+    "dest-filename": "86f49bb96da83606fd7f97095526f044deae93b57b247592cb0b27e0e69b7e1cbcfd06a94808eecb64ced51cd4d39ffe4f4611c50528e4e65738726b1c3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/47/37"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+    "sha512": "53e42c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
+    "dest-filename": "2c069da6fecdb0aa95184ffeb09e56a07596ed65d9dd4a6badfcd26a94270c2d35a9e66b82ac80fe2b9509ea3a83d8116c85e8c26179e23c36cd87bdd5f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+    "sha512": "2424e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
+    "dest-filename": "e281e74492c664ded1d34ed86731d55f19feb5164cbc262d84e188d44c4417d78c62cbf953cd79eed6fc2265eddb61ed2af92a6c487fc24de0d72ba5878a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/24"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+    "sha512": "c7aae79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
+    "dest-filename": "e79e945ad862f4cd03a4b7aaedb376033f376e2e95afc0017a10c8571556570f8b4fac190416acc6a30cc2b085ac3e3a922beb723443835015de7951d293",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/aa"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+    "sha512": "d279ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
+    "dest-filename": "ccca8c8e2d12577db30e8a569245c2c7dc9c39cfd1c33467d3fe0c023e06838e7c748bcc3bbc1cc52c54757fa08c2ca17c8156de6e69143777dafe4409a5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+    "sha512": "529424a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
+    "dest-filename": "24a1e9ebe14244ce054862923cd250c5bd198f560ea8a9ba0d1dfa07e024087cd03e1cead9ecca3b2993f4d9d0ba2e38213d025e06cbd7849a1dff09c806",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/94"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+    "sha512": "57b42be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
+    "dest-filename": "2be7622166674a3d5afe56dc3ca3e58bb1025809377c96821fa4368c45619465f04e60425ec89224a862033193f03f1db8a5431fc12c7123ca61aff31b38",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/b4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+    "sha512": "6d870ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
+    "dest-filename": "0ba7e55bd1ac2c89783ff34b8245ecc2607360d7f9779add20cc79d657d5cfd56e6c29ae7f4c274659a47fcc13363de17f1dbb10bff8f651134e895bb15a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/87"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+    "sha512": "f126c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
+    "dest-filename": "c2f01478d294ba6da08cf2c6ed6034b011541de099454ce95a0f78161877d385370006734305d6ba79365ea9ba1f6a5209845c74a8ace01c999c3d39c677",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/26"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+    "sha512": "026abd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
+    "dest-filename": "bd07f4a86587438b5905ae88e7a2a3cbc58850e16a395e22fc11526b56c07c011a02d4f596e951ad4f458a09e9a3cbc682fa5a2e2678d2ed4d7cc776f4e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/6a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+    "sha512": "357601ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
+    "dest-filename": "01ce29cdadb95fada3c6cab6cfa03d7d0b587d95f23fd66ce0598bd75137b8d781b3fd7d450f65c165264ceeb453acc03c24bdceb4068689fac82a1439c9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/76"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+    "sha512": "3fc6843f953f0f5fc895363639e62c12b77087d6c6b8b137d0d717b4a12381d1dc6a1bde428430336c9936c8a8407b16173d0feca2ae762b1baf30a0474b031e",
+    "dest-filename": "843f953f0f5fc895363639e62c12b77087d6c6b8b137d0d717b4a12381d1dc6a1bde428430336c9936c8a8407b16173d0feca2ae762b1baf30a0474b031e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+    "sha512": "74c22789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+    "dest-filename": "2789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+    "sha512": "98d0206751a6c8d843ec0baa9d31b7fd5436ea8efad3e65804f2a33efba03bcfa72db61f5fa4d5a493ec781be8a5b758faaa59fe52949e611cd4b799612dd000",
+    "dest-filename": "206751a6c8d843ec0baa9d31b7fd5436ea8efad3e65804f2a33efba03bcfa72db61f5fa4d5a493ec781be8a5b758faaa59fe52949e611cd4b799612dd000",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/98/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+    "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+    "dest-filename": "b13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz",
+    "sha512": "fa07c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9",
+    "dest-filename": "c15e5eacc5730f7bcb4a426eeaccb9d4cb90d43c93ca232447c2da42a725046231d84490bfe608d4bdd92e3b673726596b3ed1d71f950924af0b458979c9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+    "sha512": "24d03365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+    "dest-filename": "3365c5eb0ade365462ee633d337c0cc37c0bc9596e807d8943050c835790c2948da6e6c0262be3883bbb39f577ec46c587a74da3009ad169d3d1193b7a49",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/d0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz",
+    "sha512": "ad48d0a32ede8194fd5d855704ad637bd724067369eeacd164e84b431e51704a767421a55e8fa6bfabdfec09b82e29847050492086734867e04ea73d402acf4b",
+    "dest-filename": "d0a32ede8194fd5d855704ad637bd724067369eeacd164e84b431e51704a767421a55e8fa6bfabdfec09b82e29847050492086734867e04ea73d402acf4b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+    "sha512": "b3c52194d7bbbcf2a8990842d6a15e94ca24aff49cdc080d6eca379fbe2654f0392d3670901f4d9577f85cf6a62f1244f21d2087bdeb33de31bf0453d825489f",
+    "dest-filename": "2194d7bbbcf2a8990842d6a15e94ca24aff49cdc080d6eca379fbe2654f0392d3670901f4d9577f85cf6a62f1244f21d2087bdeb33de31bf0453d825489f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b3/c5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz",
+    "sha512": "4bac79c267039ac0d1454fdcd9d91c703c103d7a05733739f87a50da538df299ef1e59ef1c01e3e5694b56fc3a9fabcdc87b95ba062b168858c5b4bea6f16929",
+    "dest-filename": "79c267039ac0d1454fdcd9d91c703c103d7a05733739f87a50da538df299ef1e59ef1c01e3e5694b56fc3a9fabcdc87b95ba062b168858c5b4bea6f16929",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/ac"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+    "sha512": "fc85ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest-filename": "ed6f0124e474cfc84c32297ea11a4617c4cf676e3eb807e8a55499c2fd1e81d291f91b85776f4a556cbec3063e2d921040a696d05257fa17a5e5f4b1eed6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+    "sha512": "6b294873b67dcb8cb31d800936e1121b785f842fb421ba7f30032268e66036fe29984745c9f6618619f2e0c36201f59d050d5143699f0d698cd71f12bc6ca9f2",
+    "dest-filename": "4873b67dcb8cb31d800936e1121b785f842fb421ba7f30032268e66036fe29984745c9f6618619f2e0c36201f59d050d5143699f0d698cd71f12bc6ca9f2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+    "sha512": "f58b9b9edddef00d0e2b0c58497ca12f29865b8b02b9f70b1ba55d88375419590f869a8bc65bcfe6f975f7cde0423265deda9baccef7d668da65a3faf00828b1",
+    "dest-filename": "9b9edddef00d0e2b0c58497ca12f29865b8b02b9f70b1ba55d88375419590f869a8bc65bcfe6f975f7cde0423265deda9baccef7d668da65a3faf00828b1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+    "sha512": "6a2b27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b",
+    "dest-filename": "27ac33f818d7b4e9470a1675796df30d3c1530e23b0b19a5b059f9c7defd361a706e5d7d8c0959f945bad6a348f7a5ccd48a561b96aedf43b370dade572b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/2b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.3.tgz",
+    "sha512": "9290613222471a67ab8b3cce6c04f55cb643c8898ee1910a5dac638dfc46564c9c434539a1fff194b7a99b5233a773fede395a79d152448e5f267bf7439c55e8",
+    "dest-filename": "613222471a67ab8b3cce6c04f55cb643c8898ee1910a5dac638dfc46564c9c434539a1fff194b7a99b5233a773fede395a79d152448e5f267bf7439c55e8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+    "sha512": "4a7937d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de",
+    "dest-filename": "37d785796b214b869ddf914444b9be96b6305f3dd08f6352e7f3ff26ba7b8bba2621b000600555aca33006f8c58c6d512f71d7296e2f51ef0c36da5f50de",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/79"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+    "sha512": "04727f10aaee348a897ff41a86fc704195caca0390db9ea6c9e37f130f931dc01ae6af8f8f24d330c78d402e03670e40c1fbde96c52b03a07aecd28ca970dbcd",
+    "dest-filename": "7f10aaee348a897ff41a86fc704195caca0390db9ea6c9e37f130f931dc01ae6af8f8f24d330c78d402e03670e40c1fbde96c52b03a07aecd28ca970dbcd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/72"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+    "sha512": "b0f538b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest-filename": "38b95edd625bed589c70c311c3d0fba285536213b4f201b439496c43081f66518bce82ba103b061040e28f27c0886c4fb51135653a82b5502da7537818be",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+    "sha512": "694e4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
+    "dest-filename": "4426e20dd960de982700a76bc505fa7f9b810085626750d492c348b1b3bfe45db77a3e0eb8126c0990d745841f1a5add6c1f60935eb2f1a3f880195de83d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/4e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+    "sha512": "95cfda6a19feb78fd2595fea726ba6623ca62ec59f37710b869995b9416382c391aeeb993d54b0010af2abe1c71af3bf488d8a557dba6f1f849fece133c83c85",
+    "dest-filename": "da6a19feb78fd2595fea726ba6623ca62ec59f37710b869995b9416382c391aeeb993d54b0010af2abe1c71af3bf488d8a557dba6f1f849fece133c83c85",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/95/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+    "sha512": "64363e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest-filename": "3e6cf9b9cd34c5f98a42ac053d9cad148080983d3d10b53d4d65616fe2cfbe4cd91c815693d20ebee11dae238323423cf2b07075cf1b962f9d21cda7978b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+    "sha512": "2db833764d21e23ba843d7c22975b86f2d1426a8fe9ce3ab23d309d6c4a3e2723c688d9ea35aa6bd01227b8543d6096c4b6e749f5e4bb16b18b42ba0892b52e4",
+    "dest-filename": "33764d21e23ba843d7c22975b86f2d1426a8fe9ce3ab23d309d6c4a3e2723c688d9ea35aa6bd01227b8543d6096c4b6e749f5e4bb16b18b42ba0892b52e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/b8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+    "sha512": "3aa6ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
+    "dest-filename": "ce939a0441e019f165d6c9d96ef47263cfd59574422f6a63027179aea946234e49c7fecaac5af850def830285451d47a63bcd04a437ee76c9818cc6a8672",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+    "sha512": "5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest-filename": "d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+    "sha512": "db2c8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest-filename": "8047ca8190ddd8ba17896a7529582e54ddb6f9a2c0f2c0d07c4730d5943c031dba1c009bdeaaa8f5bbcf92543ee39164f8cafb070a95aaa96a80c5bd3308",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+    "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest-filename": "73b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+    "sha512": "0d38383096c631691f8ba55915d36ddbf71a31b432e0ebbe3a9fe1250bc611672755fa00d5003ec7344a033c3d8c3ebe19538e798aff98872e0d276e83a17afb",
+    "dest-filename": "383096c631691f8ba55915d36ddbf71a31b432e0ebbe3a9fe1250bc611672755fa00d5003ec7344a033c3d8c3ebe19538e798aff98872e0d276e83a17afb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+    "sha512": "f0e7ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+    "dest-filename": "ecfc051087c31a11cae5ab9c4e5f4090f72a53179765efc9a394c35f38ad3c7f3a604c741140f07170f944b48c34c91a70b3e668ff7afee5645bcbbbb71a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+    "sha512": "61ddd4112e665824aa47ea8d4fddd2dd4a18524a8067d94b83c6bb83dae29ac5a66062bc7154e8038fec17746bb21772577b0018c5d5526a4c60ec3e74ba4ebb",
+    "dest-filename": "d4112e665824aa47ea8d4fddd2dd4a18524a8067d94b83c6bb83dae29ac5a66062bc7154e8038fec17746bb21772577b0018c5d5526a4c60ec3e74ba4ebb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+    "sha512": "fe3299a0ca70d05f06470978fde2d138f03771f717b4b0293f44332e6513fc7b8f0995b207b218f59acc78ac363bf9c522a3d00773d533d6989b4177d760170d",
+    "dest-filename": "99a0ca70d05f06470978fde2d138f03771f717b4b0293f44332e6513fc7b8f0995b207b218f59acc78ac363bf9c522a3d00773d533d6989b4177d760170d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/32"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+    "sha512": "75107bf2cacdfe5ea0a96ba56a1f52af17989f179d7481b7d3e18ea8affd3a52d5c8b8371cf9ebe92a8e59358e5ca4700b6786602919e7d34db9282f4aba6038",
+    "dest-filename": "7bf2cacdfe5ea0a96ba56a1f52af17989f179d7481b7d3e18ea8affd3a52d5c8b8371cf9ebe92a8e59358e5ca4700b6786602919e7d34db9282f4aba6038",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/10"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+    "sha512": "96a8eb8e668ea009d67cc9813cbf97367ca7661dbeb30c625f7594134b38c841c8ea6f80c2b2b65193a2988465dd7ff841cb55a92f008998c5ab2386acc5dbff",
+    "dest-filename": "eb8e668ea009d67cc9813cbf97367ca7661dbeb30c625f7594134b38c841c8ea6f80c2b2b65193a2988465dd7ff841cb55a92f008998c5ab2386acc5dbff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+    "sha512": "ef07c7e2c2dbb783348020f3184eafcd0068d1b7d32a353b49fa6acbfee0b35a817d8cf6bc4247eaf5dc04aa4edfee98bb5b5e970774b7d1e9c8ea0b11041b21",
+    "dest-filename": "c7e2c2dbb783348020f3184eafcd0068d1b7d32a353b49fa6acbfee0b35a817d8cf6bc4247eaf5dc04aa4edfee98bb5b5e970774b7d1e9c8ea0b11041b21",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+    "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+    "dest-filename": "134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/98"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+    "sha512": "5baee22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
+    "dest-filename": "e22e5e09d845c41936df78709f7eb8c37e2b6f2c0360d14957df01545124f1f762974457a0307515812a84fb0be101b8b85aa8c683d733cac4d5d84a5b7b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5b/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+    "sha512": "36e00449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest-filename": "0449439432b9485ce7c72b30fa6e93eeded62ddf1be335d44843e15e4f494d6f82bc591ef409a0f186e360b92d971be1a39323303b3b0de5992d2267e12c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+    "sha512": "a15973920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92",
+    "dest-filename": "73920dc4340842936cddbfb209c1dfd0503e33d91c51c2991c198f29b0255c09864dab8c189d55802c733e6ebb6e26378f5a2605fc2966b83afc0a1e7e92",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+    "sha512": "94d689808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest-filename": "89808fb643951140191c7042874d038f697754c67659125413658d0c15402e684a9ed44f8dcaf81dcff688c8d8ba67d3333b976fd47f27e7cfc610ba77fb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+    "sha512": "91ba5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
+    "dest-filename": "5a4921894d674063928f55e30e2974ab3edafc0bc0bbc287496dcb1de758d19e60fe199bbc63456853a0e6e59e2f5abd0883fd4d2ae59129fee3e5a6984a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/ba"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+    "sha512": "bc324c91f09f6f46f503cdfaae01e3f8e46e65fe01e3e71cd9b01242da5ea092ee7ae15ce43b98c23219501ad2bf1fdf3b922b2e32f3fa84eb077a5c1a5868bd",
+    "dest-filename": "4c91f09f6f46f503cdfaae01e3f8e46e65fe01e3e71cd9b01242da5ea092ee7ae15ce43b98c23219501ad2bf1fdf3b922b2e32f3fa84eb077a5c1a5868bd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/32"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz",
+    "sha512": "dcac4be70215a9af04c74f23c52ce7726f42320c3c0a3385c8e43b4b1bc6f68d1c54b9614cd297c8842e4dbb57e2d18f2447fbdce111db1ae3b781c94812f8a3",
+    "dest-filename": "4be70215a9af04c74f23c52ce7726f42320c3c0a3385c8e43b4b1bc6f68d1c54b9614cd297c8842e4dbb57e2d18f2447fbdce111db1ae3b781c94812f8a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/ac"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.27.0.tgz",
+    "sha512": "404cc6c2bbcd060bf8b8f55d9db1ec3861b81ba4fdea676570523c68028f8cc53cc0e3e956870f5dbea4dd01a46996a0553bf61bd0679dba3a67725d5ebd5f43",
+    "dest-filename": "c6c2bbcd060bf8b8f55d9db1ec3861b81ba4fdea676570523c68028f8cc53cc0e3e956870f5dbea4dd01a46996a0553bf61bd0679dba3a67725d5ebd5f43",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+    "sha512": "d2e4bbe8e3e01f485608fac52a52fc918555edc90ceedff7e877db828170e8d7740995556d00b83e4ad1f26057f0bb4d50564edb921006a5761f1da1a371656d",
+    "dest-filename": "bbe8e3e01f485608fac52a52fc918555edc90ceedff7e877db828170e8d7740995556d00b83e4ad1f26057f0bb4d50564edb921006a5761f1da1a371656d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.27.0.tgz",
+    "sha512": "a200cbb2a228cc767089f3ee377ecea6ba00a346f25fab78dff6cff06cde6560560fa30e184c6cc05031deea78352fefbd604e836bb63d7a260eddeb3267504a",
+    "dest-filename": "cbb2a228cc767089f3ee377ecea6ba00a346f25fab78dff6cff06cde6560560fa30e184c6cc05031deea78352fefbd604e836bb63d7a260eddeb3267504a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+    "sha512": "6200697491cfc90d94139c7e8654977277a3cc0bc3d1bdb65363ae00ffbc3a79494fe3e358fc6d8261aa28a73e4604cceb753d80dd18ceb61cef5476593fe14c",
+    "dest-filename": "697491cfc90d94139c7e8654977277a3cc0bc3d1bdb65363ae00ffbc3a79494fe3e358fc6d8261aa28a73e4604cceb753d80dd18ceb61cef5476593fe14c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/00"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+    "sha512": "4ef016c62d270ded63febb4c7167088fde3e15f7ba9fbce1a30df7878d122b19ac9a8cece9dcff7be11a8f299fa0570777bb31367f321ccf3cdfdba2c4c395ea",
+    "dest-filename": "16c62d270ded63febb4c7167088fde3e15f7ba9fbce1a30df7878d122b19ac9a8cece9dcff7be11a8f299fa0570777bb31367f321ccf3cdfdba2c4c395ea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+    "sha512": "e212c1f0fcb8cd971ee6ce3277d5f3a29ab056fff218d855d4197c353982ab5efadc778adbe130553bfe95e19e2f5dc39e1db07dbaa8c153d70883b4cf8b5a63",
+    "dest-filename": "c1f0fcb8cd971ee6ce3277d5f3a29ab056fff218d855d4197c353982ab5efadc778adbe130553bfe95e19e2f5dc39e1db07dbaa8c153d70883b4cf8b5a63",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e2/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+    "sha512": "cc9aba44fff9abe4ced8ea45577147ce53e71639a46fb35cf7d6b948d8c913ebaefcf9290a1b3e3486524b36c1a03fba9238884978df61dc23d59450f35773ff",
+    "dest-filename": "ba44fff9abe4ced8ea45577147ce53e71639a46fb35cf7d6b948d8c913ebaefcf9290a1b3e3486524b36c1a03fba9238884978df61dc23d59450f35773ff",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+    "sha512": "2089ef53b7da6e5df8aa68bd818f17395c61632332b87db150da5bdaaf3f63eef9e762a57a3911beabc3d7d9cca145bfb901866ea36903a4ee7eee452f905983",
+    "dest-filename": "ef53b7da6e5df8aa68bd818f17395c61632332b87db150da5bdaaf3f63eef9e762a57a3911beabc3d7d9cca145bfb901866ea36903a4ee7eee452f905983",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/89"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+    "sha512": "0a2c9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
+    "dest-filename": "9e3b1153fc96723799b4cfd3df5f0e1208127a4b2833d43a65d30aa39610c418604fd469ec51510bd29eb78681b57dc8f77c7ca75e2f4d60ee2758e2fea9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
+    "sha512": "d1835d51c78c75a430a0a71ed606ad0d2726328e69bbfb5f0017e7cc4a9e1b482d4e677b9a1fd67308148ed01e394ecdf2714595b4019c52b68175b97c6be630",
+    "dest-filename": "5d51c78c75a430a0a71ed606ad0d2726328e69bbfb5f0017e7cc4a9e1b482d4e677b9a1fd67308148ed01e394ecdf2714595b4019c52b68175b97c6be630",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d1/83"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+    "sha512": "0156f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest-filename": "f0dd42767bd6eaeb8bd2692f409b47e37b53daf296c6a934ec9977da2223299ebe4394385f24eb8b8fd49ff7964f5430147ab0df124f3c30f98f7bb50242",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/01/56"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+    "sha512": "0d4589af7f942e9e335e6a25fd266415fdc91ac4bdfd222ff98dd1b7ddff5233e90e99250797f57abe0edcf3886d4b9427715782ab5ed90ed2ad4eb302ac24f3",
+    "dest-filename": "89af7f942e9e335e6a25fd266415fdc91ac4bdfd222ff98dd1b7ddff5233e90e99250797f57abe0edcf3886d4b9427715782ab5ed90ed2ad4eb302ac24f3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/45"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+    "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+    "sha512": "2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
+    "dest-filename": "733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/32"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+    "sha512": "ab2087e36d5840f4b65850f10e37ed7dcd5947958a433573aaca789fd3369108553a8fc1c9a845a143497e5e7c90e70419f43fffbc1e1530e19beb2cf0473183",
+    "dest-filename": "87e36d5840f4b65850f10e37ed7dcd5947958a433573aaca789fd3369108553a8fc1c9a845a143497e5e7c90e70419f43fffbc1e1530e19beb2cf0473183",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+    "sha512": "a9172e21d3faf4d3e6e2a6c008af9a0e8808e42043322d6329ed2bcb9ad2409cfc2552ec0bb8d5f17a622631912cba25dcdf91e6284661cacf2d39e8ea901d04",
+    "dest-filename": "2e21d3faf4d3e6e2a6c008af9a0e8808e42043322d6329ed2bcb9ad2409cfc2552ec0bb8d5f17a622631912cba25dcdf91e6284661cacf2d39e8ea901d04",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+    "sha512": "57f9a9c890284ec3787273f7d6f734c1f340d7ea76d1ebeaaa76a9d0a2e8454374624fe9df0379d83384b0be2804570b75befa865a4a3edcc9220a3aee3fd72f",
+    "dest-filename": "a9c890284ec3787273f7d6f734c1f340d7ea76d1ebeaaa76a9d0a2e8454374624fe9df0379d83384b0be2804570b75befa865a4a3edcc9220a3aee3fd72f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/f9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+    "sha512": "ec40079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3",
+    "dest-filename": "079722c7239e9510874ae7bbb01dd1ca21a0066e75cf8b0d3259b6ab41938a68aa6f508816d2359154b89ab6733e5d7952c2c6a72011ff87318c26e94ca3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/40"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/phonemizer/-/phonemizer-1.2.1.tgz",
+    "sha512": "bf4289e268b64f843b7894345b5e577781bd9389080925c4f1ba43789f238ac2f8472261356b3078a4ce8bcf105c5738af82d9973e6354be65087864a5d4fbd4",
+    "dest-filename": "89e268b64f843b7894345b5e577781bd9389080925c4f1ba43789f238ac2f8472261356b3078a4ce8bcf105c5738af82d9973e6354be65087864a5d4fbd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+    "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest-filename": "87dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+    "sha512": "46fc3072bb8d8c8d67713e7145a91ec92f4b7fc95c22dbf7e0a0fe6a27fe547f6476e0327d8062a46875db6ef8c6d7a720f675d7dfd1f4175305af200304a1d0",
+    "dest-filename": "3072bb8d8c8d67713e7145a91ec92f4b7fc95c22dbf7e0a0fe6a27fe547f6476e0327d8062a46875db6ef8c6d7a720f675d7dfd1f4175305af200304a1d0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/fc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
+    "sha512": "6419a11350bd2dc3e81fd5d949dc223ed6cf1d944ec009cccbe90815056b9cc0b16380ae765cf78013a9ce29607348ce8116a24f7b0859fa4ca265b66abda8ad",
+    "dest-filename": "a11350bd2dc3e81fd5d949dc223ed6cf1d944ec009cccbe90815056b9cc0b16380ae765cf78013a9ce29607348ce8116a24f7b0859fa4ca265b66abda8ad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/19"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+    "sha512": "c10d1bfd6e05af4d6ab691e5a92aaca5c8f712106f8a6b1d8742a51e11fc1d166732c11ad1e6b67d350b397392f5c710af7a26f86706464e1efa2b2b65657ca9",
+    "dest-filename": "1bfd6e05af4d6ab691e5a92aaca5c8f712106f8a6b1d8742a51e11fc1d166732c11ad1e6b67d350b397392f5c710af7a26f86706464e1efa2b2b65657ca9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+    "sha512": "7e759596351c853ae8e9188216f09705b36125cd8d8a337ba084316f0b322f46ee5893c6f39bfcd5e8651c8f5f5eb26c30d813a1f12858841e0a52a983114bae",
+    "dest-filename": "9596351c853ae8e9188216f09705b36125cd8d8a337ba084316f0b322f46ee5893c6f39bfcd5e8651c8f5f5eb26c30d813a1f12858841e0a52a983114bae",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7e/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+    "sha512": "c0f612c0404963d187ada2125eacaab71d276b42e93b75c45fb8cd0e19ed6dec7bb73512ee42e766c3a516bb85241e078bfae10cc8d71aa1dec0367af2761957",
+    "dest-filename": "12c0404963d187ada2125eacaab71d276b42e93b75c45fb8cd0e19ed6dec7bb73512ee42e766c3a516bb85241e078bfae10cc8d71aa1dec0367af2761957",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/f6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+    "sha512": "d0cf8bdcb003f3f9e6e79e0b3a56bd032c748f4b66159d0505ca10ec5d55b951e933f5e9882f11703cc1401f16e7e840f0bdb64c7c442f3785fb659c533bdc2e",
+    "dest-filename": "8bdcb003f3f9e6e79e0b3a56bd032c748f4b66159d0505ca10ec5d55b951e933f5e9882f11703cc1401f16e7e840f0bdb64c7c442f3785fb659c533bdc2e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/cf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+    "sha512": "bbcd8def82c5cc6f1c6be743f29b8f9e99535e8187e1f4cfa551ae21bb77e86deabcd964bdf0f49440194b16a5cb7297f134bf2f503582c0849af2a605c55b91",
+    "dest-filename": "8def82c5cc6f1c6be743f29b8f9e99535e8187e1f4cfa551ae21bb77e86deabcd964bdf0f49440194b16a5cb7297f134bf2f503582c0849af2a605c55b91",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bb/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+    "sha512": "0c4bd5d99176af6ffadd5fad2bc850beb4766469f5d2cac76d7be24e572fecaa73c3c8d688d4ea6d58233b7218f11c6bace505f153cc410172b18618bf4619c7",
+    "dest-filename": "d5d99176af6ffadd5fad2bc850beb4766469f5d2cac76d7be24e572fecaa73c3c8d688d4ea6d58233b7218f11c6bace505f153cc410172b18618bf4619c7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+    "sha512": "f7a5812e139a62127e90f84b837b96df9f53cfa23f31f72b41f2f8106bf84ab72a284302d609a81ab5c779c3c4f1e3b04d5089e08c207f333c7c569ddb9c0d7f",
+    "dest-filename": "812e139a62127e90f84b837b96df9f53cfa23f31f72b41f2f8106bf84ab72a284302d609a81ab5c779c3c4f1e3b04d5089e08c207f333c7c569ddb9c0d7f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/a5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+    "sha512": "ad3eea66742dc79734ff2fca958686bed1b8d754bded468bea0769e91219db70cb1da9cc60bc9f1815790ed4a765db6142a97b5be94455ba527f0b4ef13f8bdb",
+    "dest-filename": "ea66742dc79734ff2fca958686bed1b8d754bded468bea0769e91219db70cb1da9cc60bc9f1815790ed4a765db6142a97b5be94455ba527f0b4ef13f8bdb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/3e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+    "sha512": "08293a1b2c7df93b76b1b624e4d2b49c1d6e9078b6af269181a755fcbbf236e3b77a76b5a5ac8cdb3e82834bced5e6caf1cc5bce8e3592ed831390318f566e8b",
+    "dest-filename": "3a1b2c7df93b76b1b624e4d2b49c1d6e9078b6af269181a755fcbbf236e3b77a76b5a5ac8cdb3e82834bced5e6caf1cc5bce8e3592ed831390318f566e8b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+    "sha512": "a4c7586849e334c4b0975d728c41ad81398b911d3c9bf565f898f8e37d7aee9f5e0771d540a85809ce20987543b0b3ce0df65f8ebfcc9a2aec7726738976d02b",
+    "dest-filename": "586849e334c4b0975d728c41ad81398b911d3c9bf565f898f8e37d7aee9f5e0771d540a85809ce20987543b0b3ce0df65f8ebfcc9a2aec7726738976d02b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+    "sha512": "ce5cd3887d3578a039e5401fd4c123b6cb097879c6c4ed23e0ae03a71fa09e65fd9fe4873650ea236a0ed4abf588f379075766e5fb258c27ea285f6714be8746",
+    "dest-filename": "d3887d3578a039e5401fd4c123b6cb097879c6c4ed23e0ae03a71fa09e65fd9fe4873650ea236a0ed4abf588f379075766e5fb258c27ea285f6714be8746",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/5c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+    "sha512": "ef08f8b8c8ca69758043508383137336d47d025b2ec331df7451f5ca01070362871760ce11a5e5d4225f34f00a0a0f6a344878aee9bdef940b6828903f263a17",
+    "dest-filename": "f8b8c8ca69758043508383137336d47d025b2ec331df7451f5ca01070362871760ce11a5e5d4225f34f00a0a0f6a344878aee9bdef940b6828903f263a17",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+    "sha512": "e07b9c465a622ddd483d041736a7a8f35046b6463c022e6c98784a5bd8e33ca45cdb0408c64b20ec7975b5323621f4f607f2e05fa6df62f5f1129265eda2982b",
+    "dest-filename": "9c465a622ddd483d041736a7a8f35046b6463c022e6c98784a5bd8e33ca45cdb0408c64b20ec7975b5323621f4f607f2e05fa6df62f5f1129265eda2982b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/7b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz",
+    "sha512": "a514e49640c330c468a72a0072bafdc15ffc83f45882b2c706e2406f986512e61945d9b9caa98f8d621df377e90703e9485a847636b41fb0df77bcf55ff9e970",
+    "dest-filename": "e49640c330c468a72a0072bafdc15ffc83f45882b2c706e2406f986512e61945d9b9caa98f8d621df377e90703e9485a847636b41fb0df77bcf55ff9e970",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/14"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+    "sha512": "f76ee5171feec3241a1b02712d60994648d71b4a78f0aa4c8fab9ea188aee095f4e461ae19c833032eb675f895f1e1597ed832054bcbc7be91b0c7b6d1f265f9",
+    "dest-filename": "e5171feec3241a1b02712d60994648d71b4a78f0aa4c8fab9ea188aee095f4e461ae19c833032eb675f895f1e1597ed832054bcbc7be91b0c7b6d1f265f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/6e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+    "sha512": "ea38981c7d822066c27e7c5d1db5d9d7683248563f7f3fee959137df71ba6cfa8867817e4d7a3d89f891f3a9c01e95a77e836339bde8e444a2ec9f14cf58d71f",
+    "dest-filename": "981c7d822066c27e7c5d1db5d9d7683248563f7f3fee959137df71ba6cfa8867817e4d7a3d89f891f3a9c01e95a77e836339bde8e444a2ec9f14cf58d71f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+    "sha512": "57fd1c0c2b072877bfb5f5a47829ad84d51c129d4854ede9eafc0df17b7013d3d940b01926281bc37428ada01d7c93e2af834a26d36f381f2860629197eb740f",
+    "dest-filename": "1c0c2b072877bfb5f5a47829ad84d51c129d4854ede9eafc0df17b7013d3d940b01926281bc37428ada01d7c93e2af834a26d36f381f2860629197eb740f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/fd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+    "sha512": "1b16e8c8de00308b281cdb73e6e7f6af646ee79d62e6159e08c0fa13621be04a20aa8b9bd0d7e59e26813d543832b184e7267c255f6d50783da9c6534eb70de3",
+    "dest-filename": "e8c8de00308b281cdb73e6e7f6af646ee79d62e6159e08c0fa13621be04a20aa8b9bd0d7e59e26813d543832b184e7267c255f6d50783da9c6534eb70de3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1b/16"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz",
+    "sha512": "379e031773973560ee3fcd46d646df0b2b3c673223b8bd559ef2769a4e524d2bbf7cdc5621c5ff12eb502c0decf4a47fdb05618038b8873041ff57c8355c64d0",
+    "dest-filename": "031773973560ee3fcd46d646df0b2b3c673223b8bd559ef2769a4e524d2bbf7cdc5621c5ff12eb502c0decf4a47fdb05618038b8873041ff57c8355c64d0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/9e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+    "sha512": "fc53c3d2751cf631faadf1638e2f4806a3b3e297121370ac4f59bb129e8c75bd0bc5250c8fc86097a1a898ebd9ce936902aa866970343f7552ad92c5cc8850af",
+    "dest-filename": "c3d2751cf631faadf1638e2f4806a3b3e297121370ac4f59bb129e8c75bd0bc5250c8fc86097a1a898ebd9ce936902aa866970343f7552ad92c5cc8850af",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fc/53"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+    "sha512": "96542c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
+    "dest-filename": "2c30b4940d43d3e388ddad4fcedfbaa59e27e2b433fe670ae699972848ac8b2afb59c69c95d27dbf6c3fcde2d040019fe024475953b28cadaa0ad7e5d802",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/54"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+    "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "dest-filename": "7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+    "sha512": "3bd825df30a5e61e5b970d4a194cd02a1039a145d297caf0508339a344b79c25cc9624afcb90f3c7bfc325c23e4b08080aff889de499c21061d684b210703bd4",
+    "dest-filename": "25df30a5e61e5b970d4a194cd02a1039a145d297caf0508339a344b79c25cc9624afcb90f3c7bfc325c23e4b08080aff889de499c21061d684b210703bd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/d8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+    "sha512": "4aae025b8421c0e1c4f2e727e89df832ab5909e5853f66904a6ae5ae8620a805753e34ad221257c58b9381421f90493bcd32e39888cb994e6af9f6c3d4d9ce24",
+    "dest-filename": "025b8421c0e1c4f2e727e89df832ab5909e5853f66904a6ae5ae8620a805753e34ad221257c58b9381421f90493bcd32e39888cb994e6af9f6c3d4d9ce24",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+    "sha512": "900e56428355a38b7d94dc769103450b129e065e486db48d065d4cfed2e4c3d5829fe871341016e5087c81d86ceb70899e18c9db3416168a8f24fdac2b5015e4",
+    "dest-filename": "56428355a38b7d94dc769103450b129e065e486db48d065d4cfed2e4c3d5829fe871341016e5087c81d86ceb70899e18c9db3416168a8f24fdac2b5015e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/0e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+    "sha512": "85e9369854293ee2381350412ab4ada3e054ddedf1e31b9aaec6e2c2bdfe95fee9e388eebc5315d171564003f7c54caa5c0e11ad72c8a1a49419b4add39e9933",
+    "dest-filename": "369854293ee2381350412ab4ada3e054ddedf1e31b9aaec6e2c2bdfe95fee9e388eebc5315d171564003f7c54caa5c0e11ad72c8a1a49419b4add39e9933",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/e9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+    "sha512": "2b9cd08c3965c5691fed9e7125d574fc1d164cdab1eafc46ef4cc9138374901b382e8be6118589cd01b10bd6d2f5100abb76e0338d25adde73a0b275d8c43904",
+    "dest-filename": "d08c3965c5691fed9e7125d574fc1d164cdab1eafc46ef4cc9138374901b382e8be6118589cd01b10bd6d2f5100abb76e0338d25adde73a0b275d8c43904",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2b/9c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+    "sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+    "dest-filename": "2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/6e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
+    "sha512": "cd942a2226200c24cffdfd4dfe6011d749c91ab3c3d9947e8c3484b0a5891d80bb0a6db0a1d9706d1deea5945d0b77232234a54cb355c8eec8bb4632eedd8062",
+    "dest-filename": "2a2226200c24cffdfd4dfe6011d749c91ab3c3d9947e8c3484b0a5891d80bb0a6db0a1d9706d1deea5945d0b77232234a54cb355c8eec8bb4632eedd8062",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/94"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+    "sha512": "f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
+    "dest-filename": "b28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+    "sha512": "22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
+    "dest-filename": "fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz",
+    "sha512": "051e43b4d472f80b30589102c80d7baa1503bebac267acd73827e4418e734a66fde815546e9540bf4dd6a5c8dcc2d0b088b6c800dc7781e6c739c5d89f5107a3",
+    "dest-filename": "43b4d472f80b30589102c80d7baa1503bebac267acd73827e4418e734a66fde815546e9540bf4dd6a5c8dcc2d0b088b6c800dc7781e6c739c5d89f5107a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+    "sha512": "6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
+    "dest-filename": "d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+    "sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+    "dest-filename": "a1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/2f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+    "sha512": "1c533cae467e8b7ceb57ee0b423c10d16f9ecfdf290293063371d4acdd388f70aaccf3b397d9e63f5e58f185cd9bc4071affde69c395123aa1996a64455d0d03",
+    "dest-filename": "3cae467e8b7ceb57ee0b423c10d16f9ecfdf290293063371d4acdd388f70aaccf3b397d9e63f5e58f185cd9bc4071affde69c395123aa1996a64455d0d03",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/53"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+    "sha512": "320b86f79a228f47c2dd05775117f8576483606261267246aaf20881d10278e0c24fdf304960c027de124ae5696105284dc19420be8be32341ee3d431451d206",
+    "dest-filename": "86f79a228f47c2dd05775117f8576483606261267246aaf20881d10278e0c24fdf304960c027de124ae5696105284dc19420be8be32341ee3d431451d206",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/0b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+    "sha512": "918d40655af645afadfa9895689e20c5a15a45e6551f8d0028da3b5025fa5be744c01a3fda8649cea7ee375a8bab5a0be39a39e9c3da4d710bc2b4e1f05a6082",
+    "dest-filename": "40655af645afadfa9895689e20c5a15a45e6551f8d0028da3b5025fa5be744c01a3fda8649cea7ee375a8bab5a0be39a39e9c3da4d710bc2b4e1f05a6082",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/8d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+    "sha512": "7c6c4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest-filename": "4423bfb0b06f71aef763b2b9662f6d8e3134e21d1c0032ba2211e320abc833a0b0bf3d0afb46c4434932d483f6d9019b45f9354890773aff84482abba2f9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7c/6c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+    "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+    "dest-filename": "2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/fd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+    "sha512": "4f2789d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08",
+    "dest-filename": "89d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/27"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+    "sha512": "23d7cf5d4f6078ef5b1ceb7da471ce84e9187ab20cb2655a581d2b036008f44461ffec7f8bb315e4728136b83e9633b97a83d580272716e46327db87e88ff77a",
+    "dest-filename": "cf5d4f6078ef5b1ceb7da471ce84e9187ab20cb2655a581d2b036008f44461ffec7f8bb315e4728136b83e9633b97a83d580272716e46327db87e88ff77a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/d7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+    "sha512": "f5a64b22b851683f7bb20561b49396e9c90e121ebf1a7bd0b5d54d7dd67ab3aefedff5f02d2f6505c418cc4121615794a3037ba51ccc2ecc8684ada2ff1bd66f",
+    "dest-filename": "4b22b851683f7bb20561b49396e9c90e121ebf1a7bd0b5d54d7dd67ab3aefedff5f02d2f6505c418cc4121615794a3037ba51ccc2ecc8684ada2ff1bd66f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+    "sha512": "b7dcf6f5c2635dffefc50f1dca1092a6de87e9a4b01d393c713e48de2cba48c5ee169939981e8f2fa5df0bc3c2c2b3d3c7ddee7702949bd1d1b5e0254c604b88",
+    "dest-filename": "f6f5c2635dffefc50f1dca1092a6de87e9a4b01d393c713e48de2cba48c5ee169939981e8f2fa5df0bc3c2c2b3d3c7ddee7702949bd1d1b5e0254c604b88",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/dc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+    "sha512": "513e440ded9cbb613fe8ee22814af93d216cdb79efbee9227161f1e869ce3e51c08a261bccdb824500ae89474725072a29a94b2a5ad82678d8d32486b173505d",
+    "dest-filename": "440ded9cbb613fe8ee22814af93d216cdb79efbee9227161f1e869ce3e51c08a261bccdb824500ae89474725072a29a94b2a5ad82678d8d32486b173505d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/3e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+    "sha512": "9cb4eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061",
+    "dest-filename": "eb50a9b653288beeb9616a9bbf665e3917036091919a0a965b2076a30d883094908eccb4a4f9c20f027b04a95f79e468c82c99ca6dd402d6754fcfe80061",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/b4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+    "sha512": "4eb10c6bb2467559b4513843252c7b75dc399d59b75094bda3d082219ef6075bd2c84668ce20ea0583f75c8a22ff5da52ab251f2b1378de14732893617f327b2",
+    "dest-filename": "0c6bb2467559b4513843252c7b75dc399d59b75094bda3d082219ef6075bd2c84668ce20ea0583f75c8a22ff5da52ab251f2b1378de14732893617f327b2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/b1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+    "sha512": "82ea25b50131fbd68c7f6803674b3ad84715f25b1747ed30f3dd794c2dc84dd9f662e7ae363740621fe57afa54f6715aa02861f51512e5975032b29f54437db7",
+    "dest-filename": "25b50131fbd68c7f6803674b3ad84715f25b1747ed30f3dd794c2dc84dd9f662e7ae363740621fe57afa54f6715aa02861f51512e5975032b29f54437db7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/ea"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+    "sha512": "0cf7b9a5515a02c8a749a57a42343a81d89e7560dc4426d4ba241f41adb099657bfb10bd6c6ba5188f3e4dd466a059003da05793c0ab01b9e56362129e2278ed",
+    "dest-filename": "b9a5515a02c8a749a57a42343a81d89e7560dc4426d4ba241f41adb099657bfb10bd6c6ba5188f3e4dd466a059003da05793c0ab01b9e56362129e2278ed",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/f7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+    "sha512": "76129ff74dd4fcf41963a6e834db4019d59b1bce5601b8d3ff5c58a19202ec5018d3259aa4e05056c56b0e5e7c5bcebffded55a4c341b5157831a5df74cc9214",
+    "dest-filename": "9ff74dd4fcf41963a6e834db4019d59b1bce5601b8d3ff5c58a19202ec5018d3259aa4e05056c56b0e5e7c5bcebffded55a4c341b5157831a5df74cc9214",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/12"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+    "sha512": "619a372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+    "dest-filename": "372bcd920fb462ca2d04d4440fa232f3ee4a5ea6749023d2323db1c78355d75debdbe5d248eeda72376003c467106c71bbbdcc911e4d1c6f0a9c42b894b6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+    "sha512": "e91dc9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc",
+    "dest-filename": "c9e4ce0071bb4b51d66646fd92ca079568cec886b2d7bbd0669ce1a698009a93c7e252d3ac60d5944b8b8aeeea5b9872016cb05e15e23fff8efb04a2c1cc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+    "sha512": "c4083b48e9c486b9b9cc8de9b8e38acb2d4e31c32520965834963bc4b0704b37b452384f2e759f8f6185d84a53d239b368928858a1cbb1a4926a37f7e5b7189c",
+    "dest-filename": "3b48e9c486b9b9cc8de9b8e38acb2d4e31c32520965834963bc4b0704b37b452384f2e759f8f6185d84a53d239b368928858a1cbb1a4926a37f7e5b7189c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c4/08"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+    "sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+    "dest-filename": "a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/scrollable-component/-/scrollable-component-2.0.4.tgz",
+    "sha512": "9749460cf1b3dd0bc26a4cdc71cadaf55d0e897eb8f4d498e0fa2d26d4b1f762629fdd30fd966a4ebb21d7e534eaf8c1734adf953afed45fe1545cf768edcca9",
+    "dest-filename": "460cf1b3dd0bc26a4cdc71cadaf55d0e897eb8f4d498e0fa2d26d4b1f762629fdd30fd966a4ebb21d7e534eaf8c1734adf953afed45fe1545cf768edcca9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+    "sha512": "63bfca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0",
+    "dest-filename": "ca0ec6fc2e3a28669c1aa86cae94ee8342592c8029dc7211c693eb19218e1206f52870c044147e54af57c8e1d57e26f974c3a723bee71a222e34a6e462a0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/bf"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+    "sha512": "d609d97fb0c572821c6a34e34f08f0b838f3bb3e0f3dc6364ad28f96c180435f981f6d08455ac169749699d8e8c1327abbc45cd353e860e1875df3f599871935",
+    "dest-filename": "d97fb0c572821c6a34e34f08f0b838f3bb3e0f3dc6364ad28f96c180435f981f6d08455ac169749699d8e8c1327abbc45cd353e860e1875df3f599871935",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+    "sha512": "dcd9ee59f33abc1628cb981916f1e262c55b69fbc8f6f66fffe8e52228059f8a0fe338cd3cadcb85c634c520a079bd5ae4bf233bbd4c8adf4b94da22d947c30d",
+    "dest-filename": "ee59f33abc1628cb981916f1e262c55b69fbc8f6f66fffe8e52228059f8a0fe338cd3cadcb85c634c520a079bd5ae4bf233bbd4c8adf4b94da22d947c30d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/d9"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+    "sha512": "0a29c0ab5c566f4bd1dedc00bfd7af114f1c35691709bf6477978f00750a24190eb14a51d70b7f0af19d79c6bbbeaba62f553971269e550eb364cc62277c96b2",
+    "dest-filename": "c0ab5c566f4bd1dedc00bfd7af114f1c35691709bf6477978f00750a24190eb14a51d70b7f0af19d79c6bbbeaba62f553971269e550eb364cc62277c96b2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0a/29"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+    "sha512": "c515c19f4a4fa904d54220bcc3242b2acd8c3a55f6e334343ce19a8f492e96dbe8382b2d050339caf3a1015494c0e32342d4efb0f5a83421df3c6c1a6902614f",
+    "dest-filename": "c19f4a4fa904d54220bcc3242b2acd8c3a55f6e334343ce19a8f492e96dbe8382b2d050339caf3a1015494c0e32342d4efb0f5a83421df3c6c1a6902614f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/15"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+    "sha512": "1392c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
+    "dest-filename": "c35fb5aba7ce4a8a5e5b859bf8ea3f2339e6e82aae4932660cde05467461fcc45a4f59750cb0dae53830ab928c4c11e362fd7648c2e46f6385cdc18309a7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/92"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+    "sha512": "7a3d33547b991870a20015dc3717988694673cd3c072f6c6f1131d0408430312ca9024554a92b7232bbba9bab0dc9333a23d1111e33a7f7b492ed570974d36dd",
+    "dest-filename": "33547b991870a20015dc3717988694673cd3c072f6c6f1131d0408430312ca9024554a92b7232bbba9bab0dc9333a23d1111e33a7f7b492ed570974d36dd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/3d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+    "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest-filename": "6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/7c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+    "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+    "sha512": "228bfe27016fff61dc4e973034c29df3e21635bf2d6e84093504e4018fcb2d52bb8061fd8f2f8b1a456a3f17de90797ec8c9a2a97b337465978247e697b863a8",
+    "dest-filename": "fe27016fff61dc4e973034c29df3e21635bf2d6e84093504e4018fcb2d52bb8061fd8f2f8b1a456a3f17de90797ec8c9a2a97b337465978247e697b863a8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/8b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+    "sha512": "4e2c1c45cae4847bdbad96e745c15830b977d037e8bf71caab3a79b4ee5be29b7a1bf49ecca7188660e0d79cd7541b301e672d48040ace7a8d5b62cee6d4c3a3",
+    "dest-filename": "1c45cae4847bdbad96e745c15830b977d037e8bf71caab3a79b4ee5be29b7a1bf49ecca7188660e0d79cd7541b301e672d48040ace7a8d5b62cee6d4c3a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/2c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+    "sha512": "37a03d30b56a8f16587159fc84b9ad9de416209b69f082b330fe1e327c7e9ea92f5e8aa29d43c26d414ba7651c59310850e361964d1ec31aff8da54695cf89fa",
+    "dest-filename": "3d30b56a8f16587159fc84b9ad9de416209b69f082b330fe1e327c7e9ea92f5e8aa29d43c26d414ba7651c59310850e361964d1ec31aff8da54695cf89fa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/a0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+    "sha512": "9a39ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3",
+    "dest-filename": "ffd1b8bfa145118dce5797b21a5a2fce24926e9aea0915025f0c3c8ee3afa1056b1f69533ae53047ab67a864187397d11c8713a28e991b442f12541414d3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/39"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+    "sha512": "5428c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
+    "dest-filename": "c235f80cb1bcb7b53768d369db8ed33f7b0adaea33c79a94e17a7913621f291bdb9c67fd4ff12a38bb814605e93f063a4e56c0c23282c0fe2b8128815744",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+    "sha512": "58f4bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
+    "dest-filename": "bf1ef1d04d89c78ac2e8f4c72a0473899361641cefed969be5772ae77a6e1a790a7885a8b7832b61b3083aa74d684a84e5e7cadca621408c5d9baf6024d8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+    "sha512": "eb1e9d2bacc97694f3178b1078d631c2dbc1cdfe848381ad95eb12f781cebd3b9d51ec8ad965c06887e60e0b32b2562b441785225b22e78018b05194ba19afad",
+    "dest-filename": "9d2bacc97694f3178b1078d631c2dbc1cdfe848381ad95eb12f781cebd3b9d51ec8ad965c06887e60e0b32b2562b441785225b22e78018b05194ba19afad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+    "sha512": "c270f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest-filename": "f6644fa5f923c2feea12d2f5de13d2f5fb4c2e68ca8a95fcfd00c528dfc26cc8b48159215c1d1d51ae2eb62d9735daf2ebd606f78e5ee2c10860c2901b19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+    "sha512": "142fa5822cd53df89ed24921a9449cc11bb53bf945e8d3a026694280afbf2d8c4309393cb067a561a1c384570337e4a7dc2bfedd549ae01c9ea3e20c0b3a4c81",
+    "dest-filename": "a5822cd53df89ed24921a9449cc11bb53bf945e8d3a026694280afbf2d8c4309393cb067a561a1c384570337e4a7dc2bfedd549ae01c9ea3e20c0b3a4c81",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/2f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+    "sha512": "88e056160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7",
+    "dest-filename": "56160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/e0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+    "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest-filename": "8c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+    "sha512": "52381aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest-filename": "1aa6e99695b3219018334fb624739617513e3a17488abbc4865ead1b7303f9773fe1d0f963e9e9c9aa3cf565bab697959aa989eb55bc16396332177178ee",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/38"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz",
+    "sha512": "ff2eed24a00b559d653f3799641f636279adacbeddd0ddb3928ae28b96bbafb7611e4588b8b4f36696733092cad5d9984605ff34273889aad33b717b052d9cfc",
+    "dest-filename": "ed24a00b559d653f3799641f636279adacbeddd0ddb3928ae28b96bbafb7611e4588b8b4f36696733092cad5d9984605ff34273889aad33b717b052d9cfc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+    "sha512": "5e5916bdf226e919ac5ad349c7ebaab4a2d2f1ea856f1520d19ccb5ea63471a132f65ee1aee5fc2298839e3b0b6afa0182a08247bd53a963bc31a5d885e27745",
+    "dest-filename": "16bdf226e919ac5ad349c7ebaab4a2d2f1ea856f1520d19ccb5ea63471a132f65ee1aee5fc2298839e3b0b6afa0182a08247bd53a963bc31a5d885e27745",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/59"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+    "sha512": "c9fece10da36dc0189841ae21b1d108af63924fe98d476ebac323a58bb7a0b96ae6195e542b85ea18f210f889b7a414acf51ce7c4e3c5b0f24316327243ff371",
+    "dest-filename": "ce10da36dc0189841ae21b1d108af63924fe98d476ebac323a58bb7a0b96ae6195e542b85ea18f210f889b7a414acf51ce7c4e3c5b0f24316327243ff371",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/fe"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+    "sha512": "05b1c63902bda251cf32f40d1d6ba5e8c625ad14c038a9f4deb39ee00f0edc22d684d7f860706aab61c928a0beb1faa9c62058e76a4d79eb03ea32222c3cfc8e",
+    "dest-filename": "c63902bda251cf32f40d1d6ba5e8c625ad14c038a9f4deb39ee00f0edc22d684d7f860706aab61c928a0beb1faa9c62058e76a4d79eb03ea32222c3cfc8e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/b1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+    "sha512": "0ef132e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247",
+    "dest-filename": "32e795770c1eee927468fb888e193e5f3f5b2547cc10a2155d9278a064f32932cb5a289416870898040089137525da94e70138a18416274616501c606247",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/f1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+    "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest-filename": "90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/ac"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+    "sha512": "b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+    "dest-filename": "93224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+    "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest-filename": "153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/7f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+    "sha512": "c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+    "dest-filename": "cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/33"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+    "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest-filename": "80bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/90"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+    "sha512": "3295043763a876d533c6f29097bd9c505ed14391221ec1af4ac546d226bd73945b5862f6088e02ec4a4f4bc513048a659e5cd988db95e7ac3e16e371cb7b72d9",
+    "dest-filename": "043763a876d533c6f29097bd9c505ed14391221ec1af4ac546d226bd73945b5862f6088e02ec4a4f4bc513048a659e5cd988db95e7ac3e16e371cb7b72d9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/95"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+    "sha512": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+    "dest-filename": "169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/dd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+    "sha512": "aac8de7aae588c167978c745b946b8668b0c2f182be5167e17e6353ab0e1b8e08422744c037c7be17741b60809723f6439e227cf4584f8b8023c391916505827",
+    "dest-filename": "de7aae588c167978c745b946b8668b0c2f182be5167e17e6353ab0e1b8e08422744c037c7be17741b60809723f6439e227cf4584f8b8023c391916505827",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+    "sha512": "7a4c7de33d6b45ce4b0e2ea849469e46762177450e27176d4022f6ac5f31a56c43dd33c0b084963abc5ecea1a8bea4b7f0645939da437ef41ededb3a17b9ec9e",
+    "dest-filename": "7de33d6b45ce4b0e2ea849469e46762177450e27176d4022f6ac5f31a56c43dd33c0b084963abc5ecea1a8bea4b7f0645939da437ef41ededb3a17b9ec9e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/4c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+    "sha512": "f50364e4ac0317e06fcfe3f239b9264988c8e64b15518b635bb014db6af634a71f2c9717a7dea1903594dfe5e774eb146fe010f5085fcdf093d8ef823564f94f",
+    "dest-filename": "64e4ac0317e06fcfe3f239b9264988c8e64b15518b635bb014db6af634a71f2c9717a7dea1903594dfe5e774eb146fe010f5085fcdf093d8ef823564f94f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/03"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+    "sha512": "c84158ad586877e85d372c7b8390679246f41bab22f0726eacea0e1200bc07f3b4b972c795a7b2ffae4a46fe9cb9604d84180728044e56973b43262a1398059e",
+    "dest-filename": "58ad586877e85d372c7b8390679246f41bab22f0726eacea0e1200bc07f3b4b972c795a7b2ffae4a46fe9cb9604d84180728044e56973b43262a1398059e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
+    "sha512": "3a8ead1dda59b06a64286f3c1c9f11475ae0fd17671244047cca04936c755d1237175031794fa28d15e9895505e146cb7dcc71446c3a4db50834a61d595b104d",
+    "dest-filename": "ad1dda59b06a64286f3c1c9f11475ae0fd17671244047cca04936c755d1237175031794fa28d15e9895505e146cb7dcc71446c3a4db50834a61d595b104d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/8e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+    "sha512": "88e88f528fc11a767afb9e0eb16c5989d182b1d53c61b1383d2a5d3e29e9ec378cb5424d241a09fe8b944932631e48752a7b476a5b4797f803b36142e22e7e37",
+    "dest-filename": "8f528fc11a767afb9e0eb16c5989d182b1d53c61b1383d2a5d3e29e9ec378cb5424d241a09fe8b944932631e48752a7b476a5b4797f803b36142e22e7e37",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+    "sha512": "c1747f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
+    "dest-filename": "7f758a5ca8a99f5a911d66388a24ec023459dd0f40cc9eb5bf7188d51adb449017d581c2c51e836b963e3b9a339589cf72c8dbbae5a96c805e0d4324dada",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/74"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+    "sha512": "25eea9ee9924f8a33332fd975ca98013731c9a894e40577190ac3447c11836beec10b5b8e89aa735e4d7f326cf89082f835ca60a817c2d7b397f315a66f24f4c",
+    "dest-filename": "a9ee9924f8a33332fd975ca98013731c9a894e40577190ac3447c11836beec10b5b8e89aa735e4d7f326cf89082f835ca60a817c2d7b397f315a66f24f4c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/ee"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+    "sha512": "58c8bf390d9ac554dfff292a09081788872dfa64900c5747d9f93084fc20130bc9d644b36518a29dbd331765dbf2ee3e3aa3c2866c88e8c12ee047b3349cfe15",
+    "dest-filename": "bf390d9ac554dfff292a09081788872dfa64900c5747d9f93084fc20130bc9d644b36518a29dbd331765dbf2ee3e3aa3c2866c88e8c12ee047b3349cfe15",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/58/c8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+    "sha512": "a39b123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744",
+    "dest-filename": "123ca12483f0c840d987e37574fee7ab2eba7355e764521f2d18dbda797a5fa6ec2329e9e54a8c7fd8efc14e5654b447be246eece58844cfad3c3e500744",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/9b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+    "sha512": "1550d8771b678f41ba426fc384d3d26fc26ee7d50b72ea77b6e2719056f92bc06fda951720b6dfd3165653c3d7f0ebf5f4e5e58db532bde385c11330917ccef8",
+    "dest-filename": "d8771b678f41ba426fc384d3d26fc26ee7d50b72ea77b6e2719056f92bc06fda951720b6dfd3165653c3d7f0ebf5f4e5e58db532bde385c11330917ccef8",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/50"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+    "sha512": "85d1796608d3aa0027b4a924958c34474dcc1b6c7f6d2cd3b64c66211c3fb13355f185ec089d6d7cb017db7961c611c99447f709108e086196c37bc8dc66923f",
+    "dest-filename": "796608d3aa0027b4a924958c34474dcc1b6c7f6d2cd3b64c66211c3fb13355f185ec089d6d7cb017db7961c611c99447f709108e086196c37bc8dc66923f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+    "sha512": "2f43aba62f2a1a9446fff35df87f74bc507ede21e7b9ed734921a634e38287518b27bad4295c15d87be28e9846412d949a15197b04bd560bf1608760afe7c6d4",
+    "dest-filename": "aba62f2a1a9446fff35df87f74bc507ede21e7b9ed734921a634e38287518b27bad4295c15d87be28e9846412d949a15197b04bd560bf1608760afe7c6d4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/43"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+    "sha512": "14f02134f14cae4c33efa3fb71d8dd9a24a1c0cca765837a4a03ae8c3d6ead8e28366f343aef6831d99b478e4ba2d70a397a32ef04a61e444513a3316eb85e7f",
+    "dest-filename": "2134f14cae4c33efa3fb71d8dd9a24a1c0cca765837a4a03ae8c3d6ead8e28366f343aef6831d99b478e4ba2d70a397a32ef04a61e444513a3316eb85e7f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/f0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+    "sha512": "7f4145a4875c1e09fccdc3d26dfd5d45ebf0b74e3b60c9da889337bb6c3645ec2b07e7e86ffcde3d972b3b24282cc30eeda04875d2dc40810ae5d62390b9c6ad",
+    "dest-filename": "45a4875c1e09fccdc3d26dfd5d45ebf0b74e3b60c9da889337bb6c3645ec2b07e7e86ffcde3d972b3b24282cc30eeda04875d2dc40810ae5d62390b9c6ad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/41"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+    "sha512": "5e78b7e4d2b38e032bc1ebf2b074c202bb4b0e93efc9ef3357fd04e04c989f8dcfeffeeabd0c0f87d0469077b06ccba5567b5b8a099c4fbadd5f704da3dc1126",
+    "dest-filename": "b7e4d2b38e032bc1ebf2b074c202bb4b0e93efc9ef3357fd04e04c989f8dcfeffeeabd0c0f87d0469077b06ccba5567b5b8a099c4fbadd5f704da3dc1126",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/78"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+    "sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+    "dest-filename": "6ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/91"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+    "sha512": "79475421a0abf7adeada1e6edfe430bd8a74f9ea8fbe7f9e81ea99526d21c04442aaac7513790ae5e85b182bea484e4c40050bafaef0c34700de329cdd890cd7",
+    "dest-filename": "5421a0abf7adeada1e6edfe430bd8a74f9ea8fbe7f9e81ea99526d21c04442aaac7513790ae5e85b182bea484e4c40050bafaef0c34700de329cdd890cd7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+    "sha512": "35ef9e138af4fe25a7a40c43f39db3dc0f8dd01b7944dfff36327045dd95147126af2c317f9bec66587847a962c65e81fb0cfff1dfa669348090dd452242372d",
+    "dest-filename": "9e138af4fe25a7a40c43f39db3dc0f8dd01b7944dfff36327045dd95147126af2c317f9bec66587847a962c65e81fb0cfff1dfa669348090dd452242372d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+    "sha512": "4de4d243a1f9607be9a95c0145c9cb0c20670ce1d662eec8bc66c74fa37c00eca672bf4f2468dcd464ed896653620d0d0a0630be761612454285002bf5b8dfc0",
+    "dest-filename": "d243a1f9607be9a95c0145c9cb0c20670ce1d662eec8bc66c74fa37c00eca672bf4f2468dcd464ed896653620d0d0a0630be761612454285002bf5b8dfc0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/e4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+    "sha512": "606604573dc59b98b2fc0c9bb80d28c8d16aec7e0281035f469fea7def27bab13592e09e366dffbdf9bd5f832d97ea8bc9a289521e71ac5670a20af8d5232360",
+    "dest-filename": "04573dc59b98b2fc0c9bb80d28c8d16aec7e0281035f469fea7def27bab13592e09e366dffbdf9bd5f832d97ea8bc9a289521e71ac5670a20af8d5232360",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/66"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+    "sha512": "7da607c346a705b73f916177cc54c49f14853801945fd1856ce06d86f0dd2ec22512858e14eb52d3380289063022c90bf6219764bde40170fc3a86781a63004c",
+    "dest-filename": "07c346a705b73f916177cc54c49f14853801945fd1856ce06d86f0dd2ec22512858e14eb52d3380289063022c90bf6219764bde40170fc3a86781a63004c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/a6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+    "sha512": "8e5d6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+    "dest-filename": "6f6733c38a72ebf5e52ddc9feded5e8580d130f508ef04f772b33f4a7d00c3e357d0ac2d98e2f290762694a454f86d795bd511e12e9a7cc2d9ba3394e04b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+    "sha512": "bf75eefb2bb00578aca7a4184dc1f851b1fec58257aa7ab69bf2ed41558a5b361cd627a16272e2c6840337d147ebf8fdfe8c9b7dde96f46870925f3e50c29329",
+    "dest-filename": "eefb2bb00578aca7a4184dc1f851b1fec58257aa7ab69bf2ed41558a5b361cd627a16272e2c6840337d147ebf8fdfe8c9b7dde96f46870925f3e50c29329",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/75"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+    "sha512": "8f7ef949c57ad1da26f9890f1487d32dc3a23f190dfdbb87cf91a86e32e18b116e00d68db370bd9781a6ad6a9e8e05d627b05b25c158a53114912d467bc6e965",
+    "dest-filename": "f949c57ad1da26f9890f1487d32dc3a23f190dfdbb87cf91a86e32e18b116e00d68db370bd9781a6ad6a9e8e05d627b05b25c158a53114912d467bc6e965",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/7e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unicode-emoji-picker/-/unicode-emoji-picker-2.0.1.tgz",
+    "sha512": "cd775807b13e8e3d0d5312e1d67064323a2f2333d923e244ef3400879877bf62326d6b34d07b00915314df8fe4a1ae8ba98896a9ce3eaec6a4c899dadde4ec6f",
+    "dest-filename": "5807b13e8e3d0d5312e1d67064323a2f2333d923e244ef3400879877bf62326d6b34d07b00915314df8fe4a1ae8ba98896a9ce3eaec6a4c899dadde4ec6f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unicode-emoji/-/unicode-emoji-2.8.0.tgz",
+    "sha512": "322e24950d66adb5333513b207f72ed8ca9a1c82534eb4307181741b5696ebab2759a287a2c9fd9441dfc88f26c3f494491af9c90e5d131a930f7f8514887ab7",
+    "dest-filename": "24950d66adb5333513b207f72ed8ca9a1c82534eb4307181741b5696ebab2759a287a2c9fd9441dfc88f26c3f494491af9c90e5d131a930f7f8514887ab7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+    "sha512": "a63cb66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29",
+    "dest-filename": "b66d8852b2e7f05a52b03dcfa5ddc37bfb0b8994aeaecf461d2443a54036e5ea3a3f6253e2e266fc6a0524542f0117b57c36ecdec8f36a464b00de1ced29",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/3c"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+    "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+    "dest-filename": "94cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+    "sha512": "8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
+    "dest-filename": "f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/02"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+    "sha512": "15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
+    "dest-filename": "70d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+    "sha512": "d4c2dae68b9988e990cd46e36eef559a32f39f540b5c1870a546bb91d2d440af8a439280f48d6f9395386077bf5f60a1ecf62725f5ae593f956eec5b1b096387",
+    "dest-filename": "dae68b9988e990cd46e36eef559a32f39f540b5c1870a546bb91d2d440af8a439280f48d6f9395386077bf5f60a1ecf62725f5ae593f956eec5b1b096387",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/c2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+    "sha512": "c1aed88f25067cd667808fefb4ad141c037e9600c2c413c2ca55571a9d33bb9f45cf96a21ad3576aadc3848a2fd3adcca2b07e55fb9f2e1dc9945d8a7532b7c6",
+    "dest-filename": "d88f25067cd667808fefb4ad141c037e9600c2c413c2ca55571a9d33bb9f45cf96a21ad3576aadc3848a2fd3adcca2b07e55fb9f2e1dc9945d8a7532b7c6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/ae"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+    "sha512": "04d19b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa",
+    "dest-filename": "9b58b7ddd1e50f69b8645d4566d23f2ebaf444c93879a2f45afddca8c3f06a01b649c82fb97d4f88cd03b39802b362a6110084a8461750af778867f3d7aa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/d1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+    "sha512": "ed42cbc2c09d631fe7472ae9884c2fa9be53147acc559c81b7eae0fce0174fbae08ffcfe0ed4c3c8a15e2c074392e6c3543283f233ac9dd9b2ee6e795dc7d4b3",
+    "dest-filename": "cbc2c09d631fe7472ae9884c2fa9be53147acc559c81b7eae0fce0174fbae08ffcfe0ed4c3c8a15e2c074392e6c3543283f233ac9dd9b2ee6e795dc7d4b3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+    "sha512": "769a2306136c08d37b4fcd939bb936e80e86f4c2f7364843b27c3d9ff7a8c52465541078084b4843f29308b2361707f76ad6925d1858164422dd29671703ef3d",
+    "dest-filename": "2306136c08d37b4fcd939bb936e80e86f4c2f7364843b27c3d9ff7a8c52465541078084b4843f29308b2361707f76ad6925d1858164422dd29671703ef3d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/9a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+    "sha512": "a3caa086523c3591d4d652cfae98b6f94abb69b8781863e96003656a5cd6c725ad789382b2bfcffa83c1038f5338bbb915364ee1ddc5f4c9d625f88ca3806498",
+    "dest-filename": "a086523c3591d4d652cfae98b6f94abb69b8781863e96003656a5cd6c725ad789382b2bfcffa83c1038f5338bbb915364ee1ddc5f4c9d625f88ca3806498",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/ca"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+    "sha512": "7762562c28af999613488a207bd32c805099aede7bd418a47161989230b59219656d3783946a99d83f2f0fc13f9496bc58659b6fb3e59bcfd725857b2091d967",
+    "dest-filename": "562c28af999613488a207bd32c805099aede7bd418a47161989230b59219656d3783946a99d83f2f0fc13f9496bc58659b6fb3e59bcfd725857b2091d967",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/62"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+    "sha512": "57075d06e903ceeef5a1f7c0411f7be6e9c1206a9f299a4cfbc657eb24a4f27621568a39098699cb3b77601bd8b51b4ef9aa0696ac4f83f07cecd19567f7eeea",
+    "dest-filename": "5d06e903ceeef5a1f7c0411f7be6e9c1206a9f299a4cfbc657eb24a4f27621568a39098699cb3b77601bd8b51b4ef9aa0696ac4f83f07cecd19567f7eeea",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+    "sha512": "eaa37884974cc1f601b44dd80534c78687ae52b0c13d999b41ac5602a4802d5fcc7849d1e73d7177c50ab9dd910241683e4981fa1962d536529f28bce31cf5bd",
+    "dest-filename": "7884974cc1f601b44dd80534c78687ae52b0c13d999b41ac5602a4802d5fcc7849d1e73d7177c50ab9dd910241683e4981fa1962d536529f28bce31cf5bd",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/a3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+    "sha512": "41a2b187478d222da613da76bc47737da80e28709c8f5a49e7a1041c640e571a7cafdfe2b332d4515eeff3dc7d3b5a7f4fe3654cce56ee35baf9ccf816ad5856",
+    "dest-filename": "b187478d222da613da76bc47737da80e28709c8f5a49e7a1041c640e571a7cafdfe2b332d4515eeff3dc7d3b5a7f4fe3654cce56ee35baf9ccf816ad5856",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/a2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+    "sha512": "0deef619d419ccd4d40410a1b17b9e4149cf283920ff9039ce9ee9143b90023e5416810da62002534c250afce90069d3923fbe8a1a4ac0ac987b09ff5cd51b2b",
+    "dest-filename": "f619d419ccd4d40410a1b17b9e4149cf283920ff9039ce9ee9143b90023e5416810da62002534c250afce90069d3923fbe8a1a4ac0ac987b09ff5cd51b2b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/ee"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+    "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+    "sha512": "73d6d9a7b6f962d463db039ee9d963df630af81c7f33f77ef550764873353adb141d1d1a574b5d3fa0d687f88cb749168b5b7983522e76eea141135dd40e0f54",
+    "dest-filename": "d9a7b6f962d463db039ee9d963df630af81c7f33f77ef550764873353adb141d1d1a574b5d3fa0d687f88cb749168b5b7983522e76eea141135dd40e0f54",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/woff2-encoder/-/woff2-encoder-2.0.0.tgz",
+    "sha512": "c07d6b72c91ccc23f9f8124004cf3c68cde1a045f55545ba53e2acc7fedb997bdcb561aa17e3bf610742eaf590ee5252ee7cb6d5ad0c900a9c67238fd8ef0202",
+    "dest-filename": "6b72c91ccc23f9f8124004cf3c68cde1a045f55545ba53e2acc7fedb997bdcb561aa17e3bf610742eaf590ee5252ee7cb6d5ad0c900a9c67238fd8ef0202",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/7d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+    "sha512": "82f57324594fc9c29ce5d64de323e43fcc3b0dcdfb06d3f5c9ccc49de39be2eab7e295d972faed45399657c5be5267be5c2c4a81b8ccfa77af93214f3326dde1",
+    "dest-filename": "7324594fc9c29ce5d64de323e43fcc3b0dcdfb06d3f5c9ccc49de39be2eab7e295d972faed45399657c5be5267be5c2c4a81b8ccfa77af93214f3326dde1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/f5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+    "sha512": "6151888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest-filename": "888f691a98b493c70e8db198e80717d2c2c9f4c9c75eb26738a7e436d5ce733ee675a65f8d7f155dc4fb5d1ef98d54e43a5d2606e0052dcadfc58bb0f5e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/51"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+    "sha512": "e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+    "dest-filename": "2d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/60"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+    "sha512": "9784a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest-filename": "a9fc346c7a8afdc0be84bd5dbe4ee427eb774c90f8d9feca7d5e48214c46d5f4a94f4b5c54b19deeeff2103b8c31b5c141e1b82940f45c477402bdeccf71",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/84"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+    "sha512": "fb43539d6efb7c537f0e3422ea4fd2abf62f9384a06a3c3bbab5bc57e6ac8d79d1803b3d8321a475bec4ce07e10388285ec44864a136f1fcc85c11c4ce1ba25b",
+    "dest-filename": "539d6efb7c537f0e3422ea4fd2abf62f9384a06a3c3bbab5bc57e6ac8d79d1803b3d8321a475bec4ce07e10388285ec44864a136f1fcc85c11c4ce1ba25b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/43"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+    "sha512": "87715b8ac6b69ca18fc42a66f3d1e4df79412ec9da181bdcb50a2968148e5bfb88b3a1537b5013c809ca149af356cf6fa4676c4deef7585dd5e2522c93819a73",
+    "dest-filename": "5b8ac6b69ca18fc42a66f3d1e4df79412ec9da181bdcb50a2968148e5bfb88b3a1537b5013c809ca149af356cf6fa4676c4deef7585dd5e2522c93819a73",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/87/71"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+    "sha512": "12f18af042770e16877db465113396012e693bd31921379ab87289c9bf30c9a8d47d051e9e4220d8cbcb0d36784ff4e021c9b71d4d1314181659ba00677d141e",
+    "dest-filename": "8af042770e16877db465113396012e693bd31921379ab87289c9bf30c9a8d47d051e9e4220d8cbcb0d36784ff4e021c9b71d4d1314181659ba00677d141e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/f1"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+    "sha512": "2599c328af01d11083c3ce0535d0c022964af89b89c3eb3b2f3f2792c23b488b94dd45c926c954b61b22fae5815183b03c5c16ed6ecf44b45f50aa718ed8c50b",
+    "dest-filename": "c328af01d11083c3ce0535d0c022964af89b89c3eb3b2f3f2792c23b488b94dd45c926c954b61b22fae5815183b03c5c16ed6ecf44b45f50aa718ed8c50b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/99"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+    "sha512": "d297c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest-filename": "c5cde81e0d62472480264cb44fd83c078dd179b3b8e8f6dbb3b5d43102120d09dbd2fb79c620da8f774d00a61a8947fd0b8403544baffeed209bf7c60e7c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+    "sha512": "b55a6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest-filename": "6c256ec376379c0221696c80757b7ab1210b04e8da0f739fde4ddadb6c80b88742d5b16867a1ade0fa6d87725048ba31f3b31678549540f8652e736fcb07",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/5a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+    "sha512": "edd4b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
+    "dest-filename": "b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/d4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+    "sha512": "531e328065acbb673b8ac1567bc62ed5896e266a95871a8ad9c2d735003901c0b741f6c636933b7eed18f1bff3d7aa572e7171658bd685dddf84163d0cb982e9",
+    "dest-filename": "328065acbb673b8ac1567bc62ed5896e266a95871a8ad9c2d735003901c0b741f6c636933b7eed18f1bff3d7aa572e7171658bd685dddf84163d0cb982e9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/1e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+    "sha512": "d0b3ceb770312aa31d141640dc7040b7fb7ff2f20aabb55a4186ee03c5b10a0ba783ea7d4d5c8a458769bc26fcd0771d4cdd8d91b20a6e13702947e6ded432c1",
+    "dest-filename": "ceb770312aa31d141640dc7040b7fb7ff2f20aabb55a4186ee03c5b10a0ba783ea7d4d5c8a458769bc26fcd0771d4cdd8d91b20a6e13702947e6ded432c1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+    "sha512": "3bf3e07e7a53d712920de4184827d12391b2de13dff7598a543b982d41d924c883169b6f3f8d4c4a75a87e6f1d9c29b4db9e9935f64833b0d2cee48c0059e31c",
+    "dest-filename": "e07e7a53d712920de4184827d12391b2de13dff7598a543b982d41d924c883169b6f3f8d4c4a75a87e6f1d9c29b4db9e9935f64833b0d2cee48c0059e31c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/f3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+    "sha512": "83352dfeab7cd675ec14628815c0b76277c4031e4d92e9c27e70e5bee0524854b4d9b717bb82e679ad001485306cb5b158fc7777da7c4b94286ae8ca70d43171",
+    "dest-filename": "2dfeab7cd675ec14628815c0b76277c4031e4d92e9c27e70e5bee0524854b4d9b717bb82e679ad001485306cb5b158fc7777da7c4b94286ae8ca70d43171",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/35"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.3.tgz",
+    "sha512": "de50bd0499387d1e592717068dbd215670c5396ecaa4b5c721e6e206655de050d141955e39bceda132b14543f1956c12831acc44e34ad2ee748410f56936042a",
+    "dest-filename": "bd0499387d1e592717068dbd215670c5396ecaa4b5c721e6e206655de050d141955e39bceda132b14543f1956c12831acc44e34ad2ee748410f56936042a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/50"
+  },
+  {
+    "type": "inline",
+    "contents": "00eb23a1e4fb817f806b85707e4668789b1909dc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz\", \"integrity\": \"sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==\", \"time\": 0, \"size\": 7721669, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "50f5f8c88198105e590014a4b636ec67446a751a852f7fb224ecca081706",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "0101d01f90248958093e6fb7b31d82fd697bf6cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz\", \"integrity\": \"sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==\", \"time\": 0, \"size\": 7823, \"metadata\": {\"url\": \"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a268c635b2da226660e5131d025eb1fc4baaedb3926e1f71172a721a1f8a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/a1"
+  },
+  {
+    "type": "inline",
+    "contents": "010de3298ba09e916861045c7a74d2f8afa9f7e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz\", \"integrity\": \"sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==\", \"time\": 0, \"size\": 181128, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a73778bc7fe534d3788b3e6309e2b9294c66be6787edc101287012ba2c7c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/46"
+  },
+  {
+    "type": "inline",
+    "contents": "011a05540844b8ae7bd66dd674f148fa56c5d50e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz\", \"integrity\": \"sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1f558f51da8495fa9d3fee9e4aa8c6cfc9809b10931f4df310e7bb0fe42b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "01e627bc2ab87ab6cd6eddc3060858b8a42a8c71\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz\", \"integrity\": \"sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==\", \"time\": 0, \"size\": 4249059, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3c062c4043b022f5f799c7806fa6206b380e247f37501660e5c44dbe18fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/95"
+  },
+  {
+    "type": "inline",
+    "contents": "0327dcda608a0fabe8a4796c9768c79aa5dad397\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"integrity\": \"sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\", \"time\": 0, \"size\": 1089001, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4244544732d3e784c8fd360e0ea256a943488c53a834da3d0ddf3e83af9b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "03338782531576f8c87715e52416877d8e5e88af\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"integrity\": \"sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==\", \"time\": 0, \"size\": 28026, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dd5e6f02ebea3574006624e5dd81e72b124d66a1bd1598ab078fda7118f7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/cb"
+  },
+  {
+    "type": "inline",
+    "contents": "036c1961fea3a5b25062fe82e672a62830f78f65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz\", \"integrity\": \"sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==\", \"time\": 0, \"size\": 8689, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0665d4d429c6f894c24443e4baf4d8212fa9656914ffa02b6896c052f1d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/01"
+  },
+  {
+    "type": "inline",
+    "contents": "037421341f9e83e517c3908af8047d3ae20ee615\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz\", \"integrity\": \"sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==\", \"time\": 0, \"size\": 9705, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "243136ed99c82696e8d0da7ee6748305d1815b0c884838b842d58c2f811e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/08"
+  },
+  {
+    "type": "inline",
+    "contents": "046229e8186af75c83e30bc5e79072b5442a088f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz\", \"integrity\": \"sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==\", \"time\": 0, \"size\": 1355, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3636172cbc03abf2262c921f9f71572e6b049aa3db8c65d166bcfe5aca5f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/43"
+  },
+  {
+    "type": "inline",
+    "contents": "046742ddcf7a9dd650a67a25492f7b42043fec75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"integrity\": \"sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==\", \"time\": 0, \"size\": 2017, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ca47ff09ac9d048c991a5d94c9ef412ffa5496c2ab672947137bfb61e829",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/69"
+  },
+  {
+    "type": "inline",
+    "contents": "047f0ca5bb52dc40b60eae3caa4a5e157c55e8e6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz\", \"integrity\": \"sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==\", \"time\": 0, \"size\": 38848, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f539f027e367c9873071eb96c5d59a2e023ebe21150abb4c5225f90cb58e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/88"
+  },
+  {
+    "type": "inline",
+    "contents": "048382bedbd1bf0a4ecb6d095f9404c0fec25e6d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz\", \"integrity\": \"sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==\", \"time\": 0, \"size\": 20239097, \"metadata\": {\"url\": \"https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2726f9b4a6f972d2253af9668e67216b69b07467b278ccbec51fa34d2496",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/93"
+  },
+  {
+    "type": "inline",
+    "contents": "048e213b7fc5aeffdcefa6e58eee14d0bb4f8188\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz\", \"integrity\": \"sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==\", \"time\": 0, \"size\": 12941, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d81d78f58c80b7787c54d9bcd9ae46659d2b01100d480e43f50c139bd6c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/fa"
+  },
+  {
+    "type": "inline",
+    "contents": "0495a31a829032a62b443e2b0799d260f93061f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz\", \"integrity\": \"sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==\", \"time\": 0, \"size\": 2802, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bea253edda96ac204f8f8722d25d97d3a2fcd2fe718c32f9b74c80c7f77d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/4c"
+  },
+  {
+    "type": "inline",
+    "contents": "04a5885460a1cb7aa82fa8fc6e8bb993b46500d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.18.tgz\", \"integrity\": \"sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==\", \"time\": 0, \"size\": 13364, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a4807dcd69a07371365eef818a21c9217a3e3fbcfe6ec6f9b0da461c4ff1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/4e"
+  },
+  {
+    "type": "inline",
+    "contents": "04e0113e71931b7a6c21978b4b6856956847987a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz\", \"integrity\": \"sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==\", \"time\": 0, \"size\": 7334033, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0d0df0356a35773c76f44079ee5ebd7e6dec8de775076770da80723db815",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "0517abcf11f9f590aae1e55d303fad2fa8d34c0b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz\", \"integrity\": \"sha512-/y7tJKALVZ1lPzeZZB9jYnmtrL7d0N2zkorii5a7r7dhHkWIuLTzZpZzMJLK1dmYRgX/NCc4iarTO3F7BS2c/A==\", \"time\": 0, \"size\": 58446, \"metadata\": {\"url\": \"https://registry.npmjs.org/spawn-rx/-/spawn-rx-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "454eb1ff3ec3546d35165170f771ff1c65f055203c5ab9f907e6af7067a8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "0550e91aa3a61e4f91cb7ae5334ccc48736fda66\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.6.tgz\", \"integrity\": \"sha512-eUEUoGMDpfkgHWSE97ZZaUJtzR1M7EKnNIpD1Q16+8JR9NWghcaqMulx9PuCQ720w0UclfYn6FEbCdd5Hx087g==\", \"time\": 0, \"size\": 10757, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "42981703f9fadc43a6ae6a707d090f69ff1bc5ce7a779748834b3a21297c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/14"
+  },
+  {
+    "type": "inline",
+    "contents": "05ad4917bc34486fb95b89cbd3458c976b797db2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz\", \"integrity\": \"sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==\", \"time\": 0, \"size\": 67834, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b13cda61b890fc0ad84ab08af4b7f1efb9d6c96cb90e6ea88f020d82c1bc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/76"
+  },
+  {
+    "type": "inline",
+    "contents": "062c157a258c356eb5d0ff406805815d4fbd2c7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"integrity\": \"sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==\", \"time\": 0, \"size\": 8996, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "453bd89145eccf9d67f5797fb09e5a017b5b13f1ac45cb7b70bda45940ec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "065ee91ddf425624d19a5c73fc8e4558d498e6bd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz\", \"integrity\": \"sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==\", \"time\": 0, \"size\": 64015, \"metadata\": {\"url\": \"https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d7c558bb4ec440a0fd3643a8344a7da58f2797eb7dbd25bede9541c01026",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/d6"
+  },
+  {
+    "type": "inline",
+    "contents": "067fbc2fc960f70859479dbcb175ef9d7e4f1292\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"integrity\": \"sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==\", \"time\": 0, \"size\": 6074, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "18f75527ac37299e70f06aad31fb38c55d9ffb7d576a3961d46b9f85720a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "0724c6155c5f13604a029b609b49c2533c922433\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz\", \"integrity\": \"sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==\", \"time\": 0, \"size\": 1620, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a476f136002620b39026df5b6306a63af83b27d9a8de03c88305fd2b328e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/9d"
+  },
+  {
+    "type": "inline",
+    "contents": "07265924c591560658e83c11e4a2a137a0bc5466\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz\", \"integrity\": \"sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==\", \"time\": 0, \"size\": 3561, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "32f32b80dc3dcf17ae1eb5d53a2431f8afe36c4b745842fea3eaf2598ef5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/cc"
+  },
+  {
+    "type": "inline",
+    "contents": "0773085944f116088b53913d7cc796d0b0f7ed04\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz\", \"integrity\": \"sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==\", \"time\": 0, \"size\": 460701, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0e400ba7f45d36e6c6897b8fe2488dec0d28262fe16b223bd4e13b16573d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/97"
+  },
+  {
+    "type": "inline",
+    "contents": "07eed55e069160c15b1e52933575fd7621a06940\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz\", \"integrity\": \"sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==\", \"time\": 0, \"size\": 133027, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6e2a25c2c513156354efd47b3d382046b8e841842257909024d0088e2837",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "08237b9bade74c680ba381ae9fb57c8a61a4d354\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/platform/-/platform-1.3.6.tgz\", \"integrity\": \"sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==\", \"time\": 0, \"size\": 14043, \"metadata\": {\"url\": \"https://registry.npmjs.org/platform/-/platform-1.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "abb2830b0e473d0b84e7ff8038a88f3484e02d13468c6d80f293359180c5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/ad"
+  },
+  {
+    "type": "inline",
+    "contents": "08f70474f0a819721a36f4141d951f4775819862\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"integrity\": \"sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==\", \"time\": 0, \"size\": 15520, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "575503a996b3678372373e36b1adcb0ecf0c5e27804be136f2f9b46a57fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "08feceb25c44c3acb21b39c988472901d8508491\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-11.1.0.tgz\", \"integrity\": \"sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==\", \"time\": 0, \"size\": 45767, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-11.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e5eadb31edb99a328216181baebf4ace396ad067d3ccecc837f4e04cfd91",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/fa"
+  },
+  {
+    "type": "inline",
+    "contents": "090aa3891d33b9da0594c2b76778c2915301f20d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz\", \"integrity\": \"sha512-Yiq0H56LjXSSw/hd9YkXgSLQfzyDJzbzU2TezozxyNw+uKWAqOtqGVvBfzKRRDiaFF5avGAhHdWKx7LtDOShUw==\", \"time\": 0, \"size\": 28011570, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3db6512d9bf2f408e6302a73b1a5715a0cbc99277dda2fbd5d6194cba309",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/c8"
+  },
+  {
+    "type": "inline",
+    "contents": "091614002906b7f888de1719b87a612f64c9dfab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/express/-/express-5.2.1.tgz\", \"integrity\": \"sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==\", \"time\": 0, \"size\": 22560, \"metadata\": {\"url\": \"https://registry.npmjs.org/express/-/express-5.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d5703613efbc6b0601f6764ab3d74bc3b1ed655cb064e16db64c3034f4c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/ce"
+  },
+  {
+    "type": "inline",
+    "contents": "095a7991fff7acec25262adf2926d39030ad263c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz\", \"integrity\": \"sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==\", \"time\": 0, \"size\": 10482401, \"metadata\": {\"url\": \"https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2bf78b019c4db235feea10744d42a618481093dee5ffc972a397ad48c969",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/49"
+  },
+  {
+    "type": "inline",
+    "contents": "098c44d3426403726514f03b3036eb2d559b7772\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz\", \"integrity\": \"sha512-rUjQoy7egZT9XYVXBK1je9ckBnNp7qzRZOhLQx5RcEp2dCGlXo+mv6vf7Am4LimEcFBJIIZzSGfgTqc9QCrPSw==\", \"time\": 0, \"size\": 3162613, \"metadata\": {\"url\": \"https://registry.npmjs.org/lucide-react/-/lucide-react-0.523.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fc9a834a298aa364d38f286bfc395217fe0559c9b322231ff5f6265ba504",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8e/ff"
+  },
+  {
+    "type": "inline",
+    "contents": "09d3f2e6dac2b7fcd30add53ba3d7bf7ddecd1aa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.27.1.tgz\", \"integrity\": \"sha512-+J9EyKP6RMInfMJbIoNemqWzHxZe9XZv/7OjpsvtVZO1cxMTd5W1xIg0Ntr7YMdG9eKBC8Vwx5jjFbRm2tbM3A==\", \"time\": 0, \"size\": 2582, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-table-header/-/extension-table-header-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a73c0fce82f0daaa90b0261e2bae7cb254f748cbe83e821e2c2cac6af6e8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/e4"
+  },
+  {
+    "type": "inline",
+    "contents": "0a078b0c48359b4c20385f2a37290e977d0df120\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"integrity\": \"sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\", \"time\": 0, \"size\": 2675, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "21f3b978a3a22da2c741a07872da75d54875dd2620f1fbe58f0b0f9d92a9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "0a7a63ea5467f45886b63e042393cb32c7ba097f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz\", \"integrity\": \"sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==\", \"time\": 0, \"size\": 1811, \"metadata\": {\"url\": \"https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dc59f2e400d4c34df6aa61d4c3fd6e5e1b70324e10574255b36c34eeef9d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "0ab8055e3fbb4c7f2876add6ad4fd46fe5bd77c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz\", \"integrity\": \"sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==\", \"time\": 0, \"size\": 31000, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b8b220d25640520cb7d3e8fa36beb2f5b0b039b68f20355d2513f15ddaf7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "0b78822efa673a48023fc14a65ed80f8f2dd26a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz\", \"integrity\": \"sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==\", \"time\": 0, \"size\": 185594, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d786386d3cb319a47e5bde26244bf014bb8446bbaf8ef9061485be2962fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/c6"
+  },
+  {
+    "type": "inline",
+    "contents": "0c4c71c6b3401449dbdf2100aa4ba0a5b502ee26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz\", \"integrity\": \"sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==\", \"time\": 0, \"size\": 15999, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "90b6d6ad03203f5e42f46cbb19c6bbd21a65332f3a58870a96d087ea01df",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/98"
+  },
+  {
+    "type": "inline",
+    "contents": "0dcce340af130482c42ebac45b543b970db4e2ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz\", \"integrity\": \"sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==\", \"time\": 0, \"size\": 4829680, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "51b63e6efb8d8edd98d61c11d9891fb136eb34301670768100a2b987ea02",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "0dec3616eeac86e8a6882f4ae35d655ee8e2c902\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz\", \"integrity\": \"sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==\", \"time\": 0, \"size\": 1680, \"metadata\": {\"url\": \"https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "98d70e9e25b9a23c255f11b8acd5d9ebed836d0004871577846f3bc3f03f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/0c"
+  },
+  {
+    "type": "inline",
+    "contents": "0e3f5290c0829a6be9e79347b8ceabf69d945a4d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz\", \"integrity\": \"sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==\", \"time\": 0, \"size\": 7047224, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "eacc3514f935c660beb91bdae73f0a9c34c025f5f6b953ea5172fe4da4fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/88"
+  },
+  {
+    "type": "inline",
+    "contents": "0e56ca535acf8433c58508cbe5087a65db39a46d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz\", \"integrity\": \"sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==\", \"time\": 0, \"size\": 6290, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "481ca7eeb393e2fb68fd72d6d364f08e6c5986bf134c7dd78546ef9e4191",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2b/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "0e59844e5b609f7c714da16cd1eecb9b256d1782\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"integrity\": \"sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\", \"time\": 0, \"size\": 2842, \"metadata\": {\"url\": \"https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "452a94b385f28d524a6fd9178863fe32cc70bc3d94033a3dda9c91b2e128",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "0e9106efa529051b63fe18def78febe9d6d060f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz\", \"integrity\": \"sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==\", \"time\": 0, \"size\": 468214, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e69f58f512af6b73dce275a070931a36a62b1120a2b8f77cfdef37a72f5b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "0f38f380dd6a8953bd155fb674d27dc4b2ad6c8c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz\", \"integrity\": \"sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==\", \"time\": 0, \"size\": 3013, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "30fe170630c419847bc0d26c86af931dc642c21071bf595dc5ea2baecca1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/c5"
+  },
+  {
+    "type": "inline",
+    "contents": "0f7d79896eaed4c7da7cde7c69a2118d348003d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz\", \"integrity\": \"sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==\", \"time\": 0, \"size\": 6391, \"metadata\": {\"url\": \"https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "31cbd6ca584e75edf3642c6f8b079c1f2b5eca1d7b2780ce2e86c24f1e84",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/88"
+  },
+  {
+    "type": "inline",
+    "contents": "0fc8a0375f35ad9613c665d950bdbdc793abb895\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz\", \"integrity\": \"sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==\", \"time\": 0, \"size\": 43710, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea4170776998ad71f3b14bfb71d2300b9500d0296ea32f2e58fe5b2e4bda",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/77"
+  },
+  {
+    "type": "inline",
+    "contents": "0fecf29f27252701f1ca76500f99c128fefa890f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz\", \"integrity\": \"sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==\", \"time\": 0, \"size\": 46362, \"metadata\": {\"url\": \"https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b652b100dbb3a5a73667352080ee1a3571f2367294dfaedabb31c272d1c0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/c1"
+  },
+  {
+    "type": "inline",
+    "contents": "100eee4d6f02e54c1b059fdf3165cb1c1c848451\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz\", \"integrity\": \"sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==\", \"time\": 0, \"size\": 1912, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ae7cd1a8b22ca9de4da8168efa0ae1eac96dbf1b69b9e53751aa038626a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/c8"
+  },
+  {
+    "type": "inline",
+    "contents": "10419516d6bb216df6feb526abf888dbbbacbf81\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz\", \"integrity\": \"sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==\", \"time\": 0, \"size\": 39643, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5ffc14023d00356e8d3736924d21aa118da210e1eda701aebcb7731f72d7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/7e"
+  },
+  {
+    "type": "inline",
+    "contents": "104e151e2cf0e62a13a68ccc765001e363c0554a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz\", \"integrity\": \"sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==\", \"time\": 0, \"size\": 526, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a6b8a7a70d2a50edcdc3b67b638c7af9928e22c6286e4fdb6ca31de5de4f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/94"
+  },
+  {
+    "type": "inline",
+    "contents": "10ad99f80daec58d3eafb7d867686afd0054fb9e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz\", \"integrity\": \"sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==\", \"time\": 0, \"size\": 4802970, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "210947ec427626847471aa8444c024b2e42fd19a298e518f3de40c15b386",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/b0"
+  },
+  {
+    "type": "inline",
+    "contents": "1129b9daa8bc7cc81f936208bc6555ed6c814009\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz\", \"integrity\": \"sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==\", \"time\": 0, \"size\": 5460, \"metadata\": {\"url\": \"https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ade93a0f735f87797a660fb51fe96280b1739a94d2ea6b4fc108840809c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/17"
+  },
+  {
+    "type": "inline",
+    "contents": "11b758212ff22c713fa53c29124ff87b79144d60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"integrity\": \"sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\", \"time\": 0, \"size\": 81751, \"metadata\": {\"url\": \"https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "434e6cce71a37629e1945f6d35d5e52c1e34aa88ef24d1915846c72775f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/e2"
+  },
+  {
+    "type": "inline",
+    "contents": "126e80245284ce83881e5c5ba87ef3683779fdb0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz\", \"integrity\": \"sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==\", \"time\": 0, \"size\": 7457263, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f00427f3ff860b8d5c650e567cceaa29698a8aab1fad0691400d4f5157e3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/a0"
+  },
+  {
+    "type": "inline",
+    "contents": "126e985fc3cde9a400d7f37923cb482a7d1a2bd1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz\", \"integrity\": \"sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==\", \"time\": 0, \"size\": 10793, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05f10c002d02fa41982308025db604d12ba121bf9dbbda0d5d0933b2b51e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/07"
+  },
+  {
+    "type": "inline",
+    "contents": "1287ffe81814a679403cc13e1d541b96d1d0969d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz\", \"integrity\": \"sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==\", \"time\": 0, \"size\": 540286, \"metadata\": {\"url\": \"https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a29f2ec233233dedaf6d110ada83bf22af3e52848fda04a91b64f889f53a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/85"
+  },
+  {
+    "type": "inline",
+    "contents": "12a8ac02531d6a45044fbcbf05dff982c9b24c2a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz\", \"integrity\": \"sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==\", \"time\": 0, \"size\": 2017778, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "37db20da8c60a853186773d9676aec85475e2bab45a87492088b1abd6155",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/3a"
+  },
+  {
+    "type": "inline",
+    "contents": "13a4ebca831696b5a3cc9d8bbc89c5f2d9c31003\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"integrity\": \"sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==\", \"time\": 0, \"size\": 2030, \"metadata\": {\"url\": \"https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2937f0abc26f9973382cb3afa8b4b1d233a6a47ad4f3c5917ddb4997cddb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/12"
+  },
+  {
+    "type": "inline",
+    "contents": "13c06a14bde7e192d889f758138be2becd920dea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz\", \"integrity\": \"sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==\", \"time\": 0, \"size\": 57485, \"metadata\": {\"url\": \"https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "46c38299837b3b4dcee9dc45854a6901355864326b4e64c730727ca1c88a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/ae"
+  },
+  {
+    "type": "inline",
+    "contents": "13cb458141025f28d2a41ff6c2f42c8110baf96d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==\", \"time\": 0, \"size\": 7398543, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ef5c6352cccafe2cb1da29eda68764ea6da315df0e63f0b756a706794af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/70"
+  },
+  {
+    "type": "inline",
+    "contents": "13e82e2e2e81ee1b1ac20e12af802949ea13ff07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz\", \"integrity\": \"sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==\", \"time\": 0, \"size\": 11241, \"metadata\": {\"url\": \"https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b739b1f6f936987c26973cec93f36482ed240ab90158c0d04899bab0de13",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/50"
+  },
+  {
+    "type": "inline",
+    "contents": "1430cd3caf075fedefa9ca6a9b9256ba6212fd74\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz\", \"integrity\": \"sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==\", \"time\": 0, \"size\": 3761818, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c77f71f14936a46d9b047c056df81b90541b4fa4063b1b0ad2d863e0a63f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "14d96c42612823bed67fa8d61e7597ff75d1749a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/send/-/send-1.2.1.tgz\", \"integrity\": \"sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==\", \"time\": 0, \"size\": 10317, \"metadata\": {\"url\": \"https://registry.npmjs.org/send/-/send-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7faea0c7b747b8673ff43439c690c9a4faa1fdde8bdb2056eaf8c5056f8c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "159cbc14ae2101062a05bdc8d9ece1d5b0b73b97\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz\", \"integrity\": \"sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==\", \"time\": 0, \"size\": 4608, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ad9f74c9e8998e1f85a916fde8658ebe3692c500e207e60efed24b4a2f90",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/87"
+  },
+  {
+    "type": "inline",
+    "contents": "1637f5edfe11eeec884dbdf4aaf22b3f655fad1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz\", \"integrity\": \"sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==\", \"time\": 0, \"size\": 37225, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7d9af64207c862fd5999108d7ef244272e8b3ac217b3e1406f62917b294f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/5d"
+  },
+  {
+    "type": "inline",
+    "contents": "16921c955f3f06d9e022ba99295e2cadf0c8cf60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz\", \"integrity\": \"sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==\", \"time\": 0, \"size\": 2112, \"metadata\": {\"url\": \"https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a9299722ee9446db04f4d68afd675d400a7771f74ebf84e0e0c3d3674ebd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "16d474ae84e85ea6cff849086ce7038481ea76f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz\", \"integrity\": \"sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==\", \"time\": 0, \"size\": 21014, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "992d3e6c01fc9098d137f7dbccfcaa5f5124ba9c487e582e6e0d83f99d30",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/38"
+  },
+  {
+    "type": "inline",
+    "contents": "16e2049f8eeef68c6ec3663ad28dfe9a3deedc52\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz\", \"integrity\": \"sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==\", \"time\": 0, \"size\": 6341, \"metadata\": {\"url\": \"https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "231318a9e1f42bf3c6df07489b911aa73ff6007363dcb17e3052cb96cc5e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/74"
+  },
+  {
+    "type": "inline",
+    "contents": "17456bf89f54ba922520df765dd3217dd926e4ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.27.1.tgz\", \"integrity\": \"sha512-lhcNDcczQ75yJOSywCHb58Hmtg1aPL/2TdYmeLPxVrP048D7rRs133sfONcgyyw0AvhnfmPOkHLTv3QtKSowhw==\", \"time\": 0, \"size\": 2580, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5893e5dd2d64624d9f975eedb1ae60d21d9507f62bcbbd8d72dac5e8ff68",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/87"
+  },
+  {
+    "type": "inline",
+    "contents": "179a06a6d863c83e0a9092df9e75278a46747f26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz\", \"integrity\": \"sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==\", \"time\": 0, \"size\": 4261493, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "13cef43e2bb2f8932fed1e7a32d6bfa59bd22d7737a805b464c2c277a61f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/02"
+  },
+  {
+    "type": "inline",
+    "contents": "18114ba7ec202096b96891e32b77a9bfda541b60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz\", \"integrity\": \"sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==\", \"time\": 0, \"size\": 4565946, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "42775cb1f4c2f1848ef9d9709ae04acdcea54f4ad0f69d168bd72fda11f5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/57"
+  },
+  {
+    "type": "inline",
+    "contents": "184b97e94c923c08725ec73adca57f5b3b59275a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz\", \"integrity\": \"sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==\", \"time\": 0, \"size\": 18623, \"metadata\": {\"url\": \"https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5bc545281ee1f49775ff8b0f2921a08251d503d559ff3f999be9886f1712",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "1936eac54b03763274f05ba26990bfca0db44241\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz\", \"integrity\": \"sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==\", \"time\": 0, \"size\": 5713, \"metadata\": {\"url\": \"https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0482174dd2f0490093b9c80bd7ddb9733b8b558f603e440e930804eeb77",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/c8"
+  },
+  {
+    "type": "inline",
+    "contents": "19c64071be660c591b186e67b434f94f4a359ce7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz\", \"integrity\": \"sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==\", \"time\": 0, \"size\": 13800, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b4bddca1df9d1a5db8fc8bd09d22078228fd3c1f50ad12a3c9886499c03f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f5/91"
+  },
+  {
+    "type": "inline",
+    "contents": "1abd1b75319587330b67a5369f964160c676fa24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz\", \"integrity\": \"sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==\", \"time\": 0, \"size\": 3325762, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ccb297c37f1de2131ee8a7fbb7aa1793f532514cdbb3c4009595074ca740",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/f3"
+  },
+  {
+    "type": "inline",
+    "contents": "1ad5e60331f6634b7da563e23a5182bdd0f46183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"integrity\": \"sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\", \"time\": 0, \"size\": 3656, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aefda99ca03a1004596e312ea5d597c682502fb85fe4283d6c1079cacd8f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/f8"
+  },
+  {
+    "type": "inline",
+    "contents": "1b308231d47933b4057e9f70a81dd62f2dd8ec7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz\", \"integrity\": \"sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==\", \"time\": 0, \"size\": 24079, \"metadata\": {\"url\": \"https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e0dcccdd2dfc3e89509c9b8049a20b6337cfb9f43915fc28d1e8b68a760",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "1bb1b2a66343938e1ff5462ea2a5e9cec111ca41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz\", \"integrity\": \"sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==\", \"time\": 0, \"size\": 179825, \"metadata\": {\"url\": \"https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4024a3c3a3f7616c15d375a49d98c9f4476b1edaa324a9a8b720eb59c25e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/fa"
+  },
+  {
+    "type": "inline",
+    "contents": "1c32edd401ee495cc79f2aa631ee22fa7f43776d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.1.tgz\", \"integrity\": \"sha512-iv/m9hzl6jfSj9Q8UEjAxONvCoUDaP7M9SRCPx3PaLNxA230TTD6RE0Ye4zFJ8ze7ZVoJJMAqg9Qpq1iYg2JOQ==\", \"time\": 0, \"size\": 4830, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "54adb5553c611a948d2596ec0374894074c3d79c694816b1fd5e95026957",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/2d"
+  },
+  {
+    "type": "inline",
+    "contents": "1c5e1811a130694cfac7ea6639d95ed4e3f79177\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz\", \"integrity\": \"sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==\", \"time\": 0, \"size\": 6355, \"metadata\": {\"url\": \"https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b973fb10d0d62b5962532a6e5691f81dd1c20b63fcce513967941450a82",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/7f"
+  },
+  {
+    "type": "inline",
+    "contents": "1cd3cc3588abe2d185d34a71f5d982e3aa80ffb2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz\", \"integrity\": \"sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==\", \"time\": 0, \"size\": 11501, \"metadata\": {\"url\": \"https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fa22a40eb0cb07176c21351dda1ab02f692d46b49a71c6469daf50c8f69c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/ab"
+  },
+  {
+    "type": "inline",
+    "contents": "1d60404b3281c92034abd12e57aa0af0e64aa315\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"integrity\": \"sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\", \"time\": 0, \"size\": 22808, \"metadata\": {\"url\": \"https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c98f1cdf494d5afde6448966f8b5b9ae83d1b42c6702670e15e8a7f68552",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/61"
+  },
+  {
+    "type": "inline",
+    "contents": "1da5b0bc4fb138ee44c6cafc6d7f0ef87a3c42c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz\", \"integrity\": \"sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==\", \"time\": 0, \"size\": 4226739, \"metadata\": {\"url\": \"https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7f80d7e5fadba6065b0fe545bef8d025a2009df202a83969775ea67200a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/41"
+  },
+  {
+    "type": "inline",
+    "contents": "1ddb6ba998aff212616491fe4fdb71561afe8b92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz\", \"integrity\": \"sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==\", \"time\": 0, \"size\": 4716104, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e5bbd762981cf8a519314b814f54fc6eba7b518358a0418465ecdb67d7c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/c8"
+  },
+  {
+    "type": "inline",
+    "contents": "1e69db4e15d19688ac0214464c45502105892959\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz\", \"integrity\": \"sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==\", \"time\": 0, \"size\": 75487, \"metadata\": {\"url\": \"https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b8a37c40ec5f023c302d73a14f2adc98326bddb4ff2b58cd156fda6be238",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/45"
+  },
+  {
+    "type": "inline",
+    "contents": "1ecf3c45a727bff759c7cec96f5796d5a8f04806\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz\", \"integrity\": \"sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==\", \"time\": 0, \"size\": 1917, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7ae5128341e8be6a414b2ff18919cb6c0b5e5392b7fe3b66b26448cf68a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/da"
+  },
+  {
+    "type": "inline",
+    "contents": "1f00a148568369ebe861d3225db2c24cbdd7fd51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"integrity\": \"sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==\", \"time\": 0, \"size\": 9799, \"metadata\": {\"url\": \"https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "af28f1133468f98432a0caf94d8a9e1a4f1bcd830398a06a4e51d9d17bcd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/da"
+  },
+  {
+    "type": "inline",
+    "contents": "1fa0d82dee38e061ec937a694a28ae7f0f73164d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz\", \"integrity\": \"sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==\", \"time\": 0, \"size\": 196739, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea4e9555df962e8a55d27858ec6e935db7b0356b46d10718029046780c27",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/60"
+  },
+  {
+    "type": "inline",
+    "contents": "205276628e2bac010bcfded4bc8e4595d5853c3f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz\", \"integrity\": \"sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==\", \"time\": 0, \"size\": 5591, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b93a55ccc4e49f1f202fb8da7ee9e687e3a2a49ec42d4759cf6b22a7a96a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/39"
+  },
+  {
+    "type": "inline",
+    "contents": "206a1f88f766841d97ba2d6f82e6a237d3142662\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz\", \"integrity\": \"sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==\", \"time\": 0, \"size\": 638818, \"metadata\": {\"url\": \"https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2344a1a1f7a5b6492fa8f87d707148cc99e54411ff9ad376d6d8fa54c6b1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/bd"
+  },
+  {
+    "type": "inline",
+    "contents": "209a03d0e799b3874e59bceb75b43bbdc3cbd5a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz\", \"integrity\": \"sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==\", \"time\": 0, \"size\": 3936, \"metadata\": {\"url\": \"https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b968e19e42cda755b43c4bd1e354056b2be0e8ff44896e82e4bc9fdb6322",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/33"
+  },
+  {
+    "type": "inline",
+    "contents": "20b87270afd17b73dac1a2035794636448785890\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz\", \"integrity\": \"sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==\", \"time\": 0, \"size\": 1821, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "da18b216664b1e58df4ffd6782d77f3c28a3f61355544535ff7704cc1b2d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/be"
+  },
+  {
+    "type": "inline",
+    "contents": "20b8d084bb05f5b318bf510facb84b01e29f0839\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.27.1.tgz\", \"integrity\": \"sha512-peEcbNRrJJ9Qc/WNKQNFbkwBrJvBvq22Dp5WNqEygn/ZJez1qD9ctd10+D6f3b9GtSyx12sfDgn8yBufWa+Iug==\", \"time\": 0, \"size\": 2579, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-table-row/-/extension-table-row-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b3accb2406b413e69529e09085ba6f8322df5f0a4060d358fbdc360f6d5d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/79"
+  },
+  {
+    "type": "inline",
+    "contents": "20d2ede6704c3df5bf338e3c9db7f62af33b7358\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz\", \"integrity\": \"sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==\", \"time\": 0, \"size\": 14900, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e6be368bfff730a8fcb47c2aec06bd73fdce49f9079d2fe48ae54877ec94",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/34"
+  },
+  {
+    "type": "inline",
+    "contents": "212ea2715ebd77885d0642f077c02b6dcf904e39\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz\", \"integrity\": \"sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==\", \"time\": 0, \"size\": 114713, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3744cd6723d3c3766cdf1d934ace760a5b1e385c8f468d0b058c3543a777",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/b9"
+  },
+  {
+    "type": "inline",
+    "contents": "214821769b69ba3f606113b354639aab03511bc8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz\", \"integrity\": \"sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==\", \"time\": 0, \"size\": 316257, \"metadata\": {\"url\": \"https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "15e40435809c6722e72f369cdedf7438072ae89548e4578ad00292e0c4cd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "21545acbe2d23fb8426c0d82e908c81378ca4dae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/entities/-/entities-4.5.0.tgz\", \"integrity\": \"sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==\", \"time\": 0, \"size\": 77368, \"metadata\": {\"url\": \"https://registry.npmjs.org/entities/-/entities-4.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "06ccc91f5b90cd273774322616d2f8e79f0cefb46c235f8184f3fb60c1f5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/61"
+  },
+  {
+    "type": "inline",
+    "contents": "2156199ac9b7a41fd153d03c3cfb0faf49efd0f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yn/-/yn-3.1.1.tgz\", \"integrity\": \"sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==\", \"time\": 0, \"size\": 2729, \"metadata\": {\"url\": \"https://registry.npmjs.org/yn/-/yn-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "26a7f7dccb969c764b8bdecb3667023c64bc1159e674fbeeca633c54964c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3c/f6"
+  },
+  {
+    "type": "inline",
+    "contents": "2236712c87ff9e80ecfadad50641968cca7e8cd0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz\", \"integrity\": \"sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==\", \"time\": 0, \"size\": 237946, \"metadata\": {\"url\": \"https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f1216e75ceffb21d7adc5294ceae7aa9667952a94a062db4741d376f852c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/9e"
+  },
+  {
+    "type": "inline",
+    "contents": "2273e39c0cee5b8b0f727cdc098a3af72febe49c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==\", \"time\": 0, \"size\": 7790863, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bae51e9e0643286a1ea952823d1f6a45199c4d41a82d7eaf21b01d1c27c0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/88"
+  },
+  {
+    "type": "inline",
+    "contents": "22acbcb507b399d60f45dfad94d7e4947fc541c0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz\", \"integrity\": \"sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==\", \"time\": 0, \"size\": 3952, \"metadata\": {\"url\": \"https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "19bb6590f7312f358d7385c3500c0043cd60e890b804af0c9b986c3c5a94",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/22"
+  },
+  {
+    "type": "inline",
+    "contents": "2486739d0b8a614128e2a43a9e9eded0168392d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz\", \"integrity\": \"sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==\", \"time\": 0, \"size\": 55313, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "04157c969827c0b07f1b54ac62806e9959c266cb89283e44d648b88e7a6e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/9d"
+  },
+  {
+    "type": "inline",
+    "contents": "25047b924533cbf39d9a1d98ab0727a405ce8db6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pako/-/pako-2.2.0.tgz\", \"integrity\": \"sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==\", \"time\": 0, \"size\": 422678, \"metadata\": {\"url\": \"https://registry.npmjs.org/pako/-/pako-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "adf239fa7aeb325f3c16091882f210229d981d66e9d39fc4a44cd6f7f976",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/45"
+  },
+  {
+    "type": "inline",
+    "contents": "252fcae03e77c01520234bd6a24ef25a653c5be3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"integrity\": \"sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==\", \"time\": 0, \"size\": 5280, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "58c14b3461e0a75ddd4a0be80707cae7f82bf1ef1ae03a0dfc8054aa2570",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/3b"
+  },
+  {
+    "type": "inline",
+    "contents": "257bcd31f651be08f218c974d3e3a37bc107617e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz\", \"integrity\": \"sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==\", \"time\": 0, \"size\": 4051, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ff02e37cd523c29a4c9426260e8c56a0e7d27d5686044599b9ac9bf3615e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/98"
+  },
+  {
+    "type": "inline",
+    "contents": "25907f32d07b97452604f1fbcb80f93a84ad32a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz\", \"integrity\": \"sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==\", \"time\": 0, \"size\": 18774, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9992df32b754487309124876243835e384940a2137d7675373811b6c6ca9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/5d"
+  },
+  {
+    "type": "inline",
+    "contents": "25a4379e9e7ed3f7345c3d098d9c474bbab61fdb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz\", \"integrity\": \"sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==\", \"time\": 0, \"size\": 619449, \"metadata\": {\"url\": \"https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "97b8f3b2b4d719b59f894546526587248b312eb03333fa69ffc40d31adaa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/dc"
+  },
+  {
+    "type": "inline",
+    "contents": "25bc41d7a27018404ee849d5d6370740de827e28\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz\", \"integrity\": \"sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==\", \"time\": 0, \"size\": 49926, \"metadata\": {\"url\": \"https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "db98a8134c11772fbb961f8e80817744c1bc65c0aeb3d0b32001fd12fba1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/42"
+  },
+  {
+    "type": "inline",
+    "contents": "25d732caf932e54b57a0e20bf124865fbdb005cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz\", \"integrity\": \"sha512-ICaK+IYaVZvKbBxX2rwrPT0DdUDMnE9Vm3nQGe+mltQPmUg19pONzkPWGdY4FCsoreDETWDynvdt4ysCbF5gNQ==\", \"time\": 0, \"size\": 25110307, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "74773a62e1ef6ddf63a2c77d73cfaaaa1411e4882fd8783cdf814f9d5b5f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/6d"
+  },
+  {
+    "type": "inline",
+    "contents": "268afc526b53dd16e2bfe9ce19794f7b8569e1f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz\", \"integrity\": \"sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==\", \"time\": 0, \"size\": 6625, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2d4e4b363564f0b3d6e59012bb07573fb947a866841f5259a96439aa3964",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/47"
+  },
+  {
+    "type": "inline",
+    "contents": "27367a2db849fddd727605fa14cafc1d5c7baf9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz\", \"integrity\": \"sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==\", \"time\": 0, \"size\": 3180, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ee063debd53dc122426b227cb91b1fd4b2207a02282e0d79e4906a405162",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "27db09de822c23d77c415bdba83298f1eeaada4d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/butterchurn-presets/-/butterchurn-presets-2.4.7.tgz\", \"integrity\": \"sha512-4MdM8ripz/VfH1BCldrIKdAc/1ryJFBDvqlyow6Ivo1frwj0H3duzvSMFC7/wIjAjxb1QpwVHVqGqS9uAFKhpg==\", \"time\": 0, \"size\": 1774321, \"metadata\": {\"url\": \"https://registry.npmjs.org/butterchurn-presets/-/butterchurn-presets-2.4.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "60a681c23faa5acab7f8f478284ca0e5a1aefb8d534648a45cf8d810065d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/df"
+  },
+  {
+    "type": "inline",
+    "contents": "27dfa54febb0f2c3aa56cd9994d73b3653f255b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz\", \"integrity\": \"sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==\", \"time\": 0, \"size\": 8434051, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6c426ebc48efd30a583b33b0d97e1332d966d6fa6ee43bc12d76c5c907e7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/31"
+  },
+  {
+    "type": "inline",
+    "contents": "27f41a84f35b71366c1c3c33f95fb70ba0d5a035\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vary/-/vary-1.1.2.tgz\", \"integrity\": \"sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==\", \"time\": 0, \"size\": 3772, \"metadata\": {\"url\": \"https://registry.npmjs.org/vary/-/vary-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bc6ddfe7826874158ab240154ebbd8569ff129493af149bcc64cca3537c1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/1f"
+  },
+  {
+    "type": "inline",
+    "contents": "284997f6b860329df5686bae3c93641b48f30d01\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz\", \"integrity\": \"sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==\", \"time\": 0, \"size\": 2096, \"metadata\": {\"url\": \"https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4226971e16d707d9180cd9fe4d4c5d07b40fa7d4311fe932f69a7fce4e53",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "288e1341b85806f43269ab8d971880fec1e67784\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz\", \"integrity\": \"sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==\", \"time\": 0, \"size\": 2714, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1f2dcc55956b22d2acb68b408f8e363c63deb561bd8faab63908ed2fe506",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/84"
+  },
+  {
+    "type": "inline",
+    "contents": "29553d5ba2131864a7fd61f28ac71f3cd231baa9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz\", \"integrity\": \"sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==\", \"time\": 0, \"size\": 43868, \"metadata\": {\"url\": \"https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "47e568430e0e386923fb77580066912c7bb9f42c02af93be0b6f9eeb92c0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/58"
+  },
+  {
+    "type": "inline",
+    "contents": "2a66929a98d00add15f3f9651adccf72e8542b9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"integrity\": \"sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==\", \"time\": 0, \"size\": 5203, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "464a09af299a6607875146c73e357016c5cb1808f31cb066f94d226bc3dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "2b1622972eae3ee0a02021023a47f4085c40eaf3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz\", \"integrity\": \"sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==\", \"time\": 0, \"size\": 101216, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e155e798a329e5d8733ecb002c2f488e74684f99c80e5f301cd3ff0f0f4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/c2"
+  },
+  {
+    "type": "inline",
+    "contents": "2b4f846a858bfd4ccba976da6f295bf0c34b73df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz\", \"integrity\": \"sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==\", \"time\": 0, \"size\": 3783, \"metadata\": {\"url\": \"https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5646701f9675d666e723a7d84a5f45b4ba72b8b9578ea6271d340bb3f9b8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "2b997b800c792cecb38e6868d3071f5e8ddda3f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz\", \"integrity\": \"sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==\", \"time\": 0, \"size\": 13764, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a95f6ee3665f1b7c89de9e104ea60b0cd9674bcdbb621b1fa57880ab8c07",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/eb"
+  },
+  {
+    "type": "inline",
+    "contents": "2cc1414e1c784d72e9a59592cfc9a00f752ce915\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz\", \"integrity\": \"sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==\", \"time\": 0, \"size\": 16994, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "895a9272a5477fff9bc5a806099d1e63e16cb07a2f01fb5731dba6337adb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/8a"
+  },
+  {
+    "type": "inline",
+    "contents": "2cc55cf86c123fb17d5b8e0bb99454d7710cd009\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz\", \"integrity\": \"sha512-l44KWDHLDvEnD0N/XcrVs7VXb3A18xL7QS3WB0eL93wbmk529ffIG55vleGCqaunpRUjLrdnjK05Qki1dsjylg==\", \"time\": 0, \"size\": 25632963, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bfee28d10f3df27b2e3d1b8644e608b2aa300681152b980e453c4c67f896",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/cf"
+  },
+  {
+    "type": "inline",
+    "contents": "2cd0509e38f8b358c6e50a526803f3cdb45160b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz\", \"integrity\": \"sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==\", \"time\": 0, \"size\": 6219, \"metadata\": {\"url\": \"https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "29ae16b7b413d7a609c6beba2ab22ac51a8f88aa3c3a36759292907ce3ac",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/98"
+  },
+  {
+    "type": "inline",
+    "contents": "2d0f1a0a20ae58fecd9b98beb823093e9ffed2c1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz\", \"integrity\": \"sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==\", \"time\": 0, \"size\": 2012568, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e75f50789994d808b7ee9d3541c3916ca582545feb60b85be5254dc03726",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/33"
+  },
+  {
+    "type": "inline",
+    "contents": "2d6ab2e7cb501c736a98544263b63904506513b8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz\", \"integrity\": \"sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==\", \"time\": 0, \"size\": 173034, \"metadata\": {\"url\": \"https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "24a5977420471d8bf54333d2c9356dd18376e0d123b7f3acaa7371e8a021",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "2df4bda5e6c1f88bd3dbb04570375f11134f9a90\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz\", \"integrity\": \"sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==\", \"time\": 0, \"size\": 5222, \"metadata\": {\"url\": \"https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4b7dc1877e76de193270971c633655b2e65560cb9ffd4482f7d7bdac28cd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/51"
+  },
+  {
+    "type": "inline",
+    "contents": "2effc950335f542cb9e34be1f5613751faa274ab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz\", \"integrity\": \"sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==\", \"time\": 0, \"size\": 139395, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0289af91a3172fd5d07df274e145e62f9d3f83ecc69c58f6c3eeb84f0ec0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/c0"
+  },
+  {
+    "type": "inline",
+    "contents": "2fbe3418f7259652679d5163a30e4cd80365e855\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz\", \"integrity\": \"sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==\", \"time\": 0, \"size\": 67772, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87de74786d807a230a6db3ce121b6747b6619c10b96e0acf0a3b7c4f6433",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "2fd8f3e7d74d887a96ea327c0622706bb62925ff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz\", \"integrity\": \"sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==\", \"time\": 0, \"size\": 104730, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "188f70610b75a61c099723da11a810d45f843464d7921a20b606307d09dc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "3076fbe90f19813c9fba47d4f8dae0db99fab2ee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz\", \"integrity\": \"sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==\", \"time\": 0, \"size\": 2699, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "73f8ea59e96e412c3fb3e69953c620dd916518f93022f3df23254fa6c7da",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/c2"
+  },
+  {
+    "type": "inline",
+    "contents": "30e722379ce8246b908a28f60545b3f8c1494ddf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz\", \"integrity\": \"sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==\", \"time\": 0, \"size\": 3475, \"metadata\": {\"url\": \"https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aea46b71d372556da2bd7fcbbc5e7394d0333f1e961c2bb321ed73aeefaf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/80"
+  },
+  {
+    "type": "inline",
+    "contents": "310d996b6ea98b9e1f55b6a1a6781cd67ba66cbf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/long/-/long-5.3.2.tgz\", \"integrity\": \"sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==\", \"time\": 0, \"size\": 26736, \"metadata\": {\"url\": \"https://registry.npmjs.org/long/-/long-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "162272fde34058e302b1f160d17a705d2f14406198a3341fb33caba40f9b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/72"
+  },
+  {
+    "type": "inline",
+    "contents": "310e57d660c185b82c055aac80c968d75cda4315\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz\", \"integrity\": \"sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==\", \"time\": 0, \"size\": 4876, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "143ae50ba22ddec235347ed6a62762b673eddb52cb1939aea401679de36b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/bc"
+  },
+  {
+    "type": "inline",
+    "contents": "3136b560cca5c82f186e1ae23500ebab963b27a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz\", \"integrity\": \"sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==\", \"time\": 0, \"size\": 10026, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e413b98fb9dd3106e44211c7e85f5ef5dacedbbae40ba9d3db496aec3ad4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/c4"
+  },
+  {
+    "type": "inline",
+    "contents": "313f0f90f31857d59b7d043018ff9953fffee1f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz\", \"integrity\": \"sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==\", \"time\": 0, \"size\": 728769, \"metadata\": {\"url\": \"https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c86f96b7fdfc644772a1a7ec61a9b90db4ebc2bbdfad9b60c018adea74f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/55"
+  },
+  {
+    "type": "inline",
+    "contents": "327b64918edcd80bc3fb9c4fa628569d0ee9c44d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.1.tgz\", \"integrity\": \"sha512-faCUHnRP47o9Zh9VZZX6EX/569udw9Vopm2PgEKPWuKLE2qaS5WBuUVU0iItdJmKUqaWiOZkpoW4jvnDmj0dfg==\", \"time\": 0, \"size\": 2584, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "56676fd3bd9aea583b82d9fd8ee4c430bd1d06f9ea90b87588533ed92981",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/58"
+  },
+  {
+    "type": "inline",
+    "contents": "32820ccc0ed9c938f0330b8683cc7d888f8f219d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz\", \"integrity\": \"sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==\", \"time\": 0, \"size\": 13892, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6102f35209ff7b0b9441f1d1c2985291739a02b81249bef3d6b1cc36a258",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/80"
+  },
+  {
+    "type": "inline",
+    "contents": "32e95ee06a60f80ade4a023d77636bdf27f7340b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz\", \"integrity\": \"sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==\", \"time\": 0, \"size\": 7208941, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c720e2dc6daa31b842da26c4e986f2db4dce36fb8fd931d76cd4dd9965d1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/16"
+  },
+  {
+    "type": "inline",
+    "contents": "32f031e68c7f223de75e68dd480b08147512f556\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz\", \"integrity\": \"sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==\", \"time\": 0, \"size\": 315640, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9043468767e0c56dd9f471bf490a9dbd69791bd99c61ac2373a4bf254fe7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/b1"
+  },
+  {
+    "type": "inline",
+    "contents": "3393b7eb35260d379e90e0158c621534397fcbcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz\", \"integrity\": \"sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==\", \"time\": 0, \"size\": 662780, \"metadata\": {\"url\": \"https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5555ec03e60770ba9609872dfe682ee591735b87639b745d514a8985969c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/56"
+  },
+  {
+    "type": "inline",
+    "contents": "34e7277731edb9d12973387e94778e251a8f21f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz\", \"integrity\": \"sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==\", \"time\": 0, \"size\": 6036, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7e675770acb22a7663d5542b27d12f236ddb13ed52190394c360535e7c8a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/7d"
+  },
+  {
+    "type": "inline",
+    "contents": "35182b47b5fdb39e28244c526e52c2e248861912\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz\", \"integrity\": \"sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==\", \"time\": 0, \"size\": 9793, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c6ee23742747109d1a42feb2320530ed7b775ac82e47537940c753e4b91a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/0a"
+  },
+  {
+    "type": "inline",
+    "contents": "35646929e240d962f98b9ef7a02d61dc113aca31\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz\", \"integrity\": \"sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==\", \"time\": 0, \"size\": 30950, \"metadata\": {\"url\": \"https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8359305d350163b867a09c4628eafb02113af345ff9510a203587e3403e0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/0d"
+  },
+  {
+    "type": "inline",
+    "contents": "35f1156f96113fbdaa5e50af4f5bd10c2b7ce003\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz\", \"integrity\": \"sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==\", \"time\": 0, \"size\": 2166, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "65811b7ffaec36592ab750e03d7468554f6eae9bbea6de7c8674539ebf13",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/44"
+  },
+  {
+    "type": "inline",
+    "contents": "35f5e967b70002d9f106f55ea57f9c621603d973\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz\", \"integrity\": \"sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==\", \"time\": 0, \"size\": 4377468, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cff74a8452b6159ec5df4cd310e05e05bfaa99de31da7de4b5a7a7a849d9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "364997eb9cfd890191bd5ef6a4d36b28eefe04a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz\", \"integrity\": \"sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==\", \"time\": 0, \"size\": 4431, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6a2298196c9cd65881a7267db2824adff4d9c24f0ed6d3a2ca4c81d3e235",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/60"
+  },
+  {
+    "type": "inline",
+    "contents": "3655be30547181fe75973ab4af428f313721c8c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz\", \"integrity\": \"sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==\", \"time\": 0, \"size\": 110055, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e9e0a541b51bc0259b4ac24cb4c01dba7a4e723dbc1088cfc4c820034e47",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/7b"
+  },
+  {
+    "type": "inline",
+    "contents": "3728a416ec575d363a64eab1d1fd362d51d168f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz\", \"integrity\": \"sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==\", \"time\": 0, \"size\": 1995410, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e5ea2740e05d3b51d12a585717a45838b2b816aaf3e41f59b0ae8d2b6ec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "3792ec3f716db019a322b927460df98d641d1f0b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz\", \"integrity\": \"sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==\", \"time\": 0, \"size\": 1969, \"metadata\": {\"url\": \"https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "75bf8643b1d803f427bd1e39480195432a26cf1b842251ec3a8629bd85b9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/00"
+  },
+  {
+    "type": "inline",
+    "contents": "37f3d14e00d8739fecf05c0fd5d40020ecc6b650\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz\", \"integrity\": \"sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==\", \"time\": 0, \"size\": 3776, \"metadata\": {\"url\": \"https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "958fc085ebdc42fa37d4985cba976a5cca21f678c751c968f8fe9b259455",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/1c"
+  },
+  {
+    "type": "inline",
+    "contents": "3806e91e8ba577c7d0c59e1575c36f5620be4710\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.22.0.tgz\", \"integrity\": \"sha512-HUyvF+6C3e/sL3wZSc71Li1SkuWysixblFpVdm8csJKBOlT2kNG5kWP0AAgdXRiRWRZ27ZajNtagYgwoJ+QBpQ==\", \"time\": 0, \"size\": 570638, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.22.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b538f16f77838f551224124e612bf7d6de43454a26b80c6188f0540dca08",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/11"
+  },
+  {
+    "type": "inline",
+    "contents": "3843564a59d93133fac7d1ce00eae6b37bb8cf67\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz\", \"integrity\": \"sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==\", \"time\": 0, \"size\": 4584, \"metadata\": {\"url\": \"https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a34aeaf29195f5f9401c15f6857af1bd76c7606e0b093aab991c9bb6dc49",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "38576a1adf8cbbdd07182c380de6d1021bb0a533\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz\", \"integrity\": \"sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==\", \"time\": 0, \"size\": 3851, \"metadata\": {\"url\": \"https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9e124541d1bd7686c80038ca3b6ed601e64e680a83edccdf47801f6e21e6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "38914286fe5ebd29baadcec51edd5256c6568204\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz\", \"integrity\": \"sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==\", \"time\": 0, \"size\": 2316, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "830534a8145efd6beacbb79493cbe62a0903900d42e31c45dfcd64a28ce2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/1d"
+  },
+  {
+    "type": "inline",
+    "contents": "390ca9e54e3e14dd523581448bcb90236eaf9bbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz\", \"integrity\": \"sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==\", \"time\": 0, \"size\": 4636781, \"metadata\": {\"url\": \"https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "596e1a1da773aa1c379af0c938923d6b470cf1a4a8a8ed791db3cb091b64",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/5a"
+  },
+  {
+    "type": "inline",
+    "contents": "397b27f709fdfc1064f037683dff530b8797050d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz\", \"integrity\": \"sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==\", \"time\": 0, \"size\": 6944, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2f341048e538d1202f2e9aa373938188e96869a99f4d06f42218a1d852c4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/06"
+  },
+  {
+    "type": "inline",
+    "contents": "398492aacc53676df37ca8082ee53372db5e845b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.1.tgz\", \"integrity\": \"sha512-N889J4nXN/TPfVt8uF9N1A0SY82E90zwc1y26lqOcw6KWNLmQrlhMh/9OD4ikLDbekmFpOBq/UicpHf/6S8hbQ==\", \"time\": 0, \"size\": 4770, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fea5e1344a3508da468963f9ad1229f1afd38667a1b1d2256836cda53da3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/49"
+  },
+  {
+    "type": "inline",
+    "contents": "398c4c31056af3a3cf9dc0d209a5a8b30126a49b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz\", \"integrity\": \"sha512-BR5DtNRy+AswWJECyA17qhUDvrrCZ6zXOCfkQY5zSmb96BVUbpVAv03WpcjcwtCwiLbIANx3gebHOcXYn1EHow==\", \"time\": 0, \"size\": 18990, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-simple-code-editor/-/react-simple-code-editor-0.14.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c02d827ace565a38508b184eec46432a592ba2550cdb1930cd90b866d766",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "398d1800246b455d7634c27a2b98d6814805e23a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz\", \"integrity\": \"sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==\", \"time\": 0, \"size\": 4145, \"metadata\": {\"url\": \"https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0d0d67beda769e84926f207549943c0bc17abbf66bc20099aaa1bb51736",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "39c86b2d5b3b91542cfc10f7b0a1f0f8f10b3806\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/idb/-/idb-8.0.3.tgz\", \"integrity\": \"sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==\", \"time\": 0, \"size\": 16368, \"metadata\": {\"url\": \"https://registry.npmjs.org/idb/-/idb-8.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a7241843acd0e0d1511677e49be84d35d478312c75467e7b95d3ffa954aa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/61"
+  },
+  {
+    "type": "inline",
+    "contents": "39eb58c27de892a5305575501d06ce782004a263\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz\", \"integrity\": \"sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==\", \"time\": 0, \"size\": 20357, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1121292881231e57d779744e3cef693392d6c84bce10aa6760aa63ca04f3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/16"
+  },
+  {
+    "type": "inline",
+    "contents": "3a205fec14dd2ee78007c941e3d0204165cb261a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz\", \"integrity\": \"sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==\", \"time\": 0, \"size\": 2778, \"metadata\": {\"url\": \"https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "67e7c7174c848cc7f79c8a474ae1c8afd480da3f821551b4b5760533c5b3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/6b"
+  },
+  {
+    "type": "inline",
+    "contents": "3a2cf8ba70c468343bfdd6cda9c012f955b07bb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz\", \"integrity\": \"sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==\", \"time\": 0, \"size\": 2880, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f26dea52f5e17e7686475713bb1059b055da65c0aa1c9b779c4e21cfcff8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/e5"
+  },
+  {
+    "type": "inline",
+    "contents": "3a335be62977bd5c9773c7e41da25d1a6a47cc3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"integrity\": \"sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==\", \"time\": 0, \"size\": 28613, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b41f4759346e1d3b6651322d78c7983a4a546cdd6c18c3eb56c944571e4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "3a68713712b8f4435780af1a04dd341b49899355\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz\", \"integrity\": \"sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==\", \"time\": 0, \"size\": 7349472, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3b03f7b2a0d360328571499e669340ddb46b3e8c9cd5ccddb77d4783e1f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "3ab0e62fe465d709629e89e90e30730792f12e13\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz\", \"integrity\": \"sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==\", \"time\": 0, \"size\": 8083, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e72117e4892594ad942e805985edef3ca75efd1730b0ff9041f2af01d165",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/68"
+  },
+  {
+    "type": "inline",
+    "contents": "3aebf4d9787b8e73bdbf4a32158bc4ec1ea1c579\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz\", \"integrity\": \"sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==\", \"time\": 0, \"size\": 4096614, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "978f9c231eb28c0308e470d60a27db290eba7f4593f9fce477f2fcefd3c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/01"
+  },
+  {
+    "type": "inline",
+    "contents": "3ba2606c1b4f2a9d4d29689ed30c91064001a1f0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz\", \"integrity\": \"sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==\", \"time\": 0, \"size\": 7298733, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "418471ed42378e91e6e4b7b66a3e72f3156027bf4e1bc0926db33b55830f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/fe"
+  },
+  {
+    "type": "inline",
+    "contents": "3bf888d0f85fddceff67193efa4e7ff3ed70989a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz\", \"integrity\": \"sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==\", \"time\": 0, \"size\": 4658, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6a5b57ca4d63f37ccae38ea6b710ed659eeb763c63181c02e9470f8b29b9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "3ca6cd5b003d3ef23be1f3c2dcad864d0badf38e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz\", \"integrity\": \"sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==\", \"time\": 0, \"size\": 30098, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "49937ff840732b66341e61bf28c7bce52d9e62344db5a2cc1c4e94767f03",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "3df021440269e146d56d9f2162c0943d80f30af2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz\", \"integrity\": \"sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==\", \"time\": 0, \"size\": 3243, \"metadata\": {\"url\": \"https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e6e294a39cc9407b6358b7284df63feda5d4f96e51519630d06219175167",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/0e"
+  },
+  {
+    "type": "inline",
+    "contents": "3e1f8aa853af6960e1a881ffe691dc2494393991\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/once/-/once-1.4.0.tgz\", \"integrity\": \"sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==\", \"time\": 0, \"size\": 1979, \"metadata\": {\"url\": \"https://registry.npmjs.org/once/-/once-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "423d7e791f7fedd6bef784f0f467761c619f209ce9c788f08b63e968a880",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "3e617c83a97606ac57095e59c058fa5cc13da97c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz\", \"integrity\": \"sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==\", \"time\": 0, \"size\": 20038, \"metadata\": {\"url\": \"https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e419dcd7f6f3e64c1e8b96bb8532c1a2f730440671b31c1f7251791ac06d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "3e90ae4d5fd6077be903ac36a180f20382029b10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz\", \"integrity\": \"sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==\", \"time\": 0, \"size\": 5052, \"metadata\": {\"url\": \"https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6189df0792aa97c0ff62a3061969d948332c3ee59c2f5a1f48e473406b43",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/84"
+  },
+  {
+    "type": "inline",
+    "contents": "3ea31c4c1491157af1c8cfa7bb49cc30e88200d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz\", \"integrity\": \"sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==\", \"time\": 0, \"size\": 685134, \"metadata\": {\"url\": \"https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e5817c0c6ffa986a2284bf337d36c17f0eb4f43bb77c59558212350addc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/40"
+  },
+  {
+    "type": "inline",
+    "contents": "3fe647054c80757fdb2c792206083dba305f467f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite/-/vite-8.1.5.tgz\", \"integrity\": \"sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==\", \"time\": 0, \"size\": 549330, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite/-/vite-8.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "488d3c452cdc65387a51e7d81ec721379e342d5d2913000a1c21a21a6c96",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/ce"
+  },
+  {
+    "type": "inline",
+    "contents": "408047a532302e7278b3914ab3aff1e6e6154a06\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz\", \"integrity\": \"sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==\", \"time\": 0, \"size\": 1935948, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "edee9feb1afc71a0264d1eee9021976c23564fa9aace303ae3c4ecfbaf1a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/e1"
+  },
+  {
+    "type": "inline",
+    "contents": "409903fd0953c9dc653f04f57afbc011729956c2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz\", \"integrity\": \"sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==\", \"time\": 0, \"size\": 468935, \"metadata\": {\"url\": \"https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e1461d1f101e9948610140bd81ada81a8a27dcf943c662df88dbc98006c6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "4180ccf6c486509cd534bc906ba8b94efe6446dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz\", \"integrity\": \"sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==\", \"time\": 0, \"size\": 91761, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0ed23c75537e39e02ae800c643d5b1fd04a0d3512a0d58a064d8455efab4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "41bf3ee2059d37bc7824150376f566bb4e2de046\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.27.1.tgz\", \"integrity\": \"sha512-tNB8kjxo0+XPremnWkd6NUikpeJ+JQrss7HntL8GgIxX4t0gkdnLn9yUWb0JzcaYP7Y8iTZZHdkPs0P154DG8Q==\", \"time\": 0, \"size\": 100092, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0e237b1162f8405e4a3239275949be586be5d147e913a459749daa656d8d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/3a"
+  },
+  {
+    "type": "inline",
+    "contents": "429991106c91212e6d7d38a10e6ffcfbb3f9e0e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz\", \"integrity\": \"sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==\", \"time\": 0, \"size\": 562166, \"metadata\": {\"url\": \"https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0be93113eda4a2f0599074847509fcda5af42a2b61bc8b47367ca4250e4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/94"
+  },
+  {
+    "type": "inline",
+    "contents": "42b0549a39727275149f3ca1eb28c02bb2cf995f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz\", \"integrity\": \"sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==\", \"time\": 0, \"size\": 8838419, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d4e3329af67cb3138ada08cfb4d174f2fdc3e2242ff6e0720f7b830b732a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "42f0c2aec331f635eb9b051eab6eefe0387d20fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz\", \"integrity\": \"sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==\", \"time\": 0, \"size\": 9087, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ad25d4dbb5b3d6570b330feea3569881426863c6a9f77bc958bb51f79e1f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/8d"
+  },
+  {
+    "type": "inline",
+    "contents": "4314c8636ac993a9878299f668aa6aacece59b72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz\", \"integrity\": \"sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==\", \"time\": 0, \"size\": 2347, \"metadata\": {\"url\": \"https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "04e6f64d657039df04ffd17af0bb8c7b3f5db2f8937c8a322ae2455af62e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "435216f3fedb6985549f32f2307086643f851885\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz\", \"integrity\": \"sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==\", \"time\": 0, \"size\": 2019767, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "21e8e05bbae403743eb5f608317e35921fe436288d3246e30e9f44afece5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/d7"
+  },
+  {
+    "type": "inline",
+    "contents": "443ef1f0304d4f5bd6cb6989ed8319c4677d459a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/csso/-/csso-5.0.5.tgz\", \"integrity\": \"sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==\", \"time\": 0, \"size\": 168159, \"metadata\": {\"url\": \"https://registry.npmjs.org/csso/-/csso-5.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a74dda5e1b9f7c57a4af0683d3e1ac57143315c89c2e9d895a686317eb8b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/d2"
+  },
+  {
+    "type": "inline",
+    "contents": "448b9091274898fbd506f663441b91338b2740c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz\", \"integrity\": \"sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==\", \"time\": 0, \"size\": 9128, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2f2888e299f28b26bece83452cef6446d21dda57f9e3eeb70e23a5451b2d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/e6"
+  },
+  {
+    "type": "inline",
+    "contents": "457c349a6286b38ed3916af98804fe8151701bdb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz\", \"integrity\": \"sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==\", \"time\": 0, \"size\": 1592, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e2436831fad0b9e198d428bafc2fd9394dffbbb9b69cd26723317ab9c21b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "4649b5787464ffb6b9b953595cebf9d8b000eaec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz\", \"integrity\": \"sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==\", \"time\": 0, \"size\": 2710, \"metadata\": {\"url\": \"https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4511be3eecea50ee9cadc09a612f9be8598d7b29d5c8b1253c75fa283cc5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "4653d13f0994aeadd490043ebc7e82954852a05d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz\", \"integrity\": \"sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==\", \"time\": 0, \"size\": 2733, \"metadata\": {\"url\": \"https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2f1edd4373313cbd899bdfb10fa0acdf376a25dd5eabb8cac8170302cdb8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/f0"
+  },
+  {
+    "type": "inline",
+    "contents": "47166cf5f7eb50ec8417b9bf21093f63929e9c3c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.27.0.tgz\", \"integrity\": \"sha512-QEzGwrvNBgv4uPVdnbHsOGG4G6T96mdlcFI8aAKPjMU8wOPpVocPXb6k3QGkaZagVTv2G9Bnnbo6Z3JdXr1fQw==\", \"time\": 0, \"size\": 100893124, \"metadata\": {\"url\": \"https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "faaa43e8646314c5f6163f6c7c7f1215f3fe67b9342451c322d477b37aa3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/f2"
+  },
+  {
+    "type": "inline",
+    "contents": "476a4c8127493bcb12c8effeef7b51f818456fde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz\", \"integrity\": \"sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==\", \"time\": 0, \"size\": 6308, \"metadata\": {\"url\": \"https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6429cc47f4ecda3ff97d01807c0247f9458561ee5653a0d7fd21bfe9ffd6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/db"
+  },
+  {
+    "type": "inline",
+    "contents": "47b4647741e3455b2d726ace8f8fbe6c8992bb4e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz\", \"integrity\": \"sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==\", \"time\": 0, \"size\": 4323046, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1acf64f1a05e83b08243d01918c3ccbc77e658e992ee19ce6fe0a3a353c7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/99"
+  },
+  {
+    "type": "inline",
+    "contents": "47c47763723a996f2dbcfbaa0c2063ed878f51e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.1.tgz\", \"integrity\": \"sha512-vfxRsqW8rCc0k4pzo0ilU3wobVi2wqVj88VZI2SlgZlNnUAkrDGDIAph7CTa9k9fshV+O1ivpEgPC5yC046jow==\", \"time\": 0, \"size\": 7277, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5085a58d9b932ea42cd454a5af0c364716d0596b0aa70a6f4ec2040e83e5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/3e"
+  },
+  {
+    "type": "inline",
+    "contents": "47ff9f17f6f0b35337d5c874ada73f434c50bec7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/woff2-encoder/-/woff2-encoder-2.0.0.tgz\", \"integrity\": \"sha512-wH1rcskczCP5+BJABM88aM3hoEX1VUW6U+Ksx/7bmXvctWGqF+O/YQdC6vWQ7lJS7ny21a0MkAqcZyOP2O8CAg==\", \"time\": 0, \"size\": 550466, \"metadata\": {\"url\": \"https://registry.npmjs.org/woff2-encoder/-/woff2-encoder-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "39e38ecd070a7f99a17f2ed4c14d43204abe681551a331c0871cf2f97212",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/de"
+  },
+  {
+    "type": "inline",
+    "contents": "483e4f639cadbc300f5a0392cfcb038c02180cdb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz\", \"integrity\": \"sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==\", \"time\": 0, \"size\": 2559, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "23b227493c40e2b3232dc527271f90372559b8cef8eb722966564232258e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/1b"
+  },
+  {
+    "type": "inline",
+    "contents": "48e28b94848e8d9e3fd8ff84faf097b7ecfa9b48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz\", \"integrity\": \"sha512-RXGaD0o1/pTTguYw1aeDJh9ad6Lfrui0fI7mBderTyGr7WuUJkBIttgLkR3XJyoxOkkgfBDspaUT8wXArTqLZw==\", \"time\": 0, \"size\": 26532535, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea8e66b6c1e6fc67c52316d2bca804dacdcd1480ff322c522d3d79cc6c98",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/70"
+  },
+  {
+    "type": "inline",
+    "contents": "48fc1ce391d5fcda6c01325379998adedc34f6f8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz\", \"integrity\": \"sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==\", \"time\": 0, \"size\": 129662, \"metadata\": {\"url\": \"https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9031dbceb98d850efac8688ab7d819d3b43389ca9a00f5da6a694a962aea",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "49874de63f3bdfd637c16453fe8977a9eadfcc64\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"integrity\": \"sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\", \"time\": 0, \"size\": 3009, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9ddc9f878c52039554fd9be6ee3852f10163225591207069618d4544e7b8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "49b2f4d64b7312fc956db67f815c8f357be43d17\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz\", \"integrity\": \"sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==\", \"time\": 0, \"size\": 17410, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "696cef60a8ac3fd8982ca350e9d8943578f2ad0ea2e8434665f71f4200ac",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "49dabf6e095e9374914712d689eb3c821cd2d970\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz\", \"integrity\": \"sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==\", \"time\": 0, \"size\": 34207, \"metadata\": {\"url\": \"https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bd84c75273f8810111af2fb2a9c664a5a89d959961609303a4ac6e45fccb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/ad"
+  },
+  {
+    "type": "inline",
+    "contents": "4a123874435f1245d1c1e588214ffb2d8485699b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz\", \"integrity\": \"sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==\", \"time\": 0, \"size\": 3020, \"metadata\": {\"url\": \"https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b4d8ecef0ade0bb7e035d93835776116ac0ee816bdbc5f714bd1eec97ff6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "4a140765b0b1b3eef9da52d3316b2e08d90fa7f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz\", \"integrity\": \"sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==\", \"time\": 0, \"size\": 8805, \"metadata\": {\"url\": \"https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9a04eb3aee361841f0c54f3c2422a5a91984311b5b54537ee7dbf96b6c53",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/e4"
+  },
+  {
+    "type": "inline",
+    "contents": "4a762dd7d563b01b7040462c4f3b233d6bb82d2a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz\", \"integrity\": \"sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==\", \"time\": 0, \"size\": 19402, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8bc57373c5071bb4138b28ecf48583fa6cb750512834a51cdef78fba5e03",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9e/85"
+  },
+  {
+    "type": "inline",
+    "contents": "4acb9875ebc56c671c2d12c12823a5852ddc90f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"integrity\": \"sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==\", \"time\": 0, \"size\": 5141, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "570007f66e0a594c21201eb3e8f15d7a4d92bcb97b59246e5b7194b3b290",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/f3"
+  },
+  {
+    "type": "inline",
+    "contents": "4b1547c6fd1346ff3aa00faf9677bab253da704a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz\", \"integrity\": \"sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==\", \"time\": 0, \"size\": 1311, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "850558038dbacbcba5202b181a0a0c4f947405cf3682df3e1c20dec79137",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/60"
+  },
+  {
+    "type": "inline",
+    "contents": "4b2a8b393e7444a0f47ea055410d77ca5377120b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz\", \"integrity\": \"sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==\", \"time\": 0, \"size\": 20277, \"metadata\": {\"url\": \"https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3412665b593cbfd1177935d2208ee409af1ba13e49a94877d019a8526c8a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/5a"
+  },
+  {
+    "type": "inline",
+    "contents": "4c5b49e8a2ee33b0a33371abff09d2a4281c02a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz\", \"integrity\": \"sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==\", \"time\": 0, \"size\": 13052, \"metadata\": {\"url\": \"https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8672305e3572578af776639eb47a452a9acd07b3abe218386858ea8bb1e2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/93"
+  },
+  {
+    "type": "inline",
+    "contents": "4c6458d0ed8dc6e1da9abb20e67e2f7a0340d41c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz\", \"integrity\": \"sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==\", \"time\": 0, \"size\": 32112, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "626b833e294790284cd337a1d18d9dcfa6033cfd0cb3c40d822fb2878e38",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/de"
+  },
+  {
+    "type": "inline",
+    "contents": "4ca56389395ddb5d9d76f3510376f3717230de7c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz\", \"integrity\": \"sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==\", \"time\": 0, \"size\": 2741, \"metadata\": {\"url\": \"https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9b48180c4c71635d2e5591577ff5c9e73379ebfa6695e0fd88aec9d590d1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/61"
+  },
+  {
+    "type": "inline",
+    "contents": "4cb5deb7ea442365b045bed47ae85044680b9a15\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz\", \"integrity\": \"sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==\", \"time\": 0, \"size\": 13371, \"metadata\": {\"url\": \"https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3678b574a004fb94f4fd917131886a608a638d7ad456beee293d41979e7a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/29"
+  },
+  {
+    "type": "inline",
+    "contents": "4d0fdd6eebd0493c0b26dddf5e4b4d14686223ab\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz\", \"integrity\": \"sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==\", \"time\": 0, \"size\": 895775, \"metadata\": {\"url\": \"https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "23138df91776c7cbee1a3f86b1e29b766b7b7fa9b01844099e51d6cbe468",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/d8"
+  },
+  {
+    "type": "inline",
+    "contents": "4d2bab66f7d337a53795c56cf6879e0b4efd27db\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz\", \"integrity\": \"sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==\", \"time\": 0, \"size\": 3479, \"metadata\": {\"url\": \"https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3f88a4a01e325bbc4372a95d005f1af57c6ddf8ee21f643cb273d7814ddd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/d6"
+  },
+  {
+    "type": "inline",
+    "contents": "4d87fa2d43b1f79fe874f625be51b1ef6555204f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz\", \"integrity\": \"sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==\", \"time\": 0, \"size\": 2696, \"metadata\": {\"url\": \"https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "560a88b4bb3cf23a51b288e28f388f9139ae56910fba9c09cdd6565e0138",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/55"
+  },
+  {
+    "type": "inline",
+    "contents": "4e48ae14edb0982f1463fea22636c3221941e89e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz\", \"integrity\": \"sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==\", \"time\": 0, \"size\": 1854, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "946df9356ae372c19a7700e322d8d0276a406143c7375ce22124fad7dfcd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/21"
+  },
+  {
+    "type": "inline",
+    "contents": "4ed52e237cec1dee1ed20d9de9c5400ffbfd760d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz\", \"integrity\": \"sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==\", \"time\": 0, \"size\": 35647, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "57253d9df00692571c43199f6a9eebc8d43b78a8073cf7402e9d969b9554",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5f/c9"
+  },
+  {
+    "type": "inline",
+    "contents": "4f29c2de7854a29c04ef945d82419c720951eeb8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sax/-/sax-1.6.0.tgz\", \"integrity\": \"sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==\", \"time\": 0, \"size\": 16571, \"metadata\": {\"url\": \"https://registry.npmjs.org/sax/-/sax-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4f0500aa0af94771e3aeb0a7db7153faf4f245521a4095d765a465f508ce",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/26"
+  },
+  {
+    "type": "inline",
+    "contents": "4fef5ba5567458f075108e31e2d17da8dbfd518f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz\", \"integrity\": \"sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==\", \"time\": 0, \"size\": 4896, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f693e1cbbd8c651339dc83ea677e236d61935b81de6396cb4847fd5b08e4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/63"
+  },
+  {
+    "type": "inline",
+    "contents": "500a86d2d37be84ad19b8c07881dacfde3ffcc5e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"integrity\": \"sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\", \"time\": 0, \"size\": 18477, \"metadata\": {\"url\": \"https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "238807144536cb82d714f2a1374ef3c3a03fbbfd4fa234ff083114a25f63",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/63"
+  },
+  {
+    "type": "inline",
+    "contents": "5013a64fe3e538f50461a31e4d58ab5f7f393956\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz\", \"integrity\": \"sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==\", \"time\": 0, \"size\": 11352, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "daed6d17b16602317082f2a52ab840a1e9c72bf0807d9c2a57cfa2eacb0a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/a8"
+  },
+  {
+    "type": "inline",
+    "contents": "5086e224838db00ffda8ac0df22f9c7a07ba9245\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz\", \"integrity\": \"sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==\", \"time\": 0, \"size\": 7470, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2a77113104e4f8359bb52ee1939186c68156418dd9a5a428ad9e0c5726c4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/07"
+  },
+  {
+    "type": "inline",
+    "contents": "51329012a1c74076df30c4307053264986be4ed1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz\", \"integrity\": \"sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==\", \"time\": 0, \"size\": 4683, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "65236f189543ad235ae45169ec6dd6e18051b7adcb53932b663cf829f070",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/2d"
+  },
+  {
+    "type": "inline",
+    "contents": "5217cc9f5646d7240aa97f8862ab008c57a8440a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz\", \"integrity\": \"sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==\", \"time\": 0, \"size\": 2970, \"metadata\": {\"url\": \"https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a70839f3c418571c203f6d6273aba0f11b9abe30f22a2df95f92d82aedac",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/60"
+  },
+  {
+    "type": "inline",
+    "contents": "53cf60f74309ebc10e0c3842a36b24120d524016\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz\", \"integrity\": \"sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==\", \"time\": 0, \"size\": 3026, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "421b96b2cab5ab41a660a6a8957d92477cd89fddc998f1a18e0c62f07051",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/39"
+  },
+  {
+    "type": "inline",
+    "contents": "5420041e443457994940a715becd8a45bf740dde\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz\", \"integrity\": \"sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==\", \"time\": 0, \"size\": 2595, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6194e6f505a57ff4462ab5949459f147061e2feeb759ee0cda5713b3ebec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/84"
+  },
+  {
+    "type": "inline",
+    "contents": "54c21ef2908701eaff1819249be415a43f3cd6c5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz\", \"integrity\": \"sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==\", \"time\": 0, \"size\": 4797, \"metadata\": {\"url\": \"https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d7cd7487e60fb3aff6f4679e99cc0f8445ae36507f287aff8dc9d5dea1eb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/0a"
+  },
+  {
+    "type": "inline",
+    "contents": "54eb53989c86e83530171f22ff731b7292f78036\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz\", \"integrity\": \"sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==\", \"time\": 0, \"size\": 17469, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b53660a6bedeb14f8bf9b40272b72516049c051ad67f47e108579dbc0a9d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/48"
+  },
+  {
+    "type": "inline",
+    "contents": "54f47311cce7e4edcc3c2a2f6a763942fb29fbfd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz\", \"integrity\": \"sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==\", \"time\": 0, \"size\": 4711359, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b48bb5aed5f36a531645af8da8349e1fa9fd7753ea9e6b5c6992f85f0030",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/3b"
+  },
+  {
+    "type": "inline",
+    "contents": "54fc36a2b9798253c84aed8ebe3bc76602ce420d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/router/-/router-2.2.0.tgz\", \"integrity\": \"sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==\", \"time\": 0, \"size\": 14251, \"metadata\": {\"url\": \"https://registry.npmjs.org/router/-/router-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f4ddf7c86f3268df4a98b0fbdfc41a3b47b2c1e83a46c65410bdd1f9660d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/0f"
+  },
+  {
+    "type": "inline",
+    "contents": "560e2708fe4c8f7dcb8f267067bf88d5fb0164c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz\", \"integrity\": \"sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==\", \"time\": 0, \"size\": 11135, \"metadata\": {\"url\": \"https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2a282ab7213ce0699bbbe79d8662ec15a697ece785c9ee5b7af8b1a9061e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/29"
+  },
+  {
+    "type": "inline",
+    "contents": "574fabd6aa29f3c2c2ebfa74a405dca65453609e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz\", \"integrity\": \"sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==\", \"time\": 0, \"size\": 3308, \"metadata\": {\"url\": \"https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "863e6f3ff678c39a10b4b2306bc0a5c4bc1ee5d76440d1407754e1337933",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/04"
+  },
+  {
+    "type": "inline",
+    "contents": "58ec289799131cdbd5f1c8c767b03fdbcae4d600\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz\", \"integrity\": \"sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==\", \"time\": 0, \"size\": 5258, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0cb6b326c4d69133c57c43bdf35e876eabf894cee9d5e3f68a0b4a45ad5a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "594543328b0cb8cb4ee1953c739daf5dfe0d71a8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz\", \"integrity\": \"sha512-rV6Qn4wmC6BxfF+4mu6bqGWj9vA4oXXhsrpXaJL2uhjxeHAGofjwcHof2X84VYzeyXgdlsGmqKie4TAppVXZUQ==\", \"time\": 0, \"size\": 533129, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/core/-/core-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3d077718788df8346f715dc2a90ee094b68f3da471e0c61b56258c07db15",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/79"
+  },
+  {
+    "type": "inline",
+    "contents": "596d0838d69d40374d1e68327b7ffef20ada0390\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"integrity\": \"sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "489c0e6a9e4cbd64a8acd4fbfda113e9dfdd114f464830471fda53fff0cd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/c4"
+  },
+  {
+    "type": "inline",
+    "contents": "59c9e50e387d0dd1e8141e3371932d65ae75fba2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"integrity\": \"sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\", \"time\": 0, \"size\": 9742, \"metadata\": {\"url\": \"https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7bd13a4fbca4723a579cab6019efcd5e03ff32581fd276a8f79738dc7a68",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/18"
+  },
+  {
+    "type": "inline",
+    "contents": "59d552be2eced95ca0f827054aebebf8695eaeb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz\", \"integrity\": \"sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==\", \"time\": 0, \"size\": 279093, \"metadata\": {\"url\": \"https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6d7fb3d1069a5368621107eceb1b254820a65f46b5504ed5092c8633afe8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/67"
+  },
+  {
+    "type": "inline",
+    "contents": "5a1b1f8044325a7079ad3953e768a692db390a1d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz\", \"integrity\": \"sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==\", \"time\": 0, \"size\": 1813, \"metadata\": {\"url\": \"https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c69e312c9d281e34621cbc9ed378b6e3042a177e6963d0bb42b1e8daa44b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "5a6b965cdd31593a1d0b662649aeb784c7470319\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.22.0.tgz\", \"integrity\": \"sha512-LAFijdt2L4xxjqA16dkqVPjB85VeyHAa32M+nAZyMe4to8s35cW9sZVPnBEFjXGFN4A2WsZ07ViiG+wM6SKS4w==\", \"time\": 0, \"size\": 546976, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/inspector-client/-/inspector-client-0.22.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4a9a21cf731e60af2534fdb6cec02806715bce3d87d0a9e29bfda730fa7e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/80"
+  },
+  {
+    "type": "inline",
+    "contents": "5ad1478c49b8ecf0a909c5d677929d36985bc127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"integrity\": \"sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==\", \"time\": 0, \"size\": 132003, \"metadata\": {\"url\": \"https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a81ec09ff8849df96b20fa9c869a01023fc35e39a6fe539bee503fd77a00",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/30"
+  },
+  {
+    "type": "inline",
+    "contents": "5b00d9abbaf5d910e50c58fa5772cd8e52982747\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz\", \"integrity\": \"sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==\", \"time\": 0, \"size\": 4307, \"metadata\": {\"url\": \"https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e8bf76d62c889e9b94b74838728f1555fd895c9b0b2767b82dab815e92b7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/68"
+  },
+  {
+    "type": "inline",
+    "contents": "5c1ebc8c07559a3c5bfd5b7ca35ea8bb73a66fda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz\", \"integrity\": \"sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==\", \"time\": 0, \"size\": 69924, \"metadata\": {\"url\": \"https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c849c740953dd205340886b01fd82983e7f2ee9d29af5e888d8b06868b09",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "5cd415b6dd1d11619964f707e6b4296ab507e2b0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz\", \"integrity\": \"sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==\", \"time\": 0, \"size\": 7815587, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6ee951b9ff53b231e7a595d5dedf045d9114c9ca6a0caacddc0e556b0aa3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "5e58fe6f4c0f2f9671e48be1d50e7d30a35ea17c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz\", \"integrity\": \"sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==\", \"time\": 0, \"size\": 31100, \"metadata\": {\"url\": \"https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d0491c18c577583fab5ad8363312f5d783c63da13f8fa26d90068418e305",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "5e621ade89e852910872fb351d7f3083c1bcb416\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"integrity\": \"sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==\", \"time\": 0, \"size\": 2668, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "be90b3954e2f6e7b35b521e65a5016fd963aa11c3d6c88ccd9e0b61c069e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/ad"
+  },
+  {
+    "type": "inline",
+    "contents": "5eeba38c32699bfe5489c58d29ded948619a20bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"integrity\": \"sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==\", \"time\": 0, \"size\": 2263, \"metadata\": {\"url\": \"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87042931e5944467d47331c350feb4384bf9143ab6ceebf7108a55905843",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "5f9871680f16a59d717a0562961bb17ccfd2c723\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/qs/-/qs-6.15.3.tgz\", \"integrity\": \"sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==\", \"time\": 0, \"size\": 71213, \"metadata\": {\"url\": \"https://registry.npmjs.org/qs/-/qs-6.15.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "15d330c83f0ad89709e8c9c754fba025217cc79553febce637a1da18b058",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/c5"
+  },
+  {
+    "type": "inline",
+    "contents": "600268fd84666990873324d2b8b27caa1671384e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.3.tgz\", \"integrity\": \"sha512-kpBhMiJHGmerizzObAT1XLZDyImO4ZEKXaxjjfxGVkycQ0U5of/xlLepm1Izp3P+3jlaedFSRI5fJnv3Q5xV6A==\", \"time\": 0, \"size\": 2080650, \"metadata\": {\"url\": \"https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b1d909f54456477330a96e9e6ac7325f4b893195ef0e83874d82fae1f354",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/0a"
+  },
+  {
+    "type": "inline",
+    "contents": "604873e21f814b3bf8d27e2f344c90641d37d67b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz\", \"integrity\": \"sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==\", \"time\": 0, \"size\": 3761833, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8f2485aa0c8915f9709001b50963529565a631cee5763ed11df06c6daef1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/a2"
+  },
+  {
+    "type": "inline",
+    "contents": "60e84f6efe81e611da78e35f1a95c419c3090f84\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.2.tgz\", \"integrity\": \"sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==\", \"time\": 0, \"size\": 74008, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4f29e16838ad3d5a5038b3d69bb0308531ceff30b56a3ca3a181eb87b01f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "61524b7a9fa4f343282b41e6102390dd60668bdc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz\", \"integrity\": \"sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==\", \"time\": 0, \"size\": 4980, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "048ffbc23e94eae505a5fdf99dc454d75eb6d2cc363cd7490331a3efb958",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/28"
+  },
+  {
+    "type": "inline",
+    "contents": "616e31aa0a4002e4bb0577a828d5396750822486\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz\", \"integrity\": \"sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==\", \"time\": 0, \"size\": 5305, \"metadata\": {\"url\": \"https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6384accf902e3124c40684749909d0748099863f8b1a8c5ec4273802d0fc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/3d"
+  },
+  {
+    "type": "inline",
+    "contents": "61ac85290eb46fe71afc6a67733dba3188f1d07a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz\", \"integrity\": \"sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==\", \"time\": 0, \"size\": 3531290, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e900998c4e4691a54b3e199d80e4534853bcb2934a6571904eb097973e01",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "61b2d75c75a7d5f01882b7dd7b8d37219f50d205\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz\", \"integrity\": \"sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==\", \"time\": 0, \"size\": 352636, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aec4653012464c0199aca6671fd74951af971a89bcc5eb8dc2a9fa517915",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/3e"
+  },
+  {
+    "type": "inline",
+    "contents": "61cc9e86f3bb80697da8ee8508314094ae874865\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz\", \"integrity\": \"sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==\", \"time\": 0, \"size\": 149452, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bce1860c725239da5a0add26d94587167b689c95b99a3faa6cfef5575986",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/d3"
+  },
+  {
+    "type": "inline",
+    "contents": "61e7ada0693898fc9e1f2bc1962aa4265fd52a4e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz\", \"integrity\": \"sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==\", \"time\": 0, \"size\": 1329, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c0732592365d753d382502d91754a3c88f8b20e22cc25a0327beb9429687",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/86"
+  },
+  {
+    "type": "inline",
+    "contents": "621625b89a9f6380404a2708e09bc9b9e7a42f61\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.1.tgz\", \"integrity\": \"sha512-6ZwaZwSrDh+KFFv6V1J79oO37yPs7y1bFxvk1/9Ih2rn3Xr5AWz+eMS+n8RpH3djBVVAQpdIAeYQgcn+VCSsTg==\", \"time\": 0, \"size\": 3029, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4354a48ed2b016ebc3aa11d3ed121c56f58e8f012353ef3d4cee618de11f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "62bfab0b90402d7fc051af5b606aeed27dede499\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz\", \"integrity\": \"sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==\", \"time\": 0, \"size\": 1770, \"metadata\": {\"url\": \"https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8b147cb63e6dd3e2faa5fb1ad14793eed67eea68889f613db641eb12210b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "62ce094b331c53ce43836a85e6ae46fff80f1d3a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz\", \"integrity\": \"sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==\", \"time\": 0, \"size\": 129947, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a61772f4f883b7f4cea07733f03e8d4ae675d3ebc271edbe4ab04f702be9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/73"
+  },
+  {
+    "type": "inline",
+    "contents": "62ea36e518fb27317b74addee47c7de89db02bbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz\", \"integrity\": \"sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==\", \"time\": 0, \"size\": 1905, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2cc38693657b1c267796f699131d7ba9b9a7f2f30a6523af231542e2c130",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/bc"
+  },
+  {
+    "type": "inline",
+    "contents": "63e2cbc76f9401e3860c9332f9e7948679d39bb4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz\", \"integrity\": \"sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==\", \"time\": 0, \"size\": 4178, \"metadata\": {\"url\": \"https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8d3e93011a4b0fcb7911dc9fc2216a8abfdb083af4b6e05c24902c8ff291",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/9e"
+  },
+  {
+    "type": "inline",
+    "contents": "645b6e572c017f4ac37b66f694c3a6c98da473f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz\", \"integrity\": \"sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==\", \"time\": 0, \"size\": 44438, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3a35c272cae9f0f48d769aa94e6fc87308a8e34f29c8bfac12c2f2725f68",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/03"
+  },
+  {
+    "type": "inline",
+    "contents": "64cfabbb15b13f84dfdbfb74cf7f874fdf66a7aa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz\", \"integrity\": \"sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==\", \"time\": 0, \"size\": 2067, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "488f71f39bc65742422faf2c74e3b330852ef2192dbb3198fed044e60c20",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/a4"
+  },
+  {
+    "type": "inline",
+    "contents": "6517f39b21e46514f6a3882938a842237a854702\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"integrity\": \"sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==\", \"time\": 0, \"size\": 2766, \"metadata\": {\"url\": \"https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e7ff11dd0fe25b7d40c7f2721c5c2d99d60b0990695b20923170f8eec18",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/87"
+  },
+  {
+    "type": "inline",
+    "contents": "6520cc209e4043bd45b276ef4ea46de092057728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"integrity\": \"sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==\", \"time\": 0, \"size\": 6157, \"metadata\": {\"url\": \"https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a5acf52705a1beb66603196f4bc44e583052d0f1d5a23dfb5316da1811d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/d7"
+  },
+  {
+    "type": "inline",
+    "contents": "65ab1c1b5d007aa45f650d460663b4ac14893652\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@mcp-ui/client/-/client-6.1.1.tgz\", \"integrity\": \"sha512-kN5io7ouEpVfOTloEEGrnuWio3ZzYOVgTk4o8ULleACdKEw7VgOTozPl9aj9qVl/UBh7rXlvKH0JbBm6Tw52LQ==\", \"time\": 0, \"size\": 156552, \"metadata\": {\"url\": \"https://registry.npmjs.org/@mcp-ui/client/-/client-6.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "416072cf05edce3fd136d2a6ff0c5ca1bd0083fd8f6db51084c71bb4b714",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "65c23b3b88f5a8f8152a585b2290fcac83b9881e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz\", \"integrity\": \"sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==\", \"time\": 0, \"size\": 15149, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "496e961e4bdc855b1ed54d1b8b683df7f0af0064514517f634da3143aa18",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "66301fe5916e47fef23f150f97b4d91ea4e55965\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"integrity\": \"sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==\", \"time\": 0, \"size\": 5442, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f306f68eac58ac50c3a0a0453cb8f29d78b9505c01947c965b4768a4e60d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/98"
+  },
+  {
+    "type": "inline",
+    "contents": "67ddfb21e0fa62f3bd2c29ecf369172d4cf89507\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.3.tgz\", \"integrity\": \"sha512-3lC9BJk4fR5ZJxcGjb0hVnDFOW7KpLXHIebiBmVd4FDRQZVeObztoTKxRUPxlWwSgxrMRONK0u50hBD1aTYEKg==\", \"time\": 0, \"size\": 1672705, \"metadata\": {\"url\": \"https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "962ff1e06659787f95fb6c949ed8295e2d298c51abf5a18be08c23239026",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/54"
+  },
+  {
+    "type": "inline",
+    "contents": "68227a5236f733df541f5f76d63cfcfd5bb23d2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz\", \"integrity\": \"sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==\", \"time\": 0, \"size\": 7776, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e58a240f7a1b156aa7b4c5145722ca5054ef8ba5b3d6d7fe41c4811b9b12",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/42"
+  },
+  {
+    "type": "inline",
+    "contents": "68bd3ea8193914e7263adcf111aedf6fd7c8a3ae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/entities/-/entities-6.0.1.tgz\", \"integrity\": \"sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==\", \"time\": 0, \"size\": 112438, \"metadata\": {\"url\": \"https://registry.npmjs.org/entities/-/entities-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3b9e21673629b6553ef89825650b03e757bb84da26a92cee188368e9374b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9c/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "68e40eca1c59a062d2bbd446b519199af82dde31\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz\", \"integrity\": \"sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==\", \"time\": 0, \"size\": 12028, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7211aba95041552170427154a3ad3e8229706a5dc1589c21ba9edd1e32be",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "690c3f8c2f64f58dde2cea98df853d96ae0284e1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.27.1.tgz\", \"integrity\": \"sha512-EXawuJBO55wd8WcTbHTMoPhv0CGQxza4yCCPB5Hqz4ZPQwahIr3ej+8yp/kimIl0xokabwZ0/Fu8STQ4AkZv5g==\", \"time\": 0, \"size\": 4888, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0db129aef25d2d06464187286544c93d605a260d1a65296cb497feec194a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/d4"
+  },
+  {
+    "type": "inline",
+    "contents": "6a3ccb0ba2fad3f1f84e305366d55aeeb1e7bf5e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz\", \"integrity\": \"sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==\", \"time\": 0, \"size\": 2646, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1b2cc0831de98e115266d021c4dfa00b434da87a356d327380409a509981",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/8a"
+  },
+  {
+    "type": "inline",
+    "contents": "6b1c86df1beb64c9da5894432cd65a8e874ad334\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz\", \"integrity\": \"sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==\", \"time\": 0, \"size\": 6090, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "42d143b67ae6bab21cc82699478c74a8319ddf041c0be7c850c05e2709ba",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/78"
+  },
+  {
+    "type": "inline",
+    "contents": "6b84b8f37c618e3624796e18c35d85e15b6f7d98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"integrity\": \"sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==\", \"time\": 0, \"size\": 5338, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c2c4e4cf88f6f5a26a474eec1eb28a1a0c087f156fa82df974013a50081f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/65"
+  },
+  {
+    "type": "inline",
+    "contents": "6bdd0f0deb699b21288b2e9fa71067f1b0466c89\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz\", \"integrity\": \"sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==\", \"time\": 0, \"size\": 3680, \"metadata\": {\"url\": \"https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "217f4a9502eed2896935b005b187e4713d93ba3dc76eff284b00a1a8b92a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/5c"
+  },
+  {
+    "type": "inline",
+    "contents": "6c76f73f3768c1d040ea1b468b816c49e9b69ce4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz\", \"integrity\": \"sha512-ZlvmNFT/iIF6JD13rxbbMWD8nvGR0RaUp6yMQnoc+4Af0YjVVe/bIdW1XSQQsoxXAtg1NaT6Vak0LKFlJ4d37Q==\", \"time\": 0, \"size\": 1365127, \"metadata\": {\"url\": \"https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.120.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9027e25f3f019b46a2c876fb68d8716b5ef8eb17468f058bfbf110d5df21",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "6cb18856fd8c7d1b59b2e13508e03544a1eb2d2d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz\", \"integrity\": \"sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==\", \"time\": 0, \"size\": 3383, \"metadata\": {\"url\": \"https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d5dd5fa44593b3e2d24e270c89a4ebe5809a69837946acbe11b5f9ab29d0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/03"
+  },
+  {
+    "type": "inline",
+    "contents": "6dd74ba36cad0b4c4397bcf3e07fffb0477ef93c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz\", \"integrity\": \"sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==\", \"time\": 0, \"size\": 2997, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "89a405526d28296d8f1f0e7bbafdd0c515a367d6169d6f70671a2bdf662e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/53"
+  },
+  {
+    "type": "inline",
+    "contents": "6df552f221d77ff28939640aff315edaf7e79323\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz\", \"integrity\": \"sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==\", \"time\": 0, \"size\": 4678, \"metadata\": {\"url\": \"https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "84699419a76276c9011849e6ea37bd314714745684160b43aec9d3e35cbc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/0f"
+  },
+  {
+    "type": "inline",
+    "contents": "6ea1382030349b8c2977355d25e288cc4a90fa1c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz\", \"integrity\": \"sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==\", \"time\": 0, \"size\": 3698, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0ddf037cc184e6636002d121077ef6664a5e63d2db8ff7ab18504a14d8f7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "6eae92c8b054114812269d4d4e699f49b8435206\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz\", \"integrity\": \"sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==\", \"time\": 0, \"size\": 1658, \"metadata\": {\"url\": \"https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "44efd4af39ade1dfdcce9ecfa0c7e4957bbc572436566dbc478b40f051e4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/e5"
+  },
+  {
+    "type": "inline",
+    "contents": "6ee2e82d38dedcac927b1b393ca71b413aa2d426\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz\", \"integrity\": \"sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==\", \"time\": 0, \"size\": 4317, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8879c3cd1412a0890461590276aa13d0344cb4e09494a4b3d854a7c7660a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "6f7ade1f043c32336dc69d9f2d19f4efc48c4bcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.2.tgz\", \"integrity\": \"sha512-tgRBI3DdNwAJYE4BBZyZcz/HRRCvAsPkRvG1wvKc+41tBGMxPn/a87T/wikXAvyDypNQ9kaZwHbeZe+veHCGpA==\", \"time\": 0, \"size\": 9403, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d2ef70bec0e5f23b75881b47adf767e467de58d8ea7f8a20d67909ebb19",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "6fe327c6b56632ddbf3e19851fadbbf367aea089\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz\", \"integrity\": \"sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==\", \"time\": 0, \"size\": 7717, \"metadata\": {\"url\": \"https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cdce4f9e622ff2fcf32e02d90c84f3807c386967db2c5c8e7dba30432d72",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/7d"
+  },
+  {
+    "type": "inline",
+    "contents": "718212db38b77b768b012b5048fe41bf49440706\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz\", \"integrity\": \"sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==\", \"time\": 0, \"size\": 4040, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "14aff75696f9be146673ef7344452df537f1c8b1defdfa21e1291fe13056",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/e0"
+  },
+  {
+    "type": "inline",
+    "contents": "719ea523cc47269953393542ba84568bc220dac4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"integrity\": \"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\", \"time\": 0, \"size\": 35340, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1018bd2617c9bf8a0c2742b8d6db95d9995670b0e195cb06cfea9d61c009",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "71f3a98ea666ec2377ca1046c8e671b6b655e91a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-7.2.3.tgz\", \"integrity\": \"sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==\", \"time\": 0, \"size\": 15444, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-7.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6643cd3b9873fb99797c42a3d1709213997f83c9fee6a35449be578f8550",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/35"
+  },
+  {
+    "type": "inline",
+    "contents": "734461ac35b786308e653c9529b59d3d692eee87\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz\", \"integrity\": \"sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==\", \"time\": 0, \"size\": 24198, \"metadata\": {\"url\": \"https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8fbb72bfc03310bdf22a69288993688ad6ae76401cbe0e939548f16c39e9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/5f"
+  },
+  {
+    "type": "inline",
+    "contents": "734a50de2082856ed9462a0ebe2ec7501e7329c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz\", \"integrity\": \"sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==\", \"time\": 0, \"size\": 3995, \"metadata\": {\"url\": \"https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a4f6852cb94c03fa8ce44b745189d9a92e7203d91862561d398c174c17f6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/76"
+  },
+  {
+    "type": "inline",
+    "contents": "73f4699882736b7f82de2df569f10321fe968a70\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-1.4.0.tgz\", \"integrity\": \"sha512-3KrygnLb4ESsntxvxZA7RhJy2Ci47GdXWC8fl9HwPHNEOUDXUNv5M+x/TiBkXKjUz6jz/CRJOL2Ksgq8V3UdKw==\", \"time\": 0, \"size\": 394324, \"metadata\": {\"url\": \"https://registry.npmjs.org/harfbuzzjs/-/harfbuzzjs-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e30011afcadad5f3edc0b10e06a23b9935955ae86e3f8e1bba28bf518687",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/82"
+  },
+  {
+    "type": "inline",
+    "contents": "7419e2724e9ee1cd7621088956540a289dbb8f24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz\", \"integrity\": \"sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==\", \"time\": 0, \"size\": 4714799, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "95405c9d7b07f84e836a4ac8a606d202c2cef7f4298ea2d35bb055a559bc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/fa"
+  },
+  {
+    "type": "inline",
+    "contents": "744803cdf59d32f9ff912975ff5ad4b0bbbad6ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz\", \"integrity\": \"sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==\", \"time\": 0, \"size\": 4548281, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "900ffc772b39fdb0db98d192d9fc8348ad02480c90c6137f65cf4aaa16a6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/68/2b"
+  },
+  {
+    "type": "inline",
+    "contents": "74497c10510113dfed1bda33de4e8e586ac91a9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.27.0.tgz\", \"integrity\": \"sha512-ogDLsqIozHZwifPuN37OproAo0byX6t43/bP8GzeZWBWD6MOGExswFAx3up4NS/vvWBOg2u2PXomDt3rMmdQSg==\", \"time\": 0, \"size\": 31145737, \"metadata\": {\"url\": \"https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "070984860f88d4af9b9f0eaa7ac45ea7b3619d68724222eedf8f67377ee5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/78/46"
+  },
+  {
+    "type": "inline",
+    "contents": "746cfcc6f1103ed986e20c08a52516d4eca5c856\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz\", \"integrity\": \"sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==\", \"time\": 0, \"size\": 122046, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "381ff45406bd415e641f8f7b46c7755582a8ac3277b84e254e16e0d0c96e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/1b"
+  },
+  {
+    "type": "inline",
+    "contents": "754b79365bd940253ee09893a3910521d16d2ba0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz\", \"integrity\": \"sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==\", \"time\": 0, \"size\": 3050, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "54fa11340a90014f60928bc746a351e66ef492cb2eb854df179150e54023",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/97"
+  },
+  {
+    "type": "inline",
+    "contents": "7590d644854430ceb3d166d6a10b762f962fd1f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"integrity\": \"sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==\", \"time\": 0, \"size\": 1506, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0ff11cd5c49f9abb3792227a2806421aeb4003688278322146dd805a2cea",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/31"
+  },
+  {
+    "type": "inline",
+    "contents": "7601342bab692324fd36a738f67e43f5c2597815\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz\", \"integrity\": \"sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==\", \"time\": 0, \"size\": 4604214, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f17d1ee62a82a703303d534133f4c9ea05c735d91798f0b0334cc091efa8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/9a"
+  },
+  {
+    "type": "inline",
+    "contents": "76a2087195f6e2be63d635d180108c8eb1328b16\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz\", \"integrity\": \"sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==\", \"time\": 0, \"size\": 8148037, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aa5e19e5adc1a64c05c35622065f0029f5ddf10e01b2e0aed288552a7344",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/52"
+  },
+  {
+    "type": "inline",
+    "contents": "76bd603f9ebb6e959cb698231c7ce80803eea00f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz\", \"integrity\": \"sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==\", \"time\": 0, \"size\": 32244, \"metadata\": {\"url\": \"https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "11689d083aa9a928f678c3f811e4add6b20f36531f8db342f0a55f973075",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/c8"
+  },
+  {
+    "type": "inline",
+    "contents": "771aa069a772a9bc983257b7ef482884b053cef8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.1.tgz\", \"integrity\": \"sha512-SrC4l1kEIyv9ZXFaI/8LQqU2MyMmjczw7XXsWUQOTN4YXv0JyVgMNR3cI/wz0d2xsTfBdZ1N85Tdng+Ga1t0Sg==\", \"time\": 0, \"size\": 5399, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5ec8aaaafe0246afb3491ce2e089c0e55b96adb1b65dba7b4239039926bd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/a4"
+  },
+  {
+    "type": "inline",
+    "contents": "777b49d4888755eb60f8b7097c51cd373fcb1b4f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz\", \"integrity\": \"sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==\", \"time\": 0, \"size\": 3850, \"metadata\": {\"url\": \"https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99de9845e3f0e70ec6b3a9acdb822e8723f7ae74f870288c46afa8e4a9a4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/f1"
+  },
+  {
+    "type": "inline",
+    "contents": "77ec8e7fe9011c63863cf4f8832ffaecfdff32ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz\", \"integrity\": \"sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==\", \"time\": 0, \"size\": 368161, \"metadata\": {\"url\": \"https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e8c6353673e97bb8caf0ed714d7e61fc910bdb82a4c0c695c5edf36fcbb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/65"
+  },
+  {
+    "type": "inline",
+    "contents": "786aa2884a39f6ee594c2af39b0a45da145cc069\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz\", \"integrity\": \"sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==\", \"time\": 0, \"size\": 9622, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "58cbe482acb2f4e2b961dfc2cdd7143d35b8f091f18831fcdcf72dc7cd4f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/01"
+  },
+  {
+    "type": "inline",
+    "contents": "78b204838f9617c88a5e4c511289ce095c267c31\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz\", \"integrity\": \"sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==\", \"time\": 0, \"size\": 21605, \"metadata\": {\"url\": \"https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9dcbeecced5fe214b63e198a487274d9c040872c5952986cf0c84ad0e4dc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/b0"
+  },
+  {
+    "type": "inline",
+    "contents": "78c9cd343490083fb42d5e91ec374c7eb56f8c2e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz\", \"integrity\": \"sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==\", \"time\": 0, \"size\": 1840059, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d0780dd490a460fa25c557b57479712de67ef5003d491cbd13dd017c6867",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/85"
+  },
+  {
+    "type": "inline",
+    "contents": "78cc8fef26188700e016de57bba4c14adec73b06\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz\", \"integrity\": \"sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==\", \"time\": 0, \"size\": 10928, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ffc433a5a1f07061649bb749ee6a7d6a5f095ce85c8957cca4006aa4a0fd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "79a0adfd78390caa60cab0884f72e7d35909496a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz\", \"integrity\": \"sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==\", \"time\": 0, \"size\": 6135, \"metadata\": {\"url\": \"https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c34658b94967a2498f75a66b8ff6c87e60d36be229f7c9912de8f9a258b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/f6"
+  },
+  {
+    "type": "inline",
+    "contents": "79afd209a6bf2a1f634ae5d489034652e11dc127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/etag/-/etag-1.8.1.tgz\", \"integrity\": \"sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==\", \"time\": 0, \"size\": 4386, \"metadata\": {\"url\": \"https://registry.npmjs.org/etag/-/etag-1.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1314e79200fca71af4663702ee1e676113e408ca8a468a396de5ab6d5d2b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ae"
+  },
+  {
+    "type": "inline",
+    "contents": "79b7f3e5bf9786610bd24f8cc657087989649ed5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/butterchurn/-/butterchurn-2.6.7.tgz\", \"integrity\": \"sha512-BJiRA8L0L2+84uoG2SSfkp0kclBuN+vQKf217pK7pMlwEO2ZEg3MtO2/o+l8Qpr8Nbejg8tmL1ZHD1jmhiaaqg==\", \"time\": 0, \"size\": 248741, \"metadata\": {\"url\": \"https://registry.npmjs.org/butterchurn/-/butterchurn-2.6.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d50c77d1dab5e2f7143fccaeb712d8e55c6c5d9d33910a2a53ccfb62cf1a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/62"
+  },
+  {
+    "type": "inline",
+    "contents": "7a0b050ef48a4b39f54a6a1a39f136bff1dd716c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz\", \"integrity\": \"sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==\", \"time\": 0, \"size\": 1813, \"metadata\": {\"url\": \"https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "be0c97db34b3080241d9ad24c036132080b59ade84de3d89f93dcff014f7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "7a60b435d0a95521e045de20ac3c205666e1323d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz\", \"integrity\": \"sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==\", \"time\": 0, \"size\": 189859, \"metadata\": {\"url\": \"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8044311430e6c8d361dbbfc597f84b6c800d73c1400e5565ab6a2a81df1e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/86"
+  },
+  {
+    "type": "inline",
+    "contents": "7a7d2a6c34c41eef16eecb951ad101fa5cfa3872\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz\", \"integrity\": \"sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==\", \"time\": 0, \"size\": 13153, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8077a81b8c8ed88fe308628e580d981cf1715a3446f8e5bad9c38136f3f6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f6/2f"
+  },
+  {
+    "type": "inline",
+    "contents": "7a96398bcb23418943af4f6b2a22a767399e981b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"integrity\": \"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==\", \"time\": 0, \"size\": 13449, \"metadata\": {\"url\": \"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e25f670d26bc26d1cb236efef449fc8718223fd484c4107ba797934cb10c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/1f"
+  },
+  {
+    "type": "inline",
+    "contents": "7ab3fcd09462b6a49ab9dba5424dbebd75fe4bac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz\", \"integrity\": \"sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==\", \"time\": 0, \"size\": 3584504, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "51d04c63366ef49a3cc10481adc55214912d7e39cc6ce6b3a6e61a9f9ae7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/97/47"
+  },
+  {
+    "type": "inline",
+    "contents": "7ab8c6d7389da2a21db177b4f8fbbf36bfcf8607\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz\", \"integrity\": \"sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==\", \"time\": 0, \"size\": 86174, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "63f0a39b900c32defdf3827f12176318e5088b9aa684f0397538330d481a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/8e"
+  },
+  {
+    "type": "inline",
+    "contents": "7b6304c191afbe7c988539a175efe418a79401b5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz\", \"integrity\": \"sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==\", \"time\": 0, \"size\": 6269, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bbe3eda7761514504e4ff96218f9dbe5742776b7f39dab08f8ecaa730afb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "7bc8420b7ea264167b38c011dee0e1bbc2e0104b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz\", \"integrity\": \"sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==\", \"time\": 0, \"size\": 4210, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "06d524e01daf833434c629b41e09c628d85ed4456c51765b83a53c8d0092",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/a0"
+  },
+  {
+    "type": "inline",
+    "contents": "7bf5da0cfdf54cb0eae633b3ff67e4d247e6140e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/diff/-/diff-4.0.4.tgz\", \"integrity\": \"sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==\", \"time\": 0, \"size\": 98055, \"metadata\": {\"url\": \"https://registry.npmjs.org/diff/-/diff-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d2506402d004fdf3a732e7183dfd2d07499e95849b4eef740d74f3ad09b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/66"
+  },
+  {
+    "type": "inline",
+    "contents": "7c0597f37d053ffc3dff094886561883abb83825\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz\", \"integrity\": \"sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==\", \"time\": 0, \"size\": 193826, \"metadata\": {\"url\": \"https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9a87b1efb68b24243d2fae8fa753a9adea60e403d24a37f028895395a46c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f9/a6"
+  },
+  {
+    "type": "inline",
+    "contents": "7c481850942515ac4feb396737ad2ae9c857fd60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz\", \"integrity\": \"sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==\", \"time\": 0, \"size\": 2063, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "314b6515b77b62a66c8a2ac140ac4a6926135c5866837fddded37acb1acf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/1d"
+  },
+  {
+    "type": "inline",
+    "contents": "7c57ead6e2d98083adf099564d4f0adaf8fd7cd0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz\", \"integrity\": \"sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==\", \"time\": 0, \"size\": 8111, \"metadata\": {\"url\": \"https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99a8ac8d9fe0f2ad4894aa959445cb3e3c9b6cd11883956769678b196ced",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/b5"
+  },
+  {
+    "type": "inline",
+    "contents": "7c5a470eec87ae25eeae32ce8dadf8bc8a269742\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cors/-/cors-2.8.6.tgz\", \"integrity\": \"sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==\", \"time\": 0, \"size\": 6456, \"metadata\": {\"url\": \"https://registry.npmjs.org/cors/-/cors-2.8.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6a633a06b3cb7ea0d89ae5cd29607f92c3494ddbcd5484955426bed24e3f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/a2"
+  },
+  {
+    "type": "inline",
+    "contents": "7ca1aaff10735a730d04e84a69646d25e5c28145\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"integrity\": \"sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==\", \"time\": 0, \"size\": 26992, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "53e431efe5d40277f768cec075f9e7f618f2296715654a7b953121078b1e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/14"
+  },
+  {
+    "type": "inline",
+    "contents": "7cfe84f78520262599c8e5d269394a49cb17e870\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.8.5.tgz\", \"integrity\": \"sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==\", \"time\": 0, \"size\": 29399, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.8.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b35aa26fd53c39287596a93949ad69fc2a94fe33b5998605d9f1507cca37",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/bd"
+  },
+  {
+    "type": "inline",
+    "contents": "7d101daa651535178f5ab04f15e94a45edee5573\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz\", \"integrity\": \"sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==\", \"time\": 0, \"size\": 4682, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "509548aa676e42183cf477528449eb905e013a4156b207b848aba8c18fe5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "7d53c7e3cbd4adf5e51635defdbc8f9e405450f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz\", \"integrity\": \"sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==\", \"time\": 0, \"size\": 2956, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "36d0128d01adb48aa1d92f1d6192f3097f8e4e78ab93bc139f1cd6f7b7af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/5f"
+  },
+  {
+    "type": "inline",
+    "contents": "7d9bf54f85d288c05ada8ee927637cdd97d85b83\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz\", \"integrity\": \"sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==\", \"time\": 0, \"size\": 226417, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3cb5e3884c93658fc768ac1c691ac0b3d9f2252e8c1918dc0066142f53c5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/e1"
+  },
+  {
+    "type": "inline",
+    "contents": "7da4de2fce093132ffb787ab7965dca96a6ff66e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz\", \"integrity\": \"sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==\", \"time\": 0, \"size\": 1579083, \"metadata\": {\"url\": \"https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5767f914aa664f32503df614481bac973784e2bcd2b8af02e84faabe168d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "7e19e69fdeae172dc90a329b15b247efabeb25eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz\", \"integrity\": \"sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==\", \"time\": 0, \"size\": 4257714, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "72860007f0c6c1d7eb5d7bb780bf50c8c73bc71ae8251c31af9f255b0334",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/c4"
+  },
+  {
+    "type": "inline",
+    "contents": "7e2a22a1dc1bde1f24ae9dc32cb4b615355a77f2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"integrity\": \"sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==\", \"time\": 0, \"size\": 217611, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f3e26b8c50880e9350336dbc39f707c1ba35f75dbadc9598933ea528a990",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "7e54b6ac0d3d5a74bdfa2fef6993c130903eaf48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz\", \"integrity\": \"sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==\", \"time\": 0, \"size\": 8504, \"metadata\": {\"url\": \"https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9c312bb275081a100a2f4ee0049329b3d966da3c1f0fb4e9e828e10b1be5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/63"
+  },
+  {
+    "type": "inline",
+    "contents": "7e6f2153f8e495a4f4cc9ed9e9549428eb59a1e4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz\", \"integrity\": \"sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==\", \"time\": 0, \"size\": 4454076, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bcf7142ef4bce1ab46690c5f1fc503dec22ca6053d5c4db80e91337e3716",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/37"
+  },
+  {
+    "type": "inline",
+    "contents": "7e85b43a299e96c398fff49902579090d4a091c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz\", \"integrity\": \"sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==\", \"time\": 0, \"size\": 37491, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1721997879349b4ff1de0ef1ec1b243b3889873a984dc071e5d86fe19b24",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/d7"
+  },
+  {
+    "type": "inline",
+    "contents": "7eb3d529f70fb5761285f59fff099ad84aa8a7a2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz\", \"integrity\": \"sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==\", \"time\": 0, \"size\": 4222, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "351637575c77c096efa5bc5812c6ef369fb1e5e92862cafc196224b707a6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/55"
+  },
+  {
+    "type": "inline",
+    "contents": "7edebfcea27419818fcecc98233551e2bf37b07f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz\", \"integrity\": \"sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==\", \"time\": 0, \"size\": 3860279, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7769abd49ef04e280175cba38fc1b174e6031761cfc8178127bcc4e3aab",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "80651016cac75d59625ec270d9f2e78649974122\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz\", \"integrity\": \"sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==\", \"time\": 0, \"size\": 3464, \"metadata\": {\"url\": \"https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b0d7ba846044fe5a2fa1d8341f6a7f56438ae9161709a548cbda5f1fd7c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/2f"
+  },
+  {
+    "type": "inline",
+    "contents": "81a38c6a4ddacc402fea331e80c1bb7b117f6b57\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz\", \"integrity\": \"sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==\", \"time\": 0, \"size\": 17697, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "480c4f5b3db937b37de1e61b446390090723241f5a309c8fd253cb63a29e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/7b"
+  },
+  {
+    "type": "inline",
+    "contents": "81af1465f1b0b3897785ac12680c185a096de064\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.1.tgz\", \"integrity\": \"sha512-QlKE7qn5qMnIGVGhXQlvYedvLtNJ9z0dmit5w8vPb8tKzW4Spk6M7N2kruprrDA8GBwHfeR5wmF+njfUm34qxg==\", \"time\": 0, \"size\": 5439, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7a43f1783c6b0f1270e3e4ec1896a146195958da8494ed2adec5896a56fb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/24"
+  },
+  {
+    "type": "inline",
+    "contents": "823d5419d195e9c85890c7de0e9c05e270bc71c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz\", \"integrity\": \"sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==\", \"time\": 0, \"size\": 6681, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3dc9cfa8ed72b5329a97236a6f169606a8344ca21f60a8677b3ad62c5382",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/82"
+  },
+  {
+    "type": "inline",
+    "contents": "82b1c283797f12a5dd2f32bba4c14abaca8d1672\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz\", \"integrity\": \"sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==\", \"time\": 0, \"size\": 27916, \"metadata\": {\"url\": \"https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d577b68c4b6a2d5808da853dbe76ac78f303a91c9d61617dea54318bada4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "8436a26012277ae2f7d8b6fad4b007460136d463\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz\", \"integrity\": \"sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==\", \"time\": 0, \"size\": 65249, \"metadata\": {\"url\": \"https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "45c37cb00592b74b937a4d32671fb0dc1cb47b82c00fbe2d656ff184b1b7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/66"
+  },
+  {
+    "type": "inline",
+    "contents": "8566565da22590dcf8a9c6efd366a38bd5c637b0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz\", \"integrity\": \"sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==\", \"time\": 0, \"size\": 4741809, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f8cd5ee70f0914f9a714d5d1be53a5150ef94ac0c297ec6f200e1cb1a162",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/40"
+  },
+  {
+    "type": "inline",
+    "contents": "871e877fa9d3844ea0f57051afa6b69bddfdc4d2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz\", \"integrity\": \"sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==\", \"time\": 0, \"size\": 2119, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a5aed308943a348b895cd9d32191cf63d204e13917a9b6b1e402c36df55e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "874a9b5e899290ea79c643a3ef26c9e1ccbc68a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"integrity\": \"sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==\", \"time\": 0, \"size\": 3810, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "40122c5cee651bb244e17448855ba7beb1ffc43ef9d58d74671626ebedb0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/e0"
+  },
+  {
+    "type": "inline",
+    "contents": "876057c381a98f5efc0e9a21de22a29121b4c1d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz\", \"integrity\": \"sha512-nHK+/HHC+D0ogAHUxomgoSTdjImb6fmNNVTKmf0tyu4eDL1DqPKIHc+i+UL8+b0RnAu8224qo8F2tCVnaT0A3w==\", \"time\": 0, \"size\": 26308476, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ca5cdd649eaf419733d0cf3b387f16e6d11058bc62c98986c77e91a6f844",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e2/69"
+  },
+  {
+    "type": "inline",
+    "contents": "87afc6a434914a3c08bbf43750ce361a740d0f1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz\", \"integrity\": \"sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==\", \"time\": 0, \"size\": 106155, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "03304cebdf6fcae2bd2589d824ca3e6a7f5611ca7a1377cb66bb1be62baf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/68/5a"
+  },
+  {
+    "type": "inline",
+    "contents": "87cdd5abe05c93b12f8729b9963390c8a6c07d75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.1.tgz\", \"integrity\": \"sha512-7K7eo1gruOgAsnbK+GCV23AUVUI0cL1bTig8HaPneoFMVbig7vddk8jNLKBWO8TXVbG7TuHdnDN4F98vdtwh5Q==\", \"time\": 0, \"size\": 5452, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aa5316e24ecbac59187689c6409623f038a261e5bca66194d78ff9d465e5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/43"
+  },
+  {
+    "type": "inline",
+    "contents": "87e70597c51435ababdc0a9a8e3f62f2b371b0cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.2.tgz\", \"integrity\": \"sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==\", \"time\": 0, \"size\": 14370, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d433d1bc41fc7ff16881313bdf56bb191976161bf9e87789d53dc5de90a7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/a1"
+  },
+  {
+    "type": "inline",
+    "contents": "87fc04cbb3cb3fb3dd0f546a5ce05a1c067b7edd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz\", \"integrity\": \"sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==\", \"time\": 0, \"size\": 9135, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9e2290e824a23c203f0af407bf3dc00e9abcbbfe9fdd3ad1a8ec8204d580",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/89"
+  },
+  {
+    "type": "inline",
+    "contents": "88019322b7410bff463d69bd2943b911ee488037\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz\", \"integrity\": \"sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==\", \"time\": 0, \"size\": 5349, \"metadata\": {\"url\": \"https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9d4cef4c63c5862a4eeb26c79412345482216b7ee921a7b33336a121b865",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "89b4f218496c9e542c99509e98700561534c4d2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz\", \"integrity\": \"sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==\", \"time\": 0, \"size\": 24507, \"metadata\": {\"url\": \"https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "362a2eab8a2da3e5f7a079dc2d34b04f66f69faa08be6849d222f6fc66fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/05"
+  },
+  {
+    "type": "inline",
+    "contents": "8a0b4856a941a8475c6a90273fa2f933e04227d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz\", \"integrity\": \"sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==\", \"time\": 0, \"size\": 246183, \"metadata\": {\"url\": \"https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "86dfc11f0405dc0f65729a6574e67599a22a6640c389559f751171508c89",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/04"
+  },
+  {
+    "type": "inline",
+    "contents": "8a119350271e891d633214359d1d064da20253da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz\", \"integrity\": \"sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==\", \"time\": 0, \"size\": 1772997, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ae2fa425de2ceed0b49865808de4f5599be696e1aea56731405ef85cf970",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/94"
+  },
+  {
+    "type": "inline",
+    "contents": "8b57e40e4c73c2ea63928951101ed22315a9c4d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz\", \"integrity\": \"sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==\", \"time\": 0, \"size\": 2909, \"metadata\": {\"url\": \"https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "74fd9e0088cbe506aa447b73813ad76312f2f58c8bc4c03978dfc3eebb0c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/e6"
+  },
+  {
+    "type": "inline",
+    "contents": "8b6f3efba809ed09d490cd798f80ec3714ca7e3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz\", \"integrity\": \"sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==\", \"time\": 0, \"size\": 3856640, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "27e03d7f038ad0bdc4b5f55a389fbb03eab390233a8644cd0b86f5a9cfd6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/9f"
+  },
+  {
+    "type": "inline",
+    "contents": "8c084c7ae5707b44c8c6538a46398ea4595e9711\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz\", \"integrity\": \"sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==\", \"time\": 0, \"size\": 7677, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4823d25a60802304e58edaa16fb53111bb559d3aa89a535a31db203d673c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/e2"
+  },
+  {
+    "type": "inline",
+    "contents": "8c679b8e5a4a9080f524580da8e421f40fdcd66c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz\", \"integrity\": \"sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==\", \"time\": 0, \"size\": 14181, \"metadata\": {\"url\": \"https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "55d987428449c4f5259e6ba3f3316d8e43a5b3ccb489600c612664ce2adf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/21"
+  },
+  {
+    "type": "inline",
+    "contents": "8d5a74272c5e145f705c5c3ca8b70d7d074b4485\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz\", \"integrity\": \"sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==\", \"time\": 0, \"size\": 6448, \"metadata\": {\"url\": \"https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "25f2bae3018038cdcb0f2c1605be483cb40a8934fffd0c65ca7cd3c46618",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/81"
+  },
+  {
+    "type": "inline",
+    "contents": "8d78cc2b79c3a291db88aa9238628bdea6bd8184\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz\", \"integrity\": \"sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==\", \"time\": 0, \"size\": 11024, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9952792441cb5648ebe82691d9ceeb8d1cca1dd8853a3445083ccaffe859",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/7e"
+  },
+  {
+    "type": "inline",
+    "contents": "8da44e440337efab7d64418bae4affad5191b6d9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz\", \"integrity\": \"sha512-pHlzmZx2OlHfyQ0yRlT5UL4mGokz947DthZuYefN1OleVqOkHpWBG+2JQwqoNq6bmzMne92zbH32rhcJUEYSjA==\", \"time\": 0, \"size\": 11644, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "db7c78f523f3434ff1bb2c908b59bb818550826ece00354a4f1f90c1b567",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/4f"
+  },
+  {
+    "type": "inline",
+    "contents": "8dd3a1e06b8d5b384fa2fb3e4c4a0ae284a01e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz\", \"integrity\": \"sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==\", \"time\": 0, \"size\": 6792, \"metadata\": {\"url\": \"https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "61f663617acb9723f542888a3013dc12d0aa76452d33433d07e6d91f698f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/bb"
+  },
+  {
+    "type": "inline",
+    "contents": "8f09140c0717c44c54cd871e0dae3ff688d9944a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shx/-/shx-0.3.4.tgz\", \"integrity\": \"sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==\", \"time\": 0, \"size\": 11440, \"metadata\": {\"url\": \"https://registry.npmjs.org/shx/-/shx-0.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a206b067babc397afe5ed783197bfc607773ad05c1ab43ab83347aebd5fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/67"
+  },
+  {
+    "type": "inline",
+    "contents": "8f6e73db592dab7f7d5dd97b4476d118f51c5165\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz\", \"integrity\": \"sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==\", \"time\": 0, \"size\": 43036, \"metadata\": {\"url\": \"https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "89da6b211298b7879bc215733493ff45a7c1f8d6c7f1b6f25a54bb08be3c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/40"
+  },
+  {
+    "type": "inline",
+    "contents": "904b5da9bec79734343c1539cacb5322d1119c6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unicode-emoji/-/unicode-emoji-2.8.0.tgz\", \"integrity\": \"sha512-Mi4klQ1mrbUzNROyB/cu2MqaHIJTTrQwcYF0G1aW66snWaKHosn9lEHfyI8mw/SUSRr5yQ5dExqTD3+FFIh6tw==\", \"time\": 0, \"size\": 67699, \"metadata\": {\"url\": \"https://registry.npmjs.org/unicode-emoji/-/unicode-emoji-2.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4a2caf50579c439bcf3f254a09a2f23f7f26a3e82b10db217e55b9c725f6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "90779d54dc8a9da924890448a7eb7338aa528ce7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz\", \"integrity\": \"sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==\", \"time\": 0, \"size\": 7605, \"metadata\": {\"url\": \"https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "aec3640eba8ceb736b35317cfc0cf8943e398ef1f2c101c6e00324ada1d1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/03"
+  },
+  {
+    "type": "inline",
+    "contents": "90933b1926f6c04fba0ef5802b503bdeec2b46d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz\", \"integrity\": \"sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==\", \"time\": 0, \"size\": 4434, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ed036cc76081b7f1bfb3aa59d491eb3b3602c9381ec8d81435ceecf56b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/15"
+  },
+  {
+    "type": "inline",
+    "contents": "90fc7ecf7274ddf541e452c1f9b936bc17df7238\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"integrity\": \"sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==\", \"time\": 0, \"size\": 7603, \"metadata\": {\"url\": \"https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f7a0679c52edb767a55df3d93f847884d7909cf16c2f148ba11d53e9f7c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "91cf859a57821d613590397910a610fa21e3daec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"integrity\": \"sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e41f2c2713684e6e809753f5b2a642d98d5d19a1c17c03d0788531cebf88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/7f"
+  },
+  {
+    "type": "inline",
+    "contents": "92618261d9443d99f81e76d58dd98992ebca3a72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.1.tgz\", \"integrity\": \"sha512-Y3DW1jlSlCNCyMGHP3+3qBNNPS83wuFz4RTYGjZtvRRTCRh7apZme9XRWMq1rN5mJ2Cr7fKocA2/5Bs13KgN6Q==\", \"time\": 0, \"size\": 4729, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fcf3be6dbc88ef4767093b6fe996b4baeeafc373b182fda380d84ab51f50",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/1a"
+  },
+  {
+    "type": "inline",
+    "contents": "92750b6dec0bc209943057650528550ae19e434b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz\", \"integrity\": \"sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==\", \"time\": 0, \"size\": 6989716, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1c698295cf7c3105dfe85f5236d8f1ecfa1639fc5e5cdd7bce62f9e96013",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/86"
+  },
+  {
+    "type": "inline",
+    "contents": "92f29161aee39153a118a7e3834e60418c02b1e0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz\", \"integrity\": \"sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==\", \"time\": 0, \"size\": 11035, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "075924ce1774afb5234a7c898fbc898043ba1afd3e2eeb32acc431b2c7a1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "93592cbe8a4761abd01509ced69eafee585b7815\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz\", \"integrity\": \"sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==\", \"time\": 0, \"size\": 3846393, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4cd24eaab29f43ffd2f293e4a426b2777cf73a8ad19ac7d0bb78b38552a9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/2c"
+  },
+  {
+    "type": "inline",
+    "contents": "93a155478d5243faeda776a11ebc832145ffee14\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"integrity\": \"sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==\", \"time\": 0, \"size\": 4429, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea55e4e584609a1f0ba14a730391c0b04141931864f08f4172886bec44f9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "9471ff40aac527c1645fc548a36de3d6b6f8a940\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz\", \"integrity\": \"sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==\", \"time\": 0, \"size\": 2524, \"metadata\": {\"url\": \"https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f63f8949d6f7b077129134f7ef4f10c7cb6dc5c8a34e531d4277624c273f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/93"
+  },
+  {
+    "type": "inline",
+    "contents": "94962f5d960086f29ea8c9f7a0957b4a01523406\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/unicode-emoji-picker/-/unicode-emoji-picker-2.0.1.tgz\", \"integrity\": \"sha512-zXdYB7E+jj0NUxLh1nBkMjovIzPZI+JE7zQAh5h3v2IybWs00HsAkVMU34/koa6LqYiWqc4+rsakyJna3eTsbw==\", \"time\": 0, \"size\": 12168, \"metadata\": {\"url\": \"https://registry.npmjs.org/unicode-emoji-picker/-/unicode-emoji-picker-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05bfdb33b940d9a04e308150b54d776ff02ce2e8acf4354ca517ff81c0d5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/84/b5"
+  },
+  {
+    "type": "inline",
+    "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
+  },
+  {
+    "type": "inline",
+    "contents": "94f293228d46a4eae41b52d727755689878afd6f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz\", \"integrity\": \"sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==\", \"time\": 0, \"size\": 2144, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/number/-/number-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7b1bca9f5e6144d5380be3f3517bf56d265fa348ba908fe9a95abc2ff535",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/e4"
+  },
+  {
+    "type": "inline",
+    "contents": "9600a6ae4367ca2ed440f1512e4fc356589730a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.22.0.tgz\", \"integrity\": \"sha512-Z3NHqa1zTjZyfcd3qJcpIwqiSG7QlR3YkYPFAIoMsPw3hId0AoHtlG4SRueJzymCsF9Rqein3NzUn3qT+aqUBw==\", \"time\": 0, \"size\": 11709, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/inspector-cli/-/inspector-cli-0.22.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1a995dab5a0cc1b15b31745aa7f7b66e3b23821fa495de4bdafad9019299",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/13"
+  },
+  {
+    "type": "inline",
+    "contents": "96ae4f51b908a058ca4f4484c55d17e2a363f396\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz\", \"integrity\": \"sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==\", \"time\": 0, \"size\": 8168901, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6b397401561a9e05e40c951226a7dac43113ed9afa1e35630d1fb6a0e415",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/45"
+  },
+  {
+    "type": "inline",
+    "contents": "96cff7dd7a014649fae7ee3a3e111a4ccf17b555\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz\", \"integrity\": \"sha512-J48WIl+6YDYTFPhWXUBQk+u7+AKVUqTdvrZOQyPYCGuQMgHrYzgWrI5+HeEifUgXJ5rMIWWP3qytp7KhVVqpDQ==\", \"time\": 0, \"size\": 28242, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d9007cb087416e993906d865374c3da6aee0324af4570cdb8fe3dd22b395",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/5c"
+  },
+  {
+    "type": "inline",
+    "contents": "98ccaee5f8ce2817a09b90e28ebe806a75f4a606\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"integrity\": \"sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==\", \"time\": 0, \"size\": 2868, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d04e75208dec117f72a95a5989f81fac7565a530fd22f70ea5e3abc377c3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/62"
+  },
+  {
+    "type": "inline",
+    "contents": "98d8c0a43e347b6d69508724d92e0271b5a6411e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz\", \"integrity\": \"sha512-6wc7ck65ctA75Hq7FYHTtTvGnYs6msgdxiSUICQ+A01nVOWg6rqouZB8IdyteRlfpYYiFovkf67dIeOgWIUzTA==\", \"time\": 0, \"size\": 162808, \"metadata\": {\"url\": \"https://registry.npmjs.org/@breezystack/lamejs/-/lamejs-1.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b66881753b65b845a42ad90000730ac8bbe43a104becd9577ff890546547",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "98f30b1c3073008956461f29d2ea2f3e6a226e2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz\", \"integrity\": \"sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==\", \"time\": 0, \"size\": 10693, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "25a4d3ecb0818d3e6dd60b9f05612cc6efb08f88e7b765eaaebb33fc0f85",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "99f070baeb3c44344b1dbe79145f835215ea0262\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz\", \"integrity\": \"sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==\", \"time\": 0, \"size\": 1679, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "51bdb2a4f8e62d44922a0ff258d8cc3adf38d06f4dbc590dcaeb32cd130b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/3d"
+  },
+  {
+    "type": "inline",
+    "contents": "9a2092c66416a6b34ca232046989392af6eb0f96\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz\", \"integrity\": \"sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==\", \"time\": 0, \"size\": 4372, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b90e45414a9e52cdf1e4a96698065357795b9400d7af079b0a75ee8fd76d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/6a"
+  },
+  {
+    "type": "inline",
+    "contents": "9ad8ab1c2c74f50c0f247db8d89185e350e6c71e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz\", \"integrity\": \"sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==\", \"time\": 0, \"size\": 75331, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "10e3aa8ae9c69758e2cf6b5023b56eb7b89faf304748d6c5ee62ee7a8141",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/30"
+  },
+  {
+    "type": "inline",
+    "contents": "9b081a9be63cf4abe9180e060516b93eb7a8d95e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"integrity\": \"sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==\", \"time\": 0, \"size\": 7907, \"metadata\": {\"url\": \"https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f36d855e73b72c900bef7ba44a2a553de3d77b218493b4ddb6ae6fce516",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/b7"
+  },
+  {
+    "type": "inline",
+    "contents": "9b1438b77a5162a10a7a830d56bd181cfeb21a03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz\", \"integrity\": \"sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==\", \"time\": 0, \"size\": 33879, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fa8761e8d61cc8be2919af736040c7049784899abd5a9dd58738d6dc9833",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/c7"
+  },
+  {
+    "type": "inline",
+    "contents": "9b2081819165717146341814be28a0fe06d37b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ink/-/ink-5.2.1.tgz\", \"integrity\": \"sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==\", \"time\": 0, \"size\": 70903, \"metadata\": {\"url\": \"https://registry.npmjs.org/ink/-/ink-5.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "53693d30fe29db2f8951c92d1283adcd184209b3424ac2bbf44eb415dd26",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/55/af"
+  },
+  {
+    "type": "inline",
+    "contents": "9b7c20c325820550edd1f929ad422f5cd227d017\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz\", \"integrity\": \"sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==\", \"time\": 0, \"size\": 2013, \"metadata\": {\"url\": \"https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4668fc5547bef87618e39882539fb8ca808e798939f2b4b8bdf5c11b82d2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f7/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "9c8a850b9eef6b34ef0ed7687dee7ce92ac997b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"integrity\": \"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==\", \"time\": 0, \"size\": 2967, \"metadata\": {\"url\": \"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bd8af8e4938b9fee217abddb09ce52db330434e323c828aeabe5bd909ae7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/a7"
+  },
+  {
+    "type": "inline",
+    "contents": "9cdd8ec05a5454c7c8f47f43d37630dffb0a723d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz\", \"integrity\": \"sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==\", \"time\": 0, \"size\": 23296, \"metadata\": {\"url\": \"https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "63f826de043a03c63c0cd37147c1ea0cf19142e201d054141e60535a2952",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "9ce192feadb052cd958f6def6f6c11717fe02c42\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-13.1.0.tgz\", \"integrity\": \"sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==\", \"time\": 0, \"size\": 51398, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-13.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "75977735688016c583178c5e6055c5d811bf783ee09da9fe4b1137891c98",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/48"
+  },
+  {
+    "type": "inline",
+    "contents": "9d08b625a8cac763c70f8ff867d46bc4f7136615\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz\", \"integrity\": \"sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==\", \"time\": 0, \"size\": 71870, \"metadata\": {\"url\": \"https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b64b8850eb2447599170705e8746db80f9d81d977add5f2d41ff4731bc43",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/08"
+  },
+  {
+    "type": "inline",
+    "contents": "9d330cb624dbdd91e5af52fd961065fb5272cfda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.1.tgz\", \"integrity\": \"sha512-GYrKqD//9nHJ2r80uXqbDMzRnFpGzbaEQRTSGaO/SH7DvXWFMow8evkOdjQ7PCQO07jNjJo75+A85Jwu3Ov3AA==\", \"time\": 0, \"size\": 2584, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "77d4f7fe7ab30789f15e1b9b29d207343973179e20e88796177cc233e72b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "9d7728f73eeae512e49dda6274b2417ade127916\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz\", \"integrity\": \"sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==\", \"time\": 0, \"size\": 649650, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f6dae96ac72c3518cd54e6a1cf5ac3bc59c80cfdc62d65a101a0cb67304a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/ae"
+  },
+  {
+    "type": "inline",
+    "contents": "9dd1fa7d50ebcbcc71c727f65a2cd8bf32ae578e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz\", \"integrity\": \"sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==\", \"time\": 0, \"size\": 148161, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "efb4d294579062007db7619c140cd294e6f74b2f8721482d02d43903d575",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/20"
+  },
+  {
+    "type": "inline",
+    "contents": "9dd58a2436a36b4e793ec4b3f0357d831a3c1c8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz\", \"integrity\": \"sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==\", \"time\": 0, \"size\": 6820, \"metadata\": {\"url\": \"https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "327b2a42aca453f78ed2ad5e910699acc509dd2650a3e8b17c96ae024f33",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/f5"
+  },
+  {
+    "type": "inline",
+    "contents": "9dd636dc923f3757f1cbfbaf097ddb4f89ab2cee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz\", \"integrity\": \"sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==\", \"time\": 0, \"size\": 183284, \"metadata\": {\"url\": \"https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "07b197ee601d38d0485992fb1650a44f39c72d64ad23cc371ed3669fffa9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/4c"
+  },
+  {
+    "type": "inline",
+    "contents": "9ecdce847d014f9ef94bbe90aca387b2ade7341a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz\", \"integrity\": \"sha512-am22pX2aBqznqq1eMyIj/bZ++riF3Lk6ct7cbv+gQK0csFhr+d8O0RkOi2FF2qSgFgANbqNkIZ0/PxlnW2pLFg==\", \"time\": 0, \"size\": 24324611, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ffe86a86cf92e1f652da85d8bb544a15823242f9d5aa082fb61592a5850b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "9fd9b1a1e4afa55f7b692f577e576375785ac057\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz\", \"integrity\": \"sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g==\", \"time\": 0, \"size\": 18140, \"metadata\": {\"url\": \"https://registry.npmjs.org/global-agent/-/global-agent-4.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "22b4e88ee8af6ab670a0fb7c90506e6d2ec3a42ec6f6096fc09fd9c4cc79",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "a0116999d1205eb9f40e9902ad9072fc2e495dd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz\", \"integrity\": \"sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==\", \"time\": 0, \"size\": 7887, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "33ebb16ca229c4cbdad65ac0947fbeb3765befe98674faa960578851637f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/10"
+  },
+  {
+    "type": "inline",
+    "contents": "a02c7f7f96264d51f3a4c36eaea938e67f610c0f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz\", \"integrity\": \"sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==\", \"time\": 0, \"size\": 67265, \"metadata\": {\"url\": \"https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "73d068fcc2a338a96356ba2e79c77e96053f6000953a603fea6643d4c626",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "a07b8e2c0c3d83e5fade755d2582efe948b9da49\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz\", \"integrity\": \"sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==\", \"time\": 0, \"size\": 19365, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f8fed4ce578c4246c96e0bab20be68d2ee7a528180eec25cf4ec81618f4d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3e/eb"
+  },
+  {
+    "type": "inline",
+    "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "a106c94228b82be8242fb5256fc30e09a2a1e9c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz\", \"integrity\": \"sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==\", \"time\": 0, \"size\": 31722, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0a0ad2d0308b6807a70e488194992de068d68b749910eee4847c38629984",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cc/25"
+  },
+  {
+    "type": "inline",
+    "contents": "a143b46f6529a68f06202ff5eda3b3cc234612d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz\", \"integrity\": \"sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==\", \"time\": 0, \"size\": 3245, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ea2d2113e843fceb2377c0e02edca3aa702bfd561623620b3f7db2564d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/8e"
+  },
+  {
+    "type": "inline",
+    "contents": "a17c43dc7b56a442de20b3d29d4c621d2b5471c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz\", \"integrity\": \"sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==\", \"time\": 0, \"size\": 33636, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "97ff179f2c0848443c394cef48b13c3c0972db4d8737a8e03fbf20f262d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "a26a153237ae1eb383877e6a8aeb8e1059b3f821\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz\", \"integrity\": \"sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==\", \"time\": 0, \"size\": 7067543, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99f60f7afa8a44a29bb2417e96818024ef3e9cbb3cdf58f339a338dbcf4c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/24"
+  },
+  {
+    "type": "inline",
+    "contents": "a2aac818801219b5cff21bb6490a2a9c0576a481\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz\", \"integrity\": \"sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==\", \"time\": 0, \"size\": 126215, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "652f2699281236f01539fd27c370e1ab2c6d8fb55c290954c6a987e351ca",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/1a"
+  },
+  {
+    "type": "inline",
+    "contents": "a2db539a87ee5a664272634d4112682d944c768a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz\", \"integrity\": \"sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==\", \"time\": 0, \"size\": 3278, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fb8b168f2fca7f626e52efbae45bef6b11ecf0cc2feedba7befa2c89ced2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/17"
+  },
+  {
+    "type": "inline",
+    "contents": "a2eee1bac32146d808526b7277f214aa51aa1d54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz\", \"integrity\": \"sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==\", \"time\": 0, \"size\": 1882, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3e8c6b6c875addf2057fb5fa152fff0fab217f78a8e51c0aa457a925bf12",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/dd"
+  },
+  {
+    "type": "inline",
+    "contents": "a339a886e502408a2bf40e5d7460345e197f415b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.55.3.tgz\", \"integrity\": \"sha512-M4xU1+hJTqtLscaTlaSqyKoBfe+UlSOfbS107TT46vrUkWUxW747eDJUX8WBSfX5M/Vyy1lf7jWL+N23dteovg==\", \"time\": 0, \"size\": 441723, \"metadata\": {\"url\": \"https://registry.npmjs.org/@mediabunny/flac-encoder/-/flac-encoder-1.55.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ab3acdd88fb1cc5f531cf29f1d1ce3655db18e57ad414d4c596a8c27a34",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/bb"
+  },
+  {
+    "type": "inline",
+    "contents": "a38797a3d604654767c4a309507594bc92bb8e91\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz\", \"integrity\": \"sha512-1Tdx9faw8k0/83V6X+xCDVhV8yElGt95JxeW3YMkKQJI56QdlPz0xOdJPlMiSGJKinPyVier+x9LJD/YZUZIaw==\", \"time\": 0, \"size\": 75142, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "25710fbbac7c6ceeb0c9d31608fba1bbbd471fd00e8f19799f39a1a438c6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/2c"
+  },
+  {
+    "type": "inline",
+    "contents": "a3afc592da1ca87eb2012d3c175f4919460f0c01\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz\", \"integrity\": \"sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==\", \"time\": 0, \"size\": 3761816, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bab097e7523d30bad94b2ae36c1360ebe9fd91688afa6b4a4fc353142fb8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/91"
+  },
+  {
+    "type": "inline",
+    "contents": "a3f5ffc37f36f59fe173d1b5193aabaef2b7f935\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz\", \"integrity\": \"sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==\", \"time\": 0, \"size\": 29535, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e219d92944a2cd4993eb061933ef72c7eae1646500447becd9218e7139b9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/ab"
+  },
+  {
+    "type": "inline",
+    "contents": "a41f33b0ece14d3edf5918128a00195abdd0f6ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz\", \"integrity\": \"sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==\", \"time\": 0, \"size\": 29207, \"metadata\": {\"url\": \"https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "92a989cf347ec24035994b934b7bb07a131b9fe567752d4994a03f7ddc2a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "a4376076a1b71ecdd56a3e72dfc0ce7228e22b20\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz\", \"integrity\": \"sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b47bab34de36c68780f46b98b9bf71c86127d13d935820f70d3044295ab1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/bc"
+  },
+  {
+    "type": "inline",
+    "contents": "a45af001ba702e958028c42d52a67f8bb0ef5cd5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/phonemizer/-/phonemizer-1.2.1.tgz\", \"integrity\": \"sha512-v0KJ4mi2T4Q7eJQ0W15Xd4G9k4kICSXE8bpDeJ8jisL4RyJhNWsweKTOi88QXFc4r4LZlz5jVL5lCHhkpdT71A==\", \"time\": 0, \"size\": 1369002, \"metadata\": {\"url\": \"https://registry.npmjs.org/phonemizer/-/phonemizer-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8b498e525ce34dbe0de9a44259277429e305393f6fd8cad1de538d11d8fe",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/27"
+  },
+  {
+    "type": "inline",
+    "contents": "a474e6c2e0662ae40097337cbbdd618e896bd0b5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz\", \"integrity\": \"sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==\", \"time\": 0, \"size\": 11359, \"metadata\": {\"url\": \"https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "127f37b0ff3cd9c76b1497b5838d265a8a2b7ef495b7f9841f5d4665ba67",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/05"
+  },
+  {
+    "type": "inline",
+    "contents": "a481f9f5caade7d1e25e2005bd586788297ee48b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"integrity\": \"sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==\", \"time\": 0, \"size\": 2258, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8af21194b7c666dcff699b874730170edc9a2670a4d17bf4186649ee9fa7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/96"
+  },
+  {
+    "type": "inline",
+    "contents": "a48d0e45cf11b2108ca525d2b0e2b23949ddf65c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.22.0.tgz\", \"integrity\": \"sha512-hOrExnp8wOlSEWVU+t9UD/POHFZy09Xx8LZqX7P9R7mzcDdrwTVB96tbPD8cIi9mVYWFQDKGNVUsF6I7u7fPGA==\", \"time\": 0, \"size\": 15870, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.22.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e6c7716823dbc56aed8d1f5b872b2398c0e91d680b5301fdf29e1e5692d4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "a4c0c1ed2d9b15609bbccc574d5a9412f1d33872\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz\", \"integrity\": \"sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==\", \"time\": 0, \"size\": 2193, \"metadata\": {\"url\": \"https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6282476d454ca3b17e0ba6cf70a4b6a87142bd8f3139517d572b2f9911a4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "a4c5c56c5c668465df7f7203240216f8cc4b4452\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz\", \"integrity\": \"sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==\", \"time\": 0, \"size\": 4479364, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "922cce9bb05cef6a35207cdad51c29709e21f71f0a2ce585ff35ba1fc942",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/c3"
+  },
+  {
+    "type": "inline",
+    "contents": "a4c5d8c44d8988db5ac6ff7bdb5e3dc4ec124da9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz\", \"integrity\": \"sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==\", \"time\": 0, \"size\": 8220, \"metadata\": {\"url\": \"https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e542371e1aa84f2a351de966d3a9e6c5969ed89e41be1efcb3f58749cb8e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/be"
+  },
+  {
+    "type": "inline",
+    "contents": "a4d30eff6cd379ad7e36f2a905c06ed6eb47b728\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz\", \"integrity\": \"sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==\", \"time\": 0, \"size\": 8576, \"metadata\": {\"url\": \"https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "da2bbce756c0c5feab9837df723b4bd48ee7849efc390afe3c1f9e8207d5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/54/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "a594df06e22af03ff1c6531b6a46dbc61fc0e72c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"integrity\": \"sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==\", \"time\": 0, \"size\": 6465, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ae718527d2b9bf7fa981d80037d5b2f7b34f0e34a76fdd3bc9b604b90077",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/f8"
+  },
+  {
+    "type": "inline",
+    "contents": "a59554e49c4973b60638d98b6c501320307cfcb5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz\", \"integrity\": \"sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==\", \"time\": 0, \"size\": 3623980, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fe34e86449b27a938bd4a20bff5470f22e6d63f9809807f7539b7b84a7d2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/43"
+  },
+  {
+    "type": "inline",
+    "contents": "a63e42027424915e80b9121a7a07f21bfffce595\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz\", \"integrity\": \"sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==\", \"time\": 0, \"size\": 7392085, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "99a8bb1ed13b9fa9ed32e2ce0af8ad73a868b0dde48f218506e7bbcc9acc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/18"
+  },
+  {
+    "type": "inline",
+    "contents": "a6eeb0243f9e864b8e7daadd480a7f79b29ffd40\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ws/-/ws-8.21.1.tgz\", \"integrity\": \"sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==\", \"time\": 0, \"size\": 34995, \"metadata\": {\"url\": \"https://registry.npmjs.org/ws/-/ws-8.21.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8cd926c8b23f9c7316228d4e82e9b56df3ea7b4c50cf699697c7104070f1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/b5"
+  },
+  {
+    "type": "inline",
+    "contents": "a72a41cc337158c58e4208db4f60a0fca7d37500\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz\", \"integrity\": \"sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==\", \"time\": 0, \"size\": 3864, \"metadata\": {\"url\": \"https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d2379001671e36ddc9ae00205d07b406defe34814256a0f8538540386784",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/0d"
+  },
+  {
+    "type": "inline",
+    "contents": "a7ab6c8c8af897103bb19ec05caed0c2bb1fe6f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz\", \"integrity\": \"sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==\", \"time\": 0, \"size\": 4967, \"metadata\": {\"url\": \"https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1f488644300971cc4b1a45a301242cc8c3329ec26f573646011b9c639aa7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "a83d782e7ea6a1dc9de70c3f7e57fcc24f04ee32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz\", \"integrity\": \"sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==\", \"time\": 0, \"size\": 1721, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05c74d488e52e860b9de3668e482a62f5796264d2bf9f2700cf9423add5e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/65"
+  },
+  {
+    "type": "inline",
+    "contents": "a87e1a9c068258adad4689e94c6d4ec3159cbb50\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz\", \"integrity\": \"sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==\", \"time\": 0, \"size\": 122024, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1e4ee0acacb74899caff6991b40d72304ca0548697069bb2be93af479b72",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/63"
+  },
+  {
+    "type": "inline",
+    "contents": "a908007b5cdb3c9b182e831ad310d5ceb146f260\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz\", \"integrity\": \"sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==\", \"time\": 0, \"size\": 4454, \"metadata\": {\"url\": \"https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d8a0e25719e6c5994c8a8b6ac9d763fe679221d1f2dd1d5ea5deb49d1fa8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/86"
+  },
+  {
+    "type": "inline",
+    "contents": "a993512ecf117db974adba7a11d4eac5fce9391f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz\", \"integrity\": \"sha512-c2Upru7lj0/ZV/Ibww6cNz6sUS8m6Dp/9uygFhYcZOd3X8M0xBIEk42c6m6SQehkPziVA8QOgNJz7sMqsbz1OQ==\", \"time\": 0, \"size\": 225235, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dcd34c6f521b31adbbcaf1ac3e10e5d6cb831f504c4883fffe582390a660",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/f3"
+  },
+  {
+    "type": "inline",
+    "contents": "a9f2873fc454da846e0b552858928c8fb4ba1756\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz\", \"integrity\": \"sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==\", \"time\": 0, \"size\": 5473, \"metadata\": {\"url\": \"https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b70b72339abf422623eb04a0c2f91ec333d429d7bea5c11c64d2011e4f4d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "ab29aceb9dc9229bffcc66e7d09377aa9ce14838\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.27.1.tgz\", \"integrity\": \"sha512-+JTahgQT+NxiGjduaB3qJVyhU/wh4m3pVkht1Earioku2bm/apj5Lb8rSowa/NJYP3B+oQgV/V4YLw5dtDgBoA==\", \"time\": 0, \"size\": 7526, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f71f53cb8f54f6bc5211eb76531106efec4c4391d25113db57fa32147d51",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/e9"
+  },
+  {
+    "type": "inline",
+    "contents": "ac73cb817b56fc95839f038e019ef95384166f2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/open/-/open-10.2.0.tgz\", \"integrity\": \"sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==\", \"time\": 0, \"size\": 15470, \"metadata\": {\"url\": \"https://registry.npmjs.org/open/-/open-10.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4a802da9ee2134f8f76df15df8ddd2d0f2b05e7de9b1d7e01669c4278824",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/46"
+  },
+  {
+    "type": "inline",
+    "contents": "ac9ebe99769f680c983dce5073a1cfd70007531b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz\", \"integrity\": \"sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==\", \"time\": 0, \"size\": 8254556, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3edb6ae36dbbd404ce383cc55b3aa459cb1d80dc0a7b3f9337febd400419",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/58"
+  },
+  {
+    "type": "inline",
+    "contents": "acee02061c5d5d53040531fc00a2482b005c84d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz\", \"integrity\": \"sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==\", \"time\": 0, \"size\": 4324072, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b1cdc24ce38f3ce2374924642c5ccc18b13e5c9a5cb07c77e5729cb318e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "acf198025aadb2edda0ab04e4b6fd39d28062e5b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.1.tgz\", \"integrity\": \"sha512-zwRl01ETfCkWUvtvK5fw9bXtAajMPkvlkE3Cq6JvH3LF7XXJwDtNj5Tj7exacMpCaSZmlNc43vFb2rAYnrnwMA==\", \"time\": 0, \"size\": 2570, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6d77043159e3b032f23b4660f53d962c021f5289554c3719bb2c5a51d921",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/de/2b"
+  },
+  {
+    "type": "inline",
+    "contents": "ad80d64cc8416cad12787c72c147d1146109b8e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz\", \"integrity\": \"sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==\", \"time\": 0, \"size\": 65691, \"metadata\": {\"url\": \"https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d1dfcc2ec5cac6c8615395658f4c870b0fe567e71ee85af2f96ec3fe002c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/59"
+  },
+  {
+    "type": "inline",
+    "contents": "aeac67cfe0135b01bee5cd519337f27fd8089c35\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.18.tgz\", \"integrity\": \"sha512-YNEnTHV47hPep+U0QvVM02OJNka9uygREc+k4Nh5VSZBg4MmE+myI442x3hCGfRpX7N2WSSYSJKws4gE+Z8lgg==\", \"time\": 0, \"size\": 41876, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.18.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a7e1e371151bf5804943c25d645f505a6636702a2bf0b5d1b57d37ed1a72",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/45"
+  },
+  {
+    "type": "inline",
+    "contents": "af5a22d17e23dffdddc4a605e30566d38eee92d2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-3.7.2.tgz\", \"integrity\": \"sha512-uQf+pHv6eQhgfI8t2bFuinV0KsPyT8TZgCLwcSU8uBVgN9v6leb0mMpvp6HQAlAcplP3NCcGjxbdqef6pTzvmw==\", \"time\": 0, \"size\": 370253, \"metadata\": {\"url\": \"https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-3.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3b125e5cb82332c923d911a8be519d3b517f08dfe998b722e293ba33a5a2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/39/63"
+  },
+  {
+    "type": "inline",
+    "contents": "af60f4d31b0c14cdefaef24dd89e1d9c72d889e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.1.tgz\", \"integrity\": \"sha512-epOUpFfEmBzjvnqvjv2qHX7NAuLo5dlOGV690lWu+sAYMjibuJBeVvAiKPyFCfRCCTUxdbDB3jbaOA1yEcEJ7w==\", \"time\": 0, \"size\": 5531, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "77a82bfca1911fc4c5174def5bd0dff36d64200e43955175b1b5d22c343e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/b5"
+  },
+  {
+    "type": "inline",
+    "contents": "b129dbdf5272d2d6b0cc17fc9e0cc532e8ebeaf5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz\", \"integrity\": \"sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==\", \"time\": 0, \"size\": 3008, \"metadata\": {\"url\": \"https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9ea5f7eac400baceca422723dd933d7c505c100130f066f787943d1ac679",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ff/d6"
+  },
+  {
+    "type": "inline",
+    "contents": "b29fe8e4744862bd844e95e26157e0860f27ac8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz\", \"integrity\": \"sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==\", \"time\": 0, \"size\": 751525, \"metadata\": {\"url\": \"https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ef3ad5111001a610f814d854d1ce9853e9d6d710a41430d086d07a0986cb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/f7"
+  },
+  {
+    "type": "inline",
+    "contents": "b2bea5dee454d2c1a3c4ed2f73890ba7266eade8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz\", \"integrity\": \"sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==\", \"time\": 0, \"size\": 4283627, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "324cd9dd18136087013c1f783886819ce1abd1d1d43a4731431ff8a2429c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/49"
+  },
+  {
+    "type": "inline",
+    "contents": "b352cb3586103212e6c975c445736c2af45500cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz\", \"integrity\": \"sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==\", \"time\": 0, \"size\": 22066, \"metadata\": {\"url\": \"https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0a5d928eccd3d26024823f03c4c2dec41e70a31fa5def48d65dc75dd2cb6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/75"
+  },
+  {
+    "type": "inline",
+    "contents": "b465d40ec9982ee76620a1b1b222860b444ab01d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz\", \"integrity\": \"sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==\", \"time\": 0, \"size\": 6752, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b496e75db7f03641d485b665c41ef7a1e307e21c888c7fc726385cb2ab73",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/e6"
+  },
+  {
+    "type": "inline",
+    "contents": "b47ccba35caa61e6220f65e9e05d5fb33d72b83d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/kiwi-schema/-/kiwi-schema-0.5.0.tgz\", \"integrity\": \"sha512-X+FpfU0yTEtc6aTHS7VwbOpvQwRt70+pXXWRI5fd6CvWhe7pSVC854TVo4Zo0x5/wwcWj+/9KUlXpdcP0dY9AA==\", \"time\": 0, \"size\": 37979, \"metadata\": {\"url\": \"https://registry.npmjs.org/kiwi-schema/-/kiwi-schema-0.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "114d40f3066f7a5f4872d584801c5126b0d5afd5d585acbf0e284eb2997f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/81"
+  },
+  {
+    "type": "inline",
+    "contents": "b5d1df98ce484739cf145759b498ca22e50b3960\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz\", \"integrity\": \"sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==\", \"time\": 0, \"size\": 5268, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1f253996a55f142d99556d74b56a6c53011a3b44bcf8171f7a2ef703dd38",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "b611b8a02e79d46b1785a3cf35a3de4a66a32138\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz\", \"integrity\": \"sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==\", \"time\": 0, \"size\": 86603, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3b14259918a17e9a4898d90c3a795fdaa8ff609735dd4c2314e5417e81c0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/65"
+  },
+  {
+    "type": "inline",
+    "contents": "b676a687e39efc6cb250ba4a56436da5baff5f3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz\", \"integrity\": \"sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==\", \"time\": 0, \"size\": 8381701, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "37c8cc9b75f7db6130788554c525b038f635407e654966efadf4130b485f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/38/a6"
+  },
+  {
+    "type": "inline",
+    "contents": "b67db885f212ce7ef813b99c26bfc88182ec034d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"integrity\": \"sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\", \"time\": 0, \"size\": 17726, \"metadata\": {\"url\": \"https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3aa5d94761ad382e1a1acc61203736494009e20422bce1dd1433666dd012",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/57"
+  },
+  {
+    "type": "inline",
+    "contents": "b71b3c443ac67412226087d579dd39c241fb69a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.27.1.tgz\", \"integrity\": \"sha512-aopweoHugP+ZR5WTgb7mccXXWmjoNv7PBjtQDl8rvS4IWsJE1w23B+rkj7VuoncO8WK5bU3SS9O3l5aObql68w==\", \"time\": 0, \"size\": 2581, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-table-cell/-/extension-table-cell-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1db9795189b74d41aedd62579e09eeb4ba6ef8fce2f6f165c44a5dcf1318",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "b79b71d484639ab077a94aa8a11f220f0799b863\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz\", \"integrity\": \"sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==\", \"time\": 0, \"size\": 3078, \"metadata\": {\"url\": \"https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "77ac65e6eb4dca6a0b156cd706f3b2b558eb0d38aac2052a0ffde387d31f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b8/61"
+  },
+  {
+    "type": "inline",
+    "contents": "b7a209a0abe850d02b9459c1ebbb10eb43f70547\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz\", \"integrity\": \"sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==\", \"time\": 0, \"size\": 316943, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a1e0372340b9efaac26c39afafd39fa461f7ce18fa266e376867f7569051",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "b7b2c53e78216e19ccd892db974a1382354d600e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"integrity\": \"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\", \"time\": 0, \"size\": 4483, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e01e6bce59ac02f0d20fc97382749190cb73f6006f9526fc7fb1ec79dd4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/26"
+  },
+  {
+    "type": "inline",
+    "contents": "b80b8ae25a2a10c0c5b6691530dbf72e2c5f7a6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"integrity\": \"sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\", \"time\": 0, \"size\": 5849, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c2ea22c4bf9c5ddcd0333850e543442de3364478847c7ebc382b1ff3a70d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "b83094f81a4ce0fb77a6ebad1b7966ee48cf465a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz\", \"integrity\": \"sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==\", \"time\": 0, \"size\": 851, \"metadata\": {\"url\": \"https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f7f5c2553e6c049b34101f73a757b48a2764e6eeaec39265c917bf2df693",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/60"
+  },
+  {
+    "type": "inline",
+    "contents": "b835b23b3f1fd4279f6db7954b0a7deca7c62ae6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz\", \"integrity\": \"sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==\", \"time\": 0, \"size\": 4068, \"metadata\": {\"url\": \"https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a2b741aec6bd4dd94223969fdf1afbd63e8b8cbafb7cd5d5029acb3181e1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/74"
+  },
+  {
+    "type": "inline",
+    "contents": "b838f0a01af37ddd149a28781cd2037c3c216ff3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz\", \"integrity\": \"sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==\", \"time\": 0, \"size\": 3701, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "eb6802ed51cde6ad4d5dff333a07698f6dd891c0c9f42c59f74c4e372450",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/05"
+  },
+  {
+    "type": "inline",
+    "contents": "b89f05b847839656db303d56788f3517cbf14cd4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz\", \"integrity\": \"sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==\", \"time\": 0, \"size\": 13831, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e0a3fd661cd3c749adc8e4c0e998bf93a0d3ecc544dbe7916d8c1a5cf79f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d3/57"
+  },
+  {
+    "type": "inline",
+    "contents": "b8f19237f3bffe58d06f3d094368d3ded9e52e09\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz\", \"integrity\": \"sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==\", \"time\": 0, \"size\": 1704, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dd5667485e64fd49c7ecc3baed7e67eed4659ceb2331b4fc282ff0f771f4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a9/c7"
+  },
+  {
+    "type": "inline",
+    "contents": "ba04957e651b0151fc3e62d9ce3fa5f95220ca66\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.11.tgz\", \"integrity\": \"sha512-8XZ6Py3y3W2nEzAUGCN5cfVKaUi+CVApcz1d6lrNVVf2hvYEixMRkq8k9ggPKnQUpRRuOV5avt8uvxViH2jLwA==\", \"time\": 0, \"size\": 28487, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a748031f115a2b848483018d556b123f665f93309ed9573e3bcfacd22bec",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "ba9f2885f7a9dc3360e7b979d16e76aa31df6fbf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz\", \"integrity\": \"sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==\", \"time\": 0, \"size\": 3403, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c87ef0a71426f8ca52e558ea49756a4c51e35a3ef4d20c0761834ea49421",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/e8"
+  },
+  {
+    "type": "inline",
+    "contents": "bb06c74f720d3b0af47aa4fd4701d5ea0f3b8be2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ecma-proposal-math-extensions/-/ecma-proposal-math-extensions-0.0.2.tgz\", \"integrity\": \"sha512-80BnDp2Fn7RxXlEr5HHZblniY4aQ97MOAicdWWpSo0vkQiISSE9wLR4SqxKsu4gCtXFBIPPzy8JMhay4NWRg/Q==\", \"time\": 0, \"size\": 4319, \"metadata\": {\"url\": \"https://registry.npmjs.org/ecma-proposal-math-extensions/-/ecma-proposal-math-extensions-0.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "180cb5c1bc2cbaee9cf9f24d873ec871a0a6184ba65437c82ba6a6fb81c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "bb2ef2fe3497bf3b44af443fd6ed74d167b72bf0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz\", \"integrity\": \"sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==\", \"time\": 0, \"size\": 5495, \"metadata\": {\"url\": \"https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "46483cdb2b8e7e36f619bdac8eb94950e912856ea1423ee38a6164941514",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/24"
+  },
+  {
+    "type": "inline",
+    "contents": "bb8de35f044d599a4381ed55065ae7b68be221ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.1.tgz\", \"integrity\": \"sha512-jGGeyn9uRUnNjSTHpbqhiGsp6KaYTSbV09jDXPJI9cDwfV9hpugLvpaCZd0BMBbhU1B1W6kOfX0BE15qX/HQfA==\", \"time\": 0, \"size\": 5118, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5daed8230eb863df5375a4107153691280efda92ab8fd7518b24bf6629fe",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/47"
+  },
+  {
+    "type": "inline",
+    "contents": "bbdfd43ed128a89cf95fa2073401ec6c06fccaca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz\", \"integrity\": \"sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==\", \"time\": 0, \"size\": 4937, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1295af917239a2fbe94404f49d472949b2a2519701a35e8dc9841f02ae34",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/83"
+  },
+  {
+    "type": "inline",
+    "contents": "bc071c15d122e841b8ec82fc0e4fb1a870881ff8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"integrity\": \"sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==\", \"time\": 0, \"size\": 6318, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "216edd7104928342f4e596f226b589b3733c83a5c056ece5738890de4460",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/20"
+  },
+  {
+    "type": "inline",
+    "contents": "bc219beeb0d33a7146323c616316a283340e3502\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz\", \"integrity\": \"sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==\", \"time\": 0, \"size\": 5463, \"metadata\": {\"url\": \"https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bb80f2dd494bf2fc92b4cb821249007f5f1d61cd84fe99dd60ca56f528c4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "bc4ab5b15e5d1448c3f644228c5271285def3f72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz\", \"integrity\": \"sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==\", \"time\": 0, \"size\": 272816, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "286ad82d7ab0722964f36e0e68e1a3a4f6f7270257da8a6fe641ab178eb0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/79"
+  },
+  {
+    "type": "inline",
+    "contents": "bcfe4ed86ccacca8a1293926307b4b73f4245676\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz\", \"integrity\": \"sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==\", \"time\": 0, \"size\": 7207, \"metadata\": {\"url\": \"https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fdfb905a9939b5f915a3fade36eb19d1dc5e66be57f678abfc61be186e48",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/52"
+  },
+  {
+    "type": "inline",
+    "contents": "bd7ea250bbacca61cc095dbe5cda5fd9863cfe5e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz\", \"integrity\": \"sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==\", \"time\": 0, \"size\": 3726, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3fd6a899c59ae533d9a5bb44570ada1eddb5802483d3e7812df2c207a7e1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/3c"
+  },
+  {
+    "type": "inline",
+    "contents": "bd9c03022848ffc26bd5d84dd961f1a5df429988\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz\", \"integrity\": \"sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==\", \"time\": 0, \"size\": 199644, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b2abd228ca638980cfe42d12d418a89da30648e35d497277d5713e38c7ed",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/33"
+  },
+  {
+    "type": "inline",
+    "contents": "bfa1706df6e1faad1745fbd29769d049b24c31b2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz\", \"integrity\": \"sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==\", \"time\": 0, \"size\": 1821, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1499701156e55c38f37c319e42d8ee632f62ee16e676fb96bf268dc03e39",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/ae"
+  },
+  {
+    "type": "inline",
+    "contents": "c0b6aed529bed72f8adc4eaa1ae09516f20ca6cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz\", \"integrity\": \"sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==\", \"time\": 0, \"size\": 8111385, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3cd0563d0f4b288ffc67d543ff9990e2ef95fa52adaa90bbad88f2b20d50",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8e/9e"
+  },
+  {
+    "type": "inline",
+    "contents": "c23be424223c21d5baf811b4f72f93eac7437635\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/arg/-/arg-4.1.3.tgz\", \"integrity\": \"sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==\", \"time\": 0, \"size\": 5352, \"metadata\": {\"url\": \"https://registry.npmjs.org/arg/-/arg-4.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c0779c8e0be92c748c91a7dad4e6f0fe57ba0158b6bb1bcfddd8fc56c934",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "c26077d483829369e64740b52037d8b69ffb43fe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.1.tgz\", \"integrity\": \"sha512-OIMZNlzPSO8WRd4ic73Fxckzl4N1tesjjLL2XApaNA/uMpO0LoF6WSRPAWv+Z24Wp92ARRJAnRP7iZoI5+Jxig==\", \"time\": 0, \"size\": 2619, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "df39096c11d227409950c7cc6f100fbaab8491fb62ada4c42947cc93475a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/89"
+  },
+  {
+    "type": "inline",
+    "contents": "c2897baee54c1b4703ed3e7b4192153f6f478e9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz\", \"integrity\": \"sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==\", \"time\": 0, \"size\": 582844, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f8c741d38ac354a93254b71e8914cc8a1f05d86ab2b5f8ac4e1d11e58f4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/57/62"
+  },
+  {
+    "type": "inline",
+    "contents": "c2a2aaf04639112e3420b6ae6b4c479b72b0c974\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz\", \"integrity\": \"sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==\", \"time\": 0, \"size\": 3421578, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bae37bb1037632e1e3ad0a59862f73d144ac21877740c2b00058709cb2b6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/64"
+  },
+  {
+    "type": "inline",
+    "contents": "c2f3ef902a474a286a0d4c11c3187eb6d9091798\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.1.tgz\", \"integrity\": \"sha512-blFf9x9RG0Qr7P3FoAH/033ffa+mMLZn34trVs8Vi0Ppk6FmJAg5HpYFOtmYoeREdNDJ5rHJKV7SoACbOHgskQ==\", \"time\": 0, \"size\": 2581, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7a3f840798686b1f56e0780500736e4e7eca67a8dad859a7b9542d5692ff",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/a7"
+  },
+  {
+    "type": "inline",
+    "contents": "c304e2836156835170fba74440cfec54b21af4fe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz\", \"integrity\": \"sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==\", \"time\": 0, \"size\": 5836, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7dc86c802ff8fff670dbcca77371a2964508a335e97204bd469e0a15a72c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "c32c69ab6c8ba19de74e387e5c163c2520ba8e72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"integrity\": \"sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==\", \"time\": 0, \"size\": 2169, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c10bf71d66461aba0899e81d7a146332c45dbbacb1693c38fc2e4e578e39",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/c9"
+  },
+  {
+    "type": "inline",
+    "contents": "c36a4344f60f78677eb2a507571ca18431f911b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"integrity\": \"sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==\", \"time\": 0, \"size\": 1503, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b652af7d985d655c33bbc6261689ea2f5a550b485dde76ad3aefbe2591eb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/af"
+  },
+  {
+    "type": "inline",
+    "contents": "c3eb4189f74b7446c220c63c1d000e2118e79bda\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz\", \"integrity\": \"sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==\", \"time\": 0, \"size\": 45526, \"metadata\": {\"url\": \"https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e30182d191264a5dc408b69ccc7d1213a6540216c93266e892f4829f6779",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/5f"
+  },
+  {
+    "type": "inline",
+    "contents": "c3eb55febe46b954fd7176a98a6304adeab4c941\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz\", \"integrity\": \"sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==\", \"time\": 0, \"size\": 7753314, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b39812e0a410c1f81de850fecf5a26e6313b4b220545ef21b3d4160280a5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/b0"
+  },
+  {
+    "type": "inline",
+    "contents": "c41c0429c3b566154ad7d71291cb2dccfaaefcd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"integrity\": \"sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==\", \"time\": 0, \"size\": 2989, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e8166faad33ceb76841ce09c5e5e619d46225021c61320e9f0882993d698",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "c4f989b0c9d62dbba3c87646a8e2a66f6589e328\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz\", \"integrity\": \"sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==\", \"time\": 0, \"size\": 2825, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b44a67f952f433ac074de562f2f237cd7a723ed8aa6bab6537f6608c494",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/d8"
+  },
+  {
+    "type": "inline",
+    "contents": "c5015e7532fec1a8ab33d94080c93d8473ee539b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz\", \"integrity\": \"sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==\", \"time\": 0, \"size\": 4703755, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8cdf3936b19374fc2e52ee2f6ddc4a70efc5b434416bb573c8767484c05c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/e3"
+  },
+  {
+    "type": "inline",
+    "contents": "c576c09b00e0b2326e91f94643caaacc47d1dbd4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz\", \"integrity\": \"sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==\", \"time\": 0, \"size\": 8136, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b2e3b0e330c9d139457f7e4c6b00ed7bcb8fdc7278fe532b33cea86b696",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/1b"
+  },
+  {
+    "type": "inline",
+    "contents": "c5b97bc903ed8c3284c4aa7246d5bd6f00aeb26a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz\", \"integrity\": \"sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==\", \"time\": 0, \"size\": 4316, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "52b1c2943a9a945ffff983101f4282cf512899f2ea417b7a8d877f4c22b7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/4a"
+  },
+  {
+    "type": "inline",
+    "contents": "c601090cd6c8b1839c4124219198a5715b7d8250\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz\", \"integrity\": \"sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==\", \"time\": 0, \"size\": 80345, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9af1f2c5216d57925681562e3a425fcaed71f790c8207dcdef380ef352f5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/aa"
+  },
+  {
+    "type": "inline",
+    "contents": "c66a28d19cec3579b694b8adb4894f85ec834e60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz\", \"integrity\": \"sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==\", \"time\": 0, \"size\": 3658, \"metadata\": {\"url\": \"https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e9fc2a4b947bedffa8d6d84e3e24c9ce64f308cded0c0561fb0305521db1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8c/61"
+  },
+  {
+    "type": "inline",
+    "contents": "c69b6134321c4020717b0887dcd4d4786909b546\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz\", \"integrity\": \"sha512-QQqysE549cf/Y0VabBmAACXhj92EhB3t8yVct2BHbkWiPTFA1S91EqTVjYXXcZEefXU0pmHcdObhsNMcomJIOQ==\", \"time\": 0, \"size\": 276027, \"metadata\": {\"url\": \"https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.7.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8ec91773a91bb2a3d4c6d188f1288dd4b4fb0dc135c48a569c21651d3aa9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/1e"
+  },
+  {
+    "type": "inline",
+    "contents": "c71d0017ef591631015c437facd24fabbead18a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz\", \"integrity\": \"sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==\", \"time\": 0, \"size\": 3070300, \"metadata\": {\"url\": \"https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9b2a361c033bf7ffe3317f7196354c911428d9c394c9afffee624122f72d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/de/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "c724baa464622e99f67cd486cf902ab4070333cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"integrity\": \"sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==\", \"time\": 0, \"size\": 4474, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c68ba9a1320725050b57ca9c7fbc237e694f1f4a6cb94104f7e3e654f7f4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/fb"
+  },
+  {
+    "type": "inline",
+    "contents": "c8a5706006c7272b34109041e53fbf4865386e30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"integrity\": \"sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\", \"time\": 0, \"size\": 11577, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "375aec77f76404d91225e72006a0105b2a6ec04bb02cfa365ebcd4a0232b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "c8dc69aa53afdcd39b445f0c8cd5ac47dee550bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"integrity\": \"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==\", \"time\": 0, \"size\": 6664, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c147816be94e86ed9bbb4b9e20409e4791a8991fcfd41d7a44489dedd29b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/90"
+  },
+  {
+    "type": "inline",
+    "contents": "c95c23d282e3b8f989bb396cac5912d1dce4f984\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz\", \"integrity\": \"sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==\", \"time\": 0, \"size\": 11752, \"metadata\": {\"url\": \"https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "063438d5b4bf6abb20690b5bd2f4e55a36146cb8e9d755f6c08124b7efd6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0f/f9"
+  },
+  {
+    "type": "inline",
+    "contents": "c99149c9b8fb55120bbc47f1d4f9f6d2781b0350\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz\", \"integrity\": \"sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==\", \"time\": 0, \"size\": 3085, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4f9d86edcffef20aaea2aa430a52405fe498dcb670830f7a91aecb03a364",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "ca26cf13b4d49699bab84b16718110fb8736eb55\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz\", \"integrity\": \"sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==\", \"time\": 0, \"size\": 10397, \"metadata\": {\"url\": \"https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f5f659536626d46d4ad004241e07a841fc37703aafdf37bf35a1c422f340",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/af"
+  },
+  {
+    "type": "inline",
+    "contents": "ca8e6a3a73c46899863caf03f610164536894b32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz\", \"integrity\": \"sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==\", \"time\": 0, \"size\": 3598442, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "293f061a35aa4928bc2483c8b737cd5522b6fd2b3561e98c23ffa7e1a783",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/e0"
+  },
+  {
+    "type": "inline",
+    "contents": "ca91f04817393710e55219c7ee56712b98a44923\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz\", \"integrity\": \"sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==\", \"time\": 0, \"size\": 8645234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "74d31121387f8a002ab45838d7cfe554a9419e5045ef4e8e221216e145dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/95"
+  },
+  {
+    "type": "inline",
+    "contents": "cab86e6fe065d84d7a3978261276fb4bf42418ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz\", \"integrity\": \"sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==\", \"time\": 0, \"size\": 23891, \"metadata\": {\"url\": \"https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e8cfe7f4aa579e2a82d8b5264419760efd9ad71e92e401f8da767f44a85",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "cc92285241ca975434ae5bbf041cd810ab7d5c3e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz\", \"integrity\": \"sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d45062af43674e433f967d20768d308ed6ce195be6acadfb7cfd21d11e67",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9b/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "ccad65696f15a6d3e1e701300722daef4c3c04fe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz\", \"integrity\": \"sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==\", \"time\": 0, \"size\": 3452138, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8668502357da2be059d3a5b6a79793a15b80c74cb5017e7b746aa9243942",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/ff"
+  },
+  {
+    "type": "inline",
+    "contents": "ccf891d44b5231050430281b8f8b7373dbe1bd23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"integrity\": \"sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4d241faeb3fea9ec8318fd93dd55eb70a87cc8a6e3f849ccef9863882b4b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "cd042304e4650b357058d367f57b2b773c146d21\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz\", \"integrity\": \"sha512-3KxL5wIVqa8Ex08jxSzncm9CMgw8CjOFyOQ7SxvG9o0cVLlhTNKXyIQuTbtX4tGPJEf73OER2xrjt4HJSBL4ow==\", \"time\": 0, \"size\": 66082, \"metadata\": {\"url\": \"https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d70e879af524c61ffb609b73178a9b3d1cdff153d4b596527782a30ab649",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/3b"
+  },
+  {
+    "type": "inline",
+    "contents": "cd80d7450d7c734d93a01dc49d467360850339c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz\", \"integrity\": \"sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==\", \"time\": 0, \"size\": 11542, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b45fd8a370f0a51958a83032f89b502bb1dc12a9de68b0700847f6b33798",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/ac"
+  },
+  {
+    "type": "inline",
+    "contents": "cd9778c443eb202955f61afde92f0297963d8fcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"integrity\": \"sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c662626ec8eafafa54476678b9f71799a74ee368f2b7845a6ec9f9174a4d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/1f"
+  },
+  {
+    "type": "inline",
+    "contents": "cde3ab8f8bff0917bf108c876ab018e6e28ef501\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz\", \"integrity\": \"sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==\", \"time\": 0, \"size\": 7556, \"metadata\": {\"url\": \"https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c88721b96bdc8e89902d4d357de580ba406b0514af7deb376c95989ca3fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "cde50d7bbe0bf43ff312279d7ac8e44001a4306e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz\", \"integrity\": \"sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==\", \"time\": 0, \"size\": 5310, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "afd0bbbe4dd41f05bfc04075bc7499f079510cdf6a59f017d825ea60a8ba",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/08"
+  },
+  {
+    "type": "inline",
+    "contents": "ce0190e6df90ccc1a9357350e6cd69fb98d27da8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz\", \"integrity\": \"sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==\", \"time\": 0, \"size\": 6067, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9648614194cfe05bcf87e96e6d1a9d596eff2ccd2be75d5a63840ff5c5fa",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/33"
+  },
+  {
+    "type": "inline",
+    "contents": "cefa8038706b9b935a8965957f32b873150f73d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz\", \"integrity\": \"sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==\", \"time\": 0, \"size\": 4430, \"metadata\": {\"url\": \"https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "743e8a428d670b7a0860943002d144b0992f5ebc0aa4646b0583c71ef495",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "cf105c2fa498130a6170bf8e11f6df92defacab9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz\", \"integrity\": \"sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==\", \"time\": 0, \"size\": 1299, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "35cecb21ec81f33fbdbacc68adef5ec601e3640b0a29585d4ed815f6b08f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/5d"
+  },
+  {
+    "type": "inline",
+    "contents": "cf7abcdba5ccb82726eb76588a47536673f1e391\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jose/-/jose-6.2.3.tgz\", \"integrity\": \"sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==\", \"time\": 0, \"size\": 50070, \"metadata\": {\"url\": \"https://registry.npmjs.org/jose/-/jose-6.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "73dd2e827e8354107bfdd0d753616e97d7b00cacdb012ce0f35525742a79",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "d0070fec03e624938f916ed1181e3c37cf32035f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz\", \"integrity\": \"sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==\", \"time\": 0, \"size\": 2287, \"metadata\": {\"url\": \"https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ba29811d787f0fd92ce7f4bc3a6827dc6d66c47153d50683c80d6e7a9a6f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "d04bf98c4456aeda2a0b458ee15e7b791a21335e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"integrity\": \"sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==\", \"time\": 0, \"size\": 8913, \"metadata\": {\"url\": \"https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3823be4be0216c6b586c2eeec514837e4811d9f2cf65ab1e5bda679f7fdf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/35"
+  },
+  {
+    "type": "inline",
+    "contents": "d0d4cbb6748ecf110069da09825d1642b673cb58\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz\", \"integrity\": \"sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==\", \"time\": 0, \"size\": 12035, \"metadata\": {\"url\": \"https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e56d34b37c3170079064597cabb288d076b0d0468eaba3b8a0cf8686ce1f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/55"
+  },
+  {
+    "type": "inline",
+    "contents": "d1589cc459c211f6677158915c27177015068206\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz\", \"integrity\": \"sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==\", \"time\": 0, \"size\": 345530, \"metadata\": {\"url\": \"https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "916b8f9ed60b861c450283eebe0b06f85720b55bc700ce536d6e2e50abf2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/af"
+  },
+  {
+    "type": "inline",
+    "contents": "d1be96154325e5075e4ed09dcc414b8e61a4d934\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz\", \"integrity\": \"sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==\", \"time\": 0, \"size\": 2677, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "454c882933ab15d532e2493b0bd7ce7019f1caca2abb46f076ca0855330b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "d31c9160378263d3bc01ee81e386c673303cf2d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"integrity\": \"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\", \"time\": 0, \"size\": 138324, \"metadata\": {\"url\": \"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "97d2c6e5c772f993e1a5b5fdeae5e52c835ac89d689ba43dbe025d54d880",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e8"
+  },
+  {
+    "type": "inline",
+    "contents": "d32131d1a1cece794eb5bd5847db49c7e6344e68\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz\", \"integrity\": \"sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==\", \"time\": 0, \"size\": 8390734, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e3cedd88f946cbb8398240ff14a8c7fe6a36a40c07695e9c0d8731b69216",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/1c"
+  },
+  {
+    "type": "inline",
+    "contents": "d450ed14d79b507065508fe87d884a23186112ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz\", \"integrity\": \"sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==\", \"time\": 0, \"size\": 202724, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7f5b1c22a459a524f032a961bfc12d557754cbf1670d01de840100035dd3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/05"
+  },
+  {
+    "type": "inline",
+    "contents": "d4ef7cb5632aa23d4b6f977028bbd4edffcd3940\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz\", \"integrity\": \"sha512-z22Q/zFYSvbIJfW1CbfZPu4X8PddS6Qd2ORbc6h+aT6EcwAxUF3m6fA4HjNvA3TU4X0dTJRwNPB165ES3PJXzg==\", \"time\": 0, \"size\": 26546461, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "84a24b2ab86657586a4ddda873f6e0b002de2103b480f4bcd5270f55427d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "d5462faa35bff0216713716dc03138cc969bdd60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz\", \"integrity\": \"sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==\", \"time\": 0, \"size\": 8059, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a7f609296af013f459dea95f5b86155b1d4d3fa7dc9ec423562d0c55294f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/ee"
+  },
+  {
+    "type": "inline",
+    "contents": "d576404335f2933c50d834fce8a5bddff6115c79\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz\", \"integrity\": \"sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==\", \"time\": 0, \"size\": 72638, \"metadata\": {\"url\": \"https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "95825783e5fa02bedf53ce48341bd6793b001cecf0ed8960b3893e1daf77",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/ba"
+  },
+  {
+    "type": "inline",
+    "contents": "d605494293a08ea82461e31ea8430713fed24b7d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz\", \"integrity\": \"sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==\", \"time\": 0, \"size\": 214036, \"metadata\": {\"url\": \"https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d1c84278db1bf0d27abe3f1ac3124607562229671155a85c411027548b95",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a2/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "d62d0f9555b74d8bc634d0d46b50529ff0c991ba\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz\", \"integrity\": \"sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==\", \"time\": 0, \"size\": 58250, \"metadata\": {\"url\": \"https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ead2067d1e3493879000d309c9f8e2646c5a1e28179d9cf51740c6ceca76",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ab/48"
+  },
+  {
+    "type": "inline",
+    "contents": "d651078e6e90c5821a24960a040eb1a72ae9e1b3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.1.tgz\", \"integrity\": \"sha512-QoezN0wdvXIwLQ4ee2ccWDaX3RG0lzgQpIMpMz55oPDhpUVax1+19ApsS53LkcktpS4EbnPL4xO4DaJk0Vp7PQ==\", \"time\": 0, \"size\": 2552, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6eb09924ae3dba1c6bd9001028844f3accc6b5fc10e68101f63b125c0bfb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/f5"
+  },
+  {
+    "type": "inline",
+    "contents": "d674311c63e5e00ebdf76e3f5fc70c58b6e4acb6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz\", \"integrity\": \"sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==\", \"time\": 0, \"size\": 20726, \"metadata\": {\"url\": \"https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8f84c9241e5ca3dbdd7499bcfabffbe40f30446d6dfb87a98cb682d170d7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/a7"
+  },
+  {
+    "type": "inline",
+    "contents": "d67c09f0c62a0a3dbe4d7c7d06d7b61f78d79ced\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz\", \"integrity\": \"sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==\", \"time\": 0, \"size\": 7812, \"metadata\": {\"url\": \"https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "55189be39944cf4128880be8c6f5ac22c5f81fc4c5852b8dd3d192842037",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "d6b3470728ed6256111b27537bd8df7fe186ba09\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz\", \"integrity\": \"sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==\", \"time\": 0, \"size\": 5610, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "904a49b9061b89b7da89c73e69c176aa9f83737461e1812920e1f4649e63",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/dc"
+  },
+  {
+    "type": "inline",
+    "contents": "d6f0d7a7cbea8ad2d249faef353edff4e9d1f643\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz\", \"integrity\": \"sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==\", \"time\": 0, \"size\": 3573, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dd738c002b5e7e127c269f66aa79d539246257033fd0405552ba96533a47",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/fe"
+  },
+  {
+    "type": "inline",
+    "contents": "d7af0dccbb92c22336f80fc25356846c3a282481\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz\", \"integrity\": \"sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==\", \"time\": 0, \"size\": 7873, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "43b89d1c15ce8a3c5d1add3132f3c3d0fc8ae221a195e331cb84d785ed88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/65"
+  },
+  {
+    "type": "inline",
+    "contents": "d8283ede7456f3e3c41c6539ff0ce58250d72230\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz\", \"integrity\": \"sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==\", \"time\": 0, \"size\": 33061, \"metadata\": {\"url\": \"https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7b979c7c8c534819501ea39cc0fd39bfea0f240205db928f6288a00d04d1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/d2"
+  },
+  {
+    "type": "inline",
+    "contents": "d8a63a9ace4dfce43f3bd0997d0c6f17d5928107\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz\", \"integrity\": \"sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==\", \"time\": 0, \"size\": 51997, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4eb4e5eb8b4219dd0683c596f999b39d8e1fa3802f626c6e67a5d3eae1c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8e/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "d8d4b46c8d56f292bfa7466cf036bf4d8748b075\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz\", \"integrity\": \"sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==\", \"time\": 0, \"size\": 7785250, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0b192cec7bf59016ebb564727e640ba6faa94ff3424a592f03d4d39a9ea9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "d92cf05b281e5a322d7e8f21aeeb69ea2d896da5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz\", \"integrity\": \"sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==\", \"time\": 0, \"size\": 14509, \"metadata\": {\"url\": \"https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fb93c0000545ae37010521039d64477c326fc264458d28ea8e48147a50cf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/39/31"
+  },
+  {
+    "type": "inline",
+    "contents": "d94091d83b747062efb26a086e3ef92ec471c010\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz\", \"integrity\": \"sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==\", \"time\": 0, \"size\": 4649263, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a70cf28abdb68818f8e892c429a6553b8946d1f2e1d8fb7fa4ad352cb4d9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/9c"
+  },
+  {
+    "type": "inline",
+    "contents": "d984781d4fe92a85d124be67ee9f375d4da952ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz\", \"integrity\": \"sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==\", \"time\": 0, \"size\": 7504527, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ed2f2a7652eda0b3b1bf874b04c52f9f3a41f9fd7ec6b411ca884af54b1f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/ca"
+  },
+  {
+    "type": "inline",
+    "contents": "d9d308d9a488ff2be7ce561eec05edae6e5aa7ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"integrity\": \"sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5a271b1898a503a6f8a6b2361235fd7539e9ae1aa5622d3e78124d1a0c34",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/9d"
+  },
+  {
+    "type": "inline",
+    "contents": "da240afb2d26315b96461643ed5b53394005cb03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.1.tgz\", \"integrity\": \"sha512-/2jBfsxBZUDGJmpZifqRQPz7f1E5qpS1BckTZ39TADzUJX+feKy7RJ3DtQ02+8y6SSMzvP9loGVjrk6zEMTk4g==\", \"time\": 0, \"size\": 28886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "20783e8014a9d57fe3264c03fda7c8ba7991ba1d3d4626a9a799e5617b2e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/a3"
+  },
+  {
+    "type": "inline",
+    "contents": "da47cfe1e0f8bc09b26a73120135278dbf357502\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz\", \"integrity\": \"sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==\", \"time\": 0, \"size\": 4046, \"metadata\": {\"url\": \"https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3f11b65b50bf14c6fce46e7d0fae72d4244c0d83caea4c7c48a285dec8e1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9e/ed"
+  },
+  {
+    "type": "inline",
+    "contents": "da4f2b7748cf096c1b74845c9b4024c7cd7e548b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz\", \"integrity\": \"sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==\", \"time\": 0, \"size\": 86978, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2017c71f46d1c1ee8b9b7cd2fa4f555bf5a0a2c3cf40d280db10380bae2e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/68"
+  },
+  {
+    "type": "inline",
+    "contents": "dce2b0f75ed9856e7f27b5a7ac1f62ec3466f18f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz\", \"integrity\": \"sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==\", \"time\": 0, \"size\": 5049, \"metadata\": {\"url\": \"https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e51aeab9f2ed39d1416132dca81cf2f580dc5de2fd02b9a85d1df3b191f3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/10"
+  },
+  {
+    "type": "inline",
+    "contents": "ddb18874d80de9cf6f921c311c7d0cf2b9d60327\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"integrity\": \"sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==\", \"time\": 0, \"size\": 2768, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05a8af0a671c32b41850c1223429fe74449cfcb4c7cac54a9c7c213dfcae",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "de0d4e3cfe577ddf8a2cada53d395d509f8c44e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.1.tgz\", \"integrity\": \"sha512-VMF7xJx6qEGiX6DTKNiL31NLqypOcd/4sNjFSe8rb41PwejBJh/nOqVIbBvWkiT6NMGFLxMhj7zJ8/zPo1hXeg==\", \"time\": 0, \"size\": 197259, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "518b087157c34042dc5d5f21419ab697832f4585c79086bc5a2e70c0bd0e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "de3bd5668d47a838f942e10e0a2e6540d9a2e721\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz\", \"integrity\": \"sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==\", \"time\": 0, \"size\": 6499, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bc4a7e0cb4b181bbb8591b9cc2d834792e975abe8f99d70f808f4857b359",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/28"
+  },
+  {
+    "type": "inline",
+    "contents": "dea7d243b5907caed76b22b783dfb742d73cb99f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz\", \"integrity\": \"sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==\", \"time\": 0, \"size\": 7375, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e977e59a2e46dcf2304c208b9b991bd99351f723d4913e4892c05e4a9417",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "dec4fa36f7c4ab7cb0d2f0d60af0fb0f07fb1666\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"integrity\": \"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\", \"time\": 0, \"size\": 2625, \"metadata\": {\"url\": \"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c9aa1c46bf0c67511379e97bd07fca87532422f2506214f94db8861160d3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "df494e0c7697c3599dc3823233bcc1679aaace81\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"integrity\": \"sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==\", \"time\": 0, \"size\": 8998, \"metadata\": {\"url\": \"https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4fb51f0d6958df4998537c738c83e14af659c6a2ac678defad66458c5358",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/0c"
+  },
+  {
+    "type": "inline",
+    "contents": "df89f08a000ec15c275826042e2478ccf0cdf049\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz\", \"integrity\": \"sha512-Ffjx+vimmBU7zH/KrpXzJid3+pziCe/VL2aexSTP63cyQwKQ65LkFkCKaIsSpFdQQuakVZBGWjCA5RoBV852pw==\", \"time\": 0, \"size\": 5453, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/pm/-/pm-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8ff4917d790cc0e089a707a6a72a33cdb4df384cb7c63d950e4f32d1e852",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/db/05"
+  },
+  {
+    "type": "inline",
+    "contents": "df8a8f83044fa8e82801b0a6ae4284caa03855b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz\", \"integrity\": \"sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==\", \"time\": 0, \"size\": 3614, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "859813b09e1e5020654bf65fb2f19970c51f08f788d3c4f2ea5137051e1e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "df8cc06edfe709e48833382d2f9ca33b23d62422\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz\", \"integrity\": \"sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==\", \"time\": 0, \"size\": 5728, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5ff678b9466cf6f8d567d499a7fc509c7149395af1ac727fdfa61ef57ce9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "dfc095b983a77202312a4ce77cc7f9a7b0355b22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"integrity\": \"sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\", \"time\": 0, \"size\": 3210, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0913a74f5e223a4fe6108493dd3b03c2d47259df459926160659513c9ad3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f4"
+  },
+  {
+    "type": "inline",
+    "contents": "dfc90e33519de70494c03072095ffd3cbf830899\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz\", \"integrity\": \"sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==\", \"time\": 0, \"size\": 8520, \"metadata\": {\"url\": \"https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b9159a6c0d718294f279ecebfa9c78aea93e4940a83acd35aa77ab4ecb0b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/f0"
+  },
+  {
+    "type": "inline",
+    "contents": "dfd6447b6e3542557f75cd030fd5fc6238bc2b89\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz\", \"integrity\": \"sha512-KkgCvdHB4IhtpHpF564plA9jo6fDOwWGQ/3jvreLzgOtRLEDoPqr7QO9qejNA8jKwDsSkAKr77hqBHnyUbIw4g==\", \"time\": 0, \"size\": 90902, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ff8c03d6d2712e8fdea4bd098deb8efc2c0fe1494e43c8caab80fdc86ce0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/f8"
+  },
+  {
+    "type": "inline",
+    "contents": "e008ea56f49bfc3a4fb768c1bfe212659d2e6608\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz\", \"integrity\": \"sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==\", \"time\": 0, \"size\": 4490837, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f80c59fdfd8247b1e694779972b74c8c2f89d9dd201900767cb2a8c5e30d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "e0337ad830115637c96829d841fda834f1ef0549\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.1.tgz\", \"integrity\": \"sha512-8FbBTkfnRP4iVaoj+2h3iWa+H0eGDD3yTyVCwrmue/sQTkqUNUoSuAZa3GDG4Sd41xdPwTJxl9nUWGgM1qDCnw==\", \"time\": 0, \"size\": 3009, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e28e9bcb2485931b10262457f56ff2b2631fb9646e73b776d4686f5b4b9e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/01"
+  },
+  {
+    "type": "inline",
+    "contents": "e15db69297e7e214ef304015790ff9bfb7937ade\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz\", \"integrity\": \"sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==\", \"time\": 0, \"size\": 31413, \"metadata\": {\"url\": \"https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a8c3ab0670811a3887ede187dcd3856d14272349a18f6844f7c8007cc05e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/ca"
+  },
+  {
+    "type": "inline",
+    "contents": "e1726c14b276ed3be378393b5ea44727c9a82b4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz\", \"integrity\": \"sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==\", \"time\": 0, \"size\": 107882, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "03c3cf6a4cb82ba09861e71535fa0c7c9829488facbc1ad3312103dd4ba6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/18"
+  },
+  {
+    "type": "inline",
+    "contents": "e288379ecee6865a3a651257c4f759d52fb47df1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz\", \"integrity\": \"sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==\", \"time\": 0, \"size\": 1871161, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "47f4eef982719cafea2cf9b70b9c08c3c3f95374185318bb644d3c09c0c1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/90"
+  },
+  {
+    "type": "inline",
+    "contents": "e2d373344a196b0526846965688bdc4a4869b22b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz\", \"integrity\": \"sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==\", \"time\": 0, \"size\": 3533, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "11e7acaf77abecfa23d28eac961e36dabcada45cad9f86d21b891dd643b1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ff"
+  },
+  {
+    "type": "inline",
+    "contents": "e39a1a115aff049545109154d0d6cc87c9ca3ab8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz\", \"integrity\": \"sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==\", \"time\": 0, \"size\": 3914, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6b45375ef86aed02210a45c62fe4d8a67e7db5524b600c1c62cc471bf67d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/54"
+  },
+  {
+    "type": "inline",
+    "contents": "e3bf12845209fe5e8ec6b9f7d9df2a031ee06424\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz\", \"integrity\": \"sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==\", \"time\": 0, \"size\": 4564, \"metadata\": {\"url\": \"https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0a265c17fd9c0d008095d8426079ebc85dcf96d73711b217ad91cda8e702",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/40"
+  },
+  {
+    "type": "inline",
+    "contents": "e49e62eec7816a8a66b7e24a0641f30320547a2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz\", \"integrity\": \"sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==\", \"time\": 0, \"size\": 1920950, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a02dadbc1fa00cfd5e4f922add19e61feb0a860f2616bd4b1cd0ba92a7d8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/71/b3"
+  },
+  {
+    "type": "inline",
+    "contents": "e58bef2cd02bfabd797dae3492df048fe4ea0ce5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz\", \"integrity\": \"sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==\", \"time\": 0, \"size\": 190667, \"metadata\": {\"url\": \"https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f772185fabbb4c3f9a08a223329d6b22e4daf1bdaebae781a7b6639c7c05",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/17"
+  },
+  {
+    "type": "inline",
+    "contents": "e5f1f44165a58c1ca1c6db4479cf8fef18be4e65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz\", \"integrity\": \"sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==\", \"time\": 0, \"size\": 4434422, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "68ff20fa96f4aafa410b8279958fe0c320b80501a2c5cdd899dd098ca25b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/cb"
+  },
+  {
+    "type": "inline",
+    "contents": "e616d92213de1618fb0c357955eb9135f788167e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"integrity\": \"sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==\", \"time\": 0, \"size\": 6382, \"metadata\": {\"url\": \"https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5912d88421e6b76e5e0365ae8015aac3093d6e53b5b60fdfa91116720417",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/e2"
+  },
+  {
+    "type": "inline",
+    "contents": "e61fb3b627409a1e7ecf25d584aeb317580c7c07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/depd/-/depd-2.0.0.tgz\", \"integrity\": \"sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==\", \"time\": 0, \"size\": 8374, \"metadata\": {\"url\": \"https://registry.npmjs.org/depd/-/depd-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8564823aa3255dcec81b524fd590e5f3349ee1ada7d35311efcf7dcc5018",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/cb"
+  },
+  {
+    "type": "inline",
+    "contents": "e679f91fe24a8589a1ac6e1e50b9d121cb19d684\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz\", \"integrity\": \"sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==\", \"time\": 0, \"size\": 2233, \"metadata\": {\"url\": \"https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "87253508181b576c3a8c9c6b98d40923ec75acf1d7acef4ecea543096037",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/d0"
+  },
+  {
+    "type": "inline",
+    "contents": "e6bc6eea1030c640068c9d7d1dedbe43206071c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz\", \"integrity\": \"sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==\", \"time\": 0, \"size\": 78197, \"metadata\": {\"url\": \"https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a5c81fa43361361e7efd6d248f3e3c8d1b6f5308bf5bdb9614c12fb66af1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/68"
+  },
+  {
+    "type": "inline",
+    "contents": "e6e3f7e0a8eb63d937fc495d6f2e86865c37c729\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz\", \"integrity\": \"sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==\", \"time\": 0, \"size\": 9288, \"metadata\": {\"url\": \"https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5799a11997482f78a71307f2134a84b508b74d7faa3535d40d26c6261638",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/92"
+  },
+  {
+    "type": "inline",
+    "contents": "e7cb3134c13f5160652c36ae0c07353356e2a98e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz\", \"integrity\": \"sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==\", \"time\": 0, \"size\": 3848191, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6cce4df9c845a19ff27f9058abeac46d55bb8f3514a9b6e4d79a97a3a3be",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/70"
+  },
+  {
+    "type": "inline",
+    "contents": "e82b9630358673ae8bdd19a42ff450f170be415e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz\", \"integrity\": \"sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==\", \"time\": 0, \"size\": 226205, \"metadata\": {\"url\": \"https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "56acc4bf8ed06ffbc11fe2a5ddbe10a6aeae2d8f71927cf8da4ecc989aa1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/d3"
+  },
+  {
+    "type": "inline",
+    "contents": "e883016a98e99c18ecae2aa037e9b4882ae01637\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz\", \"integrity\": \"sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==\", \"time\": 0, \"size\": 4494497, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4b4452bafd7aa9c5642069cfc96bf7e86f9222731b9e2ad32066e77599f3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/fc"
+  },
+  {
+    "type": "inline",
+    "contents": "e8eec5e2cf13c8b448e9dd2ac0e9aa0b6017ddcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pako/-/pako-1.0.11.tgz\", \"integrity\": \"sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==\", \"time\": 0, \"size\": 204482, \"metadata\": {\"url\": \"https://registry.npmjs.org/pako/-/pako-1.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c9acbe48d825a0797e5d17c5ea77170c89cae0b587f9e7c8d8e1840432bf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/b8"
+  },
+  {
+    "type": "inline",
+    "contents": "e902852cc60e8f895e8e012a0a1b1d23c393a571\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz\", \"integrity\": \"sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==\", \"time\": 0, \"size\": 8406899, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "94062c0740a5e493af53e53c3386fc616420766cfefc77e0ccd54e6d33cf",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/68"
+  },
+  {
+    "type": "inline",
+    "contents": "ea22d9eb1feb45989824b2e15851eb9d039538a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz\", \"integrity\": \"sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==\", \"time\": 0, \"size\": 50936, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5880305615027ce5637b5255ff3294c1d8b20eff8a7d9a7ee6c8c916c5a4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/8f"
+  },
+  {
+    "type": "inline",
+    "contents": "ea76c91c3d4e1fbea79fc19b7c4505a30c7f4b3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/raf/-/raf-3.4.1.tgz\", \"integrity\": \"sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==\", \"time\": 0, \"size\": 3716, \"metadata\": {\"url\": \"https://registry.npmjs.org/raf/-/raf-3.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d2e4c3b8881869553f1d8b57c01d5ff5d3e4acac13adf4250504b0c6f271",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/88"
+  },
+  {
+    "type": "inline",
+    "contents": "eb2e7cc7c27b088084e6759b3be15c759f694a48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"integrity\": \"sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\", \"time\": 0, \"size\": 6542, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "df2b2137355548fc0e2edd8c75e03ade0d1036d9466886d3c4f7ea6248af",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/48"
+  },
+  {
+    "type": "inline",
+    "contents": "eb55e357db5ffa3616b9f331bb2b01cd24a60d41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"integrity\": \"sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==\", \"time\": 0, \"size\": 1676, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "532a4c7bf52c908d567ded2bb11b0f3282f0733d0d079a5291c2f72e0077",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/fd"
+  },
+  {
+    "type": "inline",
+    "contents": "eb97e76144d46ad462913014b17a21944b2abd20\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz\", \"integrity\": \"sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==\", \"time\": 0, \"size\": 7689, \"metadata\": {\"url\": \"https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cc598261aa7c1f089fdcd0478664f8f5c80f8f02f241f08e3be264a9e616",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/7c"
+  },
+  {
+    "type": "inline",
+    "contents": "ee74a0bbba7904e68168e039b27b255427396b03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"integrity\": \"sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==\", \"time\": 0, \"size\": 5583, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9df6136179e75a89f9d3914f7535bf2a6318e5c002f7257fc49bc7b83ece",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/8e"
+  },
+  {
+    "type": "inline",
+    "contents": "ef3de632e1cd25ffa612679f0d8c33fe990ba098\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz\", \"integrity\": \"sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==\", \"time\": 0, \"size\": 3363, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "570fb4528a8eb2302470bcb3e5637efb0dcb7c46a6edd882006882a1cff1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "efe27282532646d7631be55cce9f1c37426a37b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz\", \"integrity\": \"sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==\", \"time\": 0, \"size\": 24821, \"metadata\": {\"url\": \"https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7741857e809594830141a639d3d54110945a88bb85691de2f9dc97402c84",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/e8"
+  },
+  {
+    "type": "inline",
+    "contents": "f005cb79d4d46e692c7a2bef2158d4e59d8b82ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz\", \"integrity\": \"sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==\", \"time\": 0, \"size\": 2793, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "55206eb334c46a89b61491c3e82f514771cacbe4047461bf22c99c314b64",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/15"
+  },
+  {
+    "type": "inline",
+    "contents": "f0db717c3e21d469d0aeb74b662e6f22bd70cf0f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz\", \"integrity\": \"sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==\", \"time\": 0, \"size\": 27152, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "44b60d4fd04e917d2d59b7720386b976d2fc77a717a837caddc161f95f5a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/17/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "f135e22192746f63c62965aa37744982e9308eeb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hono/-/hono-4.13.1.tgz\", \"integrity\": \"sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==\", \"time\": 0, \"size\": 229727, \"metadata\": {\"url\": \"https://registry.npmjs.org/hono/-/hono-4.13.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0e8688e482d448301e8de2c4658c16e444b076882dc8910ae290490e3a0b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/71"
+  },
+  {
+    "type": "inline",
+    "contents": "f13a17f0520ab519af048fc7dcedbc3f42ce6949\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz\", \"integrity\": \"sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==\", \"time\": 0, \"size\": 5015, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "922cfaa166da20dba613581c3a143dd5068b4bd4eb5c9049770919fc7d4e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/05"
+  },
+  {
+    "type": "inline",
+    "contents": "f17d6519bf321ac16b00b193a09e9cf560d4f37b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz\", \"integrity\": \"sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==\", \"time\": 0, \"size\": 3592, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e38584520b09235b4a6faa3de2c2bf3d56d98d329dbf4866abab4a254c5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/62"
+  },
+  {
+    "type": "inline",
+    "contents": "f1accda2ffd6d43a3c042f3decca4106b856c259\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz\", \"integrity\": \"sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==\", \"time\": 0, \"size\": 387190, \"metadata\": {\"url\": \"https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1a57a2353dd943aee8c17fe0d53a5a21d75381970db72a9b9725c5066ebb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/64"
+  },
+  {
+    "type": "inline",
+    "contents": "f2b408cb05c77c4519252851725023f578f451f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz\", \"integrity\": \"sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==\", \"time\": 0, \"size\": 2156, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7a96344f2b139adbb2d367863738188c938fdf38d5ef69f08dbbd9f85e18",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "f38b97cd927eb7acb61bfc5aee78a7e5ad40484f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz\", \"integrity\": \"sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==\", \"time\": 0, \"size\": 11111, \"metadata\": {\"url\": \"https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "082e46038934b0de5e45561c2a3dca79441dc0d89e32d5d75db68b87dd92",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/d4"
+  },
+  {
+    "type": "inline",
+    "contents": "f3fab686a25af092488c2abef6a14848d0ff2249\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz\", \"integrity\": \"sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==\", \"time\": 0, \"size\": 24954, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "a8a4b2b95a43fb33f270c6a09d6162206edfe90782f32128560590b10dd9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/79"
+  },
+  {
+    "type": "inline",
+    "contents": "f433a97d134f68f29063c73c9722ec8486d7a3d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz\", \"integrity\": \"sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==\", \"time\": 0, \"size\": 114544, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e323722bf5e972d34eb685a126b8150859b3b4c2649b6b13518ad43f57c6",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/80"
+  },
+  {
+    "type": "inline",
+    "contents": "f475ee4fb8b73ce031b8e5c52301d012c52ce70a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz\", \"integrity\": \"sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==\", \"time\": 0, \"size\": 1452, \"metadata\": {\"url\": \"https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f8bb82009914d696dc7732600dc46fae2a5f1b722ecca576f7b8cbbf7189",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/3f"
+  },
+  {
+    "type": "inline",
+    "contents": "f49a35b62fd925f40ce87761b764297787761c3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"integrity\": \"sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\", \"time\": 0, \"size\": 1816, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "483e6b07a338fc56daa546a5c7d73c769d72f488be87ff50117370bdf004",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/db"
+  },
+  {
+    "type": "inline",
+    "contents": "f4b781104775ae43ee450aabb3627eb3eb8fac69\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz\", \"integrity\": \"sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==\", \"time\": 0, \"size\": 102934, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c034368dafb2662e1726272881867e5e84f2c97739f3d48b848daa239ae0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/65"
+  },
+  {
+    "type": "inline",
+    "contents": "f4ed27e23e4a9e4bef250f68828c049b3511b419\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz\", \"integrity\": \"sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==\", \"time\": 0, \"size\": 35374, \"metadata\": {\"url\": \"https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d5f042b972065942c3062d8de16cc7808f551815ae53eaba981199432f15",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/20"
+  },
+  {
+    "type": "inline",
+    "contents": "f5ad2ca86b8e33569ef575a3c4042013539d0d0d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/scrollable-component/-/scrollable-component-2.0.4.tgz\", \"integrity\": \"sha512-l0lGDPGz3QvCakzcccra9V0OiX649NSY4PotJtSx92Jin90w/ZZqTrsh1+U06vjBc0rflTr+1F/hVFz3aO3MqQ==\", \"time\": 0, \"size\": 9184, \"metadata\": {\"url\": \"https://registry.npmjs.org/scrollable-component/-/scrollable-component-2.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4ca2bc170f4031235cf47b307b63ebaca5e9699828ae12f6d5d58dc2f03e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/19"
+  },
+  {
+    "type": "inline",
+    "contents": "f5e269900d5e665b60c28c6523eca3e6657b8101\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz\", \"integrity\": \"sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==\", \"time\": 0, \"size\": 307299, \"metadata\": {\"url\": \"https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7277294cec850a3d8c34cba6a06a7827b3f957db2da1f9d9c059d7cac410",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/eb"
+  },
+  {
+    "type": "inline",
+    "contents": "f6bf2d2e7c33948b91ad21a9b76de1716e2d010e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz\", \"integrity\": \"sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==\", \"time\": 0, \"size\": 1812685, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "10bdc80f6e0efd84bf3dc9012d4ecf87d04434c87ab42226604fa0e004f2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/dc/76"
+  },
+  {
+    "type": "inline",
+    "contents": "f8026ff0506fa3b5f0a3c71bb2ea91bb902a725a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz\", \"integrity\": \"sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==\", \"time\": 0, \"size\": 5360, \"metadata\": {\"url\": \"https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fa4fe23b6bc134c60d26da3033c87003fb50204af907f8ec32c9a7c9e48c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/71"
+  },
+  {
+    "type": "inline",
+    "contents": "f874d3aafebd5a396210afe17a1fc426b1eb6d28\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz\", \"integrity\": \"sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==\", \"time\": 0, \"size\": 11158, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "60fe88011a8f0ba98f7a70150ea8d633acfcdc14dbc409ef0e58e7a07137",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/c2"
+  },
+  {
+    "type": "inline",
+    "contents": "f886883e4b613beecbe80b81cdc1788a85187551\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz\", \"integrity\": \"sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==\", \"time\": 0, \"size\": 2112, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ec5b21f2880d03498b61e661f036749619c9b2f016ea4f82fb2f5ec001dc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/d5"
+  },
+  {
+    "type": "inline",
+    "contents": "f8ea790763a604d695fa0e688f7be6b84f3703fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz\", \"integrity\": \"sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==\", \"time\": 0, \"size\": 7800844, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1eb5a9eef13baba7323ba4fca52015b4c83820822b6b5b80947c168e6f88",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/61/5d"
+  },
+  {
+    "type": "inline",
+    "contents": "f9e8cc4e9266c00877133a3f846e87e94f02e1d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"integrity\": \"sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==\", \"time\": 0, \"size\": 12860, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8b676d3aa47926784ae93445ccbb67ab3cd5cde01ed2fb99100c51c73d52",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/51"
+  },
+  {
+    "type": "inline",
+    "contents": "fa4ed3052d0e4a0aab3c8cee819c22034ab15f9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz\", \"integrity\": \"sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==\", \"time\": 0, \"size\": 3663, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0af58ac2be8d30dce651dd90c55da584a63d2cde826e88c398bf2dda1756",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/b2"
+  },
+  {
+    "type": "inline",
+    "contents": "fa6c14f2c5a20b04139842895c2795fa0fa5f7e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz\", \"integrity\": \"sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==\", \"time\": 0, \"size\": 173881, \"metadata\": {\"url\": \"https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9a9503827c3496efc99ccb90624bb03ab8f944992554510e25d4e4bda29c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/41"
+  },
+  {
+    "type": "inline",
+    "contents": "fa96ea1a7cd44185a896681ca122451d4d72247a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz\", \"integrity\": \"sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==\", \"time\": 0, \"size\": 3583220, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fbaf1f3ad7c767b7a055594defc295ab6bae4ec9f024d2c91b1d8432d349",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/65"
+  },
+  {
+    "type": "inline",
+    "contents": "fae104693ae9c5b951698f38ed3cd9008a223215\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz\", \"integrity\": \"sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==\", \"time\": 0, \"size\": 12587, \"metadata\": {\"url\": \"https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "0ad9cdf560680695d501bb1e53b0a05ed94492e3f0cfad0c5e3a6f6d65f7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9e/2a"
+  },
+  {
+    "type": "inline",
+    "contents": "fb2dea6b1b767e30e8beeb6e42ebfb286817e7e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.1.tgz\", \"integrity\": \"sha512-TlC5bsS+pqETTrlz4CZz9RO/cKBYtELGIxwtKeivUn3eNfnOxQbbu4WDsiwIfzRFyd0OMnKl6BPM2KnYEehoEQ==\", \"time\": 0, \"size\": 5346, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "9f35ac83b14ab70398a9cf56aef78d46077fa08dc59571b45c1069227aba",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/54"
+  },
+  {
+    "type": "inline",
+    "contents": "fb864171ff777125d4b1797c627492b13748dd25\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz\", \"integrity\": \"sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==\", \"time\": 0, \"size\": 1869535, \"metadata\": {\"url\": \"https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8e3170dfd4b4b71f233497f11b2320f2fad3db6fff747819ec8d50340fa3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "fbae79429150f51c555e67e383e0ebe081733dbe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz\", \"integrity\": \"sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==\", \"time\": 0, \"size\": 7066, \"metadata\": {\"url\": \"https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b43198f2f9bdd6d75b2b735e2a714ebaf0b8289264b876b618de9a54d020",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/d0"
+  },
+  {
+    "type": "inline",
+    "contents": "fc27e183f7b21c5c58e318d75b916346cff1813c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz\", \"integrity\": \"sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==\", \"time\": 0, \"size\": 4330, \"metadata\": {\"url\": \"https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "49ad2e42668f2957917d329c1a628dcf4b15349783223f27eb035ddcea84",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/2b"
+  },
+  {
+    "type": "inline",
+    "contents": "fc4302ee328a514184d392014e1ea63c612a3c7e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz\", \"integrity\": \"sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==\", \"time\": 0, \"size\": 38647, \"metadata\": {\"url\": \"https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ada25cd2fc2262a51324555563bd2f2c8f03716afbd9a583c7d2b2e0a967",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/3e"
+  },
+  {
+    "type": "inline",
+    "contents": "fcbda70721dcd62a77720c54dbdd0574c1a5d121\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz\", \"integrity\": \"sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ==\", \"time\": 0, \"size\": 3483, \"metadata\": {\"url\": \"https://registry.npmjs.org/matcher/-/matcher-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ab7ec50fad65d572cb1608e5d20bbb2d467a80edf44a1ccbb8a1a6e8870c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/a9"
+  },
+  {
+    "type": "inline",
+    "contents": "fdd9d94787ece916dda17c63df992d8dee0dc242\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz\", \"integrity\": \"sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==\", \"time\": 0, \"size\": 3963861, \"metadata\": {\"url\": \"https://registry.npmjs.org/jspdf/-/jspdf-4.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2e44fab26a6948fb146b9e04adb9d6e0ebfb73ac9907b59bc21e8ef8ec7d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d7/4b"
+  },
+  {
+    "type": "inline",
+    "contents": "fdfd250710ea95f4d75649e3c28bd32f64408eb0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz\", \"integrity\": \"sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==\", \"time\": 0, \"size\": 2678, \"metadata\": {\"url\": \"https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5af1ee25961517f37ab2315282f02e740c321e00298f09367872f7fd77c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/66"
+  },
+  {
+    "type": "inline",
+    "contents": "fe146b3066dd252591ddf2ba3f76c1c67621f88c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/zod/-/zod-3.25.76.tgz\", \"integrity\": \"sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==\", \"time\": 0, \"size\": 583600, \"metadata\": {\"url\": \"https://registry.npmjs.org/zod/-/zod-3.25.76.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7c6ad49d70eff131acc11a5b821e3d9d46bdb106b01afd85b2b5de6b2204",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "ff3e7305a8b16a858328112fad6779b01bc7d3e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz\", \"integrity\": \"sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==\", \"time\": 0, \"size\": 5891332, \"metadata\": {\"url\": \"https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2cfa568b2151d30a5338945e027dc853cc352eaab59bdf666e9f4f41e4b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/48"
+  },
+  {
+    "type": "inline",
+    "contents": "ff726b27ed236c890299eaae9ddaa2f547f73eec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz\", \"integrity\": \"sha512-7ImVPwBLCtkmpR5esd8RHhTqW94f0JLJQum6AneYcy94jRm18TaPPm7slaigGzFhfgt3QiD1Vj52LKmBAnKizA==\", \"time\": 0, \"size\": 24607549, \"metadata\": {\"url\": \"https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c321386f59412cab7b7768785180dc1f0fd759d83369cd5164732abc8430",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fa/54"
+  },
+  {
+    "type": "inline",
+    "contents": "ffaa2ca1a6e940ca9a998cabc2422a338e9a1816\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz\", \"integrity\": \"sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==\", \"time\": 0, \"size\": 3699964, \"metadata\": {\"url\": \"https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e86df570f0d5ccf74a9194726045695ee4a45581453c0cd08f3a32bf968b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/20"
+  },
+  {
+    "type": "inline",
+    "contents": "flatpak-node-cache",
+    "dest-filename": "INSTALLATION_COMPLETE",
+    "dest": "flatpak-node/cache/ms-playwright/chromium-1234"
+  },
+  {
+    "type": "inline",
+    "contents": "flatpak-node-cache",
+    "dest-filename": "INSTALLATION_COMPLETE",
+    "dest": "flatpak-node/cache/ms-playwright/chromium-headless-shell-1234"
+  },
+  {
+    "type": "inline",
+    "contents": "flatpak-node-cache",
+    "dest-filename": "INSTALLATION_COMPLETE",
+    "dest": "flatpak-node/cache/ms-playwright/ffmpeg-1011"
+  },
+  {
+    "type": "inline",
+    "contents": "flatpak-node-cache",
+    "dest-filename": "INSTALLATION_COMPLETE",
+    "dest": "flatpak-node/cache/ms-playwright/firefox-1538"
+  },
+  {
+    "type": "inline",
+    "contents": "flatpak-node-cache",
+    "dest-filename": "INSTALLATION_COMPLETE",
+    "dest": "flatpak-node/cache/ms-playwright/webkit-2336"
+  },
+  {
+    "type": "script",
+    "commands": [
+      "version=$(node --version | sed \"s/^v//\")",
+      "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+      "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+      "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+      "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+    ],
+    "dest-filename": "setup_sdk_node_headers.sh",
+    "dest": "flatpak-node"
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "bash flatpak-node/setup_sdk_node_headers.sh"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-arm64@0.28.2/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.28.2\"",
+      "ln -sf \"@esbuild/linux-arm64@0.28.2\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-arm@0.28.2/bin/esbuild\" \"bin/@esbuild/linux-arm@0.28.2\"",
+      "ln -sf \"@esbuild/linux-arm@0.28.2\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-ia32@0.28.2/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.28.2\"",
+      "ln -sf \"@esbuild/linux-ia32@0.28.2\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "i386"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-x64@0.28.2/bin/esbuild\" \"bin/@esbuild/linux-x64@0.28.2\"",
+      "ln -sf \"@esbuild/linux-x64@0.28.2\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+    "strip-components": 1,
+    "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.21.5",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+    "strip-components": 1,
+    "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.21.5",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+    "strip-components": 1,
+    "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.21.5",
+    "only-arches": [
+      "i386"
+    ]
+  },
+  {
+    "type": "archive",
+    "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+    "strip-components": 1,
+    "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+    "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.21.5",
+    "only-arches": [
+      "x86_64"
+    ]
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+    "sha512": "d520e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+    "dest-filename": "e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/20"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+    "sha512": "bc23efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+    "dest-filename": "efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/23"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+    "sha512": "734b97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+    "dest-filename": "97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/4b"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+    "sha512": "0fb68f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+    "dest-filename": "8f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+    "sha512": "0f0a97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+    "dest-filename": "97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/0a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+    "sha512": "b1efc98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+    "dest-filename": "c98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/ef"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+    "sha512": "e49711c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+    "dest-filename": "11c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/97"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+    "sha512": "27de643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+    "dest-filename": "643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/de"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+    "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+    "dest-filename": "f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/f6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+    "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+    "dest-filename": "af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/b2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+    "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+    "dest-filename": "d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/f8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+    "sha512": "b877f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+    "dest-filename": "f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+    "sha512": "21a8ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+    "dest-filename": "ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/a8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+    "sha512": "d611d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+    "dest-filename": "d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/11"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+    "sha512": "d877570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+    "dest-filename": "570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/77"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+    "sha512": "ceeb39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+    "dest-filename": "39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/eb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+    "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+    "dest-filename": "1d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/b6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+    "sha512": "5a88b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+    "dest-filename": "b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/88"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+    "sha512": "1cb34dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+    "dest-filename": "4dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+    "sha512": "ebe823985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+    "dest-filename": "23985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/e8"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+    "sha512": "67480e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+    "dest-filename": "0e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/48"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+    "sha512": "4965c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+    "dest-filename": "c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/65"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+    "sha512": "b5077fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+    "dest-filename": "7fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/07"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+    "sha512": "267041f0c7578f8e5c6a3bd3b8ee4598f96f155251420bebcf5b92125dcdc2a16745e00f1b06fc11a9db1a2e33da745aa8bce3252bf9fc99b27284ca9516711c",
+    "dest-filename": "41f0c7578f8e5c6a3bd3b8ee4598f96f155251420bebcf5b92125dcdc2a16745e00f1b06fc11a9db1a2e33da745aa8bce3252bf9fc99b27284ca9516711c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/70"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+    "sha512": "271da0ee24a3c3800e4f41c33c733d455dc6363457c326d6b521598990185138d4c2356b608c2ade405ff8b9e1a899735c502a4c087617b20623e3b9ebc7b13f",
+    "dest-filename": "a0ee24a3c3800e4f41c33c733d455dc6363457c326d6b521598990185138d4c2356b608c2ade405ff8b9e1a899735c502a4c087617b20623e3b9ebc7b13f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/1d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+    "sha512": "d05d4bfd9dc4aaff264f69f7742a5e3bc19c4ef1ef56a90fe7fb7a0ccb27d0ace1615720facecd725e434bcaa329811e8a8e80cf41adea7c813916b2e6a22508",
+    "dest-filename": "4bfd9dc4aaff264f69f7742a5e3bc19c4ef1ef56a90fe7fb7a0ccb27d0ace1615720facecd725e434bcaa329811e8a8e80cf41adea7c813916b2e6a22508",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/5d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+    "sha512": "a8bb6d707f3bd6e8d8e187157d44928613b0f82b284dab58cfc8116c73bb05bf76407d39f7f3f4cb9768d4a32ce357d8d01a43db1e00247fe0203d33162a9529",
+    "dest-filename": "6d707f3bd6e8d8e187157d44928613b0f82b284dab58cfc8116c73bb05bf76407d39f7f3f4cb9768d4a32ce357d8d01a43db1e00247fe0203d33162a9529",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/bb"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+    "sha512": "7d423845aa461343a1de66fc9a07ef0b53b69d4d51a436542a70d09b7c41d48a60ec2db04ece4ab2dcfb1b6b962bdf5af12db24ccabcfcfe2ec9cc0d6b49c9cb",
+    "dest-filename": "3845aa461343a1de66fc9a07ef0b53b69d4d51a436542a70d09b7c41d48a60ec2db04ece4ab2dcfb1b6b962bdf5af12db24ccabcfcfe2ec9cc0d6b49c9cb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/42"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+    "sha512": "1f962b76f25a0ed23f53dfde9ab0f86fefb192fa77cbf26f39ee2b8b31dbc6f93231f452fc289161d8e2f8f97c0f46eb11a34559487576b43180018897a5ee77",
+    "dest-filename": "2b76f25a0ed23f53dfde9ab0f86fefb192fa77cbf26f39ee2b8b31dbc6f93231f452fc289161d8e2f8f97c0f46eb11a34559487576b43180018897a5ee77",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/96"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+    "sha512": "43c08108242d0c5ad8b57a1e5174ab9c55ca3a7c94871e9bcfe4a42fa03413b57c900882279a5a9aad56b5b7e9546851e534a95d8e9a9376af9837397c74f224",
+    "dest-filename": "8108242d0c5ad8b57a1e5174ab9c55ca3a7c94871e9bcfe4a42fa03413b57c900882279a5a9aad56b5b7e9546851e534a95d8e9a9376af9837397c74f224",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/c0"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+    "sha512": "9f09e1935e7cd65d050557a59467150804f43a2d3aa27100dd6079dec7f4d553b723450f064307f6c5ce358304d8ad28bd770d6b225f36d1df9ba9a924495ab5",
+    "dest-filename": "e1935e7cd65d050557a59467150804f43a2d3aa27100dd6079dec7f4d553b723450f064307f6c5ce358304d8ad28bd770d6b225f36d1df9ba9a924495ab5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/09"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+    "sha512": "c795ebe3d870b7785d5bbe543999b7dfde58c30ccfc9aba4b6c96fdbd2a958bfd3faf540ce84f76b32dc4d6bf478c72204daf1f836231f8a5a7a11e82e93efa6",
+    "dest-filename": "ebe3d870b7785d5bbe543999b7dfde58c30ccfc9aba4b6c96fdbd2a958bfd3faf540ce84f76b32dc4d6bf478c72204daf1f836231f8a5a7a11e82e93efa6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/95"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+    "sha512": "ba7312dc7ef70e96a83f2c8454f8c62a578cfecd26926b1ab9310da70e0835063ccb8f88b8b36392e790e500ad0b40f7377f18dfcca1014f0ea19db44b64e6eb",
+    "dest-filename": "12dc7ef70e96a83f2c8454f8c62a578cfecd26926b1ab9310da70e0835063ccb8f88b8b36392e790e500ad0b40f7377f18dfcca1014f0ea19db44b64e6eb",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/73"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+    "sha512": "ccd6731919c08708c51189afa612515795da4068eceb670299e6181d44fffcd6ef1271dabb0f88f399c61be4a2560e65778197f03d486ca217fa8cc84d09e131",
+    "dest-filename": "731919c08708c51189afa612515795da4068eceb670299e6181d44fffcd6ef1271dabb0f88f399c61be4a2560e65778197f03d486ca217fa8cc84d09e131",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/d6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+    "sha512": "2dda5618bf17db4f41d9222f5a3aa573c55980ce8f29fa27b527ab19ea6e95d4261d8ac03ad9cc0977899315c66c2f8f3d954ebaee5ccc9a3b7cd57a69e5bcad",
+    "dest-filename": "5618bf17db4f41d9222f5a3aa573c55980ce8f29fa27b527ab19ea6e95d4261d8ac03ad9cc0977899315c66c2f8f3d954ebaee5ccc9a3b7cd57a69e5bcad",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/da"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+    "sha512": "102e644ed35a3463a66cc1aa6abf1dbc9cbacbf860f7d180c237c1cfefa9c598500135c67118dde9ce5e9f9c1c6ebbb4be446688c1ac40a74c24e39feaccdae2",
+    "dest-filename": "644ed35a3463a66cc1aa6abf1dbc9cbacbf860f7d180c237c1cfefa9c598500135c67118dde9ce5e9f9c1c6ebbb4be446688c1ac40a74c24e39feaccdae2",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+    "sha512": "f218b0a7a0f869c11c34aefc238acfd3f5ed4b5b249d620030904f751e25eb352dc939b92a24c3af96d7996b787e863b9c037b0138431e090b20464e58a6f35b",
+    "dest-filename": "b0a7a0f869c11c34aefc238acfd3f5ed4b5b249d620030904f751e25eb352dc939b92a24c3af96d7996b787e863b9c037b0138431e090b20464e58a6f35b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+    "sha512": "d74761fe1fc1a80ec3b8c3d64b1911f2e92cd7c151c27c0e12aaf9cce4c497e34ec0ffce333297f0e151fce7fdc710c0ec3e6a79fd4dcdaaf95830f69020abd6",
+    "dest-filename": "61fe1fc1a80ec3b8c3d64b1911f2e92cd7c151c27c0e12aaf9cce4c497e34ec0ffce333297f0e151fce7fdc710c0ec3e6a79fd4dcdaaf95830f69020abd6",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d7/47"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+    "sha512": "60a279960df90cfd7b81c00e8209e285ef803f0f472f28f55e7ee0b261ae9812405036ba3465cd8b12739a458b85c2bd4cebaec908dd6a6cef25e7e43bba8765",
+    "dest-filename": "79960df90cfd7b81c00e8209e285ef803f0f472f28f55e7ee0b261ae9812405036ba3465cd8b12739a458b85c2bd4cebaec908dd6a6cef25e7e43bba8765",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/a2"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+    "sha512": "3258a5e46d898fa6bb0772d619cb60f973cbf6f75762ecc2b4d5dfc4e4349cf8dcda6eae79492da1c3c61fd6e700cd1b35129bfdb0164ee8d453b20941d400fa",
+    "dest-filename": "a5e46d898fa6bb0772d619cb60f973cbf6f75762ecc2b4d5dfc4e4349cf8dcda6eae79492da1c3c61fd6e700cd1b35129bfdb0164ee8d453b20941d400fa",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/58"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+    "sha512": "6d558838893aa55d35a7809d51b3cfec227fe37e33f8ea286230ee15c47ee38377e58bca502eba1bc3069ef716c79996296de0eb527eb7be25dca8f5e4ac27d9",
+    "dest-filename": "8838893aa55d35a7809d51b3cfec227fe37e33f8ea286230ee15c47ee38377e58bca502eba1bc3069ef716c79996296de0eb527eb7be25dca8f5e4ac27d9",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/55"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+    "sha512": "ab2e6906f65ba8d161781cfad51d6bcec7b38e6d09eceda8346a16b46a18f3d49960b51fc40253040a830a1a8021d078ac28886e2f6717bc99f371a73622f04b",
+    "dest-filename": "6906f65ba8d161781cfad51d6bcec7b38e6d09eceda8346a16b46a18f3d49960b51fc40253040a830a1a8021d078ac28886e2f6717bc99f371a73622f04b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/2e"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+    "sha512": "13cdd35e3238ce6d3ee5fdaa3be50eb9d682608858c292798eae9809934867ee826df84aae40067b37a201204bf4497103116c452f598444aff267e78fa4ca7a",
+    "dest-filename": "d35e3238ce6d3ee5fdaa3be50eb9d682608858c292798eae9809934867ee826df84aae40067b37a201204bf4497103116c452f598444aff267e78fa4ca7a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/cd"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+    "sha512": "7db5a72aa5648eb24ddfcbcd7b76a191b93a89e8d2ff76f436dec412d3e913a44169c65c19734a6f37c73771945255ce3e08548348fa5d41abb635fdcf5b08bc",
+    "dest-filename": "a72aa5648eb24ddfcbcd7b76a191b93a89e8d2ff76f436dec412d3e913a44169c65c19734a6f37c73771945255ce3e08548348fa5d41abb635fdcf5b08bc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7d/b5"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+    "sha512": "02b325dfc89501b93435ec35a208a140d63a8a984b8b865a46c6b4dfb814cefe7278a3d8f130f70e6cb8c7644d0b5573b54feeaa6f86fbf47016b4a46b73b2da",
+    "dest-filename": "25dfc89501b93435ec35a208a140d63a8a984b8b865a46c6b4dfb814cefe7278a3d8f130f70e6cb8c7644d0b5573b54feeaa6f86fbf47016b4a46b73b2da",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/b3"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+    "sha512": "d2662d8c74bdb9c01b7004f270234af4818193f7027bf99aec49922c665db319ce03c723448c94d38c03a55003f4d88e7cb511f4a4f17623b9dee3a485eaea8d",
+    "dest-filename": "2d8c74bdb9c01b7004f270234af4818193f7027bf99aec49922c665db319ce03c723448c94d38c03a55003f4d88e7cb511f4a4f17623b9dee3a485eaea8d",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/66"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
+    "sha512": "80ad620843dfa68486f707c18a15f1bc1322f197dc59f7d8904b02fc48a1fa214435369ec2f35cac443af6520e5983b9a5e3c728b1c73bb9eae4020b18efc741",
+    "dest-filename": "620843dfa68486f707c18a15f1bc1322f197dc59f7d8904b02fc48a1fa214435369ec2f35cac443af6520e5983b9a5e3c728b1c73bb9eae4020b18efc741",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/ad"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
+    "sha512": "5fecda3f6c7e8f845719f6e9fec792a111d69cfc730298a50ecce2b19c5b607e42fe34f11610ad0cd74f1996fd949c983ecdb8c06c6bb8f17b63eb085edf46cf",
+    "dest-filename": "da3f6c7e8f845719f6e9fec792a111d69cfc730298a50ecce2b19c5b607e42fe34f11610ad0cd74f1996fd949c983ecdb8c06c6bb8f17b63eb085edf46cf",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+    "sha512": "ec28a760e0e1932f6598edb7c479d416fd17b78ddf6ed58ccb165c2dc44194591c8172ae122ac1bc7a66b49f3d60c87278672adb45ae738ec56b85e3ca78b2c0",
+    "dest-filename": "a760e0e1932f6598edb7c479d416fd17b78ddf6ed58ccb165c2dc44194591c8172ae122ac1bc7a66b49f3d60c87278672adb45ae738ec56b85e3ca78b2c0",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz",
+    "sha512": "fb8519ccbb7e78e004402c2077e4ea2a0c9424caefc7e0607572cb6aa25898fab33fe9c4e9866bfe163a0962d81906fc8c59fdf63124982eae037b4dbda980d7",
+    "dest-filename": "19ccbb7e78e004402c2077e4ea2a0c9424caefc7e0607572cb6aa25898fab33fe9c4e9866bfe163a0962d81906fc8c59fdf63124982eae037b4dbda980d7",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/85"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz",
+    "sha512": "563618b5950fa8330bbad49f244cb1144dc1cfe0cf8bb73cc02de299c920bdc88b0d92eae2ac0a271062720d015c68578c9b25f2f29681644534c3c42d0f97ca",
+    "dest-filename": "18b5950fa8330bbad49f244cb1144dc1cfe0cf8bb73cc02de299c920bdc88b0d92eae2ac0a271062720d015c68578c9b25f2f29681644534c3c42d0f97ca",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/36"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz",
+    "sha512": "c8c7a60fa7f88bde4042b892f046b3c8e1736c4df8ca39cfd7a8b720ece91c642f068cb60e3ca914c141ab436d3ee213511bff70e1a0b91b4747977bf7ff4248",
+    "dest-filename": "a60fa7f88bde4042b892f046b3c8e1736c4df8ca39cfd7a8b720ece91c642f068cb60e3ca914c141ab436d3ee213511bff70e1a0b91b4747977bf7ff4248",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/c7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz",
+    "sha512": "72023dd43db02fc1928285b06570eab7e0f09ee6423f6fdbcf4dd0004e13ae1800288b2b078857dba5bf1f510e34f514364aabb207820f4c14ea970d8d5ff993",
+    "dest-filename": "3dd43db02fc1928285b06570eab7e0f09ee6423f6fdbcf4dd0004e13ae1800288b2b078857dba5bf1f510e34f514364aabb207820f4c14ea970d8d5ff993",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/72/02"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz",
+    "sha512": "5f5ae6d01111a8002082d6131124a05eb4b7b33e126ff3a23e2cf9e14a884a55d6f86911def3481a7b32fe57a3366a17195aab8b7439dc109f422725388c913f",
+    "dest-filename": "e6d01111a8002082d6131124a05eb4b7b33e126ff3a23e2cf9e14a884a55d6f86911def3481a7b32fe57a3366a17195aab8b7439dc109f422725388c913f",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/5a"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz",
+    "sha512": "bac6cc2c96d3dcab643ab04c0d578660d337e5a4c75f1dfc4894b34cc4aaaa379420e43e8953e36f6c8018d004f8aaa605b031e0538523231e297c7633f24a19",
+    "dest-filename": "cc2c96d3dcab643ab04c0d578660d337e5a4c75f1dfc4894b34cc4aaaa379420e43e8953e36f6c8018d004f8aaa605b031e0538523231e297c7633f24a19",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ba/c6"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz",
+    "sha512": "46ee20c0928f1b472d546721446a51ba9e18e255b64927c59eb6d07321e10a588acb883c433f7b4eb5200aeaf809b5b20202b1bc68774a3ae40342c36330c68b",
+    "dest-filename": "20c0928f1b472d546721446a51ba9e18e255b64927c59eb6d07321e10a588acb883c433f7b4eb5200aeaf809b5b20202b1bc68774a3ae40342c36330c68b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/ee"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz",
+    "sha512": "7949bb4fa72537530c98d49143d81a5ac41dc9e850c761a69f9861b7f41496a65023fa9c3f63892b97676b1ab01730abd8776c128f727716aa712d6827332f53",
+    "dest-filename": "bb4fa72537530c98d49143d81a5ac41dc9e850c761a69f9861b7f41496a65023fa9c3f63892b97676b1ab01730abd8776c128f727716aa712d6827332f53",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/49"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz",
+    "sha512": "1de7995bcd2353e8154ce117e17fe10ba3554807435576a3c0fe5fc4867fdf3f56bd40bbaabb9d5f618c4e2958aba0e0d1ed2c9345e0b00243d61679c0f05750",
+    "dest-filename": "995bcd2353e8154ce117e17fe10ba3554807435576a3c0fe5fc4867fdf3f56bd40bbaabb9d5f618c4e2958aba0e0d1ed2c9345e0b00243d61679c0f05750",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/e7"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz",
+    "sha512": "6218d03597177db9022f26b34afd673e727d891144d709ba91ce751436d4d74fc3934f62a3ee8f00630b8e4c675f619d334a8c9c39938ecb58f264c356fb4a78",
+    "dest-filename": "d03597177db9022f26b34afd673e727d891144d709ba91ce751436d4d74fc3934f62a3ee8f00630b8e4c675f619d334a8c9c39938ecb58f264c356fb4a78",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/18"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz",
+    "sha512": "77625c865148a597af65545ecaa85039e90999bd541f7ae1679557eac1f7b72f444c4d132906afa6286fa127145df28aa56e87642d0cac519153466d0fec3780",
+    "dest-filename": "5c865148a597af65545ecaa85039e90999bd541f7ae1679557eac1f7b72f444c4d132906afa6286fa127145df28aa56e87642d0cac519153466d0fec3780",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/77/62"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz",
+    "sha512": "6e4dc77a6aaf191a32fb90ff75531440728c60b8250f48d59cc9bfd2218c1fab9f67ea7caf5e26e81a488b1c228f73c1bd976f391529d5889f4c3f10c5567537",
+    "dest-filename": "c77a6aaf191a32fb90ff75531440728c60b8250f48d59cc9bfd2218c1fab9f67ea7caf5e26e81a488b1c228f73c1bd976f391529d5889f4c3f10c5567537",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/4d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz",
+    "sha512": "f4bcfe268a69e90c9e116865a64331e11ffe3fd1e047e015008e2f3998654fc5daca6b73f22548fcebfdf38fd74ea809cffe60cf936b7ada8f07f5c4312dcd85",
+    "dest-filename": "fe268a69e90c9e116865a64331e11ffe3fd1e047e015008e2f3998654fc5daca6b73f22548fcebfdf38fd74ea809cffe60cf936b7ada8f07f5c4312dcd85",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/bc"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz",
+    "sha512": "942898d3ebece07bc8512bd9ac1b3c4c2dd388207430e3d19a25234eae29ad6ed295c244da374b793e8a06c26b4fd4e5a65b9f97b5b5a58e921403b78025b10c",
+    "dest-filename": "98d3ebece07bc8512bd9ac1b3c4c2dd388207430e3d19a25234eae29ad6ed295c244da374b793e8a06c26b4fd4e5a65b9f97b5b5a58e921403b78025b10c",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/28"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+    "sha512": "8dec2d50b86243b948efea3008a02373cb582c9afdd94d7a6cf39e01ae3bd8b1c97606a26cb3fcdcd71f005d9efb0904700e77171290019edbc83cecd9e7a2ce",
+    "dest-filename": "2d50b86243b948efea3008a02373cb582c9afdd94d7a6cf39e01ae3bd8b1c97606a26cb3fcdcd71f005d9efb0904700e77171290019edbc83cecd9e7a2ce",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/ec"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+    "sha512": "1a174f832d5e978fc898fd395f4e54c38730dbf33ddc10949a712f599352b650b310a304e05924f98a680393a21cd426a12ec269f6fc5dadcfc9af26d50af37a",
+    "dest-filename": "4f832d5e978fc898fd395f4e54c38730dbf33ddc10949a712f599352b650b310a304e05924f98a680393a21cd426a12ec269f6fc5dadcfc9af26d50af37a",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1a/17"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+    "sha512": "9a0dce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+    "dest-filename": "ce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/0d"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+    "sha512": "641f511ffdfdaa9ab956ee98f8d99468585047aa69f8cd97b7be970671300da19c540aa196fc6b9770766ca4b90f7347dd047beafdda4ab29a17f2a2cbb944b5",
+    "dest-filename": "511ffdfdaa9ab956ee98f8d99468585047aa69f8cd97b7be970671300da19c540aa196fc6b9770766ca4b90f7347dd047beafdda4ab29a17f2a2cbb944b5",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/1f"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+    "sha512": "15f47cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc",
+    "dest-filename": "7cb237787a6d93e9f6f723633000953b1d654cafdcdb6be7a799079e5857c26e6f94382ff45f80d2f17b6951333058c19b8ca60fef18df35e933c86981dc",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/f4"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
+    "sha512": "238296ea2b91a6ebb6b8704bada675c0d65ed033fb9674616be549f6d35a61569580a856d1a2378784589e844f7aa9747e51e6fc2a39e5beec9c40dc39f389ac",
+    "dest-filename": "96ea2b91a6ebb6b8704bada675c0d65ed033fb9674616be549f6d35a61569580a856d1a2378784589e844f7aa9747e51e6fc2a39e5beec9c40dc39f389ac",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/82"
+  },
+  {
+    "type": "file",
+    "url": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+    "sha512": "a396bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+    "dest-filename": "bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+    "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/96"
+  },
+  {
+    "type": "inline",
+    "contents": "01e46bc0dc92759455dae23fe49151b09cd35346\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz\", \"integrity\": \"sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==\", \"time\": 0, \"size\": 3884794, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "135fdff79235b08198cd4cb78de9deb671d31d6835d0e4e7f6008e178c33",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/e6"
+  },
+  {
+    "type": "inline",
+    "contents": "07e6e1d6f0732b5b4425ae996563bcaee81acdbd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz\", \"integrity\": \"sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==\", \"time\": 0, \"size\": 851639, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "cd834060a803a795d4755cfdec256a374f370be577c2394d16b5dd12df62",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/80"
+  },
+  {
+    "type": "inline",
+    "contents": "08ddc3def60ff51cfbb1eee4358f020bd010a491\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==\", \"time\": 0, \"size\": 842574, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "38f2dfd2025a9bbbf02205daac4096e480c00ab810c3fd911abfc57f3435",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/a6"
+  },
+  {
+    "type": "inline",
+    "contents": "0c0dc5c51ba0703dfa8d4b34bdb8b6c6a67e4848\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz\", \"integrity\": \"sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==\", \"time\": 0, \"size\": 3849556, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7ff78a06c8555d1e363864d4e9cfa847d64d072cce3774fe36721aa8885b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/6f"
+  },
+  {
+    "type": "inline",
+    "contents": "0fbe103cfdfe7617bdc2e60c55a572db01a4d6c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz\", \"integrity\": \"sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==\", \"time\": 0, \"size\": 813413, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b8feb7d5f4f28a49aa37c36925d4e9e331551cb07d25a9294e3815812e41",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/3b"
+  },
+  {
+    "type": "inline",
+    "contents": "14f2455ac91f5c7a75abae3b1ff4b30aef3931de\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz\", \"integrity\": \"sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==\", \"time\": 0, \"size\": 7347, \"metadata\": {\"url\": \"https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c4afbe3f64967556faf1049536c1dfbb141aed19d466aa19f225896d04eb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/38"
+  },
+  {
+    "type": "inline",
+    "contents": "157b64b930487212ac4085378b510bb5d047d0ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==\", \"time\": 0, \"size\": 4119987, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2d55f9a41c57244e431b96db470a19fead478df12c5f3a962e96832d9fae",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/af"
+  },
+  {
+    "type": "inline",
+    "contents": "175b36017eca87f99ba3dc9026bcb237f2d6e72c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz\", \"integrity\": \"sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==\", \"time\": 0, \"size\": 851056, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "717f0c417f2dd0396e552e4cba6249305b47f960f83c1d3db22c13e91ddc",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/87"
+  },
+  {
+    "type": "inline",
+    "contents": "1c0536340e2c2bfa77f5e8f783e7ab693493f70c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==\", \"time\": 0, \"size\": 880348, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "62a055c1da6ecaf524a37c9fde40be222880d3189c2d41d3d37742de4792",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/77"
+  },
+  {
+    "type": "inline",
+    "contents": "255595f4ff5243016255e589d9661b953c583cb2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz\", \"integrity\": \"sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==\", \"time\": 0, \"size\": 3507038, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7bf704b620a95281ac3e0ce6487e2cb33c1def7a88c53bfdc1997791de79",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/75"
+  },
+  {
+    "type": "inline",
+    "contents": "284ac4d442e9ca989809703a78fa3883b9fd7377\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==\", \"time\": 0, \"size\": 837617, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "75eb4b3de98628b0c58aa852fd07ceae27c79a4017571043d9dc24e3d050",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/4c"
+  },
+  {
+    "type": "inline",
+    "contents": "29117280497ad1aa3d1d78475fea0ff17f3c95c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz\", \"integrity\": \"sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==\", \"time\": 0, \"size\": 7628024, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5c4ccdc4584907392b179ab0dd8ffa805f431e6b28f04eb0c76f14d6ce0f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/b6"
+  },
+  {
+    "type": "inline",
+    "contents": "29d5da8de0ca71a0e59a9f033e43bb94987e2b65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz\", \"integrity\": \"sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==\", \"time\": 0, \"size\": 870832, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d8190be8e2c30a20c11a6438814adfd7f048646178d484ae3459828c31b8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/ef"
+  },
+  {
+    "type": "inline",
+    "contents": "31466c0d59b629646e9abc1227dab28b1875b9da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz\", \"integrity\": \"sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==\", \"time\": 0, \"size\": 3862529, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "6d8f1954e21e9af42908a4e84ef47f2f63556562197f14a0c901301da9f8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/64"
+  },
+  {
+    "type": "inline",
+    "contents": "316d60906442a6199d3d2974960d6dc49222386d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz\", \"integrity\": \"sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==\", \"time\": 0, \"size\": 980186, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2414d5445b0e68e5f657f38d8d2b6f0304139a0105e8f366540d457f1fc2",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/28"
+  },
+  {
+    "type": "inline",
+    "contents": "334402dbda547b6984c0c352f99bfc0bb54c6f9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz\", \"integrity\": \"sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==\", \"time\": 0, \"size\": 30513, \"metadata\": {\"url\": \"https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "4770783f9e8a04dc1981e9b336245aa81e7c44c38754a79c812ab556e605",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/fd"
+  },
+  {
+    "type": "inline",
+    "contents": "35f37ac1bc2f3f2f1ba1a49a1956ab0e085b1a3c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz\", \"integrity\": \"sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==\", \"time\": 0, \"size\": 8675730, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dfdab6adffba1d85c1479f4a6b1f50eb31168055a85638864ed97b38fa16",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/a7/78"
+  },
+  {
+    "type": "inline",
+    "contents": "3a0f7e3b5dcdd8c6e1050b272713773506d2481d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz\", \"integrity\": \"sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==\", \"time\": 0, \"size\": 860866, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1d839065524a870b5697c6c42037dbef3f27abcf91c3a63c321c23027c0b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/ea"
+  },
+  {
+    "type": "inline",
+    "contents": "3fd841313fa9f00d004aa0f45577665605e02086\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz\", \"integrity\": \"sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==\", \"time\": 0, \"size\": 6691, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "80ea7ab5900383ec6ec2e278e529448797e25413d9a863cc9e95de7a2ca7",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/8d"
+  },
+  {
+    "type": "inline",
+    "contents": "444ef1c491d4674fdd04410a54eca46cc7267ad4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz\", \"integrity\": \"sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==\", \"time\": 0, \"size\": 4080074, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "de13673d9ce0488425116cb65f9de1532751c13ed0efecd75b7db795da1b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/0d"
+  },
+  {
+    "type": "inline",
+    "contents": "4b0cc14a59519ca90eb7ab44c9e7e3e2cb62bcfe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==\", \"time\": 0, \"size\": 906930, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "afe2b0c89db97fb1c76cc3740cb28b4b9cfe08c6956f66f4be42c93f27dd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/58"
+  },
+  {
+    "type": "inline",
+    "contents": "4dc7ad8f415bf1d41384760eae3921a93154a7a6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz\", \"integrity\": \"sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==\", \"time\": 0, \"size\": 805441, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "05d44cdd67a87d67ddfa47b358a5b67804b89af22e23fbaec56751090b45",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/1a"
+  },
+  {
+    "type": "inline",
+    "contents": "4e9c5534ed96debcb284f946e0a82d0ce66795ca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz\", \"integrity\": \"sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==\", \"time\": 0, \"size\": 904897, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "fd3c9b11bc82a33ee96a9d7881de2b2484de88851aaf067f7d3ac30df125",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/39/db"
+  },
+  {
+    "type": "inline",
+    "contents": "50354265cb8a97efbc15a196d7a0a067f3d0660f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz\", \"integrity\": \"sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==\", \"time\": 0, \"size\": 8368953, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-riscv64-gnu/-/cli-linux-riscv64-gnu-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e33a4d7572a136301bb5663775b710d081c5fdd8be0fee6d4bba31dff617",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/64"
+  },
+  {
+    "type": "inline",
+    "contents": "504056813db7bb8855d67373cb79f0a4b8d14b39\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz\", \"integrity\": \"sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==\", \"time\": 0, \"size\": 3882784, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "80ebb8908c357227759202290a2cf797e22754ec23c5a7d620de590395b4",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/9b"
+  },
+  {
+    "type": "inline",
+    "contents": "51e0a2015c4bad4dc9d5f6576fc7196fab5df094\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz\", \"integrity\": \"sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==\", \"time\": 0, \"size\": 4195965, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2ba7247c5b8508fdb00c2b69a6dfed2e27d0bac54c0e780ad1c0de281f4e",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/5c"
+  },
+  {
+    "type": "inline",
+    "contents": "52af01ff9770dd9883e901d51c5450bb9043e8a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz\", \"integrity\": \"sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==\", \"time\": 0, \"size\": 5930, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "7b95e0dedcb8078233a6c78e446ab86eeb34fe91750c0e4ce90602a1e1eb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/93"
+  },
+  {
+    "type": "inline",
+    "contents": "5786c04680341cfb4beea954c0a4f3f2924ad818\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz\", \"integrity\": \"sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==\", \"time\": 0, \"size\": 3850679, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "65d2c134c6ff109aa75543b9f34975f18821703a6b9f3fa0ff6651b9bc55",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/36"
+  },
+  {
+    "type": "inline",
+    "contents": "5a8da8312f4f805be44ecadba1007084d24aec23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite/-/vite-5.4.21.tgz\", \"integrity\": \"sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==\", \"time\": 0, \"size\": 760049, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite/-/vite-5.4.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "446856e2adb28de3b02a5e5f396a79399380f2c39ce620c3e58951730f91",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/01"
+  },
+  {
+    "type": "inline",
+    "contents": "5dc644967f645c1277001c19cdcd0703390190d7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz\", \"integrity\": \"sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==\", \"time\": 0, \"size\": 7301180, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-win32-arm64-msvc/-/cli-win32-arm64-msvc-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5f3613c71f4b12b58d359d53e798fb55bd74d7bf02350f35fc815bcb4afe",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/d6"
+  },
+  {
+    "type": "inline",
+    "contents": "6141e29e0b0925bb3a5a52ebfabd692651857890\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz\", \"integrity\": \"sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==\", \"time\": 0, \"size\": 3990163, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "43daf96c217a2aacf85ddcd30768c6e65bf8a56b5aa6eb678ef99a4274d0",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/7a"
+  },
+  {
+    "type": "inline",
+    "contents": "63eff9dcf7ffe1cc28b303b73794b21be26cb825\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz\", \"integrity\": \"sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==\", \"time\": 0, \"size\": 135085, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ce1ecf423112d5b5ea60cc3832637c17dd03af6af66b0dfb68d212229c24",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/bf"
+  },
+  {
+    "type": "inline",
+    "contents": "65052d01c1daa920620394c4cba36d4e0becc437\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz\", \"integrity\": \"sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==\", \"time\": 0, \"size\": 797220, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e51372935c21a84eb5aa5c76d0097e8f4b61c6e249861f44e5851af61234",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/be"
+  },
+  {
+    "type": "inline",
+    "contents": "659ede5134e47b1292cab6d0332b5176d3b0f257\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz\", \"integrity\": \"sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==\", \"time\": 0, \"size\": 48456, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "dce721a470ed9a59339f21a70a7facdf932119e37da5013b141835109a47",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/4d"
+  },
+  {
+    "type": "inline",
+    "contents": "6c41e81aae321612537b6addd62fe21507f643b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz\", \"integrity\": \"sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==\", \"time\": 0, \"size\": 869570, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d814f1700558f69f3445f08327551fa7095100dc531a19cfd463e7b37ebd",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/9e"
+  },
+  {
+    "type": "inline",
+    "contents": "7176d57014e9ebac35e7dbebebccc335f98c8bb0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz\", \"integrity\": \"sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==\", \"time\": 0, \"size\": 680736, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea395f1ab8ec994903a5b8f2a2e72af0d3e8e9ea6fd3a6148b820461e2b5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/4f"
+  },
+  {
+    "type": "inline",
+    "contents": "8065911ba10e3a988ae6b91572df94acb48cd2f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz\", \"integrity\": \"sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==\", \"time\": 0, \"size\": 8195358, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2de6a90b002740e6ee3bf7d3491f510d862c3fd030a0c7e5ea21802a859b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/1c"
+  },
+  {
+    "type": "inline",
+    "contents": "8278e5b4ed30f15291aa4c70f2b719d80ebf5e1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz\", \"integrity\": \"sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==\", \"time\": 0, \"size\": 893342, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "562ab3346bddb07d7418d6602bc2e9a7753c971cce2133e4daecf32d0b3b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/2c"
+  },
+  {
+    "type": "inline",
+    "contents": "8614b6053d56c0b0e01644b4aac14116a3f8d3b4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz\", \"integrity\": \"sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==\", \"time\": 0, \"size\": 882516, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b7cb92fe827c699ee576954a49494295ff86eca2fa5904cabfa2f3046f48",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/64"
+  },
+  {
+    "type": "inline",
+    "contents": "8ca37f59912cd2c82f3ecb29c43b66f1fb410c1a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz\", \"integrity\": \"sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==\", \"time\": 0, \"size\": 21541, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/plugin-fs/-/plugin-fs-2.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ea5c9e719d254997c3dc2ea6049c70226ebaccc5c454edfb9870842d9145",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/bc"
+  },
+  {
+    "type": "inline",
+    "contents": "8d07e1a1e5c6343533d3e719f89e0512fe7c04e1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz\", \"integrity\": \"sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==\", \"time\": 0, \"size\": 939798, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "66c54d66af5c0107d013acc8139720c00a54b6935b6deba77726ec324456",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/d1"
+  },
+  {
+    "type": "inline",
+    "contents": "8ed87dee87e6598bb685ea56606968776d3d2017\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz\", \"integrity\": \"sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==\", \"time\": 0, \"size\": 8225720, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "e58a09675ea75abd60aa9b72a9fe628b6e3d4f65850f17c8eff337c86c79",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/8b"
+  },
+  {
+    "type": "inline",
+    "contents": "902b69d3360a262cbd9d2ee97faadbcffc136bcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz\", \"integrity\": \"sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==\", \"time\": 0, \"size\": 3768056, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "974ef046f769da36693d5d6a38f98646e6dd0adc620308999c6bc5158791",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/59"
+  },
+  {
+    "type": "inline",
+    "contents": "94523fbd3f83689586d2617e884f38dca91d79a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz\", \"integrity\": \"sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==\", \"time\": 0, \"size\": 3982493, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c35f135ee87267b7c80b09e75f31c4cae6d867637ad18932c4469c5e1735",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/1b"
+  },
+  {
+    "type": "inline",
+    "contents": "954e4b3ca6b48c76e475208bffd1862e71aa6c36\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==\", \"time\": 0, \"size\": 4131044, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "27a6c561329523b7a65321d67edb2bafe1455e1e75cfa90ab16e957bab16",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/d9"
+  },
+  {
+    "type": "inline",
+    "contents": "977d7da18a381fb4ab290ec179cdce3ffecf0e8d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz\", \"integrity\": \"sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==\", \"time\": 0, \"size\": 911598, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "bf2877d16b41aa6c8e55f0da3fba6fd602af85dfc912f3ae510e0531c816",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/0b"
+  },
+  {
+    "type": "inline",
+    "contents": "98b8ad37d1f9a0533ba491c806c301a620782eb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz\", \"integrity\": \"sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==\", \"time\": 0, \"size\": 570682, \"metadata\": {\"url\": \"https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "f5e592b739c38153f65544464cf8f55a87d3facb5398a6a8d59aa481493b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/6e"
+  },
+  {
+    "type": "inline",
+    "contents": "99bf66fe96401d65b135d979373201d4fbc945a4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz\", \"integrity\": \"sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==\", \"time\": 0, \"size\": 8369653, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "37a01a564b5ba10501cad760a95d493e404ba0341d9c348cfe097acf1f21",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/4f/94"
+  },
+  {
+    "type": "inline",
+    "contents": "99f33a1b3ef828bb1235579b53137ad2aafcf1fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz\", \"integrity\": \"sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==\", \"time\": 0, \"size\": 3187571, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "291c332f083c6019a62f21452f27ac3829a9e8dd260bd5c7f36bf059a2a1",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/7d"
+  },
+  {
+    "type": "inline",
+    "contents": "9b3db7663ab552843367229679d3fbb9c4dd6ebe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz\", \"integrity\": \"sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==\", \"time\": 0, \"size\": 4251628, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ba8c2a08eac7f24554a57a495f95f4c0a1e19f8768417dd5fea07931bb16",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/7f"
+  },
+  {
+    "type": "inline",
+    "contents": "9eecf74a710d507edb72891c2d9a1f3b1fb3dc24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz\", \"integrity\": \"sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==\", \"time\": 0, \"size\": 4129742, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "1a865896ac854406e778c64c746b1bbd506befa888d226b99565598f10c8",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/ed"
+  },
+  {
+    "type": "inline",
+    "contents": "9fc2beaffbfa4a9b5360d797083f4a4104073463\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz\", \"integrity\": \"sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==\", \"time\": 0, \"size\": 4023141, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "319fc3d2774a09d9f434e1cb9a70b0c3bbb58862a757fabf35cbab92dcb9",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/05"
+  },
+  {
+    "type": "inline",
+    "contents": "a13bd049bc9566cc2458717e749af0d63fc097c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==\", \"time\": 0, \"size\": 4129297, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c288142e36eb24df8a73d01898c488dd3785639fb980a0c6ec2ff54bf06a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/10"
+  },
+  {
+    "type": "inline",
+    "contents": "a373e1e787bf080c9ec7ffb632102c17c586f5b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz\", \"integrity\": \"sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==\", \"time\": 0, \"size\": 3187578, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "403c95f06d21c4286daeeeb08333a3ddb82ac99d41ce14010587828c91f5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/ce"
+  },
+  {
+    "type": "inline",
+    "contents": "a7d4aef5d0399ef6caca4d8a48c81d3b05502ef5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz\", \"integrity\": \"sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==\", \"time\": 0, \"size\": 805106, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "8d4f554037c46d41e562f3e40f034ecff943cae981e62586faef59ced40d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/ad"
+  },
+  {
+    "type": "inline",
+    "contents": "a7edbb637238a108ea474cb4c7f10ea977dbc15c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz\", \"integrity\": \"sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==\", \"time\": 0, \"size\": 7906009, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d99ba2ac0a7a2e55d31f0d60b92ac3acfad614794957919cd77b26d45e5a",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/a4"
+  },
+  {
+    "type": "inline",
+    "contents": "b526032b8852fdc5668c59d0800060baf7153075\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz\", \"integrity\": \"sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==\", \"time\": 0, \"size\": 831910, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "c7cd71331cb720c0de707936c70b8994aa6ff16517a5e2e5e4849210ca5d",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/48"
+  },
+  {
+    "type": "inline",
+    "contents": "b5d4741db6a73e5e28117693146215c486b33e52\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz\", \"integrity\": \"sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==\", \"time\": 0, \"size\": 7332930, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "130a7c473c4f9de8b57319b72709f1a0ea7f765cab03deb7cb3b2f959b1f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/41"
+  },
+  {
+    "type": "inline",
+    "contents": "b80e166b6d1dd52c7b37a62037cc0aa8493a2c31\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz\", \"integrity\": \"sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==\", \"time\": 0, \"size\": 850832, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5bbfe908ac2ed8d4d3efaa5f7708a7c0a333a7a24b57388723e4e55935e3",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/47"
+  },
+  {
+    "type": "inline",
+    "contents": "cdb7ba90d947953130a487fbd6da36e6175c8da8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz\", \"integrity\": \"sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==\", \"time\": 0, \"size\": 966484, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "17d9177f6da18c94104aa5f9a99dc3e849b5958d50ef25c04a0a41e6d21b",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/52"
+  },
+  {
+    "type": "inline",
+    "contents": "d17594b11c170a6b515dd49c187ad8ad6a9fa5a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==\", \"time\": 0, \"size\": 948967, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "3dca4a6a1e3eb0da1462dcfcdb96bcedecde1d531dc40e742fdadc35eedb",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/21"
+  },
+  {
+    "type": "inline",
+    "contents": "deac2ae624ec88cdaf7649cdcdc6950f19244288\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz\", \"integrity\": \"sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==\", \"time\": 0, \"size\": 3690416, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "2f4a7fe236605e83980e7ec10d0f4602de4cfc9a2c9cf49fc7e69c16f624",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/71"
+  },
+  {
+    "type": "inline",
+    "contents": "e074329ee154ca7a413d4ca4af8c89f1b550d009\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz\", \"integrity\": \"sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==\", \"time\": 0, \"size\": 3765769, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "5dfa2517bd157c31a86d99c03f6d8683dbbf06b3bf4f22fd4f0a7c713ee5",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/e7"
+  },
+  {
+    "type": "inline",
+    "contents": "e266fd319fdd8e02cb187910ba33a11b01dc79cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz\", \"integrity\": \"sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==\", \"time\": 0, \"size\": 920553, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "b85fd4e4c302cb0ba97c6833e7edf383ce5a43d98cfc3fdd914e2d83846f",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/69"
+  },
+  {
+    "type": "inline",
+    "contents": "e605c736456fa712c5db4b9adcbffb7bb38d427b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz\", \"integrity\": \"sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==\", \"time\": 0, \"size\": 8229257, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ca7740da57199104a148d165884b578b079e096bf051483955e501a1682c",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/71"
+  },
+  {
+    "type": "inline",
+    "contents": "e6bd359409e00ab078df6d1ecf21fb244849d838\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz\", \"integrity\": \"sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==\", \"time\": 0, \"size\": 85118, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli/-/cli-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "150a2fc8c4a47421a52019160fbc369bb26ef773beb84ac35468c49e2d20",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/5e"
+  },
+  {
+    "type": "inline",
+    "contents": "e9d8e6786fef583896651784d2d237f00d81268b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz\", \"integrity\": \"sha512-lCiY0+vs4HvIUSvZrBs8TC3TiCB0MOPRmiUjTq4prW7SlcJE2jdLeT6KBsJrT9Tlplufl7W1pY6SFAO3gCWxDA==\", \"time\": 0, \"size\": 5073, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/plugin-http/-/plugin-http-2.5.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "ef9da543589c0e00c23e769aeb79aafad0b7edb203d034f1d397a027b662",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/24"
+  },
+  {
+    "type": "inline",
+    "contents": "ea12aaf02baeeeec57c016102e93f9e43560c17d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz\", \"integrity\": \"sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==\", \"time\": 0, \"size\": 8662084, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-2.11.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "98dfff9d46b6fc8f45513a8172865aeed4bb1f47eef3b69a3935ac4bf365",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/c5"
+  },
+  {
+    "type": "inline",
+    "contents": "eec943f6dd66c8b4c8b18588e53e16de1150f32a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz\", \"integrity\": \"sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==\", \"time\": 0, \"size\": 3828886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "d56a8dccf497cee622a6d8c41e31dbc5b8fb84aeed3bd102a3370cd7ba10",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/f6/0f"
+  },
+  {
+    "type": "inline",
+    "contents": "fcf2b03890b82fbcfcdbb8eb008f8568b14e575f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz\", \"integrity\": \"sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==\", \"time\": 0, \"size\": 4119035, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+    "dest-filename": "567fa04456d9d69c442d4a6e7166c56fd84d21cd3e0b73f65746be33d473",
+    "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/cc"
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-arm64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.21.5\"",
+      "ln -sf \"@esbuild/linux-arm64@0.21.5\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "aarch64"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-arm@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm@0.21.5\"",
+      "ln -sf \"@esbuild/linux-arm@0.21.5\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "arm"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-ia32@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.21.5\"",
+      "ln -sf \"@esbuild/linux-ia32@0.21.5\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "i386"
+    ]
+  },
+  {
+    "type": "shell",
+    "commands": [
+      "mkdir -p \"bin/@esbuild\"",
+      "cp \".package/@esbuild/linux-x64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-x64@0.21.5\"",
+      "ln -sf \"@esbuild/linux-x64@0.21.5\" \"bin/esbuild-current\""
+    ],
+    "dest": "flatpak-node/cache/esbuild",
+    "only-arches": [
+      "x86_64"
+    ]
+  }
+]

--- a/tools.lolly.Desktop.yml
+++ b/tools.lolly.Desktop.yml
@@ -1,0 +1,280 @@
+# Flathub manifest for Lolly - builds ENTIRELY FROM SOURCE, offline.
+#
+# This is NOT the manifest in the parent directory. Two manifests exist because they
+# answer to different masters:
+#
+#   ../tools.lolly.Desktop.yml  unpacks a prebuilt .deb. Fast, and fine for the
+#                               bundles we hand out ourselves, but Flathub forbids
+#                               prebuilt binaries outright.
+#   this one                    compiles everything inside the offline build sandbox,
+#                               which is what Flathub requires.
+#
+# Keep them in agreement on: app id, runtime version, command, finish-args, and the
+# freedesktop metadata they install. Only the build strategy differs.
+#
+# THE OFFLINE PROBLEM, AND HOW EACH PART IS SOLVED
+#
+#   ~600 cargo crates   -> cargo-sources.json, from flatpak-cargo-generator.py
+#   ~700 npm packages   -> node-sources.json, from flatpak-node-generator over BOTH
+#                          lockfiles (the root workspace and the desktop shell, which
+#                          is deliberately not a workspace member and has its own).
+#                          They merge with zero conflicts; see ./README.md.
+#   ONNX Runtime        -> ort-sys DOWNLOADS this from its own build.rs via ureq, which
+#                          fails during the build rather than at resolution time.
+#                          Declaring it as a source and pointing ORT_LIB_LOCATION at it
+#                          makes ort-sys skip the download and link statically. The URL
+#                          and sha256 are the crate's own, read out of the vendored
+#                          ort-sys dist.txt, so they cannot drift from the pin.
+#   Rust + Node         -> SDK extensions. The GNOME SDK ships neither, but it DOES
+#                          ship webkit2gtk-4.1, GTK3, libsoup3 and OpenSSL, so no
+#                          native dependency needs building here.
+#
+# SUBMODULES ARE DECLARED ONE BY ONE, AND THAT IS DELIBERATE.
+# flatpak-builder fetches every submodule named in .gitmodules and does NOT honour
+# `update = none` - so letting it recurse makes it try to clone brands/suse, the
+# PRIVATE SUSE pack, and the build dies on a credential prompt (it did, before this
+# was written). A Flathub builder would fail identically, and must never reach that
+# repo anyway. So the top-level source sets disable-submodules and each submodule the
+# build genuinely needs is its own pinned source below.
+#
+# Omitted on purpose: brands/suse (private - its absence is what makes the build
+# resolve to the public lolly-start profile), shells/chrome-extension and
+# shells/tauri-mobile (neither is an npm workspace member nor used by this build).
+id: tools.lolly.Desktop
+
+# Was tools.lolly.desktop until 2026-08-28. flatpak-builder-lint rejects an app id
+# whose last component is a lowercase "desktop" (appid-ends-with-lowercase-desktop),
+# and the Flathub docs say that exception "is never granted". Renaming also moves the
+# app data directory, which is why it had to happen before 1.0.0 rather than after.
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+
+# rust-stable 1.98 and node24 24.20.0 on the 25.08 branch that GNOME 49 is built on.
+# The dependency tree needs Rust >= 1.88 (darling 0.23, icu_collections 2.2,
+# headless_chrome 1.0), and .nvmrc pins Node 24 - both are satisfied.
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+  - org.freedesktop.Sdk.Extension.node24
+
+command: lolly-desktop
+
+finish-args:
+  # Rendering: Wayland first, X11 fallback, GPU access for the webview compositor.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
+  # Network: catalog/asset sync and the tauri-plugin-http net bridge. Renders happen
+  # on-device; this is not telemetry.
+  - --share=network
+  # Somewhere to save exports. App state lives in the per-app dir Flatpak grants
+  # automatically, so no broader filesystem access is needed.
+  - --filesystem=xdg-download
+  - --filesystem=xdg-documents
+  # The DMABUF renderer shows a blank window under the sandbox on some GPU/driver
+  # combinations. Drop once that is no longer true of the runtime.
+  - --env=WEBKIT_DISABLE_DMABUF_RENDERER=1
+
+modules:
+  - name: lolly
+    buildsystem: simple
+
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/node24/bin
+      env:
+        # Cargo: the generated sources drop the registry and a config here. The path
+        # must match the module name ("lolly"), which is where flatpak-builder puts it.
+        CARGO_HOME: /run/build/lolly/cargo
+        CARGO_NET_OFFLINE: 'true'
+        # ONNX Runtime: the directory ABOVE lib/, which is the layout ort-sys's
+        # prepare_libort_dir() expects. ORT_SKIP_DOWNLOAD is belt and braces - if
+        # ORT_LIB_LOCATION were ever ignored, this fails the build instead of hanging
+        # on a network call the sandbox will refuse.
+        ORT_LIB_LOCATION: /run/build/lolly/onnxruntime
+        ORT_SKIP_DOWNLOAD: '1'
+        # npm: install from the generated offline cache, never the network.
+        npm_config_cache: /run/build/lolly/flatpak-node/npm-cache
+        npm_config_offline: 'true'
+        npm_config_audit: 'false'
+        npm_config_fund: 'false'
+        # The frontend reads this for its model download base; the models themselves
+        # are NOT bundled (vite.config.js prunes dist/models - embedding ~1.8 GB tips
+        # the crate's rlib past the 32-bit ar archive-offset limit).
+        #
+        # NOTE: this value does NOT decide the model host. package.json's
+        # build:frontend runs `VITE_MODELS_BASE=... vite build` with an inline shell
+        # assignment, which overrides anything inherited from here. The real setting
+        # lives there (and vite.config.js carries the same value as its default).
+        # Kept in step with them so the two never appear to disagree, but change
+        # package.json if you want to actually move the host.
+        VITE_MODELS_BASE: https://lolli.li
+
+    build-commands:
+      # 1) Workspace deps.
+      #
+      #    --ignore-scripts is REQUIRED, not tidiness: onnxruntime-node's install
+      #    script reaches api.nuget.org for a native binary, which an offline sandbox
+      #    refuses (EAI_AGAIN) and the whole install fails. It is a root devDependency
+      #    used by tests and the CLI, never by this build, so skipping its script costs
+      #    nothing. No dependency here needs a lifecycle script to be usable: the
+      #    platform packages (@esbuild/linux-x64, @rollup/*, @tauri-apps/cli-linux-*)
+      #    ship their binaries in the package rather than fetching them.
+      #
+      #    That also skips the root's OWN preinstall and postinstall, so the one that
+      #    matters is run explicitly on the next line. (The skipped preinstall,
+      #    scripts/check-bootstrap.ts, only guards against a half-cloned checkout - the
+      #    manifest pins every submodule it needs, so there is nothing for it to catch.)
+      - npm ci --offline --ignore-scripts
+
+      # 2) The root postinstall, run by hand because of the above. It builds the
+      #    repo-root tools/ and catalog/ profile VIEWS.
+      #
+      #    lolly-start is named EXPLICITLY rather than using --auto. profiles.json's
+      #    `default` is "suse" - the PRIVATE pack - and --auto only lands on
+      #    lolly-start because brands/suse happens to be absent here. Naming the
+      #    profile makes shipping public content a stated intent rather than a
+      #    side-effect of a missing directory, and fails loudly if that ever changes.
+      - node scripts/use-profile.ts lolly-start
+
+      # 3) The desktop shell has its OWN lockfile (not a workspace member).
+      - cd shells/tauri-desktop && npm ci --offline --ignore-scripts
+
+      # 4) Frontend. build:frontend also runs build:info, which generates the /info
+      #    docs HTML - without it every in-app #/docs route 404s and the footer
+      #    "What?" button goes nowhere. Vite copies tools/ and catalog/ into dist/,
+      #    and tauri-build embeds the whole of dist/ into the binary.
+      #
+      #    LOLLY_EMBED_CATALOG=profile embeds the active tools/ + catalog/ views
+      #    INCLUDING catalog/previews/ - the per-tool gallery thumbnails. The shells
+      #    default to 'neutral', which deliberately carries no previews and no og
+      #    cards (plans/131 WP-A), on the reasoning that brand content arrives from a
+      #    connected instance or a .lolly pack. The visible cost of that is a gallery
+      #    where every tile has to render itself on first load. On lolly-start the
+      #    embedded content IS the public blank brand, so shipping it is safe - which
+      #    is exactly why step 2 pins that profile rather than trusting a fallback.
+      - cd shells/tauri-desktop && LOLLY_EMBED_CATALOG=profile npm run build:frontend
+
+      # 5) The Rust side.
+      #
+      #    --features tauri/custom-protocol is NOT optional. It is what the Tauri CLI
+      #    normally adds for you, and tauri's own is_dev() is literally
+      #    `!cfg!(feature = "custom-protocol")` (tauri/src/lib.rs:309) - so a plain
+      #    `cargo build` produces a DEVELOPMENT binary that ignores the embedded
+      #    frontendDist and tries to load devUrl instead. The app then starts, shows a
+      #    window, and fails with "Could not connect to localhost: Connection refused",
+      #    while the binary comes out ~43 MB instead of ~112 MB because the frontend
+      #    was never embedded. Nothing in the build log warns about it.
+      #
+      #    --locked so the lockfile we generated cargo sources from is the one built.
+      - cd shells/tauri-desktop/src-tauri && cargo build --release --offline --locked --features tauri/custom-protocol
+
+      # 6) Install. The binary is the Cargo package name; everything else is the app id.
+      - install -Dm755 shells/tauri-desktop/src-tauri/target/release/lolly-desktop /app/bin/lolly-desktop
+      - install -Dm644 shells/tauri-desktop/flatpak/tools.lolly.Desktop.desktop /app/share/applications/tools.lolly.Desktop.desktop
+      - install -Dm644 shells/tauri-desktop/flatpak/tools.lolly.Desktop.metainfo.xml /app/share/metainfo/tools.lolly.Desktop.metainfo.xml
+      - install -Dm644 shells/tauri-desktop/flatpak/icon-32.png  /app/share/icons/hicolor/32x32/apps/tools.lolly.Desktop.png
+      - install -Dm644 shells/tauri-desktop/flatpak/icon-64.png  /app/share/icons/hicolor/64x64/apps/tools.lolly.Desktop.png
+      - install -Dm644 shells/tauri-desktop/flatpak/icon-128.png /app/share/icons/hicolor/128x128/apps/tools.lolly.Desktop.png
+      - install -Dm644 shells/tauri-desktop/flatpak/icon-256.png /app/share/icons/hicolor/256x256/apps/tools.lolly.Desktop.png
+      - install -Dm644 shells/tauri-desktop/flatpak/icon-512.png /app/share/icons/hicolor/512x512/apps/tools.lolly.Desktop.png
+      # Freedesktop INTEGRATION, single-sourced from shells/tauri-desktop/linux/ (see
+      # its README). The RPM spec and the deb-based manifest both install these; this
+      # manifest did not, which would have made Flathub - likely the highest-volume
+      # channel - the ONLY one without double-click .lolly, file-manager thumbnails or
+      # GNOME Shell search. linux/README.md already claimed "both packagings" install
+      # them, so the docs described the intent and only this file was missing.
+      #
+      # Installed straight from the git checkout rather than staged flat beside the
+      # manifest (as the deb-based one does), so there are no extra sources to keep in
+      # step and these cannot drift from linux/.
+      #
+      # mime/packages, gnome-shell/search-providers and dbus-1/services are on
+      # Flatpak's export whitelist, so the host sees them. share/thumbnailers is NOT
+      # exported - installed anyway for forward-compatibility; the RPM/deb is what
+      # thumbnails on the host today. The KDE service menu is deliberately absent:
+      # Flatpak never exports kio/servicemenus.
+      - install -Dm644 shells/tauri-desktop/linux/mime/tools.lolly.Desktop.xml /app/share/mime/packages/tools.lolly.Desktop.xml
+      - install -Dm644 shells/tauri-desktop/linux/search/tools.lolly.Desktop.search-provider.ini /app/share/gnome-shell/search-providers/tools.lolly.Desktop.search-provider.ini
+      - install -Dm644 shells/tauri-desktop/linux/search/tools.lolly.Desktop.SearchProvider.service /app/share/dbus-1/services/tools.lolly.Desktop.SearchProvider.service
+      - install -Dm644 shells/tauri-desktop/linux/search/org.lolly.Desktop1.service /app/share/dbus-1/services/org.lolly.Desktop1.service
+      - install -Dm755 shells/tauri-desktop/linux/thumbnailer/lolly-thumbnail /app/bin/lolly-thumbnail
+      - install -Dm644 shells/tauri-desktop/linux/thumbnailer/lolly.thumbnailer /app/share/thumbnailers/lolly.thumbnailer
+      # Filetype icon for application/vnd.lolly+zip, so a .lolly has a face in Files.
+      - install -Dm644 shells/tauri-desktop/linux/icons/32x32/application-vnd.lolly+zip.png /app/share/icons/hicolor/32x32/mimetypes/application-vnd.lolly+zip.png
+      - install -Dm644 shells/tauri-desktop/linux/icons/48x48/application-vnd.lolly+zip.png /app/share/icons/hicolor/48x48/mimetypes/application-vnd.lolly+zip.png
+      - install -Dm644 shells/tauri-desktop/linux/icons/64x64/application-vnd.lolly+zip.png /app/share/icons/hicolor/64x64/mimetypes/application-vnd.lolly+zip.png
+      - install -Dm644 shells/tauri-desktop/linux/icons/128x128/application-vnd.lolly+zip.png /app/share/icons/hicolor/128x128/mimetypes/application-vnd.lolly+zip.png
+      - install -Dm644 shells/tauri-desktop/linux/icons/256x256/application-vnd.lolly+zip.png /app/share/icons/hicolor/256x256/mimetypes/application-vnd.lolly+zip.png
+
+      # Flathub requires the licence be installed under the app id.
+      - install -Dm644 LICENSE /app/share/licenses/tools.lolly.Desktop/LICENSE
+
+    sources:
+      # The umbrella repo: engine/, schemas/, scripts/, profiles.json, the
+      # brands/lolly-start pack, and the packages/* workspaces.
+      - type: git
+        url: https://github.com/lolly-tools/lolly.git
+        commit: fe269e7c869cf0e61dd21d7dab2d4b53c4d22c10
+        disable-submodules: true
+
+      # The submodules this build needs, pinned to what the umbrella commit above
+      # points at. The first five are npm WORKSPACE members - `npm ci` reads every
+      # workspace package.json and fails if one is missing, so they are required even
+      # though the desktop app does not run them.
+      - type: git
+        url: https://github.com/lolly-tools/lolly-web.git
+        commit: c79dd45f10accf7712d164df7d56aeef2b8a65af
+        dest: shells/web
+      - type: git
+        url: https://github.com/lolly-tools/lolly-cli.git
+        commit: 880feaa2cc23cbe22a1fa44f2e2ef8e00a669fe1
+        dest: shells/cli
+      - type: git
+        url: https://github.com/lolly-tools/lolly-tui.git
+        commit: db9229d024e219435677f3277fc2c1d852667f93
+        dest: shells/tui
+      - type: git
+        url: https://github.com/lolly-tools/lolly-ca.git
+        commit: 6ea87b830fdd5b09e8b139b851014a159d86b7f2
+        dest: services/ca
+      - type: git
+        url: https://github.com/lolly-tools/lolly-mcp-server.git
+        commit: 1ba78efa15d00b244601759ee41e34c218fa27fb
+        dest: services/mcp
+      # Not workspaces, but the build reads them: community/ is the public tool set
+      # that scripts/use-profile.ts builds the tools/ view from, and docs/ is what
+      # build:info turns into the /info pages the in-app #/docs reader fetches.
+      - type: git
+        url: https://github.com/lolly-tools/lolly-tools.git
+        commit: c6b266e82d8bbac8d3ced56783157ca5aecb21bc
+        dest: community
+      - type: git
+        url: https://github.com/lolly-tools/lolly-docs.git
+        commit: 91f450485f91526dd91b5f89e709fe0e003aef86
+        dest: docs
+      # The shell being built.
+      - type: git
+        url: https://github.com/lolly-tools/lolly-desktop.git
+        commit: 6b00fbaeb56f5059fe4fdd13de21841693cd84d0
+        dest: shells/tauri-desktop
+
+      # ONNX Runtime, byte-identical to what ort-sys would have fetched. Extracts to
+      # onnxruntime/lib/libonnxruntime.a - a static archive, so the finished app has
+      # no libonnxruntime runtime dependency at all.
+      - type: archive
+        url: https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/x86_64-unknown-linux-gnu.tgz
+        sha256: ed1716de95974bf47ab0223ca33734a0b5a5d09a181225d0e8ed62d070aea893
+        dest: onnxruntime
+        strip-components: 1
+        only-arches: [x86_64]
+      - type: archive
+        url: https://cdn.pyke.io/0/pyke:ort-rs/ms@1.22.0/aarch64-unknown-linux-gnu.tgz
+        sha256: 24e4760207136fc50b854bb5012ab81de6189039cf6d4fd3f5b8d3db7e929f1e
+        dest: onnxruntime
+        strip-components: 1
+        only-arches: [aarch64]
+
+      # Generated - do not hand-edit. See ./README.md for the regeneration commands.
+      - cargo-sources.json
+      - node-sources.json


### PR DESCRIPTION
Lolly generates on-brand creative assets — QR codes, charts, diagrams, badges, documents, filters — as PNG, SVG, PDF or video. Everything renders on the user's device; nothing is uploaded.

- **Homepage:** https://lolly.tools
- **Source:** https://github.com/lolly-tools/lolly
- **Licence:** MPL-2.0

### Built entirely from source, offline

- ~670 cargo crates via `cargo-sources.json` (flatpak-cargo-generator)
- ~700 npm packages via `node-sources.json` (flatpak-node-generator over **both** lockfiles — the desktop shell is deliberately not an npm workspace member, so its dependencies are absent from the root lockfile)
- ONNX Runtime is declared as an archive source with `ORT_LIB_LOCATION` set, because `ort-sys` otherwise downloads it from its own `build.rs` at compile time, which an offline build cannot do
- Rust and Node come from the `rust-stable` and `node24` SDK extensions

### Submodules are pinned individually

The top-level source sets `disable-submodules` and lists each public dependency explicitly. The umbrella repo contains a private submodule that a Flathub builder cannot clone; recursing would fail on a credential prompt, and the private content must never reach a public build.

### Runtime permissions

`--share=network` is needed for catalog sync and for on-device ML models, which are downloaded on first use rather than bundled (they are ~1 GB). `--filesystem=xdg-download` / `xdg-documents` are for saving exports. `--device=dri` is for the webview compositor.

### Verified locally

Built with `org.flatpak.Builder`, installed, launched and confirmed rendering on Fedora 45 / GNOME under Wayland. `flatpak-builder-lint` passes on both the manifest and the built repo, apart from the non-blocking `runtime-update-available-to-org.gnome.Platform-50` notice.