### PR TITLE
Add chat.securebit.SecureBit

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,126 @@
+# SecureBit Desktop Applications License
+
+**Copyright (c) 2025-2026 SecureBit Inc. All rights reserved.**
+
+## License Terms
+
+This license agreement ("Agreement") governs your use of SecureBit Desktop applications ("Software").
+
+### 1. Grant of License
+
+SecureBit Inc. grants you a **non-exclusive, non-transferable, revocable license** to:
+- Install and use the Software on your personal devices
+- Use the Software for personal and commercial purposes
+- Use the Software without time or feature limitations
+
+### 2. Restrictions
+
+You **may not**:
+- Reverse engineer, decompile, or disassemble the Software
+- Modify, adapt, translate, or create derivative works of the Software
+- Redistribute, sell, rent, lease, or sublicense the Software
+- Remove or alter any proprietary notices or labels on the Software
+- Use the Software for illegal purposes or to violate any laws
+- Extract or attempt to extract the source code from the Software binaries
+
+### 3. Intellectual Property
+
+- The Software is licensed, not sold
+- SecureBit Inc. retains all rights, title, and interest in the Software
+- All trademarks, service marks, and logos are property of SecureBit Inc.
+- This license does not grant you any rights to use SecureBit trademarks
+
+### 4. Open Source Components
+
+The Software incorporates open source components:
+- **securebit-core**: Licensed under Apache License 2.0 (https://github.com/SecureBitChat/securebit-core)
+- **securebit-chat**: Licensed under MIT License (https://github.com/SecureBitChat/securebit-chat)
+
+These components are licensed separately under their respective open source licenses.
+
+### 5. Privacy & Data Collection
+
+- The Software does not collect personal data
+- The Software does not transmit usage telemetry
+- All data is stored locally on your device
+- See Privacy Policy for details: https://securebit.chat/privacy
+
+### 6. Updates and Support
+
+- Software updates are provided at SecureBit Inc.'s discretion
+- No guarantee of continued updates or support
+- Updates may be delivered automatically through the Software
+- You may opt out of automatic updates in settings
+
+### 7. Disclaimer of Warranties
+
+THE SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO:
+- Warranties of merchantability
+- Fitness for a particular purpose
+- Non-infringement
+- Accuracy or reliability
+
+### 8. Limitation of Liability
+
+IN NO EVENT SHALL SECUREBIT INC. BE LIABLE FOR:
+- Any indirect, incidental, special, or consequential damages
+- Loss of profits, data, or business opportunities
+- Damages arising from use or inability to use the Software
+- Security breaches or unauthorized access to your data
+
+Maximum liability is limited to the amount you paid for the Software (which is zero for free users).
+
+### 9. Termination
+
+This license is effective until terminated:
+- Automatically terminates if you breach any terms
+- You may terminate by uninstalling the Software
+- SecureBit Inc. may terminate at any time with notice
+- Upon termination, you must cease all use and delete all copies
+
+### 10. Export Controls
+
+You agree to comply with all applicable export laws and regulations. You may not export or re-export the Software to prohibited countries or entities.
+
+### 11. Governing Law
+
+This Agreement is governed by the laws of the United States and the State of Delaware, without regard to conflict of law principles.
+
+### 12. Entire Agreement
+
+This Agreement constitutes the entire agreement between you and SecureBit Inc. regarding the Software and supersedes all prior agreements.
+
+### 13. Severability
+
+If any provision is found unenforceable, the remaining provisions remain in full effect.
+
+### 14. Changes to Terms
+
+SecureBit Inc. reserves the right to modify this Agreement. Continued use after changes constitutes acceptance of new terms.
+
+---
+
+## Contact Information
+
+**SecureBit Inc.**
+- Website: https://securebit.chat
+- Email: legal@securebit.chat
+- Security: security@securebit.chat
+
+---
+
+## Open Source Notice
+
+While the Desktop applications are proprietary, the core cryptographic engine and web version are open source:
+
+- **Core Library**: https://github.com/SecureBitChat/securebit-core (Apache License 2.0)
+- **Web Version**: https://github.com/SecureBitChat/securebit-chat (MIT License)
+
+You are free to audit, modify, and contribute to these open source components under their respective licenses.
+
+---
+
+**Last Updated:** December 28, 2025  
+**Version:** 1.0
+
+By downloading, installing, or using SecureBit Desktop applications, you acknowledge that you have read this Agreement, understand it, and agree to be bound by its terms.

--- a/chat.securebit.SecureBit.metainfo.xml
+++ b/chat.securebit.SecureBit.metainfo.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  What the store shows, and what Flathub validates.
+
+  This file is not documentation: `appstreamcli validate` runs on it during the
+  Flathub build and a failure here fails the submission. Three things in it are
+  checked against the outside world rather than against a schema —
+
+    · <id> must equal the manifest's app-id and the installed desktop entry;
+    · every <screenshot> URL must be reachable over HTTPS and must show THIS
+      application (a reviewer opens them);
+    · <project_license> must be a real SPDX identifier, or LicenseRef- for
+      anything that is not.
+
+  The reverse-DNS id is derived from securebit.chat, which is the domain Flathub
+  checks we control — the same domain the app is verified against on the store.
+-->
+<component type="desktop-application">
+  <id>chat.securebit.SecureBit</id>
+
+  <name>SecureBit Chat</name>
+  <summary>Encrypted peer-to-peer messenger</summary>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <!--
+    The desktop client is not open source. There is no SPDX identifier for that,
+    so AppStream's convention is a LicenseRef. The protocol core the app is built
+    on IS open source and is linked below under vcs-browser.
+  -->
+  <project_license>LicenseRef-proprietary</project_license>
+
+  <developer id="chat.securebit">
+    <name>SecureBit</name>
+  </developer>
+
+  <launchable type="desktop-id">chat.securebit.SecureBit.desktop</launchable>
+
+  <description>
+    <p>
+      SecureBit Chat is a messenger with no accounts and no servers holding your
+      messages. Two people connect directly to each other, and everything that
+      travels between them — text, files, voice notes, calls — is encrypted on
+      the device it left and decrypted only on the device it reached.
+    </p>
+    <p>
+      Before a conversation opens, both people compare a short safety code out
+      loud. That comparison is what rules out somebody sitting in the middle: the
+      code covers the keys themselves, so two people who read the same digits are
+      certainly talking to each other and to nobody else.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>End-to-end encryption with a Double Ratchet, so each message has a key of its own</li>
+      <li>A safety code both sides compare before the chat opens</li>
+      <li>Encrypted voice and video calls, one to one and in groups</li>
+      <li>Group chats of up to eight people over a peer-to-peer mesh, with no shared group key</li>
+      <li>Encrypted file transfer and voice messages</li>
+      <li>Messages that vanish after they are read, or after a timer</li>
+      <li>Interface in thirteen languages, including four that read right to left</li>
+    </ul>
+    <p>
+      Interoperable with the SecureBit web client: a desktop member and a browser
+      member can share the same chat or the same group.
+    </p>
+  </description>
+
+  <!--
+    Real captures of this application, in the order the store shows them. The
+    first is the hero: what the app looks like doing the thing it is for, not
+    what it looks like before you have used it.
+
+    Every URL is opened by a Flathub reviewer, so each one has to be reachable
+    and has to show THIS application — a 404, or a screenshot of the web client,
+    is a rejection. They live on the project's own domain rather than on a code
+    host, because the domain is ours for as long as the app is.
+
+    The version is in the file name on purpose. nginx serves these paths with
+    `max-age=31536000, immutable`, and it applies that to a 404 as readily as to
+    an image: one request for a file that has not shipped yet pins a 404 in
+    Cloudflare's cache for a year, and no redeploy dislodges it. A name that
+    changes with the release is a URL the cache has never seen.
+  -->
+  <screenshots>
+    <screenshot type="default">
+      <image>https://securebit.chat/assets/screenshots/desktop-chat-1.0.0.png</image>
+      <caption>A verified channel, encrypted end to end on the device</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://securebit.chat/assets/screenshots/desktop-verification-1.0.0.png</image>
+      <caption>Comparing the safety code before the chat opens</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://securebit.chat/assets/screenshots/desktop-group-call-1.0.0.png</image>
+      <caption>A group call over the peer-to-peer mesh</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://securebit.chat/assets/screenshots/desktop-call-ringing-1.0.0.png</image>
+      <caption>Somebody has opened a call in the group</caption>
+    </screenshot>
+    <screenshot>
+      <image>https://securebit.chat/assets/screenshots/desktop-start-1.0.0.png</image>
+      <caption>Opening a channel: the keys are made here, nothing touches a server</caption>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://securebit.chat</url>
+  <url type="bugtracker">https://github.com/SecureBitChat/securebit-chat/issues</url>
+  <url type="help">https://securebit.chat</url>
+  <url type="vcs-browser">https://github.com/SecureBitChat/securebit-chat</url>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#fb7d16</color>
+    <color type="primary" scheme_preference="dark">#0d0d10</color>
+  </branding>
+
+  <!--
+    A messenger lets people say anything to each other, and the rating has to say
+    so plainly rather than describe what we hope they say.
+  -->
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+  </content_rating>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
+
+  <requires>
+    <display_length compare="ge">768</display_length>
+    <internet>always</internet>
+  </requires>
+
+  <releases>
+    <release version="1.0.0" date="2026-09-02">
+      <description>
+        <p>First stable release.</p>
+        <ul>
+          <li>Group voice and video calls over the peer-to-peer mesh</li>
+          <li>Interface in thirteen languages, including right-to-left layouts</li>
+          <li>Group chats of up to eight people</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/chat.securebit.SecureBit.yml
+++ b/chat.securebit.SecureBit.yml
@@ -1,0 +1,163 @@
+# SecureBit Chat, as Flathub builds it.
+#
+# WHY THIS MANIFEST LOOKS LIKE THIS
+# ---------------------------------
+# Flathub builds every app on its own machines, from a manifest that lives in a
+# PUBLIC repository (github.com/flathub/chat.securebit.SecureBit). This file is
+# that manifest. It contains no source code — the desktop client's source stays
+# private — only the address of a release artifact, its checksum, and the
+# instructions for unpacking it.
+#
+# The artifact is the .deb that Tauri already builds. Nothing Linux-specific is
+# compiled here: the binary that ships to Flathub users is byte for byte the one
+# our own CI produced and signed off, which is the point — one build, verified
+# once.
+#
+# WHY THE ID IS NOT chat.securebit.desktop
+# ----------------------------------------
+# That is the identifier the macOS and Windows bundles use, and it stays as it
+# is there. Flathub refuses an ID whose last component is a generic word —
+# `.desktop`, `.app`, `.linux` — because AppStream treats an ID ending in
+# `.desktop` as a legacy special case and the two spellings of the same app then
+# disagree. So the Flatpak is `chat.securebit.SecureBit`, and the manifest below
+# renames the desktop entry, the icon and the metainfo to match it. The reverse
+# domain is still securebit.chat, which is the domain Flathub checks we control.
+
+id: chat.securebit.SecureBit
+
+# The GNOME runtime carries WebKitGTK (webkit2gtk-4.1), GTK 3, libsoup 3 and the
+# rest of what a Tauri app links against, at the versions Tauri expects. Nothing
+# else has to be built.
+#
+# The version has to be one that is still supported: Flathub refuses a
+# submission on an end-of-life runtime, and flatpak will not even install one —
+# it prints an "end-of-life" note, skips it, and the builder then fails with the
+# far less helpful "Unable to find sdk". GNOME runtimes get roughly a year, so
+# this line has an expiry date and CI is what enforces it: the flatpak job
+# installs exactly what is named here and fails if it is gone.
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+
+# Tauri names the executable after the Cargo package, not after productName.
+command: tauri-webrtc-chat
+
+finish-args:
+  # Display. Wayland where there is one, X11 where there is not.
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+  # The whole application is a peer-to-peer connection: without the network
+  # there is nothing to sandbox. Chat, file transfer and calls all ride one
+  # WebRTC connection made directly to the other person.
+  - --share=network
+
+  # Calls. Audio through PulseAudio (PipeWire's server is compatible), the
+  # camera through the device node.
+  #
+  # `--device=all` rather than a narrower permission because there is no
+  # narrower one for a camera: Flatpak has no `--device=camera`, and WebKitGTK's
+  # getUserMedia reads /dev/video* directly rather than through the camera
+  # portal. A video-calling application cannot make a video call without it.
+  - --socket=pulseaudio
+  - --device=all
+
+  # Received files are written where the user asked for them, and "show in
+  # folder" hands the path to whichever file manager is running.
+  - --filesystem=xdg-download
+  - --talk-name=org.freedesktop.FileManager1
+
+  # Message notifications.
+  - --talk-name=org.freedesktop.Notifications
+
+modules:
+  - name: securebit-chat
+    buildsystem: simple
+
+    sources:
+      - type: file
+        path: chat.securebit.SecureBit.metainfo.xml
+
+      - type: file
+        path: LICENSE
+
+      # The release artifact. `url`, `sha256` and `size` are rewritten by
+      # scripts/flatpak-release.mjs from the published release, so that the
+      # three of them can never drift apart by hand.
+      #
+      # It is a plain `file` source rather than `extra-data`: we are the authors,
+      # so Flathub may redistribute the binary, and a baked-in binary means the
+      # user installs from Flathub's own mirrors rather than from us — offline
+      # installs work, and our download endpoint is not in the install path.
+      # If a reviewer would rather Flathub did not host the bits, this becomes
+      # `type: extra-data` with the same three fields plus an `apply_extra`
+      # script that runs the same unpacking on the user's machine.
+      - type: file
+        url: https://github.com/SecureBitChat/securebit-desktop/releases/download/v1.0.0/SecureBit.Chat_1.0.0_amd64.deb
+        # Quoted, always. A checksum of only digits — the all-zero placeholder
+        # this carries until a release exists — is read by YAML as a NUMBER, and
+        # flatpak-builder-lint then rejects the whole source: "Failed to
+        # deserialize sha256 property of type gchararray".
+        sha256: '74825135ab902f3c82ebeb728ecf3be082bc7fda5aa86bcbe81419667111b6c1'
+        only-arches: [x86_64]
+        # Lets Flathub's update bot notice a new release and open the PR itself.
+        #
+        # `is-main-source` marks this as the source the application's VERSION
+        # comes from. Without it the bot can still bump the URL and the
+        # checksum, but the release it writes into the metainfo is not tied to
+        # this artifact — and the metainfo's <releases> is what the store shows.
+        x-checker-data:
+          type: json
+          is-main-source: true
+          url: https://api.github.com/repos/SecureBitChat/securebit-desktop/releases/latest
+          # Quoted: both are jq programs full of characters YAML would
+          # otherwise have opinions about — a leading dot, brackets, pipes.
+          version-query: '.tag_name | sub("^v"; "")'
+          url-query: '.assets[] | select(.name | endswith("_amd64.deb")) | .browser_download_url'
+
+    build-commands:
+      # A .deb is an `ar` archive holding a tarball. Both tools are in the SDK.
+      - ar -x *.deb
+      - tar -xf data.tar.gz
+
+      # Fail LOUDLY if Tauri renames the binary. Without this the install below
+      # would quietly produce a package whose `command` points at nothing, and
+      # the first sign of it would be a user reporting that the app does not
+      # start.
+      - test -x usr/bin/tauri-webrtc-chat
+
+      - install -Dm755 usr/bin/tauri-webrtc-chat /app/bin/tauri-webrtc-chat
+
+      # Tauri names the desktop entry after productName ("SecureBit Chat"), and
+      # Flathub requires it to be named after the app ID. Renaming it is not
+      # enough on its own: the window's WM_CLASS still comes from the binary, so
+      # without StartupWMClass the running window is not matched to this desktop
+      # entry and appears with a blank icon in the dock.
+      - install -Dm644 usr/share/applications/*.desktop
+          /app/share/applications/chat.securebit.SecureBit.desktop
+      - desktop-file-edit
+          --set-key=Icon --set-value=chat.securebit.SecureBit
+          --set-key=StartupWMClass --set-value=tauri-webrtc-chat
+          --set-key=Categories --set-value="Network;InstantMessaging;AudioVideo;"
+          --set-key=Keywords --set-value="chat;messenger;encrypted;p2p;webrtc;privacy;"
+          /app/share/applications/chat.securebit.SecureBit.desktop
+
+      # Every size Tauri ships, renamed to the app ID.
+      - |
+        for size in 32x32 128x128 256x256@2 512x512; do
+          src="usr/share/icons/hicolor/$size/apps"
+          [ -d "$src" ] || continue
+          install -Dm644 "$src"/*.png \
+            "/app/share/icons/hicolor/${size%@2}/apps/chat.securebit.SecureBit.png"
+        done
+
+      - install -Dm644 chat.securebit.SecureBit.metainfo.xml
+          /app/share/metainfo/chat.securebit.SecureBit.metainfo.xml
+
+      # Flathub asks that each module install its licence where the store can
+      # find it. Tauri's .deb carries no copyright file, so the licence travels
+      # with the manifest — the same text the project publishes, not a summary
+      # of it written here.
+      - install -Dm644 LICENSE /app/share/licenses/chat.securebit.SecureBit/LICENSE

--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,4 @@
+{
+  "//": "Only the architectures we actually publish a .deb for. Flathub builds every listed arch and fails the submission on the one it cannot build, so adding aarch64 here means adding an aarch64 source to the manifest in the same commit.",
+  "only-arches": ["x86_64"]
+}


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. **SecureBit Chat is a peer-to-peer encrypted messenger: no accounts, and no server that holds messages. Two people connect directly, compare a short safety code out loud, and everything between them — text, files, voice notes, calls — is encrypted on the device it leaves and decrypted only on the device it reaches. Full description below.**
- [X] Please attach a video showcasing the application on Linux using the Flatpak. **[Screen recording](https://github.com/SecureBitChat/securebit-desktop/releases/download/v1.0.0/SecureBit.Chat_1.0.0_linux-flatpak-screencast.mp4)** and a **[still frame](https://github.com/SecureBitChat/securebit-desktop/releases/download/v1.0.0/SecureBit.Chat_1.0.0_linux-flatpak-screenshot.png)** of this Flatpak running on Linux. We have no Linux hardware, so it is recorded in CI: the bundle is installed the way a user installs it, then run under Xvfb — a real X server that draws into memory — through the ordinary `--socket=x11` path that `fallback-x11` grants. What it shows is the application starting and rendering. It cannot show a call, which needs a second person and a camera; that limit is real and I would rather state it than stage something.
- [X] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid]. **`chat.securebit.SecureBit` — `securebit.chat` is our domain; the ID does not end in a generic term. Rationale for not reusing our macOS/Windows ID is below.**
- [X] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [X] I am an **author/developer** of the project.

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission

---

SecureBit Chat is a peer-to-peer encrypted messenger: no accounts, and no server
that holds messages. Two people connect directly to each other, compare a short
safety code out loud, and everything between them — text, files, voice notes,
calls — is encrypted on the device it leaves and decrypted only on the device it
reaches.

The desktop client is built with Tauri. The protocol core it is built on is open
source: <https://github.com/SecureBitChat/securebit-core>.

### Why a prebuilt binary rather than a source build

The desktop client itself is not open source, so there is no source for Flathub
to build. The `.deb` this manifest fetches is produced by our CI from a tagged
commit, published to a public releases repository, and pinned here by sha256.

### Why `--device=all`

Flatpak has no narrower camera permission, and WebKitGTK's `getUserMedia` opens
`/dev/video*` directly rather than going through the camera portal. A
video-calling application cannot make a video call without it. `--socket=pulseaudio`
is there for the same reason on the audio side, and `--share=network` because a
peer-to-peer connection is the entire application.

### Why the ID is not `chat.securebit.desktop`

That is the identifier the macOS and Windows bundles use, and it stays as it is
there — changing it would orphan the data of everyone who already has the app.
An ID ending in a generic word is not accepted here, so the Flatpak is
`chat.securebit.SecureBit` and the manifest renames the desktop entry, the icon
and the metainfo to match. The desktop entry carries a `StartupWMClass` naming
the binary, because the window's WM_CLASS comes from the binary rather than from
the app ID.

### The in-app updater is off inside the sandbox

The app has an updater for the builds we distribute ourselves. Inside a Flatpak
it does not run: `/app` is read-only, so the download would succeed and the
install could not. The app asks the runtime whether it is sandboxed (by the
presence of `/.flatpak-info`) and, if it is, never offers an update — Flatpak
users are updated by Flathub, like everything else on their system.

### What we have and have not tested

Our CI builds this Flatpak on every commit, installs it, and verifies against
the Platform runtime that every library the binary links resolves — including
`webkit2gtk-4.1`. It also runs `flatpak-builder-lint` on the manifest and on the
AppStream metainfo.

What we have **not** been able to test is audio and camera capture through the
portal on real hardware: we have no Linux machine. If a reviewer is able to
check that a call has sound and sees the camera, we would be grateful — and if
something is wrong there, we would rather hear it now than from users.
