### PR TITLE
Add com.ndsworks.Chit

### DIFF
--- a/com.ndsworks.Chit.yaml
+++ b/com.ndsworks.Chit.yaml
@@ -1,0 +1,25 @@
+app-id: com.ndsworks.Chit
+runtime: org.gnome.Platform
+runtime-version: '50'
+sdk: org.gnome.Sdk
+command: chit
+
+finish-args:
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  - --device=dri
+
+# GlobalShortcuts, Background and file-manager access all go through portals,
+# which are reachable from the sandbox without any finish-args of their own.
+# Notes live under the app's own data directory (~/.var/app/com.ndsworks.Chit),
+# which is already writable in the sandbox, so no --filesystem grant is needed.
+
+modules:
+  - name: chit
+    buildsystem: meson
+    sources:
+      - type: git
+        url: https://github.com/ndsworks/chit.git
+        tag: v0.1.0
+        commit: e199bae5c1bf1105ded55ca590fc59c0e17d657a


### PR DESCRIPTION
### Please confirm your submission meets all the criteria

- [X] Please describe the application briefly. Chit is a simple and minimalistic note-taking app inspired by Tim Browse's Memento (Windows, 2002-2005), rebuilt for GTK4/libadwaita on Wayland.
- [X] Please attach a video showcasing the application on Linux using the Flatpak.
https://github.com/user-attachments/assets/520cd684-a813-45be-b376-4d37de906e97
- [X] The Flatpak ID follows all the rules listed in the Application ID requirements.
- [X] I have read and followed all the Submission requirements and the Submission guide and I agree to them.
  - [ ] The application has a meaningful development history, evidence of real-world use, and a clear commitment to ongoing maintenance, as required by the development history requirements. I am aware of the non-existing development history as this idea was born today, however, I intend to maintain the project going forward.
  - [X] I have disclosed any AI-generated material included in the application or its Flathub packaging, as required by the Generative AI policy. **Affected parts and approximate extent:** All code written using Claude Code through multiple sessions. Ideation, reviewing, testing, iterations and validations, all by me.
  - [X] I have not used AI tools or agents to generate or automate this submission pull request or its review interactions.
- [X] I am an author to the project.

jgarro-MrG

<!-- ⚠️⚠️  Please DO NOT modify anything below this line ⚠️⚠️  -->

[appid]: https://docs.flathub.org/docs/for-app-authors/requirements#application-id
[reqs]: https://docs.flathub.org/docs/for-app-authors/requirements
[reqs2]: https://docs.flathub.org/docs/for-app-authors/submission
[history]: https://docs.flathub.org/docs/for-app-authors/requirements#insufficient-development-history
[ai]: https://docs.flathub.org/docs/for-app-authors/requirements#generative-ai-policy
