### PR TITLE
slopsharing: Add io.github.Spaceghost.chatgpt-flatpak

### DIFF
--- a/io.github.Spaceghost.chatgpt-flatpak.desktop
+++ b/io.github.Spaceghost.chatgpt-flatpak.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=ChatGPT Desktop Wrapper
+Comment=Unofficial Flatpak wrapper for ChatGPT by OpenAI
+GenericName=AI assistant
+Exec=chatgpt %U
+Icon=io.github.Spaceghost.chatgpt-flatpak
+Type=Application
+StartupNotify=true
+Categories=Utility;Development;
+MimeType=x-scheme-handler/codex;text/csv;application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.openxmlformats-officedocument.presentationml.presentation;text/tab-separated-values;application/vnd.ms-excel;application/vnd.ms-excel.sheet.macroEnabled.12;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;
+Keywords=OpenAI;ChatGPT;Codex;AI;

--- a/io.github.Spaceghost.chatgpt-flatpak.metainfo.xml
+++ b/io.github.Spaceghost.chatgpt-flatpak.metainfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.Spaceghost.chatgpt-flatpak</id>
+  <name>ChatGPT Desktop Wrapper</name>
+  <summary>Run the official ChatGPT Linux application in a Flatpak sandbox</summary>
+  <developer id="io.github.Spaceghost">
+    <name>Spaceghost</name>
+  </developer>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <description>
+    <p>
+      An unofficial Flatpak wrapper for the proprietary ChatGPT desktop
+      application published by OpenAI. The upstream RPM is downloaded directly
+      from OpenAI during installation and is not redistributed by this project.
+    </p>
+    <p>
+      This Flathub-oriented build uses a restricted sandbox. Some ChatGPT and
+      Codex features that require direct access to host projects or commands may
+      not be available.
+    </p>
+  </description>
+  <launchable type="desktop-id">io.github.Spaceghost.chatgpt-flatpak.desktop</launchable>
+  <provides>
+    <binary>chatgpt</binary>
+  </provides>
+  <url type="homepage">https://github.com/Spaceghost/chatgpt-flatpak</url>
+  <url type="bugtracker">https://github.com/Spaceghost/chatgpt-flatpak/issues</url>
+  <url type="help">https://learn.chatgpt.com/docs/linux/linux-app</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Signing in to ChatGPT from the desktop application</caption>
+      <image>https://raw.githubusercontent.com/Spaceghost/chatgpt-flatpak/main/flathub/screenshots/chatgpt.png</image>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="26.825.51511" date="2026-08-30" />
+  </releases>
+</component>

--- a/io.github.Spaceghost.chatgpt-flatpak.svg
+++ b/io.github.Spaceghost.chatgpt-flatpak.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="background" x1="16" y1="12" x2="112" y2="116" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#28b8a6"/>
+      <stop offset="1" stop-color="#147a76"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#background)"/>
+  <path d="M31 31h66a12 12 0 0 1 12 12v39a12 12 0 0 1-12 12H61L39 111V94h-8a12 12 0 0 1-12-12V43a12 12 0 0 1 12-12Z" fill="#fff"/>
+  <path d="M44 72 54 48h8l10 24h-8l-2-6H53l-2 6Zm11-12h5l-2-7h-1Zm22-12h8v24h-8Z" fill="#147a76"/>
+</svg>

--- a/io.github.Spaceghost.chatgpt-flatpak.yaml
+++ b/io.github.Spaceghost.chatgpt-flatpak.yaml
@@ -1,0 +1,66 @@
+app-id: io.github.Spaceghost.chatgpt-flatpak
+runtime: org.freedesktop.Platform
+runtime-version: "25.08"
+sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: "25.08"
+command: chatgpt
+separate-locales: false
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.StatusNotifierWatcher
+
+modules:
+  - name: chatgpt
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 chatgpt.sh /app/bin/chatgpt
+      - install -Dm755 apply_extra /app/bin/apply_extra
+      - install -Dm644 io.github.Spaceghost.chatgpt-flatpak.desktop /app/share/applications/io.github.Spaceghost.chatgpt-flatpak.desktop
+      - install -Dm644 io.github.Spaceghost.chatgpt-flatpak.metainfo.xml /app/share/metainfo/io.github.Spaceghost.chatgpt-flatpak.metainfo.xml
+      - install -Dm644 io.github.Spaceghost.chatgpt-flatpak.svg /app/share/icons/hicolor/scalable/apps/io.github.Spaceghost.chatgpt-flatpak.svg
+    sources:
+      - type: extra-data
+        filename: chatgpt.rpm
+        only-arches:
+          - x86_64
+        url: https://persistent.oaistatic.com/codex-app-prod/linux/rpm/x86_64/chatgpt-26.825.51511-1.x86_64.rpm
+        sha256: 44e19ee796d788bffd741acb86a87be2f295d74fc4847132e7482bf04972c58d
+        size: 458831841
+      - type: extra-data
+        filename: chatgpt.rpm
+        only-arches:
+          - aarch64
+        url: https://persistent.oaistatic.com/codex-app-prod/linux/rpm/aarch64/chatgpt-26.825.51511-1.aarch64.rpm
+        sha256: 45f225f9cd6b3b6bbfda8c3555fcdc03d9cae0421c2323a9b7f2db61bbb7c4f9
+        size: 433897053
+      - type: script
+        dest-filename: apply_extra
+        commands:
+          - set -eu
+          - bsdtar --no-same-owner -xf chatgpt.rpm
+          - test -x usr/lib/chatgpt/ChatGPT
+          - mv usr/lib/chatgpt chatgpt
+          - rm -rf chatgpt.rpm etc usr
+      - type: script
+        dest-filename: chatgpt.sh
+        commands:
+          - set -eu
+          - runtime_tmp="${XDG_RUNTIME_DIR:-/tmp}/app/${FLATPAK_ID}"
+          - mkdir -p "$runtime_tmp"
+          - export TMPDIR="$runtime_tmp"
+          - exec zypak-wrapper /app/extra/chatgpt/ChatGPT "$@"
+      - type: file
+        path: io.github.Spaceghost.chatgpt-flatpak.desktop
+      - type: file
+        path: io.github.Spaceghost.chatgpt-flatpak.metainfo.xml
+      - type: file
+        path: io.github.Spaceghost.chatgpt-flatpak.svg


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. This is an unofficial Flatpak wrapper for the proprietary ChatGPT Linux app. It uses Flatpak extra-data to download versioned RPMs directly from OpenAI, so the application binary is not redistributed. This Flathub variant uses a restricted sandbox; host project and command-execution features may be unavailable.
- [x] Please attach a video showcasing the application on Linux using the Flatpak. [Flatpak launch and sign-in video](https://github.com/Spaceghost/chatgpt-flatpak/blob/main/flathub/video.webm)
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an _(please keep whichever is applicable and remove the rest)_ author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **N/A:** I am the maintainer of this packaging, not an OpenAI contributor. OpenAI distributes the proprietary Linux binary through its [official Linux documentation](https://learn.chatgpt.com/docs/linux/linux-app), but does not publish a public source repository or issue tracker for this app. This draft submission requests Flathub guidance before presenting the package as official or using upstream branding.

Maintainer: @Spaceghost

Packaging source, build instructions, and the full-access local variant: https://github.com/Spaceghost/chatgpt-flatpak

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
