### PR TITLE
Add io.github.justcoding121.TitaniumCli

### DIFF
--- a/io.github.justcoding121.TitaniumCli.metainfo.xml
+++ b/io.github.justcoding121.TitaniumCli.metainfo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="console-application">
+  <id>io.github.justcoding121.TitaniumCli</id>
+  <name>Titanium CLI</name>
+  <summary>Titanium Web Proxy command-line interface</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>MIT</project_license>
+  <developer_name>Jehonathan Thomas</developer_name>
+  <url type="homepage">https://github.com/justcoding121/titanium-web-proxy</url>
+  <description>
+    <p>Command-line interface for Titanium Web Proxy (titanium / twp).</p>
+  </description>
+  <provides>
+    <binary>titanium</binary>
+    <binary>twp</binary>
+  </provides>
+  <releases>
+    <release version="7.0.5" date="2026-09-02"/>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/io.github.justcoding121.TitaniumCli.yml
+++ b/io.github.justcoding121.TitaniumCli.yml
@@ -1,0 +1,31 @@
+# Flatpak manifest — Titanium CLI (first listing).
+# App ID: io.github.justcoding121.TitaniumCli
+
+id: io.github.justcoding121.TitaniumCli
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: titanium
+finish-args:
+  - --share=network
+  - --filesystem=home
+modules:
+  - name: titanium-cli
+    buildsystem: simple
+    build-commands:
+      - install -d /app/bin
+      - cp -a payload/. /app/bin/
+      - chmod +x /app/bin/titanium /app/bin/twp || true
+      - install -Dm644 io.github.justcoding121.TitaniumCli.metainfo.xml /app/share/metainfo/io.github.justcoding121.TitaniumCli.metainfo.xml
+    sources:
+      - type: archive
+        url: https://github.com/justcoding121/titanium-web-proxy/releases/download/v7.0.5/Titanium.Cli-linux-x64.zip
+        sha256: 421eb7ccd635863f195e1bf47c5e2f817d5e07328a0fdca95150fde3fc7d7e00
+        dest: payload
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/justcoding121/titanium-web-proxy/releases/latest
+          version-query: .tag_name | sub("^v"; "")
+          url-query: (.assets[] | select(.name == "Titanium.Cli-linux-x64.zip") | .browser_download_url)
+      - type: file
+        path: io.github.justcoding121.TitaniumCli.metainfo.xml


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [x] Please describe the application briefly. Titanium CLI (`titanium` / `twp`) is the MIT-licensed command-line MITM / reverse proxy for Titanium Web Proxy. First Flatpak listing from signed stable GitHub Release v7.0.5 (`Titanium.Cli-linux-x64.zip`).
- [x] Please attach a video showcasing the application on Linux using the Flatpak. N/A — console application (no GUI). Verified with `flatpak-builder` via repo `packaging-catalog-smoke`; happy to provide a short terminal capture on request.
- [x] The Flatpak ID follows all the rules listed in the [Application ID requirements][appid].
- [x] I have read and followed all the [Submission requirements][reqs] and the [Submission guide][reqs2] and I agree to them.
- [x] I am an author/developer/upstream contributor to the project. If not, I contacted upstream developers about this submission. **Link:** https://github.com/justcoding121/titanium-web-proxy (maintainer @justcoding121)

**Extra notes:** Runtime Freedesktop 24.08. License MIT.

<!-- Please DO NOT edit anything below this line -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission