### PR TITLE
Add io.github.muhaideennausar.Glyph

### DIFF
--- a/io.github.muhaideennausar.Glyph.yaml
+++ b/io.github.muhaideennausar.Glyph.yaml
@@ -1,0 +1,87 @@
+app-id: io.github.muhaideennausar.Glyph
+runtime: org.gnome.Platform
+runtime-version: "47"
+sdk: org.gnome.Sdk
+command: glyph
+
+finish-args:
+  # Display servers (Wayland native + X11 fallback)
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --share=ipc
+  # Notifications
+  - --talk-name=org.freedesktop.Notifications
+
+build-options:
+  env:
+    TESSDATA_PREFIX: /app/share/tessdata
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - "*.la"
+  - "*.a"
+
+modules:
+  - name: leptonica
+    cleanup:
+      - /bin
+    config-opts:
+      - --disable-static
+    sources:
+      - type: archive
+        url: https://github.com/DanBloomberg/leptonica/releases/download/1.84.1/leptonica-1.84.1.tar.gz
+        sha256: 2b3e1254b1cca381e77c819b59ca99774ff43530209b9aeb511e1d46588a64f6
+
+  - name: tesseract
+    config-opts:
+      - --disable-static
+      - --with-tessdata-prefix=/app/share/tessdata
+    sources:
+      - type: archive
+        url: https://github.com/tesseract-ocr/tesseract/archive/refs/tags/5.4.1.tar.gz
+        sha256: c4bc2a81c12a472f445b7c2fb4705a08bd643ef467f51ec84f0e148bd368051b
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata_fast/raw/main/eng.traineddata
+        sha256: 7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2
+        dest: tessdata
+        dest-filename: eng.traineddata
+      - type: file
+        url: https://github.com/tesseract-ocr/tessdata_fast/raw/main/osd.traineddata
+        sha256: 9cf5d576fcc47564f11265841e5ca839001e7e6f38ff7f7aacf46d15a96b00ff
+        dest: tessdata
+        dest-filename: osd.traineddata
+    post-install:
+      - install -Dm644 tessdata/eng.traineddata /app/share/tessdata/eng.traineddata
+      - install -Dm644 tessdata/osd.traineddata /app/share/tessdata/osd.traineddata
+
+  - name: wl-clipboard
+    buildsystem: meson
+    sources:
+      - type: archive
+        url: https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.2.1.tar.gz
+        sha256: 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+
+  - name: python3-pillow
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --no-build-isolation --no-deps --prefix=${FLATPAK_DEST} .
+    sources:
+      - type: archive
+        url: https://files.pythonhosted.org/packages/source/p/pillow/pillow-10.4.0.tar.gz
+        sha256: 166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06
+
+  - name: glyph
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --no-build-isolation --no-deps --prefix=${FLATPAK_DEST} .
+      - install -Dm644 data/io.github.muhaideennausar.Glyph.desktop ${FLATPAK_DEST}/share/applications/io.github.muhaideennausar.Glyph.desktop
+      - install -Dm644 data/io.github.muhaideennausar.Glyph.metainfo.xml ${FLATPAK_DEST}/share/metainfo/io.github.muhaideennausar.Glyph.metainfo.xml
+      - install -Dm644 assets/icons/scalable/io.github.muhaideennausar.Glyph.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.muhaideennausar.Glyph.svg
+      - install -Dm644 assets/icons/scalable/io.github.muhaideennausar.Glyph-symbolic.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/io.github.muhaideennausar.Glyph-symbolic.svg
+      - for size in 48x48 64x64 128x128 256x256 512x512; do install -Dm644 assets/icons/hicolor/${size}/apps/io.github.muhaideennausar.Glyph.png ${FLATPAK_DEST}/share/icons/hicolor/${size}/apps/io.github.muhaideennausar.Glyph.png; done
+    sources:
+      - type: git
+        url: https://github.com/muhaideennausar/glyph-text-extractor.git
+        tag: v0.1.0
+        commit: a4dcd5f379308b04230e36a1a896ba8a8beaf5a3


### PR DESCRIPTION
Please confirm your submission meets all the criteria

- [x] Please describe the application briefly.
Glyph - Text Extractor is a lightning-fast screen text extractor for Linux desktops, inspired by Microsoft PowerToys Text Extractor. It enables users to select any screen area, extract text using offline optical character recognition (Tesseract), and automatically copy it to the clipboard, with native GTK4/Libadwaita UI for Wayland and X11.

- [x] Please attach a video showcasing the application on Linux using the Flatpak.
https://github.com/user-attachments/assets/27e6ec2f-fecc-4fa5-8a58-282fefced7af

- [x] The Flatpak ID follows all the rules listed in the Application ID requirements.
- [x] I have read and followed all the Submission requirements and the Submission guide and I agree to them.
  - [x] The application has a meaningful development history, evidence of real-world use, and a clear commitment to ongoing maintenance, as required by the development history requirements.
  - [x] I have disclosed any AI-generated material included in the application or its Flathub packaging, as required by the Generative AI policy. Affected parts and approximate extent: Assisted with GTK4 Libadwaita boilerplate and packaging manifests; core logic and comprehensive unit test suite written and verified.
  - [x] I have not used AI tools or agents to generate or automate this submission pull request or its review interactions.
- [x] I am an author/developer/upstream contributor to the project.