### PR TITLE
Add io.github.edesneves.NavePro

### DIFF
--- a/io.github.edesneves.NavePro.desktop
+++ b/io.github.edesneves.NavePro.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=NavePro
+GenericName=Projeção para Igreja
+Comment=Sistema de projeção multimídia para igreja (hinos, Bíblia, mídias)
+Exec=navepro
+Icon=io.github.edesneves.NavePro
+Terminal=false
+Categories=AudioVideo;Education;Utility;
+Keywords=hino;biblia;projecao;igreja;telao;church;hymn;projection;
+StartupWMClass=Navepro
+X-Flatpak-RenamedFrom=navepro.desktop;

--- a/io.github.edesneves.NavePro.metainfo.xml
+++ b/io.github.edesneves.NavePro.metainfo.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>io.github.edesneves.NavePro</id>
+  <name>NavePro</name>
+  <summary>Sistema de projeção multimídia para igreja</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <developer id="io.github.edesneves">
+    <name>Jose Edes Neves</name>
+  </developer>
+  <description>
+    <p>
+      NavePro é um aplicativo desktop (Python/Tkinter) para projeção multimídia
+      em dois monitores: o monitor principal controla tudo e o segundo monitor
+      exibe o telão (letras de hinos, versículos bíblicos e mídias) em tela
+      cheia para a congregação.
+    </p>
+    <ul>
+      <li>Hinos com CRUD, importação XML/TXT (OpenLyrics) e projeção por slides</li>
+      <li>Bíblia com importação XML (Zefania), TXT e JSON (4 formatos)</li>
+      <li>Anúncios com importação TXT/PDF</li>
+      <li>Ordem de Serviço e Gerenciador de Mídia</li>
+      <li>Atualização automática via GitHub Releases</li>
+    </ul>
+  </description>
+  <launchable type="desktop-id">io.github.edesneves.NavePro.desktop</launchable>
+  <url type="homepage">https://github.com/edes-neves/NavePro</url>
+  <url type="bugtracker">https://github.com/edes-neves/NavePro/issues</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>Tela principal do NavePro</caption>
+      <image type="source">https://raw.githubusercontent.com/edes-neves/NavePro/main/img/Icone.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="1.9.1" date="2026-09-09">
+      <description>
+        <ul>
+          <li>Atualização automática via GitHub Releases</li>
+          <li>Importação de Bíblia em XML (Zefania), TXT e JSON (4 formatos, com BOM UTF-8)</li>
+          <li>Anúncios com importação TXT/PDF</li>
+          <li>Projeção sincronizada na Janela Bíblia</li>
+          <li>Gerenciador de mídia corrigido (lista vazia)</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1"/>
+</component>

--- a/io.github.edesneves.NavePro.yml
+++ b/io.github.edesneves.NavePro.yml
@@ -1,0 +1,98 @@
+app-id: io.github.edesneves.NavePro
+runtime: org.freedesktop.Platform
+runtime-version: '24.08'
+sdk: org.freedesktop.Sdk
+command: navepro
+separate-locales: false
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=all
+  - --filesystem=home:rw
+  - --filesystem=xdg-download
+  - --filesystem=host-os
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.FileManager1
+
+modules:
+  # Tcl/Tk 8.6 (mantém fontes do AppImage)
+  - name: tcl
+    buildsystem: autotools
+    subdir: unix
+    post-install:
+      - chmod +w ${FLATPAK_DEST}/lib/libtcl*.so
+    build-options:
+      cflags: -DTCL_UTF_MAX=4
+    cleanup:
+      - /bin
+      - /lib/pkgconfig
+      - /man
+    sources:
+      - type: archive
+        url: https://prdownloads.sourceforge.net/tcl/tcl8.6.15-src.tar.gz
+        sha256: 861e159753f2e2fbd6ec1484103715b0be56be3357522b858d3cbb5f893ffef1
+
+  - name: tk
+    buildsystem: autotools
+    subdir: unix
+    post-install:
+      - chmod +w ${FLATPAK_DEST}/lib/libtk*.so
+    build-options:
+      cflags: -DTCL_UTF_MAX=4
+    cleanup:
+      - /bin
+      - /lib/pkgconfig
+      - /man
+    sources:
+      - type: archive
+        url: https://prdownloads.sourceforge.net/tcl/tk8.6.15-src.tar.gz
+        sha256: 550969f35379f952b3020f3ab7b9dd5bfd11c1ef7c9b7c6a75f5c49aca793fec
+
+  # _tkinter para o Python da runtime
+  - name: python3-tkinter
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=${FLATPAK_DEST} --no-build-isolation --no-deps .
+    sources:
+      - type: git
+        url: https://github.com/iwalton3/tkinter-standalone
+        commit: 4f5cfe3cdd1f58cd4e136fd66d4e5e27d21d820b
+
+  # Dependências Python
+  - name: python-deps
+    buildsystem: simple
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install --prefix=${FLATPAK_DEST} --no-cache-dir -r requirements-flatpak.txt
+    sources:
+      - type: file
+        path: requirements-flatpak.txt
+
+  # NavePro (busca do repo no GitHub)
+  - name: navepro
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 navepro.sh /app/bin/navepro
+      - install -Dm644 NavePro.py config.json AS21.xml biblia-em-txt.txt -t /app/lib/navepro/
+      - install -Dm644 Icon.png Icon.xbm midia.db -t /app/lib/navepro/
+      - cp -r NHA HASD icones /app/lib/navepro/
+      - install -Dm644 io.github.edesneves.NavePro.desktop -t /app/share/applications/
+      - install -Dm644 io.github.edesneves.NavePro.metainfo.xml -t /app/share/metainfo/
+      - install -Dm644 Icon.png /app/share/icons/hicolor/256x256/apps/io.github.edesneves.NavePro.png
+    sources:
+      - type: file
+        path: navepro.sh
+      - type: git
+        url: https://github.com/edes-neves/NavePro.git
+        # Atualize a tag ao lançar nova versão:
+        tag: v1.9.1
+      - type: file
+        path: io.github.edesneves.NavePro.desktop
+      - type: file
+        path: io.github.edesneves.NavePro.metainfo.xml

--- a/navepro.sh
+++ b/navepro.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /app/lib/navepro/NavePro.py "$@"

--- a/requirements-flatpak.txt
+++ b/requirements-flatpak.txt
@@ -1,0 +1,5 @@
+# Dependências Python do NavePro para o Flatpak (runtime do app).
+# O pyinstaller (em requirements.txt) NÃO entra aqui: é só build do AppImage.
+screeninfo>=0.7
+Pillow>=10.0.0
+pypdf>=4.0.0


### PR DESCRIPTION
NavePro is a dual-monitor church multimedia projection system (Python/Tkinter, GPLv3).

- App ID: io.github.edesneves.NavePro
- Runtime: org.freedesktop.Platform//24.08
- Source: https://github.com/edes-neves/NavePro (tag v1.9.1)
- Hinos (hymns), Bíblia (Bible) with projection on a second monitor

Built and tested locally with flatpak-builder.