### PR TITLE
Add io.github.oneydef.eara (pin bf2360e, app ID fix)

### DIFF
--- a/io.github.oneydef.eara.yml
+++ b/io.github.oneydef.eara.yml
@@ -1,0 +1,102 @@
+# Flathub manifest for EarA
+app-id: io.github.oneydef.eara
+runtime: org.gnome.Platform
+runtime-version: "49"
+sdk: org.gnome.Sdk
+command: io.github.oneydef.eara
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --device=dri
+  - --system-talk-name=org.bluez
+  - --allow=bluetooth
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/aclocal
+  - /share/doc
+  - /share/gtk-doc
+  - /share/man
+  - /share/pkgconfig
+  - "*.la"
+
+modules:
+  - name: python3-dbus-python
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "dbus-python==1.2.18" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/b1/5c/ccfc167485806c1936f7d3ba97db6c448d0089c5746ba105b6eb22dba60e/dbus-python-1.2.18.tar.gz
+        sha256: 92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260
+
+  - name: python3-docutils
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} --no-deps docutils==0.21.2
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl
+        sha256: dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2
+
+  - name: bluez
+    buildsystem: autotools
+    no-make-install: true
+    config-opts:
+      - --enable-library
+      - --enable-client
+      - --disable-systemd
+      - --disable-udev
+      - --disable-cups
+      - --disable-monitor
+      - --disable-mesh
+      - --disable-hid
+      - --disable-hog
+      - --disable-health
+      - --disable-gatt
+      - --disable-obex
+      - --disable-nfc
+      - --disable-sap
+      - --disable-experimental
+    build-options:
+      cflags: -O2 -g
+      cxxflags: -O2 -g
+    build-commands:
+      - make -C client bluetoothctl
+      - install -Dm755 client/bluetoothctl ${FLATPAK_DEST}/bin/bluetoothctl
+    sources:
+      - type: archive
+        url: https://www.kernel.org/pub/linux/bluetooth/bluez-5.79.tar.xz
+        sha256: 4164a5303a9f71c70f48c03ff60be34231b568d93a9ad5e79928d34e6aa0ea8a
+        x-checker-data:
+          type: anitya
+          project-id: 5167
+          url-template: https://www.kernel.org/pub/linux/bluetooth/bluez-${version}.tar.xz
+
+  - name: eara
+    buildsystem: simple
+    build-commands:
+      - install -d ${FLATPAK_DEST}/share/eara
+      - cp -a eara ${FLATPAK_DEST}/share/eara/
+      - install -Dm755 flatpak/io.github.oneydef.eara ${FLATPAK_DEST}/bin/io.github.oneydef.eara
+      - install -Dm644 flatpak/io.github.oneydef.eara.desktop
+        ${FLATPAK_DEST}/share/applications/io.github.oneydef.eara.desktop
+      - install -Dm644 flatpak/io.github.oneydef.eara.metainfo.xml
+        ${FLATPAK_DEST}/share/metainfo/io.github.oneydef.eara.metainfo.xml
+      - install -Dm644 packaging/eara.svg
+        ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.oneydef.eara.svg
+      - install -dm755 ${FLATPAK_DEST}/share/eara/screenshots
+      - install -m644 packaging/screenshots/device.png packaging/screenshots/sound.png
+        -t ${FLATPAK_DEST}/share/eara/screenshots/
+      - install -Dm644 LICENSE -t ${FLATPAK_DEST}/share/licenses/${FLATPAK_ID}/upstream
+    sources:
+      - type: git
+        url: https://github.com/oneydef/EarA-linux.git
+        commit: bf2360eca5ba332c0efebda8d899757f7826c1ca


### PR DESCRIPTION
<!-- ⚠️⚠️  Submission pull request MUST be made against the `new-pr` **base branch** ⚠️⚠️  -->

<!-- 💡 Please go to the preview tab to view the markdown below 💡 -->

### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. EarA is an unofficial GTK4/libadwaita companion for Nothing/CMF earbuds on Linux: battery, ANC, EQ, gestures, find-my, and Bluetooth audio routing. Source: https://github.com/oneydef/EarA-linux — Demo: https://oneydef.github.io/EarA-linux/

- [x] Please attach a video showcasing the application on Linux using the Flatpak. https://youtu.be/ov3V-eLyAWM

- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].

- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.

- [x] I am an author/developer/upstream contributor to the project.

<!-- 💡 Please mention below the GitHub usernames of any additional maintainers needed (if any) 💡 -->

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
