### PR TITLE
epher: add com.epher.Desktop

### DIFF
--- a/com.epher.Desktop/com.epher.Desktop.desktop
+++ b/com.epher.Desktop/com.epher.Desktop.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=epher
+GenericName=Calculator
+Comment=A programmable, scriptable calculator
+Exec=epher gui
+Icon=com.epher.Desktop
+Terminal=false
+Categories=Science;Math;Education;
+Keywords=calculator;math;graph;script;
+StartupNotify=true

--- a/com.epher.Desktop/com.epher.Desktop.metainfo.xml
+++ b/com.epher.Desktop/com.epher.Desktop.metainfo.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The AppStream record Flathub serves beside the app (ADR-0061).
+     The release workflow's store-bumps job appends a <release> per
+     version from the same data the changelog carries. -->
+<component type="desktop-application">
+  <id>com.epher.Desktop</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+  <name>epher</name>
+  <summary>A programmable, scriptable calculator</summary>
+  <description>
+    <p>
+      One binary, every frontend: a one-shot CLI, an interactive REPL,
+      piped scripts, a full-screen terminal UI, and a desktop app with
+      keypad, history, 2D and 3D graphing, value tables, statistics,
+      units, and a script collection of hundreds of ready-to-run
+      examples — in eight languages, fully offline.
+    </p>
+  </description>
+  <launchable type="desktop-id">com.epher.Desktop.desktop</launchable>
+  <url type="homepage">https://epher.org</url>
+  <url type="bugtracker">https://github.com/upyesp/epher/issues</url>
+  <developer_name>epher contributors</developer_name>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.0.0" date="2026-09-05">
+      <url type="details">https://github.com/upyesp/epher/releases</url>
+    </release>
+  </releases>
+</component>

--- a/com.epher.Desktop/com.epher.Desktop.svg
+++ b/com.epher.Desktop/com.epher.Desktop.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- epher mark: rounded tile + monogram "e" (the epher.svg artwork kept
+       exactly as uploaded (the glyph and its semi-circular counter, painted in
+       the tile color the way the original does; corners rounded; glyph
+       recentred on the tile (2026-08: its bounding box centre is the tile
+       centre) so the corners never clip it). Variants: icon-light.svg (light
+       tile, dark glyph) for the dark theme, icon-plain.svg (transparent,
+       white glyph) for dark surfaces. -->
+  <rect width="512" height="512" rx="96" fill="#1c1c1e"/>
+  <g transform="translate(26.69 47.04) scale(4.85)">
+    <path fill="#fcfcfc" d="M66 10C72.2882 25.3312 78.7226 54.8252 54 57L54 2C36.7894 2 19.7138 2.46282 8.63812 18C3.99588 24.5122 3.00299 32.2411 3 40C2.99172 61.4514 16.8873 82.2066 40 83.9097C56.9179 85.1564 74.8247 82.3137 84.892 67C92.498 55.4303 92.6651 37.173 89.9961 24C89.1789 19.9666 88.3893 13.4681 84.6065 11.0278C80.2558 8.2212 71.0315 10 66 10z"/>
+    <path fill="#1c1c1e" d="M38 57L38 27C33.573 27.193 28.8439 27.8014 25.3403 30.8032C13.3927 41.0398 26.0822 55.9516 38 57z"/>
+  </g>
+</svg>

--- a/com.epher.Desktop/com.epher.Desktop.yml
+++ b/com.epher.Desktop/com.epher.Desktop.yml
@@ -1,0 +1,54 @@
+# The Flathub manifest (ADR-0061). Submission draft: Flathub's review
+# will pin the runtime/webkit pair and may ask for vendored build inputs
+# (Flathub builds without network). After acceptance this file lives in
+# github.com/flathub/com.epher.Desktop and the release workflow's
+# store-bumps job commits version bumps here — direct pushes trigger
+# Flathub's bot builds. This in-repo copy is the source of truth.
+app-id: com.epher.Desktop
+runtime: org.gnome.Platform
+runtime-version: "46"
+sdk: org.gnome.Sdk
+command: epher
+separate-locales: false
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --device=dri
+  - --share=network
+  # ~/.epher (settings, history, scripts) and user-chosen files.
+  - --filesystem=home
+  - --talk-name=org.a11y.Bus
+modules:
+  # WebKitGTK from Flathub's shared modules: the same webview the deb
+  # and rpm get from the distro. Keep the pair (runtime-version, this
+  # module) aligned with what Flathub's GNOME runtime supports.
+  - "https://github.com/flathub/shared-modules/raw/master/webkitgtk/webkitgtk-2.44.json"
+  - name: epher
+    buildsystem: simple
+    build-commands:
+      # The web dist the desktop shell embeds (the release workflow's
+      # own gate verifies the content hash made it into the binary).
+      - cd crates/web && trunk build --release
+      - cargo build --release --manifest-path crates/tauri-app/src-tauri/Cargo.toml --bin epher
+      - install -Dm755 target/release/epher /app/bin/epher
+      # ADR-0053/0058: the guide and the script collection ride along.
+      # /app/usr is /usr inside the sandbox — exactly where the guide
+      # loader looks (its system data-dir candidates), and the script
+      # collection's in-sandbox path documented in the guide.
+      - install -d /app/usr/share/epher
+      - cp -r crates/web/dist/guide /app/usr/share/epher/guide
+      - cp -r "epher scripts" /app/usr/share/epher/scripts
+      - install -Dm644 packaging/flatpak/com.epher.Desktop.desktop /app/usr/share/applications/com.epher.Desktop.desktop
+      - install -Dm644 site/icon.svg /app/share/icons/hicolor/scalable/apps/com.epher.Desktop.svg
+    sources:
+      - type: git
+        url: https://github.com/upyesp/epher.git
+        tag: v0.0.0
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+      - type: file
+        path: com.epher.Desktop.desktop
+      - type: file
+        path: com.epher.Desktop.svg


### PR DESCRIPTION
Initial submission for epher v0.5.34 — a programmable, scriptable calculator (MIT): CLI, REPL, piped scripts, TUI, and a GTK desktop app. Manifest, desktop file, and AppStream metainfo included.

- Homepage: https://epher.org
- Source: https://github.com/upyesp/epher
- License: MIT
- The same one binary ships as .deb/.rpm/AppImage (x86_64 + aarch64) from GitHub Releases, an apt/dnf repository on epher.org, and a Snap.