### PR TITLE
Add io.github.justcoding121.TitaniumCli

### DIFF
--- a/io.github.justcoding121.TitaniumCli.metainfo.xml
+++ b/io.github.justcoding121.TitaniumCli.metainfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.justcoding121.TitaniumCli</id>
+  <name>Titanium CLI</name>
+  <summary>Titanium Web Proxy command-line interface</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>Jehonathan Thomas</developer_name>
+  <url type="homepage">https://github.com/justcoding121/titanium-web-proxy</url>
+  <description>
+    <p>Command-line interface for Titanium Web Proxy (titanium / twp).</p>
+  </description>
+  <provides>
+    <binary>titanium</binary>
+    <binary>twp</binary>
+  </provides>
+  <releases>
+    <release version="7.0.5" date="2026-09-02"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/io.github.justcoding121.TitaniumCli.yml
+++ b/io.github.justcoding121.TitaniumCli.yml
@@ -1,0 +1,31 @@
+# Flatpak manifest — Titanium CLI (first listing).
+# App ID: io.github.justcoding121.TitaniumCli
+
+id: io.github.justcoding121.TitaniumCli
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: titanium
+finish-args:
+  - --share=network
+  - --filesystem=home
+modules:
+  - name: titanium-cli
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin
+      - cp -a payload/. /app/bin/
+      - chmod +x /app/bin/titanium /app/bin/twp || true
+      - install -Dm644 io.github.justcoding121.TitaniumCli.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumCli.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/Titanium.Cli-linux-x64.zip
+        sha256: 421eb7ccd635863f195e1bf47c5e2f817d5e07328a0fdca95150fde3fc7d7e00
+        dest: payload
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/justcoding121/titanium-web-proxy/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: (.assets[] | select(.name == "Titanium.Cli-linux-x64.zip") | .browser_download_url)
+      - type: file
+        path: io.github.justcoding121.TitaniumCli.metainfo.xml


### PR DESCRIPTION
## Summary
First listing for Titanium CLI from signed stable GitHub Release v7.0.5.

- App ID: `io.github.justcoding121.TitaniumCli`
- Runtime: Freedesktop 24.08
- License: MIT
- Source: `Titanium.Cli-linux-x64.zip` from https://github.com/justcoding121/titanium-web-proxy/releases/tag/v7.0.5
- Manifest validated with `flatpak-builder` via repo packaging-catalog-smoke